### PR TITLE
Fix Phase 0 follow-up review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,90 @@
 # symphony-ts
 
-TypeScript implementation of the Symphony spec.
+TypeScript implementation of the [Symphony spec](https://github.com/openai/symphony).
 
-Current objective: complete Phase 0 so Symphony can build Symphony.
+This repository is the new clean-room implementation. The previous scaffolded attempt lives at [`sociotechnica-org/symphony-ts-opus`](https://github.com/sociotechnica-org/symphony-ts-opus).
 
-## Local Bootstrap Usage
+## Status
 
-Prerequisites:
+Phase 0 is implemented.
 
-1. `gh auth login`
-2. `codex` installed locally
-3. GitHub issue labels `symphony:ready`, `symphony:running`, and `symphony:failed`
+Today, `symphony-ts` can:
+
+- poll real GitHub issues labeled `symphony:ready`
+- claim one of those issues locally
+- create or reuse a deterministic per-issue git workspace
+- run Codex against that workspace using the rendered `WORKFLOW.md` prompt
+- verify that a pull request exists for the issue branch
+- close the issue and leave a success comment
+- retry failed runs locally
+
+This is already being used to build `symphony-ts` itself.
+
+## How It Works
+
+The Phase 0 runtime is a narrow vertical slice:
+
+1. `bin/symphony.ts` starts the CLI.
+2. `src/config/workflow.ts` loads and validates `WORKFLOW.md`.
+3. `src/tracker/github-bootstrap.ts` polls GitHub and manages labels/comments/state.
+4. `src/workspace/local.ts` clones and resets per-issue workspaces.
+5. `src/runner/local.ts` launches Codex as a subprocess.
+6. `src/orchestrator/service.ts` ties the loop together.
+
+The default issue lifecycle is:
+
+1. an issue gets the `symphony:ready` label
+2. Symphony changes it to `symphony:running`
+3. Symphony prepares branch `symphony/<issue-number>`
+4. Codex implements the issue and opens a PR
+5. Symphony confirms the PR exists
+6. Symphony comments on the issue and closes it
+
+If a run fails, Symphony either:
+
+- re-labels the issue as `symphony:ready` and retries later, or
+- marks it `symphony:failed` after retries are exhausted
+
+## Repository Map
+
+```text
+bin/
+  symphony.ts                CLI entry point
+src/
+  cli/                       CLI wiring
+  config/                    WORKFLOW.md parsing and prompt rendering
+  domain/                    Shared runtime types and errors
+  observability/             Structured logging
+  orchestrator/              Polling, retries, dispatch
+  runner/                    Codex subprocess execution
+  tracker/                   GitHub bootstrap tracker
+  workspace/                 Local git workspace management
+tests/
+  unit/                      Small contract tests
+  integration/               Adapter and fixture tests
+  e2e/                       Full mock-GitHub runtime tests
+docs/
+  architecture.md            Layer boundaries
+  golden-principles.md       Implementation rules
+  plans/                     Issue-specific implementation plans
+  adrs/                      Architecture decision records
+```
+
+## Prerequisites
+
+- Node.js 20+
+- `pnpm`
+- `git`
+- `gh` authenticated against GitHub
+- `codex` installed locally
+
+You also need these labels in the target repository:
+
+- `symphony:ready`
+- `symphony:running`
+- `symphony:failed`
+
+## Quick Start
 
 Install dependencies:
 
@@ -30,4 +104,97 @@ Run continuously:
 pnpm tsx bin/symphony.ts run
 ```
 
-Issues labeled `symphony:ready` in `sociotechnica-org/symphony-ts` are eligible for dispatch.
+By default, the checked-in `WORKFLOW.md` targets:
+
+- repo: `sociotechnica-org/symphony-ts`
+- tracker: GitHub bootstrap adapter
+- runner: local Codex CLI
+
+## WORKFLOW.md
+
+`WORKFLOW.md` is the runtime contract for a repository.
+
+It contains:
+
+- YAML front matter for tracker, polling, workspace, hooks, and agent config
+- a Liquid template used to render the issue prompt
+
+Key fields in the current workflow:
+
+- `tracker.repo`: GitHub repository to poll
+- `polling.interval_ms`: poll interval
+- `polling.max_concurrent_runs`: local concurrency cap
+- `workspace.root`: local workspace root
+- `workspace.branch_prefix`: issue branch prefix
+- `agent.command`: subprocess command used to run Codex
+
+The checked-in default runner command is:
+
+```bash
+codex exec --dangerously-bypass-approvals-and-sandbox -C . -
+```
+
+## Development
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Run the full local gate:
+
+```bash
+pnpm format:check
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+Useful commands:
+
+```bash
+pnpm dev
+pnpm build
+```
+
+## Testing Strategy
+
+The repo uses three layers of verification:
+
+- unit tests for pure config, logger, runner, and orchestrator behavior
+- integration tests for GitHub adapter and CLI fixtures
+- end-to-end tests that exercise the full runtime against an in-process mock GitHub server and a real temporary git remote
+
+Phase 0 also includes real smoke testing against the live `sociotechnica-org/symphony-ts` repository.
+
+## Current Constraints
+
+- The Phase 0 GitHub bootstrap tracker is intended for a single local Symphony instance.
+- Issue claiming is label-based and not atomic across multiple independent orchestrators.
+- Remote execution backends are not implemented yet.
+- Beads is not integrated yet.
+
+## Documentation
+
+Start here:
+
+- [docs/architecture.md](docs/architecture.md)
+- [docs/golden-principles.md](docs/golden-principles.md)
+- [AGENTS.md](AGENTS.md)
+
+Plans and ADRs live in:
+
+- [`docs/plans/`](docs/plans/)
+- [`docs/adrs/`](docs/adrs/)
+
+## References
+
+- Symphony spec: <https://github.com/openai/symphony>
+- Symphony spec document: <https://github.com/openai/symphony/blob/main/SPEC.md>
+- Harness Engineering post: <https://openai.com/index/harness-engineering/>
+- Main project issue: <https://github.com/sociotechnica-org/company/issues/34>
+- Phase 0 issue: <https://github.com/sociotechnica-org/company/issues/35>
+- Beads: <https://github.com/steveyegge/beads>
+- Context Library: <https://github.com/sociotechnica-org/context-library>
+- Previous implementation attempt: <https://github.com/sociotechnica-org/symphony-ts-opus>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,109 @@ By default, the checked-in `WORKFLOW.md` targets:
 - tracker: GitHub bootstrap adapter
 - runner: local Codex CLI
 
+## How to Use Symphony to Build Symphony
+
+This is the recursive local setup: Symphony runs against the `symphony-ts` GitHub repo and works `symphony-ts` issues by opening PRs back to that same repo.
+
+### 1. Prepare the local machine
+
+Make sure these are installed and configured:
+
+- `pnpm`
+- `git`
+- `gh auth login`
+- `codex`
+
+Then install repo dependencies:
+
+```bash
+pnpm install
+```
+
+### 2. Confirm the workflow targets this repo
+
+The checked-in `WORKFLOW.md` should point at:
+
+- `tracker.repo: sociotechnica-org/symphony-ts`
+- `workspace.repo_url: git@github.com:sociotechnica-org/symphony-ts.git`
+- `agent.command: codex exec --dangerously-bypass-approvals-and-sandbox -C . -`
+
+That means the local orchestrator will poll the real `symphony-ts` GitHub repo and create issue branches inside local workspaces cloned from that same repository.
+
+### 3. Create a real GitHub issue in `symphony-ts`
+
+Open an issue in:
+
+- <https://github.com/sociotechnica-org/symphony-ts/issues>
+
+Describe the task normally. Then add the label:
+
+- `symphony:ready`
+
+That label is the dispatch signal.
+
+### 4. Start Symphony locally
+
+Run one poll cycle:
+
+```bash
+pnpm tsx bin/symphony.ts run --once
+```
+
+Or run the worker continuously:
+
+```bash
+pnpm tsx bin/symphony.ts run
+```
+
+In continuous mode, Symphony will keep polling for additional ready issues.
+
+### 5. Watch the issue lifecycle
+
+When Symphony picks up the issue, it should:
+
+1. replace `symphony:ready` with `symphony:running`
+2. create or reuse a local workspace under `./.tmp/workspaces/`
+3. create branch `symphony/<issue-number>`
+4. run Codex with the rendered issue prompt
+5. push the branch
+6. open a PR against `main`
+
+If the run succeeds, Symphony will comment on the issue and close it.
+
+If the run fails, Symphony will either:
+
+- retry it by restoring `symphony:ready`, or
+- mark it `symphony:failed`
+
+### 6. Review and merge the PR
+
+Once the PR exists, review it like any other change:
+
+- wait for CI
+- wait for Greptile review
+- address follow-up comments if needed
+- merge once the PR is ready
+
+That merged PR becomes the new version of Symphony that will work the next issue.
+
+### 7. Repeat
+
+Create the next `symphony-ts` issue, label it `symphony:ready`, and run Symphony again.
+
+That is the self-hosting loop:
+
+1. Symphony works a `symphony-ts` issue
+2. Symphony opens a PR into `symphony-ts`
+3. the PR merges
+4. the improved Symphony is used on the next `symphony-ts` issue
+
+### Practical notes
+
+- Run only one local Symphony instance against this repo at a time in Phase 0.
+- If you want to inspect a failed run, set `workspace.cleanup_on_success: false` temporarily or inspect the workspace before the next retry.
+- Use `--once` when you want tight control over one issue at a time.
+
 ## WORKFLOW.md
 
 `WORKFLOW.md` is the runtime contract for a repository.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -19,10 +19,7 @@ workspace:
   branch_prefix: symphony/
   cleanup_on_success: true
 hooks:
-  after_create:
-    - git fetch origin
-    - git checkout main
-    - git reset --hard origin/main
+  after_create: []
 agent:
   command: codex exec --dangerously-bypass-approvals-and-sandbox -C . -
   prompt_transport: stdin

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "dev": "tsx watch bin/symphony.ts"
   },
   "dependencies": {
-    "effect": "^3.19.6",
     "liquidjs": "^10.24.0",
     "yaml": "^2.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,6 @@ settings:
 importers:
   .:
     dependencies:
-      effect:
-        specifier: ^3.19.6
-        version: 3.19.19
       liquidjs:
         specifier: ^10.24.0
         version: 10.24.0
@@ -576,12 +573,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@standard-schema/spec@1.1.0":
-    resolution:
-      {
-        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-      }
-
   "@types/chai@5.2.3":
     resolution:
       {
@@ -912,12 +903,6 @@ packages:
         integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
       }
 
-  effect@3.19.19:
-    resolution:
-      {
-        integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==,
-      }
-
   es-module-lexer@1.7.0:
     resolution:
       {
@@ -1027,13 +1012,6 @@ packages:
         integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
       }
     engines: { node: ">=12.0.0" }
-
-  fast-check@3.23.2:
-    resolution:
-      {
-        integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==,
-      }
-    engines: { node: ">=8.0.0" }
 
   fast-deep-equal@3.1.3:
     resolution:
@@ -1381,12 +1359,6 @@ packages:
         integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
       }
     engines: { node: ">=6" }
-
-  pure-rand@6.1.0:
-    resolution:
-      {
-        integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
-      }
 
   resolve-from@4.0.0:
     resolution:
@@ -1893,8 +1865,6 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.59.0":
     optional: true
 
-  "@standard-schema/spec@1.1.0": {}
-
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -2120,11 +2090,6 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  effect@3.19.19:
-    dependencies:
-      "@standard-schema/spec": 1.1.0
-      fast-check: 3.23.2
-
   es-module-lexer@1.7.0: {}
 
   esbuild@0.27.3:
@@ -2231,10 +2196,6 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
-
-  fast-check@3.23.2:
-    dependencies:
-      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -2391,8 +2352,6 @@ snapshots:
   prettier@3.8.1: {}
 
   punycode@2.3.1: {}
-
-  pure-rand@6.1.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -34,13 +34,13 @@ async function branchExists(cwd: string, branchName: string): Promise<boolean> {
   return result.stdout.trim() !== "";
 }
 
-async function remoteBranchExists(
+async function remoteTrackingBranchExists(
   cwd: string,
   branchName: string,
 ): Promise<boolean> {
   const result = await execFileAsync(
     "git",
-    ["ls-remote", "--heads", "origin", branchName],
+    ["branch", "--remotes", "--list", `origin/${branchName}`],
     { cwd },
   );
   return result.stdout.trim() !== "";
@@ -77,15 +77,21 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
     await execFileAsync("git", ["fetch", "origin"], { cwd: workspacePath });
     const hasBranch = await branchExists(workspacePath, branchName);
-    const hasRemoteBranch = await remoteBranchExists(workspacePath, branchName);
+    const hasRemoteTrackingBranch = await remoteTrackingBranchExists(
+      workspacePath,
+      branchName,
+    );
 
-    if (hasRemoteBranch) {
+    if (hasBranch && hasRemoteTrackingBranch) {
       this.#logger.info("Deleting existing remote issue branch", {
         workspacePath,
         branchName,
         issueIdentifier: issue.identifier,
       });
       await execFileAsync("git", ["push", "origin", "--delete", branchName], {
+        cwd: workspacePath,
+      });
+      await execFileAsync("git", ["fetch", "origin", "--prune"], {
         cwd: workspacePath,
       });
     }

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -27,6 +27,25 @@ async function runShell(command: string, cwd: string): Promise<void> {
   }
 }
 
+async function branchExists(cwd: string, branchName: string): Promise<boolean> {
+  const result = await execFileAsync("git", ["branch", "--list", branchName], {
+    cwd,
+  });
+  return result.stdout.trim() !== "";
+}
+
+async function remoteBranchExists(
+  cwd: string,
+  branchName: string,
+): Promise<boolean> {
+  const result = await execFileAsync(
+    "git",
+    ["ls-remote", "--heads", "origin", branchName],
+    { cwd },
+  );
+  return result.stdout.trim() !== "";
+}
+
 export class LocalWorkspaceManager implements WorkspaceManager {
   readonly #logger: Logger;
 
@@ -57,16 +76,25 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     }
 
     await execFileAsync("git", ["fetch", "origin"], { cwd: workspacePath });
+    const hasBranch = await branchExists(workspacePath, branchName);
+    const hasRemoteBranch = await remoteBranchExists(workspacePath, branchName);
+
+    if (hasRemoteBranch) {
+      this.#logger.info("Deleting existing remote issue branch", {
+        workspacePath,
+        branchName,
+        issueIdentifier: issue.identifier,
+      });
+      await execFileAsync("git", ["push", "origin", "--delete", branchName], {
+        cwd: workspacePath,
+      });
+    }
+
     await execFileAsync("git", ["checkout", "main"], { cwd: workspacePath });
     await execFileAsync("git", ["reset", "--hard", "origin/main"], {
       cwd: workspacePath,
     });
 
-    const hasBranch = await execFileAsync(
-      "git",
-      ["branch", "--list", branchName],
-      { cwd: workspacePath },
-    ).then((result) => result.stdout.trim() !== "");
     if (hasBranch) {
       await execFileAsync("git", ["checkout", branchName], {
         cwd: workspacePath,

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -49,8 +49,7 @@ workspace:
   branch_prefix: symphony/
   cleanup_on_success: true
 hooks:
-  after_create:
-    - git fetch origin
+  after_create: []
 agent:
   command: ${options.agentCommand}
   prompt_transport: stdin
@@ -182,5 +181,64 @@ describe("Phase 0 bootstrap factory", () => {
       "IMPLEMENTED.txt",
     );
     expect(implemented).toContain("attempt 2");
+  });
+
+  it("retries successfully after a prior attempt pushed the branch without opening a PR", async () => {
+    server.seedIssue({
+      number: 3,
+      title: "Retry after pushed branch",
+      body: "First attempt pushes but forgets the PR",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve(
+        "tests/fixtures/fake-agent-push-no-pr-then-succeed.sh",
+      ),
+      retryBackoffMs: 0,
+      maxAttempts: 2,
+    });
+
+    const workflow = await loadWorkflow(workflowPath);
+    const logger = new JsonLogger();
+    const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
+    const workspace = new LocalWorkspaceManager(logger);
+    const runner = new LocalRunner(logger);
+    const orchestrator = new BootstrapOrchestrator(
+      workflow,
+      tracker,
+      workspace,
+      runner,
+      logger,
+    );
+
+    await orchestrator.runOnce();
+
+    let issue = server.getIssue(3);
+    expect(issue.state).toBe("open");
+    expect(server.getPullRequests()).toHaveLength(0);
+
+    const firstAttempt = await readRemoteBranchFile(
+      remotePath,
+      "symphony/3",
+      "IMPLEMENTED.txt",
+    );
+    expect(firstAttempt).toContain("attempt 1");
+
+    await orchestrator.runOnce();
+
+    issue = server.getIssue(3);
+    expect(issue.state).toBe("closed");
+    expect(server.getPullRequests()).toHaveLength(1);
+
+    const secondAttempt = await readRemoteBranchFile(
+      remotePath,
+      "symphony/3",
+      "IMPLEMENTED.txt",
+    );
+    expect(secondAttempt).toContain("attempt 2");
   });
 });

--- a/tests/fixtures/fake-agent-push-no-pr-then-succeed.sh
+++ b/tests/fixtures/fake-agent-push-no-pr-then-succeed.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT="$(cat)"
+printf '%s' "$PROMPT" > .agent-prompt.txt
+
+git config user.name "Symphony Test Agent"
+git config user.email "symphony-agent@example.com"
+
+echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER} attempt ${SYMPHONY_RUN_ATTEMPT}" > IMPLEMENTED.txt
+git add .agent-prompt.txt IMPLEMENTED.txt
+git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} attempt ${SYMPHONY_RUN_ATTEMPT}"
+git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+
+if [[ "${SYMPHONY_RUN_ATTEMPT}" -lt 2 ]]; then
+  exit 0
+fi
+
+gh pr create \
+  --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --base main \
+  --head "${SYMPHONY_BRANCH_NAME}"

--- a/tests/fixtures/fake-agent-push-no-pr-then-succeed.sh
+++ b/tests/fixtures/fake-agent-push-no-pr-then-succeed.sh
@@ -10,7 +10,7 @@ git config user.email "symphony-agent@example.com"
 echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER} attempt ${SYMPHONY_RUN_ATTEMPT}" > IMPLEMENTED.txt
 git add .agent-prompt.txt IMPLEMENTED.txt
 git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} attempt ${SYMPHONY_RUN_ATTEMPT}"
-git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+git push origin "HEAD:${SYMPHONY_BRANCH_NAME}"
 
 if [[ "${SYMPHONY_RUN_ATTEMPT}" -lt 2 ]]; then
   exit 0


### PR DESCRIPTION
Addresses the late Greptile review on #5.

What changed:
- delete the remote issue branch before rebuilding a retry workspace when a prior attempt already pushed commits without opening a PR
- add an end-to-end regression test for the pushed-without-PR retry path
- remove the unused `effect` dependency
- remove the redundant default workspace bootstrap hook from `WORKFLOW.md`
- expand `README.md` into a real operator/developer guide with architecture, lifecycle, usage, constraints, and reference links
- document the current single-instance GitHub bootstrap constraint

Validation:
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Context:
- follow-up to Greptile review on merged PR #5
- specifically addresses https://github.com/sociotechnica-org/symphony-ts/pull/5#pullrequestreview-3900407959