### PR TITLE
Add fix-ci skill

### DIFF
--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -27,6 +27,12 @@ Run the script:
 node skills/fix-ci/scripts/fix-ci.mjs --pr 17
 ```
 
+Resolve addressed review threads:
+
+```bash
+node skills/fix-ci/scripts/resolve-review-threads.mjs --pr 17 --repo sociotechnica-org/symphony-ts
+```
+
 Useful options:
 
 - `--pr <number>`: PR number to watch. If omitted, the script resolves the PR from the current branch.
@@ -34,6 +40,7 @@ Useful options:
 - `--interval <seconds>`: Poll interval. Default: `15`.
 - `--timeout <seconds>`: Max wait time. Default: `1800`.
 - `--once`: Print the current status once and exit immediately. Exits `3` if checks are still pending.
+- `--dry-run`: For `resolve-review-threads.mjs`, print which threads would be resolved without mutating GitHub.
 
 ## Operator use
 
@@ -45,8 +52,10 @@ Useful options:
   2. fix the branch,
   3. rerun local QA,
   4. push,
-  5. rerun the script,
-  6. repeat until it exits `0`.
+  5. resolve the addressed review threads with `resolve-review-threads.mjs`,
+  6. rerun the script,
+  7. repeat until it exits `0`.
+- Do not leave addressed review threads unresolved. The PR is not clean until the feedback is fixed and the corresponding threads are resolved.
 - If the script times out, treat that as an external blocker and inspect the stuck check directly.
 
 This skill is for closing the loop, not just observing it.

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -16,6 +16,7 @@ Use this skill when you need to drive a PR to a clean CI/review state without re
 - Exits `1` when any completed check fails or any unresolved non-outdated review thread remains.
 - Exits `2` on timeout.
 - Exits `3` when `--once` is used and checks are still pending.
+- Exits `5` on unexpected script/tooling errors (for example, `gh` failures or invalid responses).
 
 The script is the deterministic detector. The skill itself is the repair loop.
 
@@ -55,6 +56,7 @@ Useful options:
   5. resolve the addressed review threads with `resolve-review-threads.mjs`,
   6. rerun the script,
   7. repeat until it exits `0`.
+- If either script exits `5`, treat that as a tool failure, not PR feedback. Fix the script/runtime problem before attempting another PR repair cycle.
 - Do not leave addressed review threads unresolved. The PR is not clean until the feedback is fixed and the corresponding threads are resolved.
 - If the script times out, treat that as an external blocker and inspect the stuck check directly.
 

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -5,15 +5,18 @@ description: Monitor a GitHub pull request's CI until it completes using a deter
 
 # fix-ci
 
-Use this skill when you need to wait for GitHub PR checks to finish without relying on an LLM watch loop.
+Use this skill when you need to drive a PR to a clean CI/review state without relying on an LLM-only watch loop.
 
 ## What it does
 
 - Polls GitHub PR checks with `gh pr view`.
+- Polls GitHub PR review threads with GraphQL.
 - Waits until all checks are complete.
 - Exits `0` when all checks succeed or are neutral/skipped.
-- Exits `1` when any completed check fails.
+- Exits `1` when any completed check fails or any unresolved non-outdated review thread remains.
 - Exits `2` on timeout.
+
+The script is the deterministic detector. The skill itself is the repair loop.
 
 ## How to use it
 
@@ -33,6 +36,16 @@ Useful options:
 
 ## Operator use
 
-- Prefer this script over ad hoc manual polling when the task is "wait for CI/review checks to finish."
-- If the script exits non-zero because checks failed, inspect the failing checks and fix the PR in the normal branch -> QA -> push loop.
+- Prefer this skill over ad hoc manual polling when the task is "get this PR clean."
+- Run the script first to determine whether there is anything to fix.
+- If the script exits `0`, the PR is clean from a CI/review-thread perspective.
+- If the script exits `1`, do not stop at reporting:
+  1. inspect the failing checks and unresolved review threads it surfaced,
+  2. fix the branch,
+  3. rerun local QA,
+  4. push,
+  5. rerun the script,
+  6. repeat until it exits `0`.
 - If the script times out, treat that as an external blocker and inspect the stuck check directly.
+
+This skill is for closing the loop, not just observing it.

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when you need to drive a PR to a clean CI/review state without re
 - Exits `0` when all checks succeed or are neutral/skipped.
 - Exits `1` when any completed check fails or any unresolved non-outdated review thread remains.
 - Exits `2` on timeout.
+- Exits `3` when `--once` is used and checks are still pending.
 
 The script is the deterministic detector. The skill itself is the repair loop.
 
@@ -32,7 +33,7 @@ Useful options:
 - `--repo <owner/name>`: GitHub repo override.
 - `--interval <seconds>`: Poll interval. Default: `15`.
 - `--timeout <seconds>`: Max wait time. Default: `1800`.
-- `--once`: Print the current status once and exit immediately.
+- `--once`: Print the current status once and exit immediately. Exits `3` if checks are still pending.
 
 ## Operator use
 

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: fix-ci
+description: Monitor a GitHub pull request's CI until it completes using a deterministic script, then report whether the checks passed or failed. Use this when you want `/fix-ci` style PR check monitoring instead of an LLM-driven watch loop.
+---
+
+# fix-ci
+
+Use this skill when you need to wait for GitHub PR checks to finish without relying on an LLM watch loop.
+
+## What it does
+
+- Polls GitHub PR checks with `gh pr view`.
+- Waits until all checks are complete.
+- Exits `0` when all checks succeed or are neutral/skipped.
+- Exits `1` when any completed check fails.
+- Exits `2` on timeout.
+
+## How to use it
+
+Run the script:
+
+```bash
+node skills/fix-ci/scripts/fix-ci.mjs --pr 17
+```
+
+Useful options:
+
+- `--pr <number>`: PR number to watch. If omitted, the script resolves the PR from the current branch.
+- `--repo <owner/name>`: GitHub repo override.
+- `--interval <seconds>`: Poll interval. Default: `15`.
+- `--timeout <seconds>`: Max wait time. Default: `1800`.
+- `--once`: Print the current status once and exit immediately.
+
+## Operator use
+
+- Prefer this script over ad hoc manual polling when the task is "wait for CI/review checks to finish."
+- If the script exits non-zero because checks failed, inspect the failing checks and fix the PR in the normal branch -> QA -> push loop.
+- If the script times out, treat that as an external blocker and inspect the stuck check directly.

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-ci
-description: Monitor a GitHub pull request's CI until it completes using a deterministic script, then report whether the checks passed or failed. Use this when you want `/fix-ci` style PR check monitoring instead of an LLM-driven watch loop.
+description: Drive a GitHub pull request to a clean CI and review state using a deterministic detector plus an agent repair loop. Use this when you want `/fix-ci` style PR closure instead of an LLM-only watch loop.
 ---
 
 # fix-ci

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -25,6 +25,7 @@ export function normalizeChecks(statusCheckRollup) {
 
 export function normalizeReviewThreads(reviewThreads) {
   return (reviewThreads ?? []).map((thread) => ({
+    id: thread.id ?? "",
     isResolved: thread.isResolved === true,
     isOutdated: thread.isOutdated === true,
     comments: (thread.comments?.nodes ?? []).map((comment) => ({

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -41,6 +41,18 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
   const unresolvedThreads = threads.filter(
     (thread) => thread.isResolved !== true && thread.isOutdated !== true,
   );
+  const successful = checks.filter((check) =>
+    SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
+  );
+  const failed = checks.filter((check) =>
+    FAILED_CONCLUSIONS.has(check.conclusion),
+  );
+  const unknown = checks.filter(
+    (check) =>
+      check.status === "COMPLETED" &&
+      !SUCCESSFUL_CONCLUSIONS.has(check.conclusion) &&
+      !FAILED_CONCLUSIONS.has(check.conclusion),
+  );
 
   if (checks.length === 0) {
     return {
@@ -51,6 +63,7 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
       pending: [],
       failed: [],
       successful: [],
+      unknown: [],
     };
   }
 
@@ -62,16 +75,12 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
       reviewThreads: threads,
       unresolvedThreads,
       pending,
-      failed: [],
-      successful: checks.filter((check) =>
-        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
-      ),
+      failed,
+      successful,
+      unknown,
     };
   }
 
-  const failed = checks.filter((check) =>
-    FAILED_CONCLUSIONS.has(check.conclusion),
-  );
   if (failed.length > 0) {
     return {
       overall: "failure",
@@ -80,9 +89,21 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
       unresolvedThreads,
       pending: [],
       failed,
-      successful: checks.filter((check) =>
-        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
-      ),
+      successful,
+      unknown,
+    };
+  }
+
+  if (unknown.length > 0) {
+    return {
+      overall: "failure",
+      checks,
+      reviewThreads: threads,
+      unresolvedThreads,
+      pending: [],
+      failed: [],
+      successful,
+      unknown,
     };
   }
 
@@ -94,9 +115,8 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
       unresolvedThreads,
       pending: [],
       failed: [],
-      successful: checks.filter((check) =>
-        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
-      ),
+      successful,
+      unknown,
     };
   }
 
@@ -107,8 +127,24 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
     unresolvedThreads,
     pending: [],
     failed: [],
-    successful: checks.filter((check) =>
-      SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
-    ),
+    successful,
+    unknown,
   };
+}
+
+export function nextPollDelayMilliseconds({
+  startedAt,
+  now = Date.now(),
+  intervalSeconds,
+  timeoutSeconds,
+}) {
+  const intervalMilliseconds = intervalSeconds * 1000;
+  const deadline = startedAt + timeoutSeconds * 1000;
+  const remaining = deadline - now;
+
+  if (remaining <= 0) {
+    return 0;
+  }
+
+  return Math.min(intervalMilliseconds, remaining);
 }

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -45,11 +45,17 @@ export function normalizeReviewThreads(reviewThreads) {
     id: thread.id ?? "",
     isResolved: thread.isResolved === true,
     isOutdated: thread.isOutdated === true,
-    comments: (thread.comments?.nodes ?? []).map((comment) => ({
-      authorLogin: comment.author?.login ?? "",
-      body: comment.body ?? "",
-      path: comment.path ?? "",
-    })),
+    comments: Array.isArray(thread.comments)
+      ? thread.comments.map((comment) => ({
+          authorLogin: comment.authorLogin ?? comment.author?.login ?? "",
+          body: comment.body ?? "",
+          path: comment.path ?? "",
+        }))
+      : (thread.comments?.nodes ?? []).map((comment) => ({
+          authorLogin: comment.author?.login ?? "",
+          body: comment.body ?? "",
+          path: comment.path ?? "",
+        })),
   }));
 }
 
@@ -204,7 +210,11 @@ export async function fetchReviewThreads(
   ]);
   const result = JSON.parse(stdout);
 
-  return normalizeReviewThreads(
-    result.data.repository.pullRequest.reviewThreads.nodes,
-  );
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    throw new Error(
+      `GraphQL error fetching review threads: ${result.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+
+  return result.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
 }

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -23,13 +23,31 @@ export function normalizeChecks(statusCheckRollup) {
   }));
 }
 
-export function summarizeChecks(statusCheckRollup) {
+export function normalizeReviewThreads(reviewThreads) {
+  return (reviewThreads ?? []).map((thread) => ({
+    isResolved: thread.isResolved === true,
+    isOutdated: thread.isOutdated === true,
+    comments: (thread.comments?.nodes ?? []).map((comment) => ({
+      authorLogin: comment.author?.login ?? "",
+      body: comment.body ?? "",
+      path: comment.path ?? "",
+    })),
+  }));
+}
+
+export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
   const checks = normalizeChecks(statusCheckRollup);
+  const threads = normalizeReviewThreads(reviewThreads);
+  const unresolvedThreads = threads.filter(
+    (thread) => thread.isResolved !== true && thread.isOutdated !== true,
+  );
 
   if (checks.length === 0) {
     return {
       overall: "pending",
       checks,
+      reviewThreads: threads,
+      unresolvedThreads,
       pending: [],
       failed: [],
       successful: [],
@@ -41,6 +59,8 @@ export function summarizeChecks(statusCheckRollup) {
     return {
       overall: "pending",
       checks,
+      reviewThreads: threads,
+      unresolvedThreads,
       pending,
       failed: [],
       successful: checks.filter((check) =>
@@ -56,8 +76,24 @@ export function summarizeChecks(statusCheckRollup) {
     return {
       overall: "failure",
       checks,
+      reviewThreads: threads,
+      unresolvedThreads,
       pending: [],
       failed,
+      successful: checks.filter((check) =>
+        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
+      ),
+    };
+  }
+
+  if (unresolvedThreads.length > 0) {
+    return {
+      overall: "failure",
+      checks,
+      reviewThreads: threads,
+      unresolvedThreads,
+      pending: [],
+      failed: [],
       successful: checks.filter((check) =>
         SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
       ),
@@ -67,6 +103,8 @@ export function summarizeChecks(statusCheckRollup) {
   return {
     overall: "success",
     checks,
+    reviewThreads: threads,
+    unresolvedThreads,
     pending: [],
     failed: [],
     successful: checks.filter((check) =>

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -27,7 +27,12 @@ export function normalizeChecks(statusCheckRollup) {
 }
 
 export function validateRepoName(repo) {
-  if (repo === null || !repo.includes("/")) {
+  if (repo === null) {
+    throw new Error(`Repo must be in owner/name form, got: ${String(repo)}`);
+  }
+
+  const segments = repo.split("/");
+  if (segments.length !== 2 || segments[0] === "" || segments[1] === "") {
     throw new Error(`Repo must be in owner/name form, got: ${String(repo)}`);
   }
 

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -13,6 +13,9 @@ export const FAILED_CONCLUSIONS = new Set([
   "TIMED_OUT",
 ]);
 
+export const REVIEW_THREADS_QUERY =
+  "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }";
+
 export function normalizeChecks(statusCheckRollup) {
   return (statusCheckRollup ?? []).map((check) => ({
     name: check.name,
@@ -21,6 +24,20 @@ export function normalizeChecks(statusCheckRollup) {
     detailsUrl: check.detailsUrl ?? "",
     workflowName: check.workflowName ?? "",
   }));
+}
+
+export function validateRepoName(repo) {
+  if (repo === null || !repo.includes("/")) {
+    throw new Error(`Repo must be in owner/name form, got: ${String(repo)}`);
+  }
+
+  return repo;
+}
+
+export function parseRepo(repo) {
+  const validatedRepo = validateRepoName(repo);
+  const [owner, name] = validatedRepo.split("/", 2);
+  return { owner, name };
 }
 
 export function normalizeReviewThreads(reviewThreads) {
@@ -148,4 +165,46 @@ export function nextPollDelayMilliseconds({
   }
 
   return Math.min(intervalMilliseconds, remaining);
+}
+
+export async function resolveRepoName(repo, execFileAsync) {
+  if (repo !== null) {
+    return validateRepoName(repo);
+  }
+
+  const { stdout } = await execFileAsync("gh", [
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+
+  return validateRepoName(stdout.trim());
+}
+
+export async function fetchReviewThreads(
+  pullRequestNumber,
+  repo,
+  execFileAsync,
+) {
+  const { owner, name } = parseRepo(repo);
+  const { stdout } = await execFileAsync("gh", [
+    "api",
+    "graphql",
+    "-f",
+    REVIEW_THREADS_QUERY,
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `repo=${name}`,
+    "-F",
+    `number=${pullRequestNumber}`,
+  ]);
+  const result = JSON.parse(stdout);
+
+  return normalizeReviewThreads(
+    result.data.repository.pullRequest.reviewThreads.nodes,
+  );
 }

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -84,8 +84,9 @@ export function summarizeChecks(statusCheckRollup, reviewThreads = []) {
   );
 
   if (checks.length === 0) {
+    const overall = unresolvedThreads.length > 0 ? "failure" : "pending";
     return {
-      overall: "pending",
+      overall,
       checks,
       reviewThreads: threads,
       unresolvedThreads,

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -1,0 +1,76 @@
+export const SUCCESSFUL_CONCLUSIONS = new Set([
+  "SUCCESS",
+  "NEUTRAL",
+  "SKIPPED",
+]);
+
+export const FAILED_CONCLUSIONS = new Set([
+  "ACTION_REQUIRED",
+  "CANCELLED",
+  "FAILURE",
+  "STALE",
+  "STARTUP_FAILURE",
+  "TIMED_OUT",
+]);
+
+export function normalizeChecks(statusCheckRollup) {
+  return (statusCheckRollup ?? []).map((check) => ({
+    name: check.name,
+    status: check.status ?? "",
+    conclusion: check.conclusion ?? "",
+    detailsUrl: check.detailsUrl ?? "",
+    workflowName: check.workflowName ?? "",
+  }));
+}
+
+export function summarizeChecks(statusCheckRollup) {
+  const checks = normalizeChecks(statusCheckRollup);
+
+  if (checks.length === 0) {
+    return {
+      overall: "pending",
+      checks,
+      pending: [],
+      failed: [],
+      successful: [],
+    };
+  }
+
+  const pending = checks.filter((check) => check.status !== "COMPLETED");
+  if (pending.length > 0) {
+    return {
+      overall: "pending",
+      checks,
+      pending,
+      failed: [],
+      successful: checks.filter((check) =>
+        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
+      ),
+    };
+  }
+
+  const failed = checks.filter((check) =>
+    FAILED_CONCLUSIONS.has(check.conclusion),
+  );
+  if (failed.length > 0) {
+    return {
+      overall: "failure",
+      checks,
+      pending: [],
+      failed,
+      successful: checks.filter((check) =>
+        SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
+      ),
+    };
+  }
+
+  return {
+    overall: "success",
+    checks,
+    pending: [],
+    failed: [],
+    successful: checks.filter((check) =>
+      SUCCESSFUL_CONCLUSIONS.has(check.conclusion),
+    ),
+  };
+}

--- a/skills/fix-ci/scripts/fix-ci-lib.mjs
+++ b/skills/fix-ci/scripts/fix-ci-lib.mjs
@@ -14,11 +14,11 @@ export const FAILED_CONCLUSIONS = new Set([
 ]);
 
 export const REVIEW_THREADS_QUERY =
-  "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }";
+  "query=query($owner:String!, $repo:String!, $number:Int!, $after:String) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100, after: $after) { pageInfo { hasNextPage endCursor } nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }";
 
 export function normalizeChecks(statusCheckRollup) {
   return (statusCheckRollup ?? []).map((check) => ({
-    name: check.name,
+    name: check.name ?? "",
     status: check.status ?? "",
     conclusion: check.conclusion ?? "",
     detailsUrl: check.detailsUrl ?? "",
@@ -196,25 +196,47 @@ export async function fetchReviewThreads(
   execFileAsync,
 ) {
   const { owner, name } = parseRepo(repo);
-  const { stdout } = await execFileAsync("gh", [
-    "api",
-    "graphql",
-    "-f",
-    REVIEW_THREADS_QUERY,
-    "-F",
-    `owner=${owner}`,
-    "-F",
-    `repo=${name}`,
-    "-F",
-    `number=${pullRequestNumber}`,
-  ]);
-  const result = JSON.parse(stdout);
+  const reviewThreads = [];
+  let after = null;
 
-  if (Array.isArray(result.errors) && result.errors.length > 0) {
-    throw new Error(
-      `GraphQL error fetching review threads: ${result.errors.map((error) => error.message).join("; ")}`,
-    );
+  while (true) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      REVIEW_THREADS_QUERY,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `repo=${name}`,
+      "-F",
+      `number=${pullRequestNumber}`,
+    ];
+    if (after !== null) {
+      args.push("-F", `after=${after}`);
+    }
+
+    const { stdout } = await execFileAsync("gh", args);
+    const result = JSON.parse(stdout);
+
+    if (Array.isArray(result.errors) && result.errors.length > 0) {
+      throw new Error(
+        `GraphQL error fetching review threads: ${result.errors.map((error) => error.message).join("; ")}`,
+      );
+    }
+
+    const connection = result.data?.repository?.pullRequest?.reviewThreads;
+    reviewThreads.push(...(connection?.nodes ?? []));
+
+    if (connection?.pageInfo?.hasNextPage !== true) {
+      return reviewThreads;
+    }
+
+    after = connection.pageInfo.endCursor ?? null;
+    if (after === null) {
+      throw new Error(
+        "GraphQL error fetching review threads: missing endCursor for next page",
+      );
+    }
   }
-
-  return result.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
 }

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { summarizeChecks } from "./fix-ci-lib.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const options = {
+    pr: null,
+    repo: process.env["GITHUB_REPO"] ?? null,
+    intervalSeconds: 15,
+    timeoutSeconds: 1800,
+    once: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--pr") {
+      options.pr = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--interval") {
+      options.intervalSeconds = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--timeout") {
+      options.timeoutSeconds = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--once") {
+      options.once = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (
+    options.pr !== null &&
+    (!Number.isInteger(options.pr) || options.pr <= 0)
+  ) {
+    throw new Error(`Invalid PR number: ${options.pr}`);
+  }
+  if (
+    !Number.isFinite(options.intervalSeconds) ||
+    options.intervalSeconds <= 0
+  ) {
+    throw new Error(`Invalid interval: ${options.intervalSeconds}`);
+  }
+  if (!Number.isFinite(options.timeoutSeconds) || options.timeoutSeconds <= 0) {
+    throw new Error(`Invalid timeout: ${options.timeoutSeconds}`);
+  }
+
+  return options;
+}
+
+async function ghJson(args, repo) {
+  const fullArgs = [...args];
+  if (repo !== null) {
+    fullArgs.push("--repo", repo);
+  }
+  const { stdout } = await execFileAsync("gh", fullArgs);
+  return JSON.parse(stdout);
+}
+
+async function resolvePullRequest(options) {
+  if (options.pr !== null) {
+    return await ghJson(
+      [
+        "pr",
+        "view",
+        String(options.pr),
+        "--json",
+        "number,title,url,headRefName,baseRefName,statusCheckRollup",
+      ],
+      options.repo,
+    );
+  }
+
+  return await ghJson(
+    [
+      "pr",
+      "view",
+      "--json",
+      "number,title,url,headRefName,baseRefName,statusCheckRollup",
+    ],
+    options.repo,
+  );
+}
+
+function printSnapshot(pullRequest, summary) {
+  console.log(
+    `[${new Date().toISOString()}] PR #${pullRequest.number}: ${pullRequest.title}`,
+  );
+  console.log(`URL: ${pullRequest.url}`);
+  console.log(`Status: ${summary.overall}`);
+
+  if (summary.checks.length === 0) {
+    console.log("Checks: none reported yet");
+    return;
+  }
+
+  for (const check of summary.checks) {
+    const workflowPrefix = check.workflowName ? `${check.workflowName} / ` : "";
+    const conclusion = check.conclusion || "-";
+    console.log(
+      `- ${workflowPrefix}${check.name}: status=${check.status} conclusion=${conclusion}`,
+    );
+  }
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const startedAt = Date.now();
+
+  while (true) {
+    const pullRequest = await resolvePullRequest(options);
+    const summary = summarizeChecks(pullRequest.statusCheckRollup);
+    printSnapshot(pullRequest, summary);
+
+    if (summary.overall === "success") {
+      process.exitCode = 0;
+      return;
+    }
+
+    if (summary.overall === "failure") {
+      process.exitCode = 1;
+      return;
+    }
+
+    if (options.once) {
+      process.exitCode = 3;
+      return;
+    }
+
+    if (Date.now() - startedAt >= options.timeoutSeconds * 1000) {
+      console.error("Timed out waiting for CI to finish");
+      process.exitCode = 2;
+      return;
+    }
+
+    await sleep(options.intervalSeconds * 1000);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -115,7 +115,7 @@ async function fetchReviewThreads(pullRequestNumber, repo) {
       "api",
       "graphql",
       "-f",
-      "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
+      "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
       "-F",
       `owner=${owner}`,
       "-F",
@@ -162,7 +162,7 @@ function printSnapshot(pullRequest, summary) {
         .trim()
         .slice(0, 180);
       console.log(
-        `  ${index + 1}. ${author} @ ${path}${body ? ` :: ${body}` : ""}`,
+        `  ${index + 1}. ${author} @ ${path}${body ? ` :: ${body}` : ""} [thread=${thread.id}]`,
       );
     }
   }

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -5,6 +5,10 @@ import { promisify } from "node:util";
 import { nextPollDelayMilliseconds, summarizeChecks } from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
+const EXIT_PR_FAILURE = 1;
+const EXIT_TIMEOUT = 2;
+const EXIT_PENDING = 3;
+const EXIT_UNEXPECTED = 5;
 
 function parseArgs(argv) {
   const options = {
@@ -200,10 +204,10 @@ function sleep(milliseconds) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const startedAt = Date.now();
+  const repo = await resolveRepoName(options.repo);
+  const resolvedOptions = { ...options, repo };
 
   while (true) {
-    const repo = await resolveRepoName(options.repo);
-    const resolvedOptions = { ...options, repo };
     let pullRequest;
     let reviewThreads;
 
@@ -229,12 +233,12 @@ async function main() {
     }
 
     if (summary.overall === "failure") {
-      process.exitCode = 1;
+      process.exitCode = EXIT_PR_FAILURE;
       return;
     }
 
     if (options.once) {
-      process.exitCode = 3;
+      process.exitCode = EXIT_PENDING;
       return;
     }
 
@@ -245,7 +249,7 @@ async function main() {
     });
     if (delayMilliseconds <= 0) {
       console.error("Timed out waiting for CI to finish");
-      process.exitCode = 2;
+      process.exitCode = EXIT_TIMEOUT;
       return;
     }
 
@@ -255,5 +259,5 @@ async function main() {
 
 main().catch((error) => {
   console.error(error.message);
-  process.exitCode = 1;
+  process.exitCode = EXIT_UNEXPECTED;
 });

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -97,6 +97,38 @@ async function resolvePullRequest(options) {
   );
 }
 
+function parseRepo(repo) {
+  if (repo === null || !repo.includes("/")) {
+    throw new Error(
+      "A repo in owner/name form is required to inspect review threads",
+    );
+  }
+
+  const [owner, name] = repo.split("/", 2);
+  return { owner, name };
+}
+
+async function fetchReviewThreads(pullRequestNumber, repo) {
+  const { owner, name } = parseRepo(repo);
+  const result = await ghJson(
+    [
+      "api",
+      "graphql",
+      "-f",
+      "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `repo=${name}`,
+      "-F",
+      `number=${pullRequestNumber}`,
+    ],
+    null,
+  );
+
+  return result.data.repository.pullRequest.reviewThreads.nodes;
+}
+
 function printSnapshot(pullRequest, summary) {
   console.log(
     `[${new Date().toISOString()}] PR #${pullRequest.number}: ${pullRequest.title}`,
@@ -116,6 +148,24 @@ function printSnapshot(pullRequest, summary) {
       `- ${workflowPrefix}${check.name}: status=${check.status} conclusion=${conclusion}`,
     );
   }
+
+  if (summary.unresolvedThreads.length > 0) {
+    console.log(
+      `Unresolved review threads: ${summary.unresolvedThreads.length}`,
+    );
+    for (const [index, thread] of summary.unresolvedThreads.entries()) {
+      const firstComment = thread.comments[0];
+      const author = firstComment?.authorLogin || "unknown";
+      const path = firstComment?.path || "(general)";
+      const body = (firstComment?.body || "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 180);
+      console.log(
+        `  ${index + 1}. ${author} @ ${path}${body ? ` :: ${body}` : ""}`,
+      );
+    }
+  }
 }
 
 function sleep(milliseconds) {
@@ -128,7 +178,14 @@ async function main() {
 
   while (true) {
     const pullRequest = await resolvePullRequest(options);
-    const summary = summarizeChecks(pullRequest.statusCheckRollup);
+    const reviewThreads = await fetchReviewThreads(
+      pullRequest.number,
+      options.repo,
+    );
+    const summary = summarizeChecks(
+      pullRequest.statusCheckRollup,
+      reviewThreads,
+    );
     printSnapshot(pullRequest, summary);
 
     if (summary.overall === "success") {

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -2,7 +2,12 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { nextPollDelayMilliseconds, summarizeChecks } from "./fix-ci-lib.mjs";
+import {
+  fetchReviewThreads,
+  nextPollDelayMilliseconds,
+  resolveRepoName,
+  summarizeChecks,
+} from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
 const EXIT_PR_FAILURE = 1;
@@ -101,54 +106,6 @@ async function resolvePullRequest(options) {
   );
 }
 
-async function resolveRepoName(repo) {
-  if (repo !== null) {
-    return repo;
-  }
-
-  const { stdout } = await execFileAsync("gh", [
-    "repo",
-    "view",
-    "--json",
-    "nameWithOwner",
-    "--jq",
-    ".nameWithOwner",
-  ]);
-
-  const inferredRepo = stdout.trim();
-  if (!inferredRepo.includes("/")) {
-    throw new Error("Unable to infer repo in owner/name form");
-  }
-
-  return inferredRepo;
-}
-
-function parseRepo(repo) {
-  const [owner, name] = repo.split("/", 2);
-  return { owner, name };
-}
-
-async function fetchReviewThreads(pullRequestNumber, repo) {
-  const { owner, name } = parseRepo(repo);
-  const result = await ghJson(
-    [
-      "api",
-      "graphql",
-      "-f",
-      "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
-      "-F",
-      `owner=${owner}`,
-      "-F",
-      `repo=${name}`,
-      "-F",
-      `number=${pullRequestNumber}`,
-    ],
-    null,
-  );
-
-  return result.data.repository.pullRequest.reviewThreads.nodes;
-}
-
 function printSnapshot(pullRequest, summary) {
   console.log(
     `[${new Date().toISOString()}] PR #${pullRequest.number}: ${pullRequest.title}`,
@@ -204,7 +161,7 @@ function sleep(milliseconds) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const startedAt = Date.now();
-  const repo = await resolveRepoName(options.repo);
+  const repo = await resolveRepoName(options.repo, execFileAsync);
   const resolvedOptions = { ...options, repo };
 
   while (true) {
@@ -214,11 +171,15 @@ async function main() {
     if (options.pr !== null) {
       [pullRequest, reviewThreads] = await Promise.all([
         resolvePullRequest(resolvedOptions),
-        fetchReviewThreads(options.pr, repo),
+        fetchReviewThreads(options.pr, repo, execFileAsync),
       ]);
     } else {
       pullRequest = await resolvePullRequest(resolvedOptions);
-      reviewThreads = await fetchReviewThreads(pullRequest.number, repo);
+      reviewThreads = await fetchReviewThreads(
+        pullRequest.number,
+        repo,
+        execFileAsync,
+      );
     }
 
     const summary = summarizeChecks(

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -2,7 +2,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { summarizeChecks } from "./fix-ci-lib.mjs";
+import { nextPollDelayMilliseconds, summarizeChecks } from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -166,6 +166,15 @@ function printSnapshot(pullRequest, summary) {
       );
     }
   }
+
+  if (summary.unknown.length > 0) {
+    console.log(`Unknown completed conclusions: ${summary.unknown.length}`);
+    for (const check of summary.unknown) {
+      console.log(
+        `  - ${check.name}: status=${check.status} conclusion=${check.conclusion || "(empty)"}`,
+      );
+    }
+  }
 }
 
 function sleep(milliseconds) {
@@ -203,13 +212,18 @@ async function main() {
       return;
     }
 
-    if (Date.now() - startedAt >= options.timeoutSeconds * 1000) {
+    const delayMilliseconds = nextPollDelayMilliseconds({
+      startedAt,
+      intervalSeconds: options.intervalSeconds,
+      timeoutSeconds: options.timeoutSeconds,
+    });
+    if (delayMilliseconds <= 0) {
       console.error("Timed out waiting for CI to finish");
       process.exitCode = 2;
       return;
     }
 
-    await sleep(options.intervalSeconds * 1000);
+    await sleep(delayMilliseconds);
   }
 }
 

--- a/skills/fix-ci/scripts/fix-ci.mjs
+++ b/skills/fix-ci/scripts/fix-ci.mjs
@@ -97,13 +97,29 @@ async function resolvePullRequest(options) {
   );
 }
 
-function parseRepo(repo) {
-  if (repo === null || !repo.includes("/")) {
-    throw new Error(
-      "A repo in owner/name form is required to inspect review threads",
-    );
+async function resolveRepoName(repo) {
+  if (repo !== null) {
+    return repo;
   }
 
+  const { stdout } = await execFileAsync("gh", [
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+
+  const inferredRepo = stdout.trim();
+  if (!inferredRepo.includes("/")) {
+    throw new Error("Unable to infer repo in owner/name form");
+  }
+
+  return inferredRepo;
+}
+
+function parseRepo(repo) {
   const [owner, name] = repo.split("/", 2);
   return { owner, name };
 }
@@ -186,11 +202,21 @@ async function main() {
   const startedAt = Date.now();
 
   while (true) {
-    const pullRequest = await resolvePullRequest(options);
-    const reviewThreads = await fetchReviewThreads(
-      pullRequest.number,
-      options.repo,
-    );
+    const repo = await resolveRepoName(options.repo);
+    const resolvedOptions = { ...options, repo };
+    let pullRequest;
+    let reviewThreads;
+
+    if (options.pr !== null) {
+      [pullRequest, reviewThreads] = await Promise.all([
+        resolvePullRequest(resolvedOptions),
+        fetchReviewThreads(options.pr, repo),
+      ]);
+    } else {
+      pullRequest = await resolvePullRequest(resolvedOptions);
+      reviewThreads = await fetchReviewThreads(pullRequest.number, repo);
+    }
+
     const summary = summarizeChecks(
       pullRequest.statusCheckRollup,
       reviewThreads,

--- a/skills/fix-ci/scripts/resolve-review-threads.mjs
+++ b/skills/fix-ci/scripts/resolve-review-threads.mjs
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { normalizeReviewThreads } from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
+const EXIT_UNEXPECTED = 5;
 
 function parseArgs(argv) {
   const options = {
@@ -106,6 +107,13 @@ async function main() {
     return;
   }
 
+  const results = options.dryRun
+    ? unresolved.map(() => ({ status: "fulfilled" }))
+    : await Promise.allSettled(
+        unresolved.map((thread) => resolveThread(thread.id)),
+      );
+
+  let hadFailure = false;
   for (const [index, thread] of unresolved.entries()) {
     const firstComment = thread.comments[0];
     const author = firstComment?.authorLogin || "unknown";
@@ -114,19 +122,29 @@ async function main() {
       .replace(/\s+/g, " ")
       .trim()
       .slice(0, 180);
-    const action = options.dryRun ? "Would resolve" : "Resolved";
-
-    if (!options.dryRun) {
-      await resolveThread(thread.id);
-    }
+    const result = results[index];
+    const action = options.dryRun
+      ? "Would resolve"
+      : result?.status === "fulfilled"
+        ? "Resolved"
+        : "Failed to resolve";
 
     console.log(
       `${action} ${index + 1}/${unresolved.length}: ${author} @ ${path}${body ? ` :: ${body}` : ""} [thread=${thread.id}]`,
     );
+
+    if (result?.status === "rejected") {
+      hadFailure = true;
+      console.error(`  Error: ${result.reason?.message ?? result.reason}`);
+    }
+  }
+
+  if (hadFailure) {
+    process.exitCode = EXIT_UNEXPECTED;
   }
 }
 
 main().catch((error) => {
   console.error(error.message);
-  process.exitCode = 1;
+  process.exitCode = EXIT_UNEXPECTED;
 });

--- a/skills/fix-ci/scripts/resolve-review-threads.mjs
+++ b/skills/fix-ci/scripts/resolve-review-threads.mjs
@@ -2,7 +2,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { normalizeReviewThreads } from "./fix-ci-lib.mjs";
+import { fetchReviewThreads, resolveRepoName } from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
 const EXIT_UNEXPECTED = 5;
@@ -36,9 +36,6 @@ function parseArgs(argv) {
   if (options.pr === null || !Number.isInteger(options.pr) || options.pr <= 0) {
     throw new Error("A positive --pr value is required");
   }
-  if (options.repo === null || !options.repo.includes("/")) {
-    throw new Error("A repo in owner/name form is required");
-  }
 
   return options;
 }
@@ -46,31 +43,6 @@ function parseArgs(argv) {
 async function ghJson(args) {
   const { stdout } = await execFileAsync("gh", args);
   return JSON.parse(stdout);
-}
-
-function parseRepo(repo) {
-  const [owner, name] = repo.split("/", 2);
-  return { owner, name };
-}
-
-async function fetchReviewThreads(pullRequestNumber, repo) {
-  const { owner, name } = parseRepo(repo);
-  const result = await ghJson([
-    "api",
-    "graphql",
-    "-f",
-    "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
-    "-F",
-    `owner=${owner}`,
-    "-F",
-    `repo=${name}`,
-    "-F",
-    `number=${pullRequestNumber}`,
-  ]);
-
-  return normalizeReviewThreads(
-    result.data.repository.pullRequest.reviewThreads.nodes,
-  );
 }
 
 async function resolveThread(threadId) {
@@ -97,7 +69,8 @@ async function resolveThread(threadId) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const threads = await fetchReviewThreads(options.pr, options.repo);
+  const repo = await resolveRepoName(options.repo, execFileAsync);
+  const threads = await fetchReviewThreads(options.pr, repo, execFileAsync);
   const unresolved = threads.filter(
     (thread) => thread.isResolved !== true && thread.isOutdated !== true,
   );

--- a/skills/fix-ci/scripts/resolve-review-threads.mjs
+++ b/skills/fix-ci/scripts/resolve-review-threads.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { normalizeReviewThreads } from "./fix-ci-lib.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const options = {
+    pr: null,
+    repo: process.env["GITHUB_REPO"] ?? null,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--pr") {
+      options.pr = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (options.pr === null || !Number.isInteger(options.pr) || options.pr <= 0) {
+    throw new Error("A positive --pr value is required");
+  }
+  if (options.repo === null || !options.repo.includes("/")) {
+    throw new Error("A repo in owner/name form is required");
+  }
+
+  return options;
+}
+
+async function ghJson(args) {
+  const { stdout } = await execFileAsync("gh", args);
+  return JSON.parse(stdout);
+}
+
+function parseRepo(repo) {
+  const [owner, name] = repo.split("/", 2);
+  return { owner, name };
+}
+
+async function fetchReviewThreads(pullRequestNumber, repo) {
+  const { owner, name } = parseRepo(repo);
+  const result = await ghJson([
+    "api",
+    "graphql",
+    "-f",
+    "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first: 100) { nodes { id isResolved isOutdated comments(first: 20) { nodes { author { login } body path } } } } } } }",
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `repo=${name}`,
+    "-F",
+    `number=${pullRequestNumber}`,
+  ]);
+
+  return normalizeReviewThreads(
+    result.data.repository.pullRequest.reviewThreads.nodes,
+  );
+}
+
+async function resolveThread(threadId) {
+  await ghJson([
+    "api",
+    "graphql",
+    "-f",
+    "query=mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }",
+    "-F",
+    `threadId=${threadId}`,
+  ]);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const threads = await fetchReviewThreads(options.pr, options.repo);
+  const unresolved = threads.filter(
+    (thread) => thread.isResolved !== true && thread.isOutdated !== true,
+  );
+
+  if (unresolved.length === 0) {
+    console.log("No unresolved non-outdated review threads");
+    return;
+  }
+
+  for (const [index, thread] of unresolved.entries()) {
+    const firstComment = thread.comments[0];
+    const author = firstComment?.authorLogin || "unknown";
+    const path = firstComment?.path || "(general)";
+    const body = (firstComment?.body || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 180);
+    const action = options.dryRun ? "Would resolve" : "Resolved";
+
+    if (!options.dryRun) {
+      await resolveThread(thread.id);
+    }
+
+    console.log(
+      `${action} ${index + 1}/${unresolved.length}: ${author} @ ${path}${body ? ` :: ${body}` : ""} [thread=${thread.id}]`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/skills/fix-ci/scripts/resolve-review-threads.mjs
+++ b/skills/fix-ci/scripts/resolve-review-threads.mjs
@@ -2,7 +2,11 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { fetchReviewThreads, resolveRepoName } from "./fix-ci-lib.mjs";
+import {
+  fetchReviewThreads,
+  normalizeReviewThreads,
+  resolveRepoName,
+} from "./fix-ci-lib.mjs";
 
 const execFileAsync = promisify(execFile);
 const EXIT_UNEXPECTED = 5;
@@ -70,7 +74,9 @@ async function resolveThread(threadId) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const repo = await resolveRepoName(options.repo, execFileAsync);
-  const threads = await fetchReviewThreads(options.pr, repo, execFileAsync);
+  const threads = normalizeReviewThreads(
+    await fetchReviewThreads(options.pr, repo, execFileAsync),
+  );
   const unresolved = threads.filter(
     (thread) => thread.isResolved !== true && thread.isOutdated !== true,
   );

--- a/skills/fix-ci/scripts/resolve-review-threads.mjs
+++ b/skills/fix-ci/scripts/resolve-review-threads.mjs
@@ -73,7 +73,7 @@ async function fetchReviewThreads(pullRequestNumber, repo) {
 }
 
 async function resolveThread(threadId) {
-  await ghJson([
+  const result = await ghJson([
     "api",
     "graphql",
     "-f",
@@ -81,6 +81,17 @@ async function resolveThread(threadId) {
     "-F",
     `threadId=${threadId}`,
   ]);
+
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    throw new Error(
+      `Failed to resolve thread ${threadId}: ${result.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+
+  const resolved = result.data?.resolveReviewThread?.thread?.isResolved;
+  if (resolved !== true) {
+    throw new Error(`Thread ${threadId} was not marked resolved`);
+  }
 }
 
 async function main() {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  fetchReviewThreads,
   parseRepo,
   nextPollDelayMilliseconds,
+  normalizeChecks,
   normalizeReviewThreads,
   summarizeChecks,
   validateRepoName,
@@ -194,6 +196,96 @@ describe("fix-ci skill", () => {
 
     expect(summary.overall).toBe("success");
     expect(summary.failed).toHaveLength(0);
+  });
+
+  it("normalizes missing check names to empty strings", () => {
+    const checks = normalizeChecks([
+      {
+        name: null,
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        detailsUrl: "https://example.test/check",
+        workflowName: "CI",
+      },
+    ]);
+
+    expect(checks[0]?.name).toBe("");
+  });
+
+  it("fetches review threads across multiple pages", async () => {
+    const responses = [
+      {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: {
+                    hasNextPage: true,
+                    endCursor: "CURSOR_1",
+                  },
+                  nodes: [
+                    {
+                      id: "THREAD_1",
+                      isResolved: false,
+                      isOutdated: false,
+                      comments: { nodes: [] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      },
+      {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: "CURSOR_2",
+                  },
+                  nodes: [
+                    {
+                      id: "THREAD_2",
+                      isResolved: true,
+                      isOutdated: false,
+                      comments: { nodes: [] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      },
+    ];
+    const calls = [];
+    const execFileAsync = async (_command, args) => {
+      calls.push(args);
+      const response = responses.shift();
+      if (response === undefined) {
+        throw new Error("Unexpected extra fetch");
+      }
+      return response;
+    };
+
+    const threads = await fetchReviewThreads(
+      20,
+      "sociotechnica-org/symphony-ts",
+      execFileAsync,
+    );
+
+    expect(threads).toHaveLength(2);
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "THREAD_1",
+      "THREAD_2",
+    ]);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain("after=CURSOR_1");
   });
 
   it("caps the next poll delay at the remaining timeout", () => {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { summarizeChecks } from "../../skills/fix-ci/scripts/fix-ci-lib.mjs";
+
+describe("fix-ci skill", () => {
+  it("treats incomplete checks as pending", () => {
+    const summary = summarizeChecks([
+      {
+        name: "check",
+        status: "IN_PROGRESS",
+        conclusion: "",
+        detailsUrl: "https://example.test/check",
+        workflowName: "CI",
+      },
+    ]);
+
+    expect(summary.overall).toBe("pending");
+    expect(summary.pending).toHaveLength(1);
+  });
+
+  it("treats failing completed checks as failure", () => {
+    const summary = summarizeChecks([
+      {
+        name: "check",
+        status: "COMPLETED",
+        conclusion: "FAILURE",
+        detailsUrl: "https://example.test/check",
+        workflowName: "CI",
+      },
+    ]);
+
+    expect(summary.overall).toBe("failure");
+    expect(summary.failed).toHaveLength(1);
+  });
+
+  it("treats successful completed checks as success", () => {
+    const summary = summarizeChecks([
+      {
+        name: "check",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        detailsUrl: "https://example.test/check",
+        workflowName: "CI",
+      },
+      {
+        name: "Greptile Review",
+        status: "COMPLETED",
+        conclusion: "NEUTRAL",
+        detailsUrl: "https://example.test/review",
+        workflowName: "",
+      },
+    ]);
+
+    expect(summary.overall).toBe("success");
+    expect(summary.failed).toHaveLength(0);
+  });
+});

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   nextPollDelayMilliseconds,
+  normalizeReviewThreads,
   summarizeChecks,
 } from "../../skills/fix-ci/scripts/fix-ci-lib.mjs";
 
@@ -102,6 +103,21 @@ describe("fix-ci skill", () => {
 
     expect(summary.overall).toBe("failure");
     expect(summary.unresolvedThreads).toHaveLength(1);
+  });
+
+  it("preserves review thread ids for later resolution", () => {
+    const threads = normalizeReviewThreads([
+      {
+        id: "THREAD_123",
+        isResolved: false,
+        isOutdated: false,
+        comments: {
+          nodes: [],
+        },
+      },
+    ]);
+
+    expect(threads[0]?.id).toBe("THREAD_123");
   });
 
   it("treats successful completed checks as success", () => {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -107,6 +107,42 @@ describe("fix-ci skill", () => {
     expect(summary.unresolvedThreads).toHaveLength(1);
   });
 
+  it("preserves thread comment details when passed pre-normalized threads", () => {
+    const summary = summarizeChecks(
+      [
+        {
+          name: "check",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          detailsUrl: "https://example.test/check",
+          workflowName: "CI",
+        },
+      ],
+      [
+        {
+          id: "THREAD_123",
+          isResolved: false,
+          isOutdated: false,
+          comments: [
+            {
+              authorLogin: "greptile-apps",
+              body: "Please fix this",
+              path: "src/example.ts",
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(summary.overall).toBe("failure");
+    expect(summary.unresolvedThreads[0]?.comments[0]?.authorLogin).toBe(
+      "greptile-apps",
+    );
+    expect(summary.unresolvedThreads[0]?.comments[0]?.path).toBe(
+      "src/example.ts",
+    );
+  });
+
   it("preserves review thread ids for later resolution", () => {
     const threads = normalizeReviewThreads([
       {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -167,6 +167,12 @@ describe("fix-ci skill", () => {
     expect(() => validateRepoName("badformat")).toThrow(
       "Repo must be in owner/name form",
     );
+    expect(() => validateRepoName("owner/")).toThrow(
+      "Repo must be in owner/name form",
+    );
+    expect(() => validateRepoName("/repo")).toThrow(
+      "Repo must be in owner/name form",
+    );
   });
 
   it("parses validated repo names", () => {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -32,6 +32,38 @@ describe("fix-ci skill", () => {
     expect(summary.failed).toHaveLength(1);
   });
 
+  it("treats unresolved review threads as failure once checks are complete", () => {
+    const summary = summarizeChecks(
+      [
+        {
+          name: "check",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          detailsUrl: "https://example.test/check",
+          workflowName: "CI",
+        },
+      ],
+      [
+        {
+          isResolved: false,
+          isOutdated: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: "greptile-apps" },
+                body: "Please fix this",
+                path: "src/example.ts",
+              },
+            ],
+          },
+        },
+      ],
+    );
+
+    expect(summary.overall).toBe("failure");
+    expect(summary.unresolvedThreads).toHaveLength(1);
+  });
+
   it("treats successful completed checks as success", () => {
     const summary = summarizeChecks([
       {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -25,6 +25,31 @@ describe("fix-ci skill", () => {
     expect(summary.pending).toHaveLength(1);
   });
 
+  it("treats unresolved review threads as failure even before checks appear", () => {
+    const summary = summarizeChecks(
+      [],
+      [
+        {
+          id: "THREAD_0",
+          isResolved: false,
+          isOutdated: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: "cursor" },
+                body: "Please fix this before merge",
+                path: "skills/fix-ci/scripts/fix-ci-lib.mjs",
+              },
+            ],
+          },
+        },
+      ],
+    );
+
+    expect(summary.overall).toBe("failure");
+    expect(summary.unresolvedThreads).toHaveLength(1);
+  });
+
   it("treats failing completed checks as failure", () => {
     const summary = summarizeChecks([
       {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  parseRepo,
   nextPollDelayMilliseconds,
   normalizeReviewThreads,
   summarizeChecks,
+  validateRepoName,
 } from "../../skills/fix-ci/scripts/fix-ci-lib.mjs";
 
 describe("fix-ci skill", () => {
@@ -118,6 +120,22 @@ describe("fix-ci skill", () => {
     ]);
 
     expect(threads[0]?.id).toBe("THREAD_123");
+  });
+
+  it("validates repo names in owner/name form", () => {
+    expect(validateRepoName("sociotechnica-org/symphony-ts")).toBe(
+      "sociotechnica-org/symphony-ts",
+    );
+    expect(() => validateRepoName("badformat")).toThrow(
+      "Repo must be in owner/name form",
+    );
+  });
+
+  it("parses validated repo names", () => {
+    expect(parseRepo("sociotechnica-org/symphony-ts")).toEqual({
+      owner: "sociotechnica-org",
+      name: "symphony-ts",
+    });
   });
 
   it("treats successful completed checks as success", () => {

--- a/tests/unit/fix-ci.test.mjs
+++ b/tests/unit/fix-ci.test.mjs
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { summarizeChecks } from "../../skills/fix-ci/scripts/fix-ci-lib.mjs";
+import {
+  nextPollDelayMilliseconds,
+  summarizeChecks,
+} from "../../skills/fix-ci/scripts/fix-ci-lib.mjs";
 
 describe("fix-ci skill", () => {
   it("treats incomplete checks as pending", () => {
@@ -30,6 +33,43 @@ describe("fix-ci skill", () => {
 
     expect(summary.overall).toBe("failure");
     expect(summary.failed).toHaveLength(1);
+  });
+
+  it("keeps failed checks visible while other checks are still pending", () => {
+    const summary = summarizeChecks([
+      {
+        name: "failed-check",
+        status: "COMPLETED",
+        conclusion: "FAILURE",
+        detailsUrl: "https://example.test/check/failed",
+        workflowName: "CI",
+      },
+      {
+        name: "pending-check",
+        status: "IN_PROGRESS",
+        conclusion: "",
+        detailsUrl: "https://example.test/check/pending",
+        workflowName: "CI",
+      },
+    ]);
+
+    expect(summary.overall).toBe("pending");
+    expect(summary.failed).toHaveLength(1);
+  });
+
+  it("treats unknown completed conclusions as failure", () => {
+    const summary = summarizeChecks([
+      {
+        name: "weird-check",
+        status: "COMPLETED",
+        conclusion: "",
+        detailsUrl: "https://example.test/check",
+        workflowName: "CI",
+      },
+    ]);
+
+    expect(summary.overall).toBe("failure");
+    expect(summary.unknown).toHaveLength(1);
   });
 
   it("treats unresolved review threads as failure once checks are complete", () => {
@@ -84,5 +124,16 @@ describe("fix-ci skill", () => {
 
     expect(summary.overall).toBe("success");
     expect(summary.failed).toHaveLength(0);
+  });
+
+  it("caps the next poll delay at the remaining timeout", () => {
+    const delay = nextPollDelayMilliseconds({
+      startedAt: 1_000,
+      now: 5_500,
+      intervalSeconds: 15,
+      timeoutSeconds: 6,
+    });
+
+    expect(delay).toBe(1_500);
   });
 });


### PR DESCRIPTION
## Summary
- add a repo-local `fix-ci` skill for deterministic PR check monitoring
- add a small `gh pr view`-based script that waits for checks to complete and exits with a meaningful status code
- add unit coverage for pending, failing, and successful check rollups

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `codex review --base main`
