### PR TITLE
Normalize runtime domain and service contracts

### DIFF
--- a/docs/plans/008-normalize-runtime-contracts/plan.md
+++ b/docs/plans/008-normalize-runtime-contracts/plan.md
@@ -1,0 +1,143 @@
+# Phase 1.1 Technical Plan: Normalize Runtime Domain and Service Contracts
+
+## Goal
+
+Refactor the working GitHub bootstrap loop into clearer, spec-shaped runtime contracts without breaking the current self-hosting path.
+
+This slice should make the orchestrator depend on normalized domain models and service interfaces instead of Phase 0 bootstrap assumptions.
+
+## Scope
+
+Required outcomes for issue `#8`:
+
+1. define normalized runtime types for issue, workspace, run attempt/session, and retry state
+2. separate service interfaces from the current bootstrap adapter implementations
+3. make the orchestrator consume explicit contracts where practical
+4. preserve the real GitHub bootstrap loop through the existing e2e harness
+
+## Current Gaps
+
+The current Phase 0 code has the right layers, but several boundaries are still too bootstrap-shaped:
+
+- `src/domain/types.ts` mixes workflow config, runtime state, and adapter-facing types in one file
+- `Tracker`, `WorkspaceManager`, and `Runner` interfaces still expose bootstrap-specific assumptions
+- the orchestrator renders prompts directly and decides success by calling a GitHub-specific `hasPullRequest`
+- retry bookkeeping is implicit inside the orchestrator rather than modeled as runtime state
+- workspace creation still takes raw config and hooks on each call instead of a normalized workspace request
+
+## Design Direction
+
+### 1. Normalize runtime domain types
+
+Introduce explicit runtime models under `src/domain/` for:
+
+- issue identity and issue state
+- workspace key and prepared workspace session data
+- run attempt / run session lifecycle
+- retry state and retry scheduling
+
+These types should remain tracker-agnostic and runner-agnostic.
+
+### 2. Separate service contracts from adapter configuration
+
+Refactor the service interfaces so the orchestrator depends on stable operations:
+
+- tracker service owns claim, release, fail, complete, and post-run verification
+- workspace service owns workspace preparation and cleanup
+- runner service owns launching a run attempt against a prepared workspace
+
+Bootstrap-specific details such as GitHub labels, branch-to-PR verification, repo cloning, and shell command execution stay inside the concrete adapters.
+
+### 3. Move prompt rendering to the workflow/config boundary
+
+The orchestrator should consume a rendered prompt builder contract instead of calling workflow helpers directly.
+
+That keeps prompt construction outside runner behavior and makes the runtime contract clearer.
+
+### 4. Make orchestrator state explicit
+
+Refactor the orchestration loop around typed runtime state:
+
+- running issue ids
+- active run sessions
+- retry entries keyed by issue id
+
+This is still in-memory for Phase 1.1, but the state shape should be explicit and testable.
+
+## Implementation Plan
+
+### 1. Domain split
+
+Create or reshape domain modules for:
+
+- `issue`
+- `workspace`
+- `run`
+- `retry`
+- workflow/config types that remain repository-owned
+
+Keep the types small and explicit rather than rebuilding one large shared file.
+
+### 2. Contract refactor
+
+Update the interfaces in:
+
+- `src/tracker/service.ts`
+- `src/workspace/service.ts`
+- `src/runner/service.ts`
+
+Target changes:
+
+- tracker returns normalized issue models
+- tracker exposes post-run completion verification behind its own contract
+- workspace prepare call accepts a normalized workspace request and returns prepared workspace info
+- runner launch call accepts a normalized run attempt context and returns a normalized run result
+
+### 3. Bootstrap adapter migration
+
+Update the existing implementations so they satisfy the new contracts:
+
+- GitHub bootstrap tracker performs branch/PR verification internally
+- local workspace manager prepares deterministic issue workspaces and returns normalized workspace info
+- local runner launches against the normalized run attempt context
+
+### 4. Orchestrator refactor
+
+Update the orchestrator to:
+
+- use the normalized service interfaces
+- store explicit runtime state and retry entries
+- treat failures through a shared failure path
+- preserve current concurrency and retry behavior
+
+### 5. Test coverage
+
+Add or update tests for:
+
+- normalized domain and workflow prompt context shape
+- orchestrator concurrency and retry behavior under the new contracts
+- GitHub bootstrap tracker verification and lifecycle behavior
+- e2e GitHub bootstrap flow to confirm the loop still works
+
+## Risks
+
+### Contract drift
+
+Avoid introducing abstractions that the current bootstrap flow does not actually need. The contracts should be clearer, not more speculative.
+
+### Hidden GitHub assumptions
+
+The current success check is PR-based. That policy should move behind the tracker contract rather than disappear.
+
+### Refactor regressions
+
+The branch/workspace retry path is already covered by the e2e harness and must remain green.
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. the runtime domain is split into clearer normalized contracts
+2. the orchestrator uses explicit service interfaces instead of bootstrap-specific assumptions
+3. unit, integration, and e2e tests cover the refactor
+4. the GitHub bootstrap path still works locally end-to-end

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { loadWorkflow } from "../config/workflow.js";
+import { createPromptBuilder, loadWorkflow } from "../config/workflow.js";
 import { JsonLogger } from "../observability/logger.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
 import { LocalRunner } from "../runner/local.js";
@@ -33,11 +33,17 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseArgs(argv);
   const logger = new JsonLogger();
   const workflow = await loadWorkflow(args.workflowPath);
+  const promptBuilder = createPromptBuilder(workflow);
   const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
-  const workspace = new LocalWorkspaceManager(logger);
-  const runner = new LocalRunner(logger);
+  const workspace = new LocalWorkspaceManager(
+    workflow.config.workspace,
+    workflow.config.hooks.afterCreate,
+    logger,
+  );
+  const runner = new LocalRunner(workflow.config.agent, logger);
   const orchestrator = new BootstrapOrchestrator(
-    workflow,
+    workflow.config,
+    promptBuilder,
     tracker,
     workspace,
     runner,

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -4,10 +4,11 @@ import fs from "node:fs/promises";
 import * as yaml from "yaml";
 import { ConfigError, WorkflowError } from "../domain/errors.js";
 import type {
-  IssueRef,
+  PromptBuilder,
+  PromptRenderInput,
   ResolvedConfig,
   WorkflowDefinition,
-} from "../domain/types.js";
+} from "../domain/workflow.js";
 
 interface RawWorkflow {
   readonly tracker?: Record<string, unknown>;
@@ -197,20 +198,36 @@ export async function loadWorkflow(
   };
 }
 
-export async function renderPrompt(
+async function renderPromptTemplate(
   definition: WorkflowDefinition,
-  issue: IssueRef,
-  attempt: number | null,
+  input: PromptRenderInput,
 ): Promise<string> {
   try {
     return await liquid.parseAndRender(definition.promptTemplate, {
-      issue,
-      attempt,
-      config: definition.config,
+      issue: input.issue,
+      attempt: input.attempt,
+      config: input.config,
     });
   } catch (error) {
-    throw new WorkflowError(`Failed to render prompt for ${issue.identifier}`, {
-      cause: error as Error,
-    });
+    throw new WorkflowError(
+      `Failed to render prompt for ${input.issue.identifier}`,
+      {
+        cause: error as Error,
+      },
+    );
   }
+}
+
+export function createPromptBuilder(
+  definition: WorkflowDefinition,
+): PromptBuilder {
+  return {
+    async build(input): Promise<string> {
+      return await renderPromptTemplate(definition, {
+        issue: input.issue,
+        attempt: input.attempt,
+        config: definition.config,
+      });
+    },
+  };
 }

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -5,7 +5,6 @@ import * as yaml from "yaml";
 import { ConfigError, WorkflowError } from "../domain/errors.js";
 import type {
   PromptBuilder,
-  PromptRenderInput,
   ResolvedConfig,
   WorkflowDefinition,
 } from "../domain/workflow.js";
@@ -22,6 +21,14 @@ const liquid = new Liquid({
   strictFilters: true,
   strictVariables: true,
 });
+
+interface PromptRenderInput {
+  readonly issue: {
+    readonly identifier: string;
+  };
+  readonly attempt: number | null;
+  readonly config: ResolvedConfig;
+}
 
 function requireString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim() === "") {

--- a/src/domain/issue.ts
+++ b/src/domain/issue.ts
@@ -1,0 +1,12 @@
+export interface RuntimeIssue {
+  readonly id: string;
+  readonly identifier: string;
+  readonly number: number;
+  readonly title: string;
+  readonly description: string;
+  readonly labels: readonly string[];
+  readonly state: string;
+  readonly url: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}

--- a/src/domain/retry.ts
+++ b/src/domain/retry.ts
@@ -1,0 +1,8 @@
+import type { RuntimeIssue } from "./issue.js";
+
+export interface RetryState {
+  readonly issue: RuntimeIssue;
+  readonly nextAttempt: number;
+  readonly dueAt: number;
+  readonly lastError: string;
+}

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -1,0 +1,24 @@
+import type { RuntimeIssue } from "./issue.js";
+import type { PreparedWorkspace } from "./workspace.js";
+
+export interface RunAttempt {
+  readonly issueId: string;
+  readonly issueIdentifier: string;
+  readonly sequence: number;
+}
+
+export interface RunSession {
+  readonly id: string;
+  readonly issue: RuntimeIssue;
+  readonly workspace: PreparedWorkspace;
+  readonly prompt: string;
+  readonly attempt: RunAttempt;
+}
+
+export interface RunResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+}

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -2,8 +2,6 @@ import type { RuntimeIssue } from "./issue.js";
 import type { PreparedWorkspace } from "./workspace.js";
 
 export interface RunAttempt {
-  readonly issueId: string;
-  readonly issueIdentifier: string;
   readonly sequence: number;
 }
 

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -1,15 +1,4 @@
-export interface IssueRef {
-  readonly id: string;
-  readonly identifier: string;
-  readonly number: number;
-  readonly title: string;
-  readonly description: string;
-  readonly labels: readonly string[];
-  readonly state: string;
-  readonly url: string;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-}
+import type { RuntimeIssue } from "./issue.js";
 
 export interface RetryPolicy {
   readonly maxAttempts: number;
@@ -64,39 +53,15 @@ export interface WorkflowDefinition {
   readonly promptTemplate: string;
 }
 
-export interface WorkspaceInfo {
-  readonly issueId: string;
-  readonly issueIdentifier: string;
-  readonly path: string;
-  readonly branchName: string;
-  readonly createdNow: boolean;
+export interface PromptRenderInput {
+  readonly issue: RuntimeIssue;
+  readonly attempt: number | null;
+  readonly config: ResolvedConfig;
 }
 
-export interface RunContext {
-  readonly issue: IssueRef;
-  readonly workspace: WorkspaceInfo;
-  readonly prompt: string;
-  readonly attempt: number;
-}
-
-export interface RunResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly startedAt: string;
-  readonly finishedAt: string;
-}
-
-export interface RetryEntry {
-  readonly issue: IssueRef;
-  readonly attempt: number;
-  readonly dueAt: number;
-  readonly lastError: string;
-}
-
-export interface PullRequestRecord {
-  readonly title: string;
-  readonly body: string;
-  readonly head: string;
-  readonly base: string;
+export interface PromptBuilder {
+  build(input: {
+    readonly issue: RuntimeIssue;
+    readonly attempt: number | null;
+  }): Promise<string>;
 }

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -53,12 +53,6 @@ export interface WorkflowDefinition {
   readonly promptTemplate: string;
 }
 
-export interface PromptRenderInput {
-  readonly issue: RuntimeIssue;
-  readonly attempt: number | null;
-  readonly config: ResolvedConfig;
-}
-
 export interface PromptBuilder {
   build(input: {
     readonly issue: RuntimeIssue;

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -1,0 +1,14 @@
+import type { RuntimeIssue } from "./issue.js";
+
+export interface WorkspacePreparationRequest {
+  readonly issue: RuntimeIssue;
+}
+
+export interface PreparedWorkspace {
+  readonly key: string;
+  readonly issueId: string;
+  readonly issueIdentifier: string;
+  readonly path: string;
+  readonly branchName: string;
+  readonly createdNow: boolean;
+}

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -6,8 +6,6 @@ export interface WorkspacePreparationRequest {
 
 export interface PreparedWorkspace {
   readonly key: string;
-  readonly issueId: string;
-  readonly issueIdentifier: string;
   readonly path: string;
   readonly branchName: string;
   readonly createdNow: boolean;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { OrchestratorError } from "../domain/errors.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RetryState } from "../domain/retry.js";
@@ -27,6 +28,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #runner: Runner;
   readonly #logger: Logger;
   readonly #state = createOrchestratorState();
+  readonly #instanceId = randomUUID();
 
   constructor(
     config: ResolvedConfig,
@@ -216,7 +218,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     attempt: number,
   ): RunSession {
     return {
-      id: `${issue.identifier}/attempt-${attempt}`,
+      id: `${issue.identifier}/attempt-${attempt}-${this.#instanceId}`,
       issue,
       workspace,
       prompt,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -133,6 +133,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#state.runningIssueNumbers.add(issue.number);
     let claimedIssue = issue;
     let completedWorkspace: RunSession["workspace"] | null = null;
+    let completedRunSessionId: string | null = null;
 
     try {
       const claimed = await this.#tracker.claimIssue(issue.number);
@@ -180,11 +181,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       }
 
       completedWorkspace = workspace;
-      this.#logger.info("Issue completed", {
-        issueNumber: claimed.number,
-        branchName: workspace.branchName,
-        runSessionId: session.id,
-      });
+      completedRunSessionId = session.id;
     } catch (error) {
       await this.#handleUnexpectedFailure(
         claimedIssue,
@@ -193,6 +190,18 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
     } finally {
       this.#state.runningIssueNumbers.delete(issue.number);
+    }
+
+    if (completedWorkspace !== null && completedRunSessionId !== null) {
+      try {
+        this.#logger.info("Issue completed", {
+          issueNumber: claimedIssue.number,
+          branchName: completedWorkspace.branchName,
+          runSessionId: completedRunSessionId,
+        });
+      } catch {
+        // Observability must not perturb the completed issue state.
+      }
     }
 
     if (

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -115,6 +115,9 @@ export class BootstrapOrchestrator implements Orchestrator {
       });
     }
     for (const issue of candidates) {
+      if (!merged.has(issue.number) && this.#state.retries.has(issue.number)) {
+        continue;
+      }
       const existing = merged.get(issue.number);
       merged.set(issue.number, {
         issue,
@@ -235,7 +238,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       workspacePath: session.workspace.path,
       runSessionId: session.id,
     });
-    await this.#scheduleRetryOrFail(session.issue, attempt, message);
+    await this.#scheduleRetryOrFailSafely(session.issue, attempt, message);
   }
 
   async #handleUnexpectedFailure(
@@ -249,7 +252,24 @@ export class BootstrapOrchestrator implements Orchestrator {
       attempt,
       error: message,
     });
-    await this.#scheduleRetryOrFail(issue, attempt, message);
+    await this.#scheduleRetryOrFailSafely(issue, attempt, message);
+  }
+
+  async #scheduleRetryOrFailSafely(
+    issue: RuntimeIssue,
+    attempt: number,
+    message: string,
+  ): Promise<void> {
+    try {
+      await this.#scheduleRetryOrFail(issue, attempt, message);
+    } catch (error) {
+      this.#logger.error("Failure handling failed", {
+        issueNumber: issue.number,
+        attempt,
+        originalError: message,
+        error: this.#normalizeFailure(error as Error),
+      });
+    }
   }
 
   async #scheduleRetryOrFail(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -78,7 +78,13 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   async runLoop(signal?: AbortSignal): Promise<void> {
     while (!signal?.aborted) {
-      await this.runOnce();
+      try {
+        await this.runOnce();
+      } catch (error) {
+        this.#logger.error("Poll cycle failed", {
+          error: this.#normalizeFailure(error as Error),
+        });
+      }
       await new Promise((resolve) =>
         setTimeout(resolve, this.#config.polling.intervalMs),
       );
@@ -145,7 +151,6 @@ export class BootstrapOrchestrator implements Orchestrator {
         prompt,
         attempt,
       );
-      this.#state.activeRuns.set(claimed.number, session);
       const result = await this.#runner.run(session);
 
       if (result.exitCode !== 0) {
@@ -184,7 +189,6 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
     } finally {
       this.#state.runningIssueNumbers.delete(issue.number);
-      this.#state.activeRuns.delete(issue.number);
     }
   }
 
@@ -200,8 +204,6 @@ export class BootstrapOrchestrator implements Orchestrator {
       workspace,
       prompt,
       attempt: {
-        issueId: issue.id,
-        issueIdentifier: issue.identifier,
         sequence: attempt,
       },
     };
@@ -219,17 +221,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       workspacePath: session.workspace.path,
       runSessionId: session.id,
     });
-    if (attempt < this.#config.polling.retry.maxAttempts) {
-      await this.#tracker.releaseIssue(session.issue.number, message);
-      this.#state.retries.set(session.issue.number, {
-        issue: session.issue,
-        nextAttempt: attempt + 1,
-        dueAt: Date.now() + this.#config.polling.retry.backoffMs,
-        lastError: message,
-      });
-      return;
-    }
-    await this.#tracker.markIssueFailed(session.issue.number, message);
+    await this.#scheduleRetryOrFail(session.issue, attempt, message);
   }
 
   async #handleUnexpectedFailure(
@@ -243,6 +235,14 @@ export class BootstrapOrchestrator implements Orchestrator {
       attempt,
       error: message,
     });
+    await this.#scheduleRetryOrFail(issue, attempt, message);
+  }
+
+  async #scheduleRetryOrFail(
+    issue: RuntimeIssue,
+    attempt: number,
+    message: string,
+  ): Promise<void> {
     if (attempt < this.#config.polling.retry.maxAttempts) {
       await this.#tracker.releaseIssue(issue.number, message);
       this.#state.retries.set(issue.number, {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,11 +1,10 @@
 import { OrchestratorError } from "../domain/errors.js";
-import type {
-  IssueRef,
-  RetryEntry,
-  WorkflowDefinition,
-} from "../domain/types.js";
-import { renderPrompt } from "../config/workflow.js";
+import type { RuntimeIssue } from "../domain/issue.js";
+import type { RetryState } from "../domain/retry.js";
+import type { RunSession } from "../domain/run.js";
+import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import { createOrchestratorState } from "./state.js";
 import type { Runner } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
@@ -16,27 +15,29 @@ export interface Orchestrator {
 }
 
 interface QueueEntry {
-  readonly issue: IssueRef;
+  readonly issue: RuntimeIssue;
   readonly attempt: number;
 }
 
 export class BootstrapOrchestrator implements Orchestrator {
-  readonly #definition: WorkflowDefinition;
+  readonly #config: ResolvedConfig;
+  readonly #promptBuilder: PromptBuilder;
   readonly #tracker: Tracker;
   readonly #workspaceManager: WorkspaceManager;
   readonly #runner: Runner;
   readonly #logger: Logger;
-  readonly #running = new Set<number>();
-  readonly #retries = new Map<number, RetryEntry>();
+  readonly #state = createOrchestratorState();
 
   constructor(
-    definition: WorkflowDefinition,
+    config: ResolvedConfig,
+    promptBuilder: PromptBuilder,
     tracker: Tracker,
     workspaceManager: WorkspaceManager,
     runner: Runner,
     logger: Logger,
   ) {
-    this.#definition = definition;
+    this.#config = config;
+    this.#promptBuilder = promptBuilder;
     this.#tracker = tracker;
     this.#workspaceManager = workspaceManager;
     this.#runner = runner;
@@ -50,7 +51,8 @@ export class BootstrapOrchestrator implements Orchestrator {
     const dueRetries = this.#collectDueRetries();
     const queue = this.#mergeQueue(candidates, dueRetries);
     const availableSlots =
-      this.#definition.config.polling.maxConcurrentRuns - this.#running.size;
+      this.#config.polling.maxConcurrentRuns -
+      this.#state.runningIssueNumbers.size;
     this.#logger.info("Poll candidates fetched", {
       candidateCount: queue.length,
       availableSlots,
@@ -65,7 +67,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       if (runs.length >= availableSlots) {
         break;
       }
-      if (this.#running.has(issue.issue.number)) {
+      if (this.#state.runningIssueNumbers.has(issue.issue.number)) {
         continue;
       }
       runs.push(this.#processIssue(issue.issue, issue.attempt));
@@ -78,32 +80,32 @@ export class BootstrapOrchestrator implements Orchestrator {
     while (!signal?.aborted) {
       await this.runOnce();
       await new Promise((resolve) =>
-        setTimeout(resolve, this.#definition.config.polling.intervalMs),
+        setTimeout(resolve, this.#config.polling.intervalMs),
       );
     }
   }
 
-  #collectDueRetries(): readonly RetryEntry[] {
+  #collectDueRetries(): readonly RetryState[] {
     const now = Date.now();
-    const due: RetryEntry[] = [];
-    for (const [issueNumber, entry] of this.#retries.entries()) {
+    const due: RetryState[] = [];
+    for (const [issueNumber, entry] of this.#state.retries.entries()) {
       if (entry.dueAt <= now) {
         due.push(entry);
-        this.#retries.delete(issueNumber);
+        this.#state.retries.delete(issueNumber);
       }
     }
     return due;
   }
 
   #mergeQueue(
-    candidates: readonly IssueRef[],
-    dueRetries: readonly RetryEntry[],
+    candidates: readonly RuntimeIssue[],
+    dueRetries: readonly RetryState[],
   ): readonly QueueEntry[] {
     const merged = new Map<number, QueueEntry>();
     for (const retry of dueRetries) {
       merged.set(retry.issue.number, {
         issue: retry.issue,
-        attempt: retry.attempt,
+        attempt: retry.nextAttempt,
       });
     }
     for (const issue of candidates) {
@@ -116,8 +118,9 @@ export class BootstrapOrchestrator implements Orchestrator {
     return [...merged.values()].sort((a, b) => a.issue.number - b.issue.number);
   }
 
-  async #processIssue(issue: IssueRef, attempt: number): Promise<void> {
-    this.#running.add(issue.number);
+  async #processIssue(issue: RuntimeIssue, attempt: number): Promise<void> {
+    this.#state.runningIssueNumbers.add(issue.number);
+    let claimedIssue = issue;
 
     try {
       const claimed = await this.#tracker.claimIssue(issue.number);
@@ -127,112 +130,135 @@ export class BootstrapOrchestrator implements Orchestrator {
         });
         return;
       }
+      claimedIssue = claimed;
 
-      const workspace = await this.#workspaceManager.ensureWorkspace(
+      const workspace = await this.#workspaceManager.prepareWorkspace({
+        issue: claimed,
+      });
+      const prompt = await this.#promptBuilder.build({
+        issue: claimed,
+        attempt: attempt > 1 ? attempt : null,
+      });
+      const session = this.#createRunSession(
         claimed,
-        this.#definition.config.workspace,
-        this.#definition.config.hooks.afterCreate,
+        workspace,
+        prompt,
+        attempt,
       );
-      const prompt = await renderPrompt(
-        this.#definition,
-        claimed,
-        attempt > 1 ? attempt : null,
-      );
-      const result = await this.#runner.run(
-        { issue: claimed, workspace, prompt, attempt },
-        this.#definition.config.agent,
-      );
+      this.#state.activeRuns.set(claimed.number, session);
+      const result = await this.#runner.run(session);
 
       if (result.exitCode !== 0) {
         await this.#handleFailure(
-          claimed,
-          workspace,
+          session,
           attempt,
           `Runner exited with ${result.exitCode}\n${result.stderr}`,
         );
         return;
       }
 
-      const hasPullRequest = await this.#tracker.hasPullRequest(
-        workspace.branchName,
-      );
-      if (!hasPullRequest) {
+      try {
+        await this.#tracker.completeRun(session, result);
+      } catch (error) {
         await this.#handleFailure(
-          claimed,
-          workspace,
+          session,
           attempt,
-          `Runner exited successfully but no pull request was found for ${workspace.branchName}`,
+          this.#normalizeFailure(error as Error),
         );
         return;
       }
 
-      await this.#tracker.completeIssue(
-        claimed.number,
-        this.#definition.config.tracker.successComment,
-      );
-      if (this.#definition.config.workspace.cleanupOnSuccess) {
+      if (this.#config.workspace.cleanupOnSuccess) {
         await this.#workspaceManager.cleanupWorkspace(workspace);
       }
       this.#logger.info("Issue completed", {
         issueNumber: claimed.number,
         branchName: workspace.branchName,
+        runSessionId: session.id,
       });
     } catch (error) {
-      await this.#handleUnexpectedFailure(issue, attempt, error as Error);
+      await this.#handleUnexpectedFailure(
+        claimedIssue,
+        attempt,
+        error as Error,
+      );
     } finally {
-      this.#running.delete(issue.number);
+      this.#state.runningIssueNumbers.delete(issue.number);
+      this.#state.activeRuns.delete(issue.number);
     }
   }
 
+  #createRunSession(
+    issue: RuntimeIssue,
+    workspace: RunSession["workspace"],
+    prompt: string,
+    attempt: number,
+  ): RunSession {
+    return {
+      id: `${issue.identifier}/attempt-${attempt}`,
+      issue,
+      workspace,
+      prompt,
+      attempt: {
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        sequence: attempt,
+      },
+    };
+  }
+
   async #handleFailure(
-    issue: IssueRef,
-    workspace: { readonly path: string },
+    session: RunSession,
     attempt: number,
     message: string,
   ): Promise<void> {
     this.#logger.error("Issue run failed", {
-      issueNumber: issue.number,
+      issueNumber: session.issue.number,
       attempt,
       error: message,
-      workspacePath: workspace.path,
+      workspacePath: session.workspace.path,
+      runSessionId: session.id,
     });
-    if (attempt < this.#definition.config.polling.retry.maxAttempts) {
-      await this.#tracker.releaseIssue(issue.number, message);
-      this.#retries.set(issue.number, {
-        issue,
-        attempt: attempt + 1,
-        dueAt: Date.now() + this.#definition.config.polling.retry.backoffMs,
+    if (attempt < this.#config.polling.retry.maxAttempts) {
+      await this.#tracker.releaseIssue(session.issue.number, message);
+      this.#state.retries.set(session.issue.number, {
+        issue: session.issue,
+        nextAttempt: attempt + 1,
+        dueAt: Date.now() + this.#config.polling.retry.backoffMs,
         lastError: message,
       });
       return;
     }
-    await this.#tracker.markIssueFailed(issue.number, message);
+    await this.#tracker.markIssueFailed(session.issue.number, message);
   }
 
   async #handleUnexpectedFailure(
-    issue: IssueRef,
+    issue: RuntimeIssue,
     attempt: number,
     error: Error,
   ): Promise<void> {
-    const message =
-      error instanceof OrchestratorError
-        ? error.message
-        : `${error.name}: ${error.message}`;
+    const message = this.#normalizeFailure(error);
     this.#logger.error("Unexpected issue failure", {
       issueNumber: issue.number,
       attempt,
       error: message,
     });
-    if (attempt < this.#definition.config.polling.retry.maxAttempts) {
+    if (attempt < this.#config.polling.retry.maxAttempts) {
       await this.#tracker.releaseIssue(issue.number, message);
-      this.#retries.set(issue.number, {
+      this.#state.retries.set(issue.number, {
         issue,
-        attempt: attempt + 1,
-        dueAt: Date.now() + this.#definition.config.polling.retry.backoffMs,
+        nextAttempt: attempt + 1,
+        dueAt: Date.now() + this.#config.polling.retry.backoffMs,
         lastError: message,
       });
       return;
     }
     await this.#tracker.markIssueFailed(issue.number, message);
+  }
+
+  #normalizeFailure(error: Error): string {
+    return error instanceof OrchestratorError
+      ? error.message
+      : `${error.name}: ${error.message}`;
   }
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -127,6 +127,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   async #processIssue(issue: RuntimeIssue, attempt: number): Promise<void> {
     this.#state.runningIssueNumbers.add(issue.number);
     let claimedIssue = issue;
+    let completedWorkspace: RunSession["workspace"] | null = null;
 
     try {
       const claimed = await this.#tracker.claimIssue(issue.number);
@@ -173,9 +174,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         return;
       }
 
-      if (this.#config.workspace.cleanupOnSuccess) {
-        await this.#workspaceManager.cleanupWorkspace(workspace);
-      }
+      completedWorkspace = workspace;
       this.#logger.info("Issue completed", {
         issueNumber: claimed.number,
         branchName: workspace.branchName,
@@ -189,6 +188,21 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
     } finally {
       this.#state.runningIssueNumbers.delete(issue.number);
+    }
+
+    if (
+      this.#config.workspace.cleanupOnSuccess &&
+      completedWorkspace !== null
+    ) {
+      try {
+        await this.#workspaceManager.cleanupWorkspace(completedWorkspace);
+      } catch (error) {
+        this.#logger.error("Workspace cleanup failed", {
+          issueNumber: claimedIssue.number,
+          workspacePath: completedWorkspace.path,
+          error: this.#normalizeFailure(error as Error),
+        });
+      }
     }
   }
 

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,0 +1,16 @@
+import type { RunSession } from "../domain/run.js";
+import type { RetryState } from "../domain/retry.js";
+
+export interface OrchestratorState {
+  readonly runningIssueNumbers: Set<number>;
+  readonly activeRuns: Map<number, RunSession>;
+  readonly retries: Map<number, RetryState>;
+}
+
+export function createOrchestratorState(): OrchestratorState {
+  return {
+    runningIssueNumbers: new Set<number>(),
+    activeRuns: new Map<number, RunSession>(),
+    retries: new Map<number, RetryState>(),
+  };
+}

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,16 +1,13 @@
-import type { RunSession } from "../domain/run.js";
 import type { RetryState } from "../domain/retry.js";
 
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
-  readonly activeRuns: Map<number, RunSession>;
   readonly retries: Map<number, RetryState>;
 }
 
 export function createOrchestratorState(): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
-    activeRuns: new Map<number, RunSession>(),
     retries: new Map<number, RetryState>(),
   };
 }

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -2,48 +2,53 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { RunnerError } from "../domain/errors.js";
-import type { AgentConfig, RunContext, RunResult } from "../domain/types.js";
+import type { RunResult, RunSession } from "../domain/run.js";
+import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { Runner } from "./service.js";
 
 export class LocalRunner implements Runner {
+  readonly #config: AgentConfig;
   readonly #logger: Logger;
 
-  constructor(logger: Logger) {
+  constructor(config: AgentConfig, logger: Logger) {
+    this.#config = config;
     this.#logger = logger;
   }
 
-  async run(context: RunContext, config: AgentConfig): Promise<RunResult> {
+  async run(session: RunSession): Promise<RunResult> {
     const startedAt = new Date().toISOString();
-    const promptFile = path.join(context.workspace.path, ".symphony-prompt.md");
+    const promptFile = path.join(session.workspace.path, ".symphony-prompt.md");
     const command =
-      config.promptTransport === "file"
-        ? `${config.command} ${JSON.stringify(promptFile)}`
-        : config.command;
+      this.#config.promptTransport === "file"
+        ? `${this.#config.command} ${JSON.stringify(promptFile)}`
+        : this.#config.command;
 
-    if (config.promptTransport === "file") {
-      await fs.writeFile(promptFile, context.prompt, "utf8");
+    if (this.#config.promptTransport === "file") {
+      await fs.writeFile(promptFile, session.prompt, "utf8");
     }
 
     this.#logger.info("Launching runner", {
       command,
-      workspacePath: context.workspace.path,
-      issueIdentifier: context.issue.identifier,
-      attempt: context.attempt,
+      workspacePath: session.workspace.path,
+      issueIdentifier: session.issue.identifier,
+      attempt: session.attempt.sequence,
+      runSessionId: session.id,
     });
 
     return await new Promise<RunResult>((resolve, reject) => {
       const child = spawn("bash", ["-lc", command], {
-        cwd: context.workspace.path,
+        cwd: session.workspace.path,
         env: {
           ...process.env,
-          ...config.env,
-          SYMPHONY_ISSUE_ID: context.issue.id,
-          SYMPHONY_ISSUE_IDENTIFIER: context.issue.identifier,
-          SYMPHONY_ISSUE_NUMBER: String(context.issue.number),
-          SYMPHONY_RUN_ATTEMPT: String(context.attempt),
-          SYMPHONY_BRANCH_NAME: context.workspace.branchName,
-          SYMPHONY_WORKSPACE_PATH: context.workspace.path,
+          ...this.#config.env,
+          SYMPHONY_ISSUE_ID: session.issue.id,
+          SYMPHONY_ISSUE_IDENTIFIER: session.issue.identifier,
+          SYMPHONY_ISSUE_NUMBER: String(session.issue.number),
+          SYMPHONY_RUN_ATTEMPT: String(session.attempt.sequence),
+          SYMPHONY_BRANCH_NAME: session.workspace.branchName,
+          SYMPHONY_WORKSPACE_PATH: session.workspace.path,
+          SYMPHONY_RUN_SESSION_ID: session.id,
         },
         stdio: ["pipe", "pipe", "pipe"],
       });
@@ -81,7 +86,7 @@ export class LocalRunner implements Runner {
 
       const timeout = setTimeout(() => {
         child.kill("SIGTERM");
-      }, config.timeoutMs);
+      }, this.#config.timeoutMs);
 
       child.stdout.on("data", (chunk: Buffer | string) => {
         stdout += chunk.toString();
@@ -104,7 +109,9 @@ export class LocalRunner implements Runner {
           const finishedAt = new Date().toISOString();
           if (signal === "SIGTERM") {
             reject(
-              new RunnerError(`Runner timed out after ${config.timeoutMs}ms`),
+              new RunnerError(
+                `Runner timed out after ${this.#config.timeoutMs}ms`,
+              ),
             );
             return;
           }
@@ -118,8 +125,8 @@ export class LocalRunner implements Runner {
         });
       });
 
-      if (config.promptTransport === "stdin") {
-        child.stdin.end(context.prompt);
+      if (this.#config.promptTransport === "stdin") {
+        child.stdin.end(session.prompt);
         return;
       }
       child.stdin.end();

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig, RunContext, RunResult } from "../domain/types.js";
+import type { RunResult, RunSession } from "../domain/run.js";
 
 export interface Runner {
-  run(context: RunContext, config: AgentConfig): Promise<RunResult>;
+  run(session: RunSession): Promise<RunResult>;
 }

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -75,6 +75,7 @@ export class GitHubBootstrapTracker implements Tracker {
   readonly #config: TrackerConfig;
   readonly #logger: Logger;
   readonly #tokenPromise: Promise<string>;
+  #labelsEnsured = false;
 
   constructor(config: TrackerConfig, logger: Logger) {
     this.#config = config;
@@ -83,6 +84,10 @@ export class GitHubBootstrapTracker implements Tracker {
   }
 
   async ensureLabels(): Promise<void> {
+    if (this.#labelsEnsured) {
+      return;
+    }
+
     await this.#ensureLabel(
       this.#config.readyLabel,
       "0e8a16",
@@ -98,6 +103,7 @@ export class GitHubBootstrapTracker implements Tracker {
       "d73a4a",
       "Issue failed in Symphony",
     );
+    this.#labelsEnsured = true;
   }
 
   async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { TrackerError } from "../domain/errors.js";
-import type { IssueRef, TrackerConfig } from "../domain/types.js";
+import type { RuntimeIssue } from "../domain/issue.js";
+import type { RunResult, RunSession } from "../domain/run.js";
+import type { TrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { Tracker } from "./service.js";
 
@@ -29,7 +31,10 @@ interface GitHubPullRequestResponse {
   };
 }
 
-function toIssueRef(issue: GitHubIssueResponse, repo: string): IssueRef {
+function toRuntimeIssue(
+  issue: GitHubIssueResponse,
+  repo: string,
+): RuntimeIssue {
   return {
     id: String(issue.number),
     identifier: `${repo}#${issue.number}`,
@@ -95,25 +100,25 @@ export class GitHubBootstrapTracker implements Tracker {
     );
   }
 
-  async fetchEligibleIssues(): Promise<readonly IssueRef[]> {
+  async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {
     const issues = await this.#request<GitHubIssueResponse[]>(
       "GET",
       this.#issuePath(
         `issues?state=open&labels=${encodeURIComponent(this.#config.readyLabel)}`,
       ),
     );
-    return issues.map((issue) => toIssueRef(issue, this.#config.repo));
+    return issues.map((issue) => toRuntimeIssue(issue, this.#config.repo));
   }
 
-  async getIssue(issueNumber: number): Promise<IssueRef> {
+  async getIssue(issueNumber: number): Promise<RuntimeIssue> {
     const issue = await this.#request<GitHubIssueResponse>(
       "GET",
       this.#issuePath(`issues/${issueNumber}`),
     );
-    return toIssueRef(issue, this.#config.repo);
+    return toRuntimeIssue(issue, this.#config.repo);
   }
 
-  async claimIssue(issueNumber: number): Promise<IssueRef | null> {
+  async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
     const issue = await this.getIssue(issueNumber);
     if (
       !issue.labels.includes(this.#config.readyLabel) ||
@@ -134,7 +139,19 @@ export class GitHubBootstrapTracker implements Tracker {
     return updated;
   }
 
-  async hasPullRequest(headBranch: string): Promise<boolean> {
+  async completeRun(session: RunSession, _result: RunResult): Promise<void> {
+    const hasPullRequest = await this.#hasPullRequest(
+      session.workspace.branchName,
+    );
+    if (!hasPullRequest) {
+      throw new TrackerError(
+        `Runner exited successfully but no pull request was found for ${session.workspace.branchName}`,
+      );
+    }
+    await this.#completeIssue(session.issue.number);
+  }
+
+  async #hasPullRequest(headBranch: string): Promise<boolean> {
     const [owner] = this.#config.repo.split("/");
     const pulls = await this.#request<GitHubPullRequestResponse[]>(
       "GET",
@@ -179,10 +196,7 @@ export class GitHubBootstrapTracker implements Tracker {
     );
   }
 
-  async completeIssue(
-    issueNumber: number,
-    successComment: string,
-  ): Promise<void> {
+  async #completeIssue(issueNumber: number): Promise<void> {
     const issue = await this.getIssue(issueNumber);
     const nextLabels = issue.labels.filter(
       (label) =>
@@ -190,7 +204,7 @@ export class GitHubBootstrapTracker implements Tracker {
         label !== this.#config.readyLabel &&
         label !== this.#config.failedLabel,
     );
-    await this.#createComment(issueNumber, successComment);
+    await this.#createComment(issueNumber, this.#config.successComment);
     await this.#updateIssue(issueNumber, {
       state: "closed",
       labels: nextLabels,
@@ -230,13 +244,13 @@ export class GitHubBootstrapTracker implements Tracker {
   async #updateIssue(
     issueNumber: number,
     body: Record<string, unknown>,
-  ): Promise<IssueRef> {
+  ): Promise<RuntimeIssue> {
     const issue = await this.#request<GitHubIssueResponse>(
       "PATCH",
       this.#issuePath(`issues/${issueNumber}`),
       body,
     );
-    return toIssueRef(issue, this.#config.repo);
+    return toRuntimeIssue(issue, this.#config.repo);
   }
 
   async #request<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -75,7 +75,7 @@ export class GitHubBootstrapTracker implements Tracker {
   readonly #config: TrackerConfig;
   readonly #logger: Logger;
   readonly #tokenPromise: Promise<string>;
-  #labelsEnsured = false;
+  #ensureLabelsPromise: Promise<void> | null = null;
 
   constructor(config: TrackerConfig, logger: Logger) {
     this.#config = config;
@@ -84,26 +84,13 @@ export class GitHubBootstrapTracker implements Tracker {
   }
 
   async ensureLabels(): Promise<void> {
-    if (this.#labelsEnsured) {
-      return;
+    if (this.#ensureLabelsPromise === null) {
+      this.#ensureLabelsPromise = this.#doEnsureLabels().catch((error) => {
+        this.#ensureLabelsPromise = null;
+        throw error;
+      });
     }
-
-    await this.#ensureLabel(
-      this.#config.readyLabel,
-      "0e8a16",
-      "Issue is ready for Symphony to work on",
-    );
-    await this.#ensureLabel(
-      this.#config.runningLabel,
-      "1d76db",
-      "Issue is currently being worked by Symphony",
-    );
-    await this.#ensureLabel(
-      this.#config.failedLabel,
-      "d73a4a",
-      "Issue failed in Symphony",
-    );
-    this.#labelsEnsured = true;
+    await this.#ensureLabelsPromise;
   }
 
   async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {
@@ -154,7 +141,25 @@ export class GitHubBootstrapTracker implements Tracker {
         `Runner exited successfully but no pull request was found for ${session.workspace.branchName}`,
       );
     }
-    await this.#completeIssue(session.issue.number);
+    await this.#completeIssue(session.issue);
+  }
+
+  async #doEnsureLabels(): Promise<void> {
+    await this.#ensureLabel(
+      this.#config.readyLabel,
+      "0e8a16",
+      "Issue is ready for Symphony to work on",
+    );
+    await this.#ensureLabel(
+      this.#config.runningLabel,
+      "1d76db",
+      "Issue is currently being worked by Symphony",
+    );
+    await this.#ensureLabel(
+      this.#config.failedLabel,
+      "d73a4a",
+      "Issue failed in Symphony",
+    );
   }
 
   async #hasPullRequest(headBranch: string): Promise<boolean> {
@@ -202,16 +207,15 @@ export class GitHubBootstrapTracker implements Tracker {
     );
   }
 
-  async #completeIssue(issueNumber: number): Promise<void> {
-    const issue = await this.getIssue(issueNumber);
+  async #completeIssue(issue: RuntimeIssue): Promise<void> {
     const nextLabels = issue.labels.filter(
       (label) =>
         label !== this.#config.runningLabel &&
         label !== this.#config.readyLabel &&
         label !== this.#config.failedLabel,
     );
-    await this.#createComment(issueNumber, this.#config.successComment);
-    await this.#updateIssue(issueNumber, {
+    await this.#createComment(issue.number, this.#config.successComment);
+    await this.#updateIssue(issue.number, {
       state: "closed",
       labels: nextLabels,
     });

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -228,7 +228,10 @@ export class GitHubBootstrapTracker implements Tracker {
         this.#issuePath(`labels/${encodeURIComponent(name)}`),
       );
     } catch (error) {
-      if (!(error instanceof TrackerError) || !error.message.includes("404")) {
+      if (
+        !(error instanceof TrackerError) ||
+        !error.message.includes(" failed with 404:")
+      ) {
         throw error;
       }
       await this.#request<GitHubLabelResponse>(

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -141,7 +141,8 @@ export class GitHubBootstrapTracker implements Tracker {
         `Runner exited successfully but no pull request was found for ${session.workspace.branchName}`,
       );
     }
-    await this.#completeIssue(session.issue);
+    // Re-fetch before closing so we preserve labels added after the issue was claimed.
+    await this.#completeIssue(await this.getIssue(session.issue.number));
   }
 
   async #doEnsureLabels(): Promise<void> {

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -1,12 +1,12 @@
-import type { IssueRef } from "../domain/types.js";
+import type { RuntimeIssue } from "../domain/issue.js";
+import type { RunResult, RunSession } from "../domain/run.js";
 
 export interface Tracker {
   ensureLabels(): Promise<void>;
-  fetchEligibleIssues(): Promise<readonly IssueRef[]>;
-  getIssue(issueNumber: number): Promise<IssueRef>;
-  claimIssue(issueNumber: number): Promise<IssueRef | null>;
-  hasPullRequest(headBranch: string): Promise<boolean>;
+  fetchEligibleIssues(): Promise<readonly RuntimeIssue[]>;
+  getIssue(issueNumber: number): Promise<RuntimeIssue>;
+  claimIssue(issueNumber: number): Promise<RuntimeIssue | null>;
+  completeRun(session: RunSession, result: RunResult): Promise<void>;
   releaseIssue(issueNumber: number, reason: string): Promise<void>;
   markIssueFailed(issueNumber: number, reason: string): Promise<void>;
-  completeIssue(issueNumber: number, successComment: string): Promise<void>;
 }

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -134,8 +134,6 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
     return {
       key: workspaceKey,
-      issueId: issue.id,
-      issueIdentifier: issue.identifier,
       path: workspacePath,
       branchName,
       createdNow: !exists,

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -4,10 +4,10 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { WorkspaceError } from "../domain/errors.js";
 import type {
-  IssueRef,
-  WorkspaceConfig,
-  WorkspaceInfo,
-} from "../domain/types.js";
+  PreparedWorkspace,
+  WorkspacePreparationRequest,
+} from "../domain/workspace.js";
+import type { WorkspaceConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { WorkspaceManager } from "./service.js";
 
@@ -47,30 +47,41 @@ async function remoteTrackingBranchExists(
 }
 
 export class LocalWorkspaceManager implements WorkspaceManager {
+  readonly #config: WorkspaceConfig;
+  readonly #afterCreate: readonly string[];
   readonly #logger: Logger;
 
-  constructor(logger: Logger) {
+  constructor(
+    config: WorkspaceConfig,
+    afterCreate: readonly string[],
+    logger: Logger,
+  ) {
+    this.#config = config;
+    this.#afterCreate = afterCreate;
     this.#logger = logger;
   }
 
-  async ensureWorkspace(
-    issue: IssueRef,
-    config: WorkspaceConfig,
-    afterCreate: readonly string[],
-  ): Promise<WorkspaceInfo> {
+  async prepareWorkspace(
+    request: WorkspacePreparationRequest,
+  ): Promise<PreparedWorkspace> {
+    const issue = request.issue;
     const workspaceKey = sanitize(issue.identifier);
-    const workspacePath = path.join(config.root, workspaceKey);
-    const branchName = `${config.branchPrefix}${issue.number}`;
+    const workspacePath = path.join(this.#config.root, workspaceKey);
+    const branchName = `${this.#config.branchPrefix}${issue.number}`;
     const exists = await fs
       .stat(workspacePath)
       .then(() => true)
       .catch(() => false);
 
-    await fs.mkdir(config.root, { recursive: true });
+    await fs.mkdir(this.#config.root, { recursive: true });
 
     if (!exists) {
-      await execFileAsync("git", ["clone", config.repoUrl, workspacePath]);
-      for (const command of afterCreate) {
+      await execFileAsync("git", [
+        "clone",
+        this.#config.repoUrl,
+        workspacePath,
+      ]);
+      for (const command of this.#afterCreate) {
         await runShell(command, workspacePath);
       }
     }
@@ -122,6 +133,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     });
 
     return {
+      key: workspaceKey,
       issueId: issue.id,
       issueIdentifier: issue.identifier,
       path: workspacePath,
@@ -130,7 +142,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     };
   }
 
-  async cleanupWorkspace(workspace: WorkspaceInfo): Promise<void> {
+  async cleanupWorkspace(workspace: PreparedWorkspace): Promise<void> {
     this.#logger.info("Cleaning workspace", { workspacePath: workspace.path });
     await fs.rm(workspace.path, { recursive: true, force: true });
   }

--- a/src/workspace/service.ts
+++ b/src/workspace/service.ts
@@ -1,14 +1,11 @@
 import type {
-  IssueRef,
-  WorkspaceConfig,
-  WorkspaceInfo,
-} from "../domain/types.js";
+  PreparedWorkspace,
+  WorkspacePreparationRequest,
+} from "../domain/workspace.js";
 
 export interface WorkspaceManager {
-  ensureWorkspace(
-    issue: IssueRef,
-    config: WorkspaceConfig,
-    afterCreate: readonly string[],
-  ): Promise<WorkspaceInfo>;
-  cleanupWorkspace(workspace: WorkspaceInfo): Promise<void>;
+  prepareWorkspace(
+    request: WorkspacePreparationRequest,
+  ): Promise<PreparedWorkspace>;
+  cleanupWorkspace(workspace: PreparedWorkspace): Promise<void>;
 }

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCli } from "../../src/cli/index.js";
-import { loadWorkflow } from "../../src/config/workflow.js";
+import {
+  createPromptBuilder,
+  loadWorkflow,
+} from "../../src/config/workflow.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import { LocalRunner } from "../../src/runner/local.js";
@@ -151,11 +154,17 @@ describe("Phase 0 bootstrap factory", () => {
 
     const workflow = await loadWorkflow(workflowPath);
     const logger = new JsonLogger();
+    const promptBuilder = createPromptBuilder(workflow);
     const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
-    const workspace = new LocalWorkspaceManager(logger);
-    const runner = new LocalRunner(logger);
+    const workspace = new LocalWorkspaceManager(
+      workflow.config.workspace,
+      workflow.config.hooks.afterCreate,
+      logger,
+    );
+    const runner = new LocalRunner(workflow.config.agent, logger);
     const orchestrator = new BootstrapOrchestrator(
-      workflow,
+      workflow.config,
+      promptBuilder,
       tracker,
       workspace,
       runner,
@@ -204,11 +213,17 @@ describe("Phase 0 bootstrap factory", () => {
 
     const workflow = await loadWorkflow(workflowPath);
     const logger = new JsonLogger();
+    const promptBuilder = createPromptBuilder(workflow);
     const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
-    const workspace = new LocalWorkspaceManager(logger);
-    const runner = new LocalRunner(logger);
+    const workspace = new LocalWorkspaceManager(
+      workflow.config.workspace,
+      workflow.config.hooks.afterCreate,
+      logger,
+    );
+    const runner = new LocalRunner(workflow.config.agent, logger);
     const orchestrator = new BootstrapOrchestrator(
-      workflow,
+      workflow.config,
+      promptBuilder,
       tracker,
       workspace,
       runner,

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -62,8 +62,6 @@ describe("GitHubBootstrapTracker", () => {
       issue: (await tracker.claimIssue(7))!,
       workspace: {
         key: "sociotechnica-org_symphony-ts_7",
-        issueId: "7",
-        issueIdentifier: "sociotechnica-org/symphony-ts#7",
         path: "/tmp/workspaces/7",
         branchName: "symphony/7",
         createdNow: true,
@@ -115,8 +113,6 @@ describe("GitHubBootstrapTracker", () => {
           issue: claimed,
           workspace: {
             key: "sociotechnica-org_symphony-ts_7",
-            issueId: "7",
-            issueIdentifier: "sociotechnica-org/symphony-ts#7",
             path: "/tmp/workspaces/7",
             branchName: "symphony/7",
             createdNow: true,

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -70,8 +70,6 @@ describe("GitHubBootstrapTracker", () => {
       },
       prompt: "prompt",
       attempt: {
-        issueId: "7",
-        issueIdentifier: "sociotechnica-org/symphony-ts#7",
         sequence: 1,
       },
     };
@@ -125,8 +123,6 @@ describe("GitHubBootstrapTracker", () => {
           },
           prompt: "prompt",
           attempt: {
-            issueId: "7",
-            issueIdentifier: "sociotechnica-org/symphony-ts#7",
             sequence: 1,
           },
         },

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RunResult, RunSession } from "../../src/domain/run.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { GitHubBootstrapTracker } from "../../src/tracker/github-bootstrap.js";
 import { MockGitHubServer } from "../support/mock-github-server.js";
@@ -56,10 +57,87 @@ describe("GitHubBootstrapTracker", () => {
       "symphony:ready",
     );
 
-    await tracker.claimIssue(7);
-    await tracker.completeIssue(7, "done");
+    const runSession: RunSession = {
+      id: "sociotechnica-org/symphony-ts#7/attempt-1",
+      issue: (await tracker.claimIssue(7))!,
+      workspace: {
+        key: "sociotechnica-org_symphony-ts_7",
+        issueId: "7",
+        issueIdentifier: "sociotechnica-org/symphony-ts#7",
+        path: "/tmp/workspaces/7",
+        branchName: "symphony/7",
+        createdNow: true,
+      },
+      prompt: "prompt",
+      attempt: {
+        issueId: "7",
+        issueIdentifier: "sociotechnica-org/symphony-ts#7",
+        sequence: 1,
+      },
+    };
+    const runResult: RunResult = {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    };
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    await tracker.completeRun(runSession, runResult);
     const issue = server.getIssue(7);
     expect(issue.state).toBe("closed");
     expect(issue.comments).toContain("done");
+  });
+
+  it("fails completion when no pull request exists for the run branch", async () => {
+    const tracker = new GitHubBootstrapTracker(
+      {
+        kind: "github-bootstrap",
+        repo: "sociotechnica-org/symphony-ts",
+        apiUrl: server.baseUrl,
+        readyLabel: "symphony:ready",
+        runningLabel: "symphony:running",
+        failedLabel: "symphony:failed",
+        successComment: "done",
+      },
+      logger,
+    );
+
+    const claimed = (await tracker.claimIssue(7))!;
+
+    await expect(
+      tracker.completeRun(
+        {
+          id: "sociotechnica-org/symphony-ts#7/attempt-1",
+          issue: claimed,
+          workspace: {
+            key: "sociotechnica-org_symphony-ts_7",
+            issueId: "7",
+            issueIdentifier: "sociotechnica-org/symphony-ts#7",
+            path: "/tmp/workspaces/7",
+            branchName: "symphony/7",
+            createdNow: true,
+          },
+          prompt: "prompt",
+          attempt: {
+            issueId: "7",
+            issueIdentifier: "sociotechnica-org/symphony-ts#7",
+            sequence: 1,
+          },
+        },
+        {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+        },
+      ),
+    ).rejects.toThrow(/no pull request/i);
   });
 });

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -132,4 +132,23 @@ describe("GitHubBootstrapTracker", () => {
       ),
     ).rejects.toThrow(/no pull request/i);
   });
+
+  it("ensures labels only once across concurrent calls", async () => {
+    const tracker = new GitHubBootstrapTracker(
+      {
+        kind: "github-bootstrap",
+        repo: "sociotechnica-org/symphony-ts",
+        apiUrl: server.baseUrl,
+        readyLabel: "symphony:ready",
+        runningLabel: "symphony:running",
+        failedLabel: "symphony:failed",
+        successComment: "done",
+      },
+      logger,
+    );
+
+    await Promise.all([tracker.ensureLabels(), tracker.ensureLabels()]);
+
+    expect(server.countRequests("POST labels")).toBe(3);
+  });
 });

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -151,4 +151,56 @@ describe("GitHubBootstrapTracker", () => {
 
     expect(server.countRequests("POST labels")).toBe(3);
   });
+
+  it("preserves labels added after claim when completing an issue", async () => {
+    const tracker = new GitHubBootstrapTracker(
+      {
+        kind: "github-bootstrap",
+        repo: "sociotechnica-org/symphony-ts",
+        apiUrl: server.baseUrl,
+        readyLabel: "symphony:ready",
+        runningLabel: "symphony:running",
+        failedLabel: "symphony:failed",
+        successComment: "done",
+      },
+      logger,
+    );
+
+    const claimed = (await tracker.claimIssue(7))!;
+    server.setIssueLabels(7, [...claimed.labels, "external:keep"]);
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+
+    await tracker.completeRun(
+      {
+        id: "sociotechnica-org/symphony-ts#7/attempt-1",
+        issue: claimed,
+        workspace: {
+          key: "sociotechnica-org_symphony-ts_7",
+          path: "/tmp/workspaces/7",
+          branchName: "symphony/7",
+          createdNow: true,
+        },
+        prompt: "prompt",
+        attempt: {
+          sequence: 1,
+        },
+      },
+      {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+    );
+
+    expect(server.getIssue(7).labels.map((label) => label.name)).toContain(
+      "external:keep",
+    );
+  });
 });

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -65,6 +65,7 @@ export class MockGitHubServer {
   }
 
   async stop(): Promise<void> {
+    this.#server.closeAllConnections();
     this.#server.close();
     await once(this.#server, "close");
   }

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -1,7 +1,13 @@
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import { once } from "node:events";
 import { randomUUID } from "node:crypto";
-import type { PullRequestRecord } from "../../src/domain/types.js";
+
+interface PullRequestRecord {
+  readonly title: string;
+  readonly body: string;
+  readonly head: string;
+  readonly base: string;
+}
 
 interface MockIssue {
   id: string;

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -105,6 +105,15 @@ export class MockGitHubServer {
     return structuredClone(issue);
   }
 
+  setIssueLabels(number: number, labels: readonly string[]): void {
+    const issue = this.#issues.get(number);
+    if (!issue) {
+      throw new Error(`Issue ${number} not found`);
+    }
+    issue.labels = labels.map((name) => ({ name }));
+    issue.updated_at = new Date().toISOString();
+  }
+
   getPullRequests(): readonly PullRequestRecord[] {
     return structuredClone(this.#prs);
   }

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -51,6 +51,7 @@ export class MockGitHubServer {
   readonly #issues = new Map<number, MockIssue>();
   readonly #labels = new Map<string, MockLabel>();
   readonly #prs: PullRequestRecord[] = [];
+  readonly #requestCounts = new Map<string, number>();
   readonly #server = http.createServer(this.#handle.bind(this));
   #baseUrl = "";
 
@@ -108,6 +109,10 @@ export class MockGitHubServer {
     return structuredClone(this.#prs);
   }
 
+  countRequests(key: string): number {
+    return this.#requestCounts.get(key) ?? 0;
+  }
+
   async recordPullRequest(pr: PullRequestRecord): Promise<void> {
     this.#prs.push(pr);
   }
@@ -133,6 +138,11 @@ export class MockGitHubServer {
     }
 
     const suffix = pathMatch[3] ?? "";
+    const requestKey = `${method} ${suffix}`;
+    this.#requestCounts.set(
+      requestKey,
+      (this.#requestCounts.get(requestKey) ?? 0) + 1,
+    );
 
     if (method === "GET" && suffix === "labels") {
       json(response, 200, [...this.#labels.values()]);

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -184,7 +184,10 @@ export class MockGitHubServer {
 
     if (method === "GET" && suffix === "pulls") {
       const head = url.searchParams.get("head");
+      const state = url.searchParams.get("state") ?? "open";
       const pulls = this.#prs
+        // The mock does not model PR lifecycle; stored PRs are treated as open.
+        .filter(() => state === "open" || state === "all")
         .filter((pull) =>
           head ? `${pathMatch[1]}:${pull.head}` === head : true,
         )

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -184,9 +184,7 @@ export class MockGitHubServer {
 
     if (method === "GET" && suffix === "pulls") {
       const head = url.searchParams.get("head");
-      const state = url.searchParams.get("state") ?? "open";
       const pulls = this.#prs
-        .filter(() => state === "open" || state === "all")
         .filter((pull) =>
           head ? `${pathMatch[1]}:${pull.head}` === head : true,
         )

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -1,35 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { RunSession } from "../../src/domain/run.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { LocalRunner } from "../../src/runner/local.js";
 
 describe("LocalRunner", () => {
   it("handles a closed stdin pipe without crashing the process", async () => {
-    const runner = new LocalRunner(new JsonLogger());
-
-    const result = await runner.run(
-      {
-        issue: {
-          id: "1",
-          identifier: "sociotechnica-org/symphony-ts#1",
-          number: 1,
-          title: "Runner stdin closes early",
-          description: "",
-          labels: [],
-          state: "open",
-          url: "https://example.test/issues/1",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        },
-        workspace: {
-          issueId: "1",
-          issueIdentifier: "sociotechnica-org/symphony-ts#1",
-          path: process.cwd(),
-          branchName: "symphony/1",
-          createdNow: false,
-        },
-        prompt: "x".repeat(10_000_000),
-        attempt: 1,
-      },
+    const runner = new LocalRunner(
       {
         command:
           'node -e "process.stdin.destroy(); setTimeout(() => process.exit(0), 10)"',
@@ -37,7 +13,39 @@ describe("LocalRunner", () => {
         timeoutMs: 5_000,
         env: {},
       },
+      new JsonLogger(),
     );
+    const session: RunSession = {
+      id: "sociotechnica-org/symphony-ts#1/attempt-1",
+      issue: {
+        id: "1",
+        identifier: "sociotechnica-org/symphony-ts#1",
+        number: 1,
+        title: "Runner stdin closes early",
+        description: "",
+        labels: [],
+        state: "open",
+        url: "https://example.test/issues/1",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      workspace: {
+        key: "sociotechnica-org_symphony-ts_1",
+        issueId: "1",
+        issueIdentifier: "sociotechnica-org/symphony-ts#1",
+        path: process.cwd(),
+        branchName: "symphony/1",
+        createdNow: false,
+      },
+      prompt: "x".repeat(10_000_000),
+      attempt: {
+        issueId: "1",
+        issueIdentifier: "sociotechnica-org/symphony-ts#1",
+        sequence: 1,
+      },
+    };
+
+    const result = await runner.run(session);
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain("stdin write failed");

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -39,8 +39,6 @@ describe("LocalRunner", () => {
       },
       prompt: "x".repeat(10_000_000),
       attempt: {
-        issueId: "1",
-        issueIdentifier: "sociotechnica-org/symphony-ts#1",
         sequence: 1,
       },
     };

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -31,8 +31,6 @@ describe("LocalRunner", () => {
       },
       workspace: {
         key: "sociotechnica-org_symphony-ts_1",
-        issueId: "1",
-        issueIdentifier: "sociotechnica-org/symphony-ts#1",
         path: process.cwd(),
         branchName: "symphony/1",
         createdNow: false,

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -87,10 +87,18 @@ function createIssue(number: number): RuntimeIssue {
 class NullLogger implements Logger {
   readonly errors: string[] = [];
 
-  info(): void {}
+  info(_message: string, _data?: Record<string, unknown>): void {}
 
-  error(message: string): void {
+  error(message: string, _data?: Record<string, unknown>): void {
     this.errors.push(message);
+  }
+}
+
+class CompletionLoggingFailingLogger extends NullLogger {
+  override info(message: string, _data?: Record<string, unknown>): void {
+    if (message === "Issue completed") {
+      throw new Error("logger failed");
+    }
   }
 }
 
@@ -450,5 +458,35 @@ describe("BootstrapOrchestrator", () => {
       /^sociotechnica-org\/symphony-ts#1\/attempt-1-/,
     );
     expect(new Set(runner.sessionIds).size).toBe(2);
+  });
+
+  it("does not retry or fail an issue if completion logging throws", async () => {
+    const tracker = new StaticTracker([createIssue(1)]);
+    const workspace = new StaticWorkspaceManager();
+    const runner: Runner = {
+      async run(): Promise<RunResult> {
+        const timestamp = new Date().toISOString();
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt: timestamp,
+          finishedAt: timestamp,
+        };
+      },
+    };
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      workspace,
+      runner,
+      new CompletionLoggingFailingLogger(),
+    );
+
+    await expect(orchestrator.runOnce()).resolves.toBeUndefined();
+    expect(tracker.completed).toEqual([1]);
+    expect(tracker.released).toEqual([]);
+    expect(tracker.failed).toEqual([]);
   });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -85,9 +85,13 @@ function createIssue(number: number): RuntimeIssue {
 }
 
 class NullLogger implements Logger {
+  readonly errors: string[] = [];
+
   info(): void {}
 
-  error(): void {}
+  error(message: string): void {
+    this.errors.push(message);
+  }
 }
 
 class StaticTracker implements Tracker {
@@ -119,6 +123,17 @@ class StaticTracker implements Tracker {
   async releaseIssue(): Promise<void> {}
 
   async markIssueFailed(): Promise<void> {}
+}
+
+class FlakyTracker extends StaticTracker {
+  attempts = 0;
+
+  override async ensureLabels(): Promise<void> {
+    this.attempts += 1;
+    if (this.attempts === 1) {
+      throw new Error("transient label failure");
+    }
+  }
 }
 
 class StaticWorkspaceManager implements WorkspaceManager {
@@ -203,5 +218,32 @@ describe("BootstrapOrchestrator", () => {
     await runOnce;
 
     expect(tracker.completed).toEqual([1, 2]);
+  });
+
+  it("keeps polling after a transient poll-level failure", async () => {
+    const tracker = new FlakyTracker([createIssue(1)]);
+    const workspace = new StaticWorkspaceManager();
+    const runner = new ConcurrencyRunner();
+    const logger = new NullLogger();
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      workspace,
+      runner,
+      logger,
+    );
+    const controller = new AbortController();
+
+    setTimeout(() => {
+      controller.abort();
+      runner.finish();
+    }, 50);
+
+    await orchestrator.runLoop(controller.signal);
+
+    expect(tracker.attempts).toBeGreaterThanOrEqual(2);
+    expect(logger.errors).toContain("Poll cycle failed");
+    expect(tracker.completed).toEqual([1]);
   });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -97,6 +97,8 @@ class NullLogger implements Logger {
 class StaticTracker implements Tracker {
   readonly #issues: readonly RuntimeIssue[];
   readonly completed: number[] = [];
+  readonly released: Array<{ issueNumber: number; reason: string }> = [];
+  readonly failed: Array<{ issueNumber: number; reason: string }> = [];
 
   constructor(issues: readonly RuntimeIssue[]) {
     this.#issues = issues;
@@ -120,9 +122,13 @@ class StaticTracker implements Tracker {
     this.completed.push(session.issue.number);
   }
 
-  async releaseIssue(): Promise<void> {}
+  async releaseIssue(issueNumber: number, reason: string): Promise<void> {
+    this.released.push({ issueNumber, reason });
+  }
 
-  async markIssueFailed(): Promise<void> {}
+  async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
+    this.failed.push({ issueNumber, reason });
+  }
 }
 
 class FlakyTracker extends StaticTracker {
@@ -144,15 +150,22 @@ class StaticWorkspaceManager implements WorkspaceManager {
   }): Promise<PreparedWorkspace> {
     return {
       key: `sociotechnica-org_symphony-ts_${issue.number}`,
-      issueId: issue.id,
-      issueIdentifier: issue.identifier,
       path: `/tmp/workspaces/${issue.number}`,
       branchName: `symphony/${issue.number}`,
       createdNow: true,
     };
   }
 
-  async cleanupWorkspace(): Promise<void> {}
+  async cleanupWorkspace(_workspace: PreparedWorkspace): Promise<void> {}
+}
+
+class CleanupFailingWorkspaceManager extends StaticWorkspaceManager {
+  readonly cleaned: string[] = [];
+
+  override async cleanupWorkspace(workspace: PreparedWorkspace): Promise<void> {
+    this.cleaned.push(workspace.path);
+    throw new Error("rm failed");
+  }
 }
 
 class ConcurrencyRunner implements Runner {
@@ -245,5 +258,45 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.attempts).toBeGreaterThanOrEqual(2);
     expect(logger.errors).toContain("Poll cycle failed");
     expect(tracker.completed).toEqual([1]);
+  });
+
+  it("does not retry or fail an issue after successful completion if cleanup fails", async () => {
+    const tracker = new StaticTracker([createIssue(1)]);
+    const workspace = new CleanupFailingWorkspaceManager();
+    const logger = new NullLogger();
+    const runner: Runner = {
+      async run(): Promise<RunResult> {
+        const timestamp = new Date().toISOString();
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt: timestamp,
+          finishedAt: timestamp,
+        };
+      },
+    };
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        workspace: {
+          ...baseConfig.workspace,
+          cleanupOnSuccess: true,
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      workspace,
+      runner,
+      logger,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(tracker.completed).toEqual([1]);
+    expect(tracker.released).toEqual([]);
+    expect(tracker.failed).toEqual([]);
+    expect(workspace.cleaned).toEqual(["/tmp/workspaces/1"]);
+    expect(logger.errors).toContain("Workspace cleanup failed");
   });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { RuntimeIssue } from "../../src/domain/issue.js";
+import type { RunResult, RunSession } from "../../src/domain/run.js";
+import type { PreparedWorkspace } from "../../src/domain/workspace.js";
 import type {
-  AgentConfig,
-  IssueRef,
+  PromptBuilder,
   ResolvedConfig,
-  RunContext,
-  RunResult,
-  WorkflowDefinition,
-  WorkspaceInfo,
-} from "../../src/domain/types.js";
+} from "../../src/domain/workflow.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import type { Logger } from "../../src/observability/logger.js";
 import type { Runner } from "../../src/runner/service.js";
@@ -64,7 +62,13 @@ const baseConfig: ResolvedConfig = {
   },
 };
 
-function createIssue(number: number): IssueRef {
+const staticPromptBuilder: PromptBuilder = {
+  async build({ issue }): Promise<string> {
+    return `Issue ${issue.identifier}`;
+  },
+};
+
+function createIssue(number: number): RuntimeIssue {
   const timestamp = new Date().toISOString();
   return {
     id: String(number),
@@ -87,43 +91,44 @@ class NullLogger implements Logger {
 }
 
 class StaticTracker implements Tracker {
-  readonly #issues: readonly IssueRef[];
+  readonly #issues: readonly RuntimeIssue[];
   readonly completed: number[] = [];
 
-  constructor(issues: readonly IssueRef[]) {
+  constructor(issues: readonly RuntimeIssue[]) {
     this.#issues = issues;
   }
 
   async ensureLabels(): Promise<void> {}
 
-  async fetchEligibleIssues(): Promise<readonly IssueRef[]> {
+  async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {
     return this.#issues;
   }
 
-  async getIssue(issueNumber: number): Promise<IssueRef> {
+  async getIssue(issueNumber: number): Promise<RuntimeIssue> {
     return this.#issues.find((issue) => issue.number === issueNumber)!;
   }
 
-  async claimIssue(issueNumber: number): Promise<IssueRef | null> {
+  async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
     return await this.getIssue(issueNumber);
   }
 
-  async hasPullRequest(): Promise<boolean> {
-    return true;
+  async completeRun(session: RunSession): Promise<void> {
+    this.completed.push(session.issue.number);
   }
 
   async releaseIssue(): Promise<void> {}
 
   async markIssueFailed(): Promise<void> {}
-
-  async completeIssue(issueNumber: number): Promise<void> {
-    this.completed.push(issueNumber);
-  }
 }
 
 class StaticWorkspaceManager implements WorkspaceManager {
-  async ensureWorkspace(issue: IssueRef): Promise<WorkspaceInfo> {
+  async prepareWorkspace({
+    issue,
+  }: {
+    readonly issue: RuntimeIssue;
+  }): Promise<PreparedWorkspace> {
     return {
+      key: `sociotechnica-org_symphony-ts_${issue.number}`,
       issueId: issue.id,
       issueIdentifier: issue.identifier,
       path: `/tmp/workspaces/${issue.number}`,
@@ -150,8 +155,8 @@ class ConcurrencyRunner implements Runner {
     this.#finishBarrier.resolve();
   }
 
-  async run(context: RunContext, _config: AgentConfig): Promise<RunResult> {
-    this.startedIssues.push(context.issue.number);
+  async run(session: RunSession): Promise<RunResult> {
+    this.startedIssues.push(session.issue.number);
     this.#active += 1;
     this.maxActive = Math.max(this.maxActive, this.#active);
     if (this.startedIssues.length >= 2) {
@@ -180,10 +185,8 @@ describe("BootstrapOrchestrator", () => {
     const workspace = new StaticWorkspaceManager();
     const runner = new ConcurrencyRunner();
     const orchestrator = new BootstrapOrchestrator(
-      {
-        config: baseConfig,
-        promptTemplate: "Issue {{ issue.identifier }}",
-      } satisfies WorkflowDefinition,
+      baseConfig,
+      staticPromptBuilder,
       tracker,
       workspace,
       runner,

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -99,6 +99,7 @@ class StaticTracker implements Tracker {
   readonly completed: number[] = [];
   readonly released: Array<{ issueNumber: number; reason: string }> = [];
   readonly failed: Array<{ issueNumber: number; reason: string }> = [];
+  claimCalls = 0;
 
   constructor(issues: readonly RuntimeIssue[]) {
     this.#issues = issues;
@@ -115,6 +116,7 @@ class StaticTracker implements Tracker {
   }
 
   async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
+    this.claimCalls += 1;
     return await this.getIssue(issueNumber);
   }
 
@@ -139,6 +141,19 @@ class FlakyTracker extends StaticTracker {
     if (this.attempts === 1) {
       throw new Error("transient label failure");
     }
+  }
+}
+
+class ReleaseFailingTracker extends StaticTracker {
+  releaseAttempts = 0;
+
+  override async releaseIssue(
+    issueNumber: number,
+    reason: string,
+  ): Promise<void> {
+    this.releaseAttempts += 1;
+    await super.releaseIssue(issueNumber, reason);
+    throw new Error("release failed");
   }
 }
 
@@ -298,5 +313,92 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.failed).toEqual([]);
     expect(workspace.cleaned).toEqual(["/tmp/workspaces/1"]);
     expect(logger.errors).toContain("Workspace cleanup failed");
+  });
+
+  it("does not requeue a retrying issue before its backoff window expires", async () => {
+    const tracker = new StaticTracker([createIssue(1)]);
+    const workspace = new StaticWorkspaceManager();
+    const runnerCalls: number[] = [];
+    const runner: Runner = {
+      async run(session): Promise<RunResult> {
+        runnerCalls.push(session.attempt.sequence);
+        const timestamp = new Date().toISOString();
+        return {
+          exitCode: 17,
+          stdout: "",
+          stderr: "simulated failure",
+          startedAt: timestamp,
+          finishedAt: timestamp,
+        };
+      },
+    };
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 2,
+            backoffMs: 60_000,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      workspace,
+      runner,
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    expect(runnerCalls).toEqual([1]);
+    expect(tracker.claimCalls).toBe(1);
+    expect(tracker.released).toHaveLength(1);
+    expect(tracker.failed).toEqual([]);
+  });
+
+  it("does not invoke the unexpected failure path when retry scheduling fails", async () => {
+    const tracker = new ReleaseFailingTracker([createIssue(1)]);
+    const workspace = new StaticWorkspaceManager();
+    const logger = new NullLogger();
+    const runner: Runner = {
+      async run(): Promise<RunResult> {
+        const timestamp = new Date().toISOString();
+        return {
+          exitCode: 17,
+          stdout: "",
+          stderr: "simulated failure",
+          startedAt: timestamp,
+          finishedAt: timestamp,
+        };
+      },
+    };
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 2,
+            backoffMs: 0,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      workspace,
+      runner,
+      logger,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(tracker.releaseAttempts).toBe(1);
+    expect(tracker.released).toHaveLength(1);
+    expect(tracker.failed).toEqual([]);
+    expect(logger.errors).toContain("Issue run failed");
+    expect(logger.errors).toContain("Failure handling failed");
   });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -275,10 +275,16 @@ describe("BootstrapOrchestrator", () => {
   it("keeps polling after a transient poll-level failure", async () => {
     const tracker = new FlakyTracker([createIssue(1)]);
     const workspace = new StaticWorkspaceManager();
-    const runner = new ConcurrencyRunner();
+    const runner = new RecordingRunner();
     const logger = new NullLogger();
     const orchestrator = new BootstrapOrchestrator(
-      baseConfig,
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          intervalMs: 1,
+        },
+      },
       staticPromptBuilder,
       tracker,
       workspace,
@@ -286,13 +292,29 @@ describe("BootstrapOrchestrator", () => {
       logger,
     );
     const controller = new AbortController();
+    const loop = orchestrator.runLoop(controller.signal);
 
-    setTimeout(() => {
-      controller.abort();
-      runner.finish();
-    }, 50);
+    await new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 500;
+      const check = () => {
+        if (tracker.completed.length === 1) {
+          controller.abort();
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          controller.abort();
+          reject(
+            new Error("Timed out waiting for the orchestrator to recover"),
+          );
+          return;
+        }
+        setTimeout(check, 1);
+      };
+      check();
+    });
 
-    await orchestrator.runLoop(controller.signal);
+    await loop;
 
     expect(tracker.attempts).toBeGreaterThanOrEqual(2);
     expect(logger.errors).toContain("Poll cycle failed");

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -218,6 +218,22 @@ class ConcurrencyRunner implements Runner {
   }
 }
 
+class RecordingRunner implements Runner {
+  readonly sessionIds: string[] = [];
+
+  async run(session: RunSession): Promise<RunResult> {
+    this.sessionIds.push(session.id);
+    const timestamp = new Date().toISOString();
+    return {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      startedAt: timestamp,
+      finishedAt: timestamp,
+    };
+  }
+}
+
 describe("BootstrapOrchestrator", () => {
   it("starts up to maxConcurrentRuns issues in parallel", async () => {
     const tracker = new StaticTracker([
@@ -400,5 +416,39 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.failed).toEqual([]);
     expect(logger.errors).toContain("Issue run failed");
     expect(logger.errors).toContain("Failure handling failed");
+  });
+
+  it("generates unique run session ids across orchestrator instances", async () => {
+    const issue = createIssue(1);
+    const runner = new RecordingRunner();
+
+    const first = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      new StaticTracker([issue]),
+      new StaticWorkspaceManager(),
+      runner,
+      new NullLogger(),
+    );
+    const second = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      new StaticTracker([issue]),
+      new StaticWorkspaceManager(),
+      runner,
+      new NullLogger(),
+    );
+
+    await first.runOnce();
+    await second.runOnce();
+
+    expect(runner.sessionIds).toHaveLength(2);
+    expect(runner.sessionIds[0]).toMatch(
+      /^sociotechnica-org\/symphony-ts#1\/attempt-1-/,
+    );
+    expect(runner.sessionIds[1]).toMatch(
+      /^sociotechnica-org\/symphony-ts#1\/attempt-1-/,
+    );
+    expect(new Set(runner.sessionIds).size).toBe(2);
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { loadWorkflow, renderPrompt } from "../../src/config/workflow.js";
+import {
+  createPromptBuilder,
+  loadWorkflow,
+} from "../../src/config/workflow.js";
 import { createTempDir } from "../support/git.js";
 
 describe("workflow config", () => {
@@ -47,9 +50,9 @@ Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
     expect(workflow.config.workspace.root).toContain(
       `${path.sep}.tmp${path.sep}ws`,
     );
-    const rendered = await renderPrompt(
-      workflow,
-      {
+    const promptBuilder = createPromptBuilder(workflow);
+    const rendered = await promptBuilder.build({
+      issue: {
         id: "1",
         identifier: "repo#1",
         number: 1,
@@ -61,8 +64,8 @@ Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
         createdAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
       },
-      null,
-    );
+      attempt: null,
+    });
     expect(rendered).toContain("repo#1");
     expect(rendered).toContain("sociotechnica-org/symphony-ts");
   });


### PR DESCRIPTION
Closes #8

## Summary
- split the Phase 0 shared runtime types into normalized issue, workspace, run, retry, and workflow contracts
- moved prompt rendering, workspace config, runner config, and tracker completion policy behind explicit service boundaries
- kept the GitHub bootstrap e2e loop green while adding contract-focused unit and integration coverage

## Verification
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test