### PR TITLE
Make the factory own the PR lifecycle and review loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TypeScript implementation of the [Symphony spec](https://github.com/openai/symph
 
 ## Status
 
-Phase 0 is implemented.
+Phase 1.2 is implemented.
 
 Today, `symphony-ts` can:
 
@@ -12,15 +12,17 @@ Today, `symphony-ts` can:
 - claim one of those issues locally
 - create or reuse a deterministic per-issue git workspace
 - run Codex against that workspace using the rendered `WORKFLOW.md` prompt
-- verify that a pull request exists for the issue branch
-- close the issue and leave a success comment
+- observe the pull request associated with the issue branch
+- wait for PR checks and automated review feedback after PR creation
+- re-enter the same workspace branch when CI or review feedback needs follow-up
+- close the issue only after the PR is merge-ready
 - retry failed runs locally
 
 This is already being used to build `symphony-ts` itself.
 
 ## How It Works
 
-The Phase 0 runtime is a narrow vertical slice:
+The current runtime is a narrow vertical slice:
 
 1. `bin/symphony.ts` starts the CLI.
 2. `src/config/workflow.ts` loads and validates `WORKFLOW.md`.
@@ -35,12 +37,13 @@ The default issue lifecycle is:
 2. Symphony changes it to `symphony:running`
 3. Symphony prepares branch `symphony/<issue-number>`
 4. Codex implements the issue and opens a PR
-5. Symphony confirms the PR exists
-6. Symphony comments on the issue and closes it
+5. Symphony keeps the issue in `symphony:running` while PR checks or review feedback are still in flight
+6. Symphony re-enters the same branch if CI fails or actionable review feedback appears
+7. Symphony comments on the issue and closes it only after the PR is green and review feedback is resolved
 
 If a run fails, Symphony either:
 
-- re-labels the issue as `symphony:ready` and retries later, or
+- schedules a retry while keeping the issue in the in-flight factory loop, or
 - marks it `symphony:failed` after retries are exhausted
 
 ## Repository Map
@@ -175,22 +178,26 @@ When Symphony picks up the issue, it should:
 4. run Codex with the rendered issue prompt
 5. push the branch
 6. open a PR against `main`
+7. keep polling that PR for CI and automated review state
+8. push follow-up commits on the same branch until the PR is actually clean
 
-If the run succeeds, Symphony will comment on the issue and close it.
+If the PR reaches a clean merge-ready state, Symphony will comment on the issue and close it.
 
 If the run fails, Symphony will either:
 
-- retry it by restoring `symphony:ready`, or
+- retry it in the running loop, or
 - mark it `symphony:failed`
 
 ### 6. Review and merge the PR
 
-Once the PR exists, review it like any other change:
+Symphony now owns the local PR follow-through loop:
 
-- wait for CI
-- wait for Greptile review
-- address follow-up comments if needed
-- merge once the PR is ready
+- wait for CI and automated review checks
+- detect actionable review feedback
+- push follow-up commits when the PR needs more work
+- stop only when the PR is actually clean
+
+Human merge remains a separate repository action once the PR is ready.
 
 That merged PR becomes the new version of Symphony that will work the next issue.
 
@@ -223,6 +230,7 @@ It contains:
 Key fields in the current workflow:
 
 - `tracker.repo`: GitHub repository to poll
+- `tracker.review_bot_logins`: PR comment authors whose feedback should be treated as actionable bot review
 - `polling.interval_ms`: poll interval
 - `polling.max_concurrent_runs`: local concurrency cap
 - `workspace.root`: local workspace root

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,6 +7,9 @@ tracker:
   running_label: symphony:running
   failed_label: symphony:failed
   success_comment: Symphony completed this issue successfully.
+  review_bot_logins:
+    - greptile[bot]
+    - bugbot[bot]
 polling:
   interval_ms: 30000
   max_concurrent_runs: 1
@@ -36,6 +39,16 @@ Labels: {{ issue.labels | join: ", " }}
 Description:
 {{ issue.description }}
 
+{% if pull_request %}
+Pull Request State:
+
+- Status: {{ pull_request.kind }}
+- URL: {{ pull_request.pullRequest.url }}
+- Pending checks: {{ pull_request.pendingCheckNames | join: ", " }}
+- Failing checks: {{ pull_request.failingCheckNames | join: ", " }}
+- Actionable feedback count: {{ pull_request.actionableReviewFeedback | size }}
+  {% endif %}
+
 Rules:
 
 1. Work only inside this repository clone.
@@ -44,4 +57,6 @@ Rules:
 4. Run the relevant checks before finishing.
 5. Open a pull request against `main` in `{{ config.tracker.repo }}`.
 6. Reference the issue in the PR body.
-7. Leave the workspace in a git state that can be inspected if the run fails.
+7. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.
+8. Do not treat "PR opened" as complete; keep going until the PR is green and actionable review feedback is resolved.
+9. Leave the workspace in a git state that can be inspected if the run fails.

--- a/docs/plans/016-pr-lifecycle-review-loop/plan.md
+++ b/docs/plans/016-pr-lifecycle-review-loop/plan.md
@@ -1,0 +1,162 @@
+# Phase 1.2 Technical Plan: Make the Factory Own PR Lifecycle and Review Loop
+
+## Goal
+
+Extend the Phase 1 runtime so a claimed issue remains under Symphony control until its pull request is truly merge-ready, not merely opened.
+
+For issue `#16`, "merge-ready" means:
+
+- a PR exists for the issue branch
+- all observed PR checks have reached a terminal successful state
+- required review bots have reached terminal state because they surface as PR checks
+- unresolved, non-outdated review threads are zero
+- no newer actionable automated review feedback remains on the PR after the latest Symphony follow-up
+
+## Scope
+
+Required outcomes for issue `#16`:
+
+1. add explicit PR lifecycle state to the normalized runtime model
+2. teach the tracker to locate the active PR for an issue branch and refresh its CI/review state
+3. keep issues in an in-flight PR stage after PR creation instead of closing them immediately
+4. let the orchestrator revisit the same running issue branch when CI fails or review feedback appears
+5. explicitly resolve addressed review threads after a successful follow-up run
+6. extend tests and the e2e harness to cover the full post-PR loop
+
+## Current Gaps
+
+Today the runtime still behaves like a Phase 0 handoff:
+
+- `GitHubBootstrapTracker.completeRun()` only checks whether a PR exists for the branch
+- the tracker closes the issue immediately after the first successful run with a PR
+- the orchestrator only polls `symphony:ready` issues and has no post-PR continuation loop
+- the runtime state does not distinguish "implementation complete" from "PR review in progress"
+- the mock GitHub server does not model PR checks, review threads, or review thread resolution
+
+## Design Direction
+
+### 1. Add a normalized PR lifecycle model
+
+Introduce explicit runtime types for:
+
+- active PR identity
+- aggregate check status
+- actionable review feedback
+- PR lifecycle state such as `missing`, `awaiting-review`, `needs-follow-up`, and `ready`
+
+The orchestrator should consume these normalized states rather than GitHub-specific payloads.
+
+### 2. Keep the issue running until the PR is merge-ready
+
+After the first successful implementation run:
+
+- if no PR exists, treat the run as failed
+- if a PR exists but checks/review are still pending, keep the issue labeled `symphony:running`
+- only close the issue and post the success comment once the PR lifecycle state is `ready`
+
+This makes "PR opened" an intermediate state instead of terminal success.
+
+### 3. Add tracker support for PR lifecycle refresh
+
+Extend the GitHub tracker to:
+
+- list currently running issues in addition to ready issues
+- find the PR attached to an issue branch
+- inspect check results for the PR head
+- inspect unresolved, non-outdated review threads
+- inspect actionable automated review comments posted after the latest Symphony commit
+- resolve review threads after Symphony pushes a follow-up fix
+
+The GitHub-specific policy lives in the tracker; the orchestrator only reacts to normalized lifecycle state.
+
+### 4. Extend orchestration for post-PR continuation
+
+Update the orchestrator loop so it:
+
+- continues polling claimed/running issues
+- refreshes PR lifecycle state for those issues
+- waits when the PR is still pending external checks/review
+- re-enters the existing workspace and reruns the agent when CI or review feedback is actionable
+- completes the issue only when the tracker reports the PR as merge-ready
+
+### 5. Expand prompt context for follow-up work
+
+The prompt builder should receive PR lifecycle context so follow-up runs can see:
+
+- PR URL and branch
+- failing or pending checks
+- unresolved actionable review feedback
+
+That keeps prompt construction at the workflow boundary while making follow-up runs concrete.
+
+## Implementation Plan
+
+### 1. Domain and service contracts
+
+Add domain types for PR lifecycle and update service contracts so the orchestrator can:
+
+- fetch ready issues
+- fetch running issues
+- refresh PR lifecycle state for an issue branch
+- finalize a merge-ready issue
+- resolve addressed review feedback after successful follow-up runs
+
+### 2. GitHub tracker implementation
+
+Update `src/tracker/github-bootstrap.ts` to:
+
+- keep issue completion separate from "PR exists"
+- query PR, check, and review-thread state from GitHub
+- normalize that data into lifecycle state
+- close the issue only after the PR is clean
+
+### 3. Orchestrator behavior
+
+Refactor `src/orchestrator/service.ts` and runtime state so:
+
+- ready issues still start at implementation attempt `1`
+- running issues are refreshed each poll for PR lifecycle state
+- only issues with actionable follow-up work are rerun
+- pending-only PRs are observed without unnecessary reruns
+
+### 4. Mock and test harness
+
+Extend the mock GitHub server and fixture `gh` shim so tests can model:
+
+- PR creation
+- check states transitioning through pending, failure, and success
+- unresolved review threads
+- post-fix review thread resolution
+- PR becoming merge-ready only after follow-up work
+
+### 5. Validation and docs
+
+Update README / workflow documentation to describe the new lifecycle and validate with:
+
+- unit tests for orchestrator decisions
+- integration tests for GitHub tracker PR lifecycle inspection
+- e2e tests for PR-open, CI-fail, review-feedback, follow-up-push, and merge-ready paths
+
+## Risks
+
+### GitHub API complexity
+
+Review thread resolution and lifecycle inspection are easier through GraphQL than the REST endpoints already in use. Keep the GraphQL usage narrowly scoped to PR review state so the tracker remains understandable.
+
+### Over-triggering follow-up runs
+
+The orchestrator must not rerun the agent simply because a PR exists. It should only rerun when checks fail or actionable feedback exists.
+
+### Mock fidelity
+
+The e2e harness must model the PR lifecycle closely enough that it tests the actual control flow rather than a toy shortcut.
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. the runtime models PR lifecycle explicitly
+2. the tracker can refresh active PR, checks, and review state for a running issue branch
+3. the orchestrator keeps working a single issue through PR follow-up until merge-ready
+4. tests cover the post-PR CI/review loop
+5. the self-hosting flow no longer treats "PR opened" as completion

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -27,6 +27,7 @@ interface PromptRenderInput {
     readonly identifier: string;
   };
   readonly attempt: number | null;
+  readonly pullRequest: unknown;
   readonly config: ResolvedConfig;
 }
 
@@ -111,6 +112,13 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         tracker["success_comment"],
         "tracker.success_comment",
       ),
+      reviewBotLogins:
+        tracker["review_bot_logins"] === undefined
+          ? []
+          : requireStringArray(
+              tracker["review_bot_logins"],
+              "tracker.review_bot_logins",
+            ),
     },
     polling: {
       intervalMs: requireNumber(polling["interval_ms"], "polling.interval_ms"),
@@ -213,6 +221,7 @@ async function renderPromptTemplate(
     return await liquid.parseAndRender(definition.promptTemplate, {
       issue: input.issue,
       attempt: input.attempt,
+      pull_request: input.pullRequest,
       config: input.config,
     });
   } catch (error) {
@@ -233,6 +242,7 @@ export function createPromptBuilder(
       return await renderPromptTemplate(definition, {
         issue: input.issue,
         attempt: input.attempt,
+        pullRequest: input.pullRequest,
         config: definition.config,
       });
     },

--- a/src/domain/pull-request.ts
+++ b/src/domain/pull-request.ts
@@ -1,0 +1,47 @@
+export type PullRequestLifecycleKind =
+  | "missing"
+  | "awaiting-review"
+  | "needs-follow-up"
+  | "ready";
+
+export type PullRequestCheckStatus = "pending" | "success" | "failure";
+
+export interface PullRequestHandle {
+  readonly number: number;
+  readonly url: string;
+  readonly branchName: string;
+  readonly latestCommitAt: string | null;
+}
+
+export interface PullRequestCheck {
+  readonly name: string;
+  readonly status: PullRequestCheckStatus;
+  readonly conclusion: string | null;
+  readonly detailsUrl: string | null;
+}
+
+export type ReviewFeedbackKind = "review-thread" | "issue-comment";
+
+export interface ReviewFeedback {
+  readonly id: string;
+  readonly kind: ReviewFeedbackKind;
+  readonly threadId: string | null;
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+  readonly path: string | null;
+  readonly line: number | null;
+}
+
+export interface PullRequestLifecycle {
+  readonly kind: PullRequestLifecycleKind;
+  readonly branchName: string;
+  readonly pullRequest: PullRequestHandle | null;
+  readonly checks: readonly PullRequestCheck[];
+  readonly pendingCheckNames: readonly string[];
+  readonly failingCheckNames: readonly string[];
+  readonly actionableReviewFeedback: readonly ReviewFeedback[];
+  readonly unresolvedThreadIds: readonly string[];
+  readonly summary: string;
+}

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -1,4 +1,5 @@
 import type { RuntimeIssue } from "./issue.js";
+import type { PullRequestLifecycle } from "./pull-request.js";
 
 export interface RetryPolicy {
   readonly maxAttempts: number;
@@ -13,6 +14,7 @@ export interface TrackerConfig {
   readonly runningLabel: string;
   readonly failedLabel: string;
   readonly successComment: string;
+  readonly reviewBotLogins: readonly string[];
 }
 
 export interface PollingConfig {
@@ -57,5 +59,6 @@ export interface PromptBuilder {
   build(input: {
     readonly issue: RuntimeIssue;
     readonly attempt: number | null;
+    readonly pullRequest: PullRequestLifecycle | null;
   }): Promise<string>;
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,14 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { OrchestratorError } from "../domain/errors.js";
 import type { RuntimeIssue } from "../domain/issue.js";
+import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 import type { RunSession } from "../domain/run.js";
 import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import { createOrchestratorState } from "./state.js";
 import type { Runner } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
+import { createOrchestratorState } from "./state.js";
 
 export interface Orchestrator {
   runOnce(): Promise<void>;
@@ -18,6 +19,7 @@ export interface Orchestrator {
 interface QueueEntry {
   readonly issue: RuntimeIssue;
   readonly attempt: number;
+  readonly source: "ready" | "running";
 }
 
 export class BootstrapOrchestrator implements Orchestrator {
@@ -49,13 +51,22 @@ export class BootstrapOrchestrator implements Orchestrator {
   async runOnce(): Promise<void> {
     await this.#tracker.ensureLabels();
     this.#logger.info("Poll started");
-    const candidates = await this.#tracker.fetchEligibleIssues();
+    const [readyCandidates, runningCandidates] = await Promise.all([
+      this.#tracker.fetchReadyIssues(),
+      this.#tracker.fetchRunningIssues(),
+    ]);
     const dueRetries = this.#collectDueRetries();
-    const queue = this.#mergeQueue(candidates, dueRetries);
+    const queue = this.#mergeQueue(
+      readyCandidates,
+      runningCandidates,
+      dueRetries,
+    );
     const availableSlots =
       this.#config.polling.maxConcurrentRuns -
       this.#state.runningIssueNumbers.size;
     this.#logger.info("Poll candidates fetched", {
+      readyCount: readyCandidates.length,
+      runningCount: runningCandidates.length,
       candidateCount: queue.length,
       availableSlots,
     });
@@ -65,14 +76,18 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
 
     const runs: Promise<void>[] = [];
-    for (const issue of queue) {
+    for (const entry of queue) {
       if (runs.length >= availableSlots) {
         break;
       }
-      if (this.#state.runningIssueNumbers.has(issue.issue.number)) {
+      if (this.#state.runningIssueNumbers.has(entry.issue.number)) {
         continue;
       }
-      runs.push(this.#processIssue(issue.issue, issue.attempt));
+      runs.push(
+        entry.source === "ready"
+          ? this.#processReadyIssue(entry.issue, entry.attempt)
+          : this.#processRunningIssue(entry.issue, entry.attempt),
+      );
     }
 
     await Promise.all(runs);
@@ -106,35 +121,70 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #mergeQueue(
-    candidates: readonly RuntimeIssue[],
+    readyCandidates: readonly RuntimeIssue[],
+    runningCandidates: readonly RuntimeIssue[],
     dueRetries: readonly RetryState[],
   ): readonly QueueEntry[] {
-    const merged = new Map<number, QueueEntry>();
+    const retryAttempts = new Map<number, number>();
     for (const retry of dueRetries) {
-      merged.set(retry.issue.number, {
-        issue: retry.issue,
-        attempt: retry.nextAttempt,
-      });
+      retryAttempts.set(retry.issue.number, retry.nextAttempt);
     }
-    for (const issue of candidates) {
-      if (!merged.has(issue.number) && this.#state.retries.has(issue.number)) {
+
+    const merged = new Map<number, QueueEntry>();
+    for (const issue of runningCandidates) {
+      if (
+        !retryAttempts.has(issue.number) &&
+        this.#state.retries.has(issue.number)
+      ) {
         continue;
       }
-      const existing = merged.get(issue.number);
       merged.set(issue.number, {
         issue,
-        attempt: existing?.attempt ?? 1,
+        attempt: this.#resolveAttemptNumber(issue.number, retryAttempts),
+        source: "running",
       });
     }
-    return [...merged.values()].sort((a, b) => a.issue.number - b.issue.number);
+    for (const issue of readyCandidates) {
+      if (
+        !retryAttempts.has(issue.number) &&
+        this.#state.retries.has(issue.number)
+      ) {
+        continue;
+      }
+      if (merged.has(issue.number)) {
+        continue;
+      }
+      merged.set(issue.number, {
+        issue,
+        attempt: this.#resolveAttemptNumber(issue.number, retryAttempts),
+        source: "ready",
+      });
+    }
+
+    return [...merged.values()].sort((left, right) => {
+      if (left.source !== right.source) {
+        return left.source === "running" ? -1 : 1;
+      }
+      return left.issue.number - right.issue.number;
+    });
   }
 
-  async #processIssue(issue: RuntimeIssue, attempt: number): Promise<void> {
-    this.#state.runningIssueNumbers.add(issue.number);
-    let claimedIssue = issue;
-    let completedWorkspace: RunSession["workspace"] | null = null;
-    let completedRunSessionId: string | null = null;
+  #resolveAttemptNumber(
+    issueNumber: number,
+    retryAttempts: ReadonlyMap<number, number>,
+  ): number {
+    return (
+      retryAttempts.get(issueNumber) ??
+      this.#state.nextAttemptByIssueNumber.get(issueNumber) ??
+      1
+    );
+  }
 
+  async #processReadyIssue(
+    issue: RuntimeIssue,
+    attempt: number,
+  ): Promise<void> {
+    this.#state.runningIssueNumbers.add(issue.number);
     try {
       const claimed = await this.#tracker.claimIssue(issue.number);
       if (claimed === null) {
@@ -143,81 +193,155 @@ export class BootstrapOrchestrator implements Orchestrator {
         });
         return;
       }
-      claimedIssue = claimed;
-
-      const workspace = await this.#workspaceManager.prepareWorkspace({
-        issue: claimed,
-      });
-      const prompt = await this.#promptBuilder.build({
-        issue: claimed,
-        attempt: attempt > 1 ? attempt : null,
-      });
-      const session = this.#createRunSession(
-        claimed,
-        workspace,
-        prompt,
-        attempt,
-      );
-      const result = await this.#runner.run(session);
-
-      if (result.exitCode !== 0) {
-        await this.#handleFailure(
-          session,
-          attempt,
-          `Runner exited with ${result.exitCode}\n${result.stderr}`,
-        );
-        return;
-      }
-
-      try {
-        await this.#tracker.completeRun(session, result);
-      } catch (error) {
-        await this.#handleFailure(
-          session,
-          attempt,
-          this.#normalizeFailure(error as Error),
-        );
-        return;
-      }
-
-      completedWorkspace = workspace;
-      completedRunSessionId = session.id;
+      await this.#processClaimedIssue(claimed, attempt);
     } catch (error) {
-      await this.#handleUnexpectedFailure(
-        claimedIssue,
-        attempt,
-        error as Error,
-      );
+      await this.#handleUnexpectedFailure(issue, attempt, error as Error);
     } finally {
       this.#state.runningIssueNumbers.delete(issue.number);
     }
+  }
 
-    if (completedWorkspace !== null && completedRunSessionId !== null) {
-      try {
-        this.#logger.info("Issue completed", {
-          issueNumber: claimedIssue.number,
-          branchName: completedWorkspace.branchName,
-          runSessionId: completedRunSessionId,
-        });
-      } catch {
-        // Observability must not perturb the completed issue state.
-      }
+  async #processRunningIssue(
+    issue: RuntimeIssue,
+    attempt: number,
+  ): Promise<void> {
+    this.#state.runningIssueNumbers.add(issue.number);
+    try {
+      await this.#processClaimedIssue(issue, attempt);
+    } catch (error) {
+      await this.#handleUnexpectedFailure(issue, attempt, error as Error);
+    } finally {
+      this.#state.runningIssueNumbers.delete(issue.number);
+    }
+  }
+
+  async #processClaimedIssue(
+    issue: RuntimeIssue,
+    attempt: number,
+  ): Promise<void> {
+    const branchName = this.#branchName(issue.number);
+    const lifecycle = await this.#refreshLifecycle(issue.number, branchName);
+
+    if (lifecycle.kind === "ready") {
+      await this.#completeIssue(issue.number);
+      return;
     }
 
-    if (
-      this.#config.workspace.cleanupOnSuccess &&
-      completedWorkspace !== null
-    ) {
-      try {
-        await this.#workspaceManager.cleanupWorkspace(completedWorkspace);
-      } catch (error) {
-        this.#logger.error("Workspace cleanup failed", {
-          issueNumber: claimedIssue.number,
-          workspacePath: completedWorkspace.path,
-          error: this.#normalizeFailure(error as Error),
-        });
-      }
+    if (lifecycle.kind === "awaiting-review") {
+      this.#logger.info("Issue remains in PR review", {
+        issueNumber: issue.number,
+        summary: lifecycle.summary,
+      });
+      return;
     }
+
+    await this.#runIssue(
+      issue,
+      attempt,
+      lifecycle.kind === "missing" ? null : lifecycle,
+    );
+  }
+
+  async #runIssue(
+    issue: RuntimeIssue,
+    attempt: number,
+    pullRequest: PullRequestLifecycle | null,
+  ): Promise<void> {
+    const workspace = await this.#workspaceManager.prepareWorkspace({ issue });
+    const prompt = await this.#promptBuilder.build({
+      issue,
+      attempt,
+      pullRequest,
+    });
+    const session = this.#createRunSession(issue, workspace, prompt, attempt);
+    const result = await this.#runner.run(session);
+
+    if (result.exitCode !== 0) {
+      await this.#handleFailure(
+        session,
+        attempt,
+        `Runner exited with ${result.exitCode}\n${result.stderr}`,
+      );
+      return;
+    }
+
+    try {
+      if (pullRequest !== null && pullRequest.unresolvedThreadIds.length > 0) {
+        await this.#tracker.resolveReviewThreads(
+          pullRequest.unresolvedThreadIds,
+        );
+      }
+
+      const nextLifecycle = await this.#refreshLifecycle(
+        issue.number,
+        workspace.branchName,
+      );
+      this.#state.nextAttemptByIssueNumber.set(issue.number, attempt + 1);
+
+      if (nextLifecycle.kind === "ready") {
+        await this.#completeIssue(issue.number);
+        await this.#cleanupWorkspaceIfNeeded(workspace, issue.number);
+        return;
+      }
+
+      if (nextLifecycle.kind === "missing") {
+        await this.#handleFailure(session, attempt, nextLifecycle.summary);
+        return;
+      }
+
+      this.#logger.info("Issue remains in PR lifecycle", {
+        issueNumber: issue.number,
+        branchName: workspace.branchName,
+        runSessionId: session.id,
+        lifecycle: nextLifecycle.kind,
+        summary: nextLifecycle.summary,
+      });
+    } catch (error) {
+      await this.#handleFailure(
+        session,
+        attempt,
+        this.#normalizeFailure(error as Error),
+      );
+    }
+  }
+
+  async #completeIssue(issueNumber: number): Promise<void> {
+    await this.#tracker.completeIssue(issueNumber);
+    this.#state.pullRequestLifecycles.delete(issueNumber);
+    this.#state.retries.delete(issueNumber);
+    this.#state.nextAttemptByIssueNumber.delete(issueNumber);
+    this.#logger.info("Issue completed", { issueNumber });
+  }
+
+  async #cleanupWorkspaceIfNeeded(
+    workspace: RunSession["workspace"],
+    issueNumber: number,
+  ): Promise<void> {
+    if (!this.#config.workspace.cleanupOnSuccess) {
+      return;
+    }
+
+    try {
+      await this.#workspaceManager.cleanupWorkspace(workspace);
+    } catch (error) {
+      this.#logger.error("Workspace cleanup failed", {
+        issueNumber,
+        workspacePath: workspace.path,
+        error: this.#normalizeFailure(error as Error),
+      });
+    }
+  }
+
+  async #refreshLifecycle(
+    issueNumber: number,
+    branchName: string,
+  ): Promise<PullRequestLifecycle> {
+    const lifecycle = await this.#tracker.inspectPullRequestLifecycle(
+      issueNumber,
+      branchName,
+    );
+    this.#state.pullRequestLifecycles.set(issueNumber, lifecycle);
+    return lifecycle;
   }
 
   #createRunSession(
@@ -235,6 +359,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         sequence: attempt,
       },
     };
+  }
+
+  #branchName(issueNumber: number): string {
+    return `${this.#config.workspace.branchPrefix}${issueNumber.toString()}`;
   }
 
   async #handleFailure(
@@ -288,8 +416,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     attempt: number,
     message: string,
   ): Promise<void> {
+    this.#state.pullRequestLifecycles.delete(issue.number);
     if (attempt < this.#config.polling.retry.maxAttempts) {
-      await this.#tracker.releaseIssue(issue.number, message);
+      await this.#tracker.recordRetry(issue.number, message);
+      this.#state.nextAttemptByIssueNumber.set(issue.number, attempt + 1);
       this.#state.retries.set(issue.number, {
         issue,
         nextAttempt: attempt + 1,
@@ -298,6 +428,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       });
       return;
     }
+    this.#state.retries.delete(issue.number);
+    this.#state.nextAttemptByIssueNumber.delete(issue.number);
     await this.#tracker.markIssueFailed(issue.number, message);
   }
 

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,13 +1,18 @@
+import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
   readonly retries: Map<number, RetryState>;
+  readonly nextAttemptByIssueNumber: Map<number, number>;
+  readonly pullRequestLifecycles: Map<number, PullRequestLifecycle>;
 }
 
 export function createOrchestratorState(): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
     retries: new Map<number, RetryState>(),
+    nextAttemptByIssueNumber: new Map<number, number>(),
+    pullRequestLifecycles: new Map<number, PullRequestLifecycle>(),
   };
 }

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -2,7 +2,12 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { TrackerError } from "../domain/errors.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { RunResult, RunSession } from "../domain/run.js";
+import type {
+  PullRequestCheck,
+  PullRequestLifecycle,
+  PullRequestCheckStatus,
+  ReviewFeedback,
+} from "../domain/pull-request.js";
 import type { TrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { Tracker } from "./service.js";
@@ -25,11 +30,137 @@ interface GitHubLabelResponse {
 }
 
 interface GitHubPullRequestResponse {
+  readonly number: number;
   readonly html_url: string;
   readonly head: {
     readonly ref: string;
   };
 }
+
+interface GitHubCheckRunsResponse {
+  readonly check_runs: ReadonlyArray<{
+    readonly name: string;
+    readonly status: string;
+    readonly conclusion: string | null;
+    readonly details_url: string | null;
+  }>;
+}
+
+interface GitHubCommitStatusResponse {
+  readonly statuses: ReadonlyArray<{
+    readonly context: string;
+    readonly state: string;
+    readonly target_url: string | null;
+  }>;
+}
+
+interface GraphQlResponse<T> {
+  readonly data?: T;
+  readonly errors?: ReadonlyArray<{ readonly message: string }>;
+}
+
+interface PullRequestReviewStateResponse {
+  readonly repository: {
+    readonly pullRequest: {
+      readonly commits: {
+        readonly nodes: ReadonlyArray<{
+          readonly commit: {
+            readonly committedDate: string;
+          };
+        }>;
+      };
+      readonly comments: {
+        readonly nodes: ReadonlyArray<{
+          readonly id: string;
+          readonly body: string;
+          readonly createdAt: string;
+          readonly url: string;
+          readonly author: {
+            readonly login: string;
+          } | null;
+        }>;
+      };
+      readonly reviewThreads: {
+        readonly nodes: ReadonlyArray<{
+          readonly id: string;
+          readonly isResolved: boolean;
+          readonly isOutdated: boolean;
+          readonly comments: {
+            readonly nodes: ReadonlyArray<{
+              readonly id: string;
+              readonly body: string;
+              readonly createdAt: string;
+              readonly url: string;
+              readonly path: string | null;
+              readonly line: number | null;
+              readonly author: {
+                readonly login: string;
+              } | null;
+            }>;
+          };
+        }>;
+      };
+    } | null;
+  } | null;
+}
+
+const PULL_REQUEST_REVIEW_STATE_QUERY = `
+  query PullRequestReviewState($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        commits(last: 1) {
+          nodes {
+            commit {
+              committedDate
+            }
+          }
+        }
+        comments(last: 50) {
+          nodes {
+            id
+            body
+            createdAt
+            url
+            author {
+              login
+            }
+          }
+        }
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(last: 20) {
+              nodes {
+                id
+                body
+                createdAt
+                url
+                path
+                line
+                author {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const RESOLVE_REVIEW_THREAD_MUTATION = `
+  mutation ResolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread {
+        id
+        isResolved
+      }
+    }
+  }
+`;
 
 function toRuntimeIssue(
   issue: GitHubIssueResponse,
@@ -46,6 +177,52 @@ function toRuntimeIssue(
     url: issue.html_url,
     createdAt: issue.created_at,
     updatedAt: issue.updated_at,
+  };
+}
+
+function isAfter(left: string, right: string | null): boolean {
+  if (right === null) {
+    return true;
+  }
+  return Date.parse(left) > Date.parse(right);
+}
+
+function normalizeCheckStatus(
+  status: string,
+  conclusion: string | null,
+): {
+  readonly status: PullRequestCheckStatus;
+  readonly conclusion: string | null;
+} {
+  const normalizedStatus = status.toLowerCase();
+  if (
+    normalizedStatus === "queued" ||
+    normalizedStatus === "in_progress" ||
+    normalizedStatus === "pending" ||
+    normalizedStatus === "expected"
+  ) {
+    return {
+      status: "pending",
+      conclusion,
+    };
+  }
+
+  const normalizedConclusion = conclusion?.toLowerCase() ?? null;
+  if (
+    normalizedStatus === "success" ||
+    normalizedConclusion === "success" ||
+    normalizedConclusion === "neutral" ||
+    normalizedConclusion === "skipped"
+  ) {
+    return {
+      status: "success",
+      conclusion: normalizedConclusion,
+    };
+  }
+
+  return {
+    status: "failure",
+    conclusion: normalizedConclusion ?? normalizedStatus,
   };
 }
 
@@ -75,12 +252,20 @@ export class GitHubBootstrapTracker implements Tracker {
   readonly #config: TrackerConfig;
   readonly #logger: Logger;
   readonly #tokenPromise: Promise<string>;
+  readonly #repoOwner: string;
+  readonly #repoName: string;
   #ensureLabelsPromise: Promise<void> | null = null;
 
   constructor(config: TrackerConfig, logger: Logger) {
     this.#config = config;
     this.#logger = logger;
     this.#tokenPromise = resolveToken();
+    const [repoOwner, repoName] = config.repo.split("/");
+    if (!repoOwner || !repoName) {
+      throw new TrackerError(`Invalid tracker.repo value: ${config.repo}`);
+    }
+    this.#repoOwner = repoOwner;
+    this.#repoName = repoName;
   }
 
   async ensureLabels(): Promise<void> {
@@ -93,14 +278,12 @@ export class GitHubBootstrapTracker implements Tracker {
     await this.#ensureLabelsPromise;
   }
 
-  async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {
-    const issues = await this.#request<GitHubIssueResponse[]>(
-      "GET",
-      this.#issuePath(
-        `issues?state=open&labels=${encodeURIComponent(this.#config.readyLabel)}`,
-      ),
-    );
-    return issues.map((issue) => toRuntimeIssue(issue, this.#config.repo));
+  async fetchReadyIssues(): Promise<readonly RuntimeIssue[]> {
+    return await this.#fetchIssuesByLabel(this.#config.readyLabel);
+  }
+
+  async fetchRunningIssues(): Promise<readonly RuntimeIssue[]> {
+    return await this.#fetchIssuesByLabel(this.#config.runningLabel);
   }
 
   async getIssue(issueNumber: number): Promise<RuntimeIssue> {
@@ -132,17 +315,211 @@ export class GitHubBootstrapTracker implements Tracker {
     return updated;
   }
 
-  async completeRun(session: RunSession, _result: RunResult): Promise<void> {
-    const hasPullRequest = await this.#hasPullRequest(
-      session.workspace.branchName,
-    );
-    if (!hasPullRequest) {
-      throw new TrackerError(
-        `Runner exited successfully but no pull request was found for ${session.workspace.branchName}`,
-      );
+  async inspectPullRequestLifecycle(
+    issueNumber: number,
+    branchName: string,
+  ): Promise<PullRequestLifecycle> {
+    const pullRequest = await this.#findPullRequest(branchName);
+    if (pullRequest === null) {
+      return {
+        kind: "missing",
+        branchName,
+        pullRequest: null,
+        checks: [],
+        pendingCheckNames: [],
+        failingCheckNames: [],
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        summary: `No open pull request found for ${branchName}`,
+      };
     }
-    // Re-fetch before closing so we preserve labels added after the issue was claimed.
-    await this.#completeIssue(await this.getIssue(session.issue.number));
+
+    const [checks, reviewState] = await Promise.all([
+      this.#getChecks(branchName),
+      this.#getPullRequestReviewState(pullRequest.number),
+    ]);
+    const reviewStateData = reviewState!;
+
+    const latestCommitAt =
+      reviewStateData.commits.nodes[0]?.commit.committedDate ?? null;
+
+    const unresolvedThreads = reviewStateData.reviewThreads.nodes
+      .filter((thread) => !thread.isResolved && !thread.isOutdated)
+      .map((thread) => {
+        const comment = thread.comments.nodes.at(-1);
+        if (!comment) {
+          throw new TrackerError(
+            `Pull request review thread ${thread.id} had no comments`,
+          );
+        }
+        const feedback: ReviewFeedback = {
+          id: comment.id,
+          kind: "review-thread",
+          threadId: thread.id,
+          authorLogin: comment.author?.login ?? null,
+          body: comment.body,
+          createdAt: comment.createdAt,
+          url: comment.url,
+          path: comment.path,
+          line: comment.line,
+        };
+        return feedback;
+      });
+
+    const reviewBotLogins = new Set(
+      this.#config.reviewBotLogins.map((login) => login.toLowerCase()),
+    );
+    const actionableBotComments =
+      reviewBotLogins.size === 0
+        ? []
+        : reviewStateData.comments.nodes
+            .filter((comment) => {
+              const authorLogin = comment.author?.login;
+              if (!authorLogin) {
+                return false;
+              }
+              return reviewBotLogins.has(authorLogin.toLowerCase());
+            })
+            .filter((comment) => isAfter(comment.createdAt, latestCommitAt))
+            .map<ReviewFeedback>((comment) => ({
+              id: comment.id,
+              kind: "issue-comment",
+              threadId: null,
+              authorLogin: comment.author?.login ?? null,
+              body: comment.body,
+              createdAt: comment.createdAt,
+              url: comment.url,
+              path: null,
+              line: null,
+            }));
+
+    const actionableReviewFeedback = [
+      ...unresolvedThreads,
+      ...actionableBotComments,
+    ];
+    const pendingCheckNames = checks
+      .filter((check) => check.status === "pending")
+      .map((check) => check.name);
+    const failingCheckNames = checks
+      .filter((check) => check.status === "failure")
+      .map((check) => check.name);
+    const unresolvedThreadIds = unresolvedThreads
+      .map((feedback) => feedback.threadId)
+      .filter((threadId): threadId is string => threadId !== null);
+
+    if (failingCheckNames.length > 0 || actionableReviewFeedback.length > 0) {
+      return {
+        kind: "needs-follow-up",
+        branchName,
+        pullRequest: {
+          number: pullRequest.number,
+          url: pullRequest.html_url,
+          branchName: pullRequest.head.ref,
+          latestCommitAt,
+        },
+        checks,
+        pendingCheckNames,
+        failingCheckNames,
+        actionableReviewFeedback,
+        unresolvedThreadIds,
+        summary: this.#summarizeLifecycle(
+          pullRequest.html_url,
+          failingCheckNames,
+          pendingCheckNames,
+          actionableReviewFeedback,
+        ),
+      };
+    }
+
+    if (checks.length === 0 || pendingCheckNames.length > 0) {
+      return {
+        kind: "awaiting-review",
+        branchName,
+        pullRequest: {
+          number: pullRequest.number,
+          url: pullRequest.html_url,
+          branchName: pullRequest.head.ref,
+          latestCommitAt,
+        },
+        checks,
+        pendingCheckNames,
+        failingCheckNames,
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        summary:
+          checks.length === 0
+            ? `Waiting for PR checks to appear on ${pullRequest.html_url}`
+            : `Waiting for ${pendingCheckNames.join(", ")} on ${pullRequest.html_url}`,
+      };
+    }
+
+    return {
+      kind: "ready",
+      branchName,
+      pullRequest: {
+        number: pullRequest.number,
+        url: pullRequest.html_url,
+        branchName: pullRequest.head.ref,
+        latestCommitAt,
+      },
+      checks,
+      pendingCheckNames,
+      failingCheckNames,
+      actionableReviewFeedback: [],
+      unresolvedThreadIds: [],
+      summary: `Pull request ${pullRequest.html_url} is merge-ready`,
+    };
+  }
+
+  async resolveReviewThreads(threadIds: readonly string[]): Promise<void> {
+    for (const threadId of threadIds) {
+      await this.#graphqlRequest(RESOLVE_REVIEW_THREAD_MUTATION, { threadId });
+    }
+  }
+
+  async recordRetry(issueNumber: number, reason: string): Promise<void> {
+    const issue = await this.getIssue(issueNumber);
+    const nextLabels = issue.labels.filter(
+      (label) =>
+        label !== this.#config.readyLabel && label !== this.#config.failedLabel,
+    );
+    if (!nextLabels.includes(this.#config.runningLabel)) {
+      nextLabels.push(this.#config.runningLabel);
+    }
+    await this.#updateIssue(issueNumber, { labels: nextLabels });
+    await this.#createComment(
+      issueNumber,
+      `Retry scheduled by Symphony: ${reason}`,
+    );
+  }
+
+  async completeIssue(issueNumber: number): Promise<void> {
+    await this.#completeIssue(await this.getIssue(issueNumber));
+  }
+
+  async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
+    const issue = await this.getIssue(issueNumber);
+    const nextLabels = issue.labels.filter(
+      (label) =>
+        label !== this.#config.runningLabel &&
+        label !== this.#config.readyLabel,
+    );
+    if (!nextLabels.includes(this.#config.failedLabel)) {
+      nextLabels.push(this.#config.failedLabel);
+    }
+    await this.#updateIssue(issueNumber, { labels: nextLabels });
+    await this.#createComment(
+      issueNumber,
+      `Symphony failed this run: ${reason}`,
+    );
+  }
+
+  async #fetchIssuesByLabel(label: string): Promise<readonly RuntimeIssue[]> {
+    const issues = await this.#request<GitHubIssueResponse[]>(
+      "GET",
+      this.#issuePath(`issues?state=open&labels=${encodeURIComponent(label)}`),
+    );
+    return issues.map((issue) => toRuntimeIssue(issue, this.#config.repo));
   }
 
   async #doEnsureLabels(): Promise<void> {
@@ -163,49 +540,96 @@ export class GitHubBootstrapTracker implements Tracker {
     );
   }
 
-  async #hasPullRequest(headBranch: string): Promise<boolean> {
-    const [owner] = this.#config.repo.split("/");
+  async #findPullRequest(
+    headBranch: string,
+  ): Promise<GitHubPullRequestResponse | null> {
     const pulls = await this.#request<GitHubPullRequestResponse[]>(
       "GET",
       this.#issuePath(
-        `pulls?state=all&head=${encodeURIComponent(`${owner}:${headBranch}`)}`,
+        `pulls?state=open&head=${encodeURIComponent(`${this.#repoOwner}:${headBranch}`)}`,
       ),
     );
-    return pulls.some((pull) => pull.head.ref === headBranch);
+    return pulls.find((pull) => pull.head.ref === headBranch) ?? null;
   }
 
-  async releaseIssue(issueNumber: number, reason: string): Promise<void> {
-    const issue = await this.getIssue(issueNumber);
-    const nextLabels = issue.labels.filter(
-      (label) =>
-        label !== this.#config.runningLabel &&
-        label !== this.#config.failedLabel,
-    );
-    if (!nextLabels.includes(this.#config.readyLabel)) {
-      nextLabels.push(this.#config.readyLabel);
+  async #getChecks(branchName: string): Promise<readonly PullRequestCheck[]> {
+    const [checkRuns, statuses] = await Promise.all([
+      this.#request<GitHubCheckRunsResponse>(
+        "GET",
+        this.#issuePath(`commits/${encodeURIComponent(branchName)}/check-runs`),
+      ),
+      this.#request<GitHubCommitStatusResponse>(
+        "GET",
+        this.#issuePath(`commits/${encodeURIComponent(branchName)}/status`),
+      ),
+    ]);
+
+    const checks: PullRequestCheck[] = checkRuns.check_runs.map((checkRun) => {
+      const normalized = normalizeCheckStatus(
+        checkRun.status,
+        checkRun.conclusion,
+      );
+      return {
+        name: checkRun.name,
+        status: normalized.status,
+        conclusion: normalized.conclusion,
+        detailsUrl: checkRun.details_url,
+      };
+    });
+
+    for (const status of statuses.statuses) {
+      const normalized = normalizeCheckStatus(status.state, status.state);
+      checks.push({
+        name: status.context,
+        status: normalized.status,
+        conclusion: normalized.conclusion,
+        detailsUrl: status.target_url,
+      });
     }
-    await this.#updateIssue(issueNumber, { labels: nextLabels });
-    await this.#createComment(
-      issueNumber,
-      `Retry scheduled by Symphony: ${reason}`,
-    );
+
+    return checks;
   }
 
-  async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
-    const issue = await this.getIssue(issueNumber);
-    const nextLabels = issue.labels.filter(
-      (label) =>
-        label !== this.#config.runningLabel &&
-        label !== this.#config.readyLabel,
+  async #getPullRequestReviewState(
+    number: number,
+  ): Promise<
+    NonNullable<PullRequestReviewStateResponse["repository"]>["pullRequest"]
+  > {
+    const response = await this.#graphqlRequest<PullRequestReviewStateResponse>(
+      PULL_REQUEST_REVIEW_STATE_QUERY,
+      {
+        owner: this.#repoOwner,
+        repo: this.#repoName,
+        number,
+      },
     );
-    if (!nextLabels.includes(this.#config.failedLabel)) {
-      nextLabels.push(this.#config.failedLabel);
+
+    const pullRequest = response.repository?.pullRequest;
+    if (!pullRequest) {
+      throw new TrackerError(`Pull request ${number} was not found in GraphQL`);
     }
-    await this.#updateIssue(issueNumber, { labels: nextLabels });
-    await this.#createComment(
-      issueNumber,
-      `Symphony failed this run: ${reason}`,
-    );
+    return pullRequest;
+  }
+
+  #summarizeLifecycle(
+    url: string,
+    failingCheckNames: readonly string[],
+    pendingCheckNames: readonly string[],
+    actionableReviewFeedback: readonly ReviewFeedback[],
+  ): string {
+    const parts: string[] = [`Follow-up required for ${url}`];
+    if (failingCheckNames.length > 0) {
+      parts.push(`failing checks: ${failingCheckNames.join(", ")}`);
+    }
+    if (pendingCheckNames.length > 0) {
+      parts.push(`pending checks: ${pendingCheckNames.join(", ")}`);
+    }
+    if (actionableReviewFeedback.length > 0) {
+      parts.push(
+        `actionable feedback: ${actionableReviewFeedback.length.toString()}`,
+      );
+    }
+    return parts.join("; ");
   }
 
   async #completeIssue(issue: RuntimeIssue): Promise<void> {
@@ -265,6 +689,43 @@ export class GitHubBootstrapTracker implements Tracker {
       body,
     );
     return toRuntimeIssue(issue, this.#config.repo);
+  }
+
+  async #graphqlRequest<T>(
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<T> {
+    const token = await this.#tokenPromise;
+    const response = await fetch(`${this.#config.apiUrl}/graphql`, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new TrackerError(
+        `GitHub GraphQL request failed with ${response.status}: ${text}`,
+      );
+    }
+
+    const payload = (await response.json()) as GraphQlResponse<T>;
+    if (payload.errors && payload.errors.length > 0) {
+      throw new TrackerError(
+        `GitHub GraphQL request failed: ${payload.errors
+          .map((error) => error.message)
+          .join("; ")}`,
+      );
+    }
+    if (!payload.data) {
+      throw new TrackerError("GitHub GraphQL request returned no data");
+    }
+    return payload.data;
   }
 
   async #request<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -1,12 +1,18 @@
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { RunResult, RunSession } from "../domain/run.js";
+import type { PullRequestLifecycle } from "../domain/pull-request.js";
 
 export interface Tracker {
   ensureLabels(): Promise<void>;
-  fetchEligibleIssues(): Promise<readonly RuntimeIssue[]>;
+  fetchReadyIssues(): Promise<readonly RuntimeIssue[]>;
+  fetchRunningIssues(): Promise<readonly RuntimeIssue[]>;
   getIssue(issueNumber: number): Promise<RuntimeIssue>;
   claimIssue(issueNumber: number): Promise<RuntimeIssue | null>;
-  completeRun(session: RunSession, result: RunResult): Promise<void>;
-  releaseIssue(issueNumber: number, reason: string): Promise<void>;
+  inspectPullRequestLifecycle(
+    issueNumber: number,
+    branchName: string,
+  ): Promise<PullRequestLifecycle>;
+  resolveReviewThreads(threadIds: readonly string[]): Promise<void>;
+  recordRetry(issueNumber: number, reason: string): Promise<void>;
+  completeIssue(issueNumber: number): Promise<void>;
   markIssueFailed(issueNumber: number, reason: string): Promise<void>;
 }

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -93,36 +93,31 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       branchName,
     );
 
-    if (hasBranch && hasRemoteTrackingBranch) {
-      this.#logger.info("Deleting existing remote issue branch", {
-        workspacePath,
-        branchName,
-        issueIdentifier: issue.identifier,
-      });
-      await execFileAsync("git", ["push", "origin", "--delete", branchName], {
+    if (hasRemoteTrackingBranch) {
+      await execFileAsync("git", ["checkout", "-B", branchName], {
         cwd: workspacePath,
       });
-      await execFileAsync("git", ["fetch", "origin", "--prune"], {
-        cwd: workspacePath,
-      });
-    }
-
-    await execFileAsync("git", ["checkout", "main"], { cwd: workspacePath });
-    await execFileAsync("git", ["reset", "--hard", "origin/main"], {
-      cwd: workspacePath,
-    });
-
-    if (hasBranch) {
-      await execFileAsync("git", ["checkout", branchName], {
-        cwd: workspacePath,
-      });
-      await execFileAsync("git", ["reset", "--hard", "origin/main"], {
+      await execFileAsync("git", ["reset", "--hard", `origin/${branchName}`], {
         cwd: workspacePath,
       });
     } else {
-      await execFileAsync("git", ["checkout", "-b", branchName], {
+      await execFileAsync("git", ["checkout", "main"], { cwd: workspacePath });
+      await execFileAsync("git", ["reset", "--hard", "origin/main"], {
         cwd: workspacePath,
       });
+
+      if (hasBranch) {
+        await execFileAsync("git", ["checkout", branchName], {
+          cwd: workspacePath,
+        });
+        await execFileAsync("git", ["reset", "--hard", "origin/main"], {
+          cwd: workspacePath,
+        });
+      } else {
+        await execFileAsync("git", ["checkout", "-b", branchName], {
+          cwd: workspacePath,
+        });
+      }
     }
 
     this.#logger.info("Workspace ready", {

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { runCli } from "../../src/cli/index.js";
 import {
   createPromptBuilder,
   loadWorkflow,
@@ -12,6 +11,7 @@ import { LocalRunner } from "../../src/runner/local.js";
 import { GitHubBootstrapTracker } from "../../src/tracker/github-bootstrap.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
 import {
+  countRemoteBranchCommits,
   createSeedRemote,
   createTempDir,
   readRemoteBranchFile,
@@ -40,6 +40,9 @@ tracker:
   running_label: symphony:running
   failed_label: symphony:failed
   success_comment: Symphony completed this issue successfully.
+  review_bot_logins:
+    - greptile[bot]
+    - bugbot[bot]
 polling:
   interval_ms: 5
   max_concurrent_runs: 1
@@ -62,13 +65,43 @@ agent:
 ---
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 Description: {{ issue.description }}
+{% if pull_request %}
+Pull request lifecycle: {{ pull_request.kind }}
+Pull request URL: {{ pull_request.pullRequest.url }}
+Pending checks: {{ pull_request.pendingCheckNames | join: ", " }}
+Failing checks: {{ pull_request.failingCheckNames | join: ", " }}
+Actionable feedback: {{ pull_request.actionableReviewFeedback | size }}
+{% endif %}
 `,
     "utf8",
   );
   return workflowPath;
 }
 
-describe("Phase 0 bootstrap factory", () => {
+async function createOrchestrator(
+  workflowPath: string,
+): Promise<BootstrapOrchestrator> {
+  const workflow = await loadWorkflow(workflowPath);
+  const logger = new JsonLogger();
+  const promptBuilder = createPromptBuilder(workflow);
+  const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
+  const workspace = new LocalWorkspaceManager(
+    workflow.config.workspace,
+    workflow.config.hooks.afterCreate,
+    logger,
+  );
+  const runner = new LocalRunner(workflow.config.agent, logger);
+  return new BootstrapOrchestrator(
+    workflow.config,
+    promptBuilder,
+    tracker,
+    workspace,
+    runner,
+    logger,
+  );
+}
+
+describe("Phase 1.2 PR lifecycle factory", () => {
   let server: MockGitHubServer;
   let tempDir: string;
   let remotePath: string;
@@ -95,7 +128,7 @@ describe("Phase 0 bootstrap factory", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  it("processes a real issue end-to-end with a fake GitHub API and fake agent", async () => {
+  it("keeps the issue running after PR open until checks become green", async () => {
     server.seedIssue({
       number: 1,
       title: "Implement Symphony",
@@ -109,23 +142,28 @@ describe("Phase 0 bootstrap factory", () => {
       apiUrl: server.baseUrl,
       agentCommand: path.resolve("tests/fixtures/fake-agent-success.sh"),
     });
+    const orchestrator = await createOrchestrator(workflowPath);
 
-    await runCli([
-      "node",
-      "symphony",
-      "run",
-      "--once",
-      "--workflow",
-      workflowPath,
+    await orchestrator.runOnce();
+
+    let issue = server.getIssue(1);
+    expect(issue.state).toBe("open");
+    expect(issue.labels.map((label) => label.name)).toContain(
+      "symphony:running",
+    );
+    expect(server.getPullRequests()).toHaveLength(1);
+
+    server.setPullRequestCheckRuns("symphony/1", [
+      { name: "CI", status: "completed", conclusion: "success" },
     ]);
 
-    const issue = server.getIssue(1);
+    await orchestrator.runOnce();
+
+    issue = server.getIssue(1);
     expect(issue.state).toBe("closed");
     expect(issue.comments).toContain(
       "Symphony completed this issue successfully.",
     );
-    expect(server.getPullRequests()).toHaveLength(1);
-    expect(server.getPullRequests()[0]?.head).toBe("symphony/1");
 
     const implemented = await readRemoteBranchFile(
       remotePath,
@@ -135,11 +173,11 @@ describe("Phase 0 bootstrap factory", () => {
     expect(implemented).toContain("sociotechnica-org/symphony-ts#1");
   });
 
-  it("retries a failed run and succeeds on the next attempt", async () => {
+  it("reruns the same PR branch after CI failure and closes only after the rerun goes green", async () => {
     server.seedIssue({
       number: 2,
-      title: "Retry this",
-      body: "Needs one retry",
+      title: "Retry CI failures",
+      body: "Carry the PR through CI",
       labels: ["symphony:ready"],
     });
 
@@ -147,56 +185,44 @@ describe("Phase 0 bootstrap factory", () => {
       rootDir: tempDir,
       remotePath,
       apiUrl: server.baseUrl,
-      agentCommand: path.resolve("tests/fixtures/fake-agent-flaky.sh"),
-      retryBackoffMs: 0,
-      maxAttempts: 2,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-pr-follow-up.sh"),
     });
-
-    const workflow = await loadWorkflow(workflowPath);
-    const logger = new JsonLogger();
-    const promptBuilder = createPromptBuilder(workflow);
-    const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
-    const workspace = new LocalWorkspaceManager(
-      workflow.config.workspace,
-      workflow.config.hooks.afterCreate,
-      logger,
-    );
-    const runner = new LocalRunner(workflow.config.agent, logger);
-    const orchestrator = new BootstrapOrchestrator(
-      workflow.config,
-      promptBuilder,
-      tracker,
-      workspace,
-      runner,
-      logger,
-    );
+    const orchestrator = await createOrchestrator(workflowPath);
 
     await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/2", [
+      { name: "CI", status: "completed", conclusion: "failure" },
+    ]);
+
+    await orchestrator.runOnce();
+
     let issue = server.getIssue(2);
     expect(issue.state).toBe("open");
-    expect(
-      issue.comments.some((comment) =>
-        comment.includes("Retry scheduled by Symphony"),
-      ),
-    ).toBe(true);
-
-    await orchestrator.runOnce();
-    issue = server.getIssue(2);
-    expect(issue.state).toBe("closed");
     expect(server.getPullRequests()).toHaveLength(1);
-    const implemented = await readRemoteBranchFile(
+
+    const secondAttempt = await readRemoteBranchFile(
       remotePath,
       "symphony/2",
       "IMPLEMENTED.txt",
     );
-    expect(implemented).toContain("attempt 2");
+    expect(secondAttempt).toContain("attempt 2");
+    expect(await countRemoteBranchCommits(remotePath, "symphony/2")).toBe(2);
+
+    server.setPullRequestCheckRuns("symphony/2", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+
+    await orchestrator.runOnce();
+
+    issue = server.getIssue(2);
+    expect(issue.state).toBe("closed");
   });
 
-  it("retries successfully after a prior attempt pushed the branch without opening a PR", async () => {
+  it("resolves actionable review feedback after a follow-up push and waits for the PR to become clean", async () => {
     server.seedIssue({
       number: 3,
-      title: "Retry after pushed branch",
-      body: "First attempt pushes but forgets the PR",
+      title: "Handle review feedback",
+      body: "Address bot comments on the open PR",
       labels: ["symphony:ready"],
     });
 
@@ -204,50 +230,30 @@ describe("Phase 0 bootstrap factory", () => {
       rootDir: tempDir,
       remotePath,
       apiUrl: server.baseUrl,
-      agentCommand: path.resolve(
-        "tests/fixtures/fake-agent-push-no-pr-then-succeed.sh",
-      ),
-      retryBackoffMs: 0,
-      maxAttempts: 2,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-pr-follow-up.sh"),
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/3", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    const threadId = server.addPullRequestReviewThread({
+      head: "symphony/3",
+      authorLogin: "greptile[bot]",
+      body: "Please tighten this implementation",
+      path: "src/tracker/github-bootstrap.ts",
+      line: 42,
+    });
+    server.addPullRequestComment({
+      head: "symphony/3",
+      authorLogin: "bugbot[bot]",
+      body: "There is still one more issue to fix",
     });
 
-    const workflow = await loadWorkflow(workflowPath);
-    const logger = new JsonLogger();
-    const promptBuilder = createPromptBuilder(workflow);
-    const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
-    const workspace = new LocalWorkspaceManager(
-      workflow.config.workspace,
-      workflow.config.hooks.afterCreate,
-      logger,
-    );
-    const runner = new LocalRunner(workflow.config.agent, logger);
-    const orchestrator = new BootstrapOrchestrator(
-      workflow.config,
-      promptBuilder,
-      tracker,
-      workspace,
-      runner,
-      logger,
-    );
-
     await orchestrator.runOnce();
 
-    let issue = server.getIssue(3);
-    expect(issue.state).toBe("open");
-    expect(server.getPullRequests()).toHaveLength(0);
-
-    const firstAttempt = await readRemoteBranchFile(
-      remotePath,
-      "symphony/3",
-      "IMPLEMENTED.txt",
-    );
-    expect(firstAttempt).toContain("attempt 1");
-
-    await orchestrator.runOnce();
-
-    issue = server.getIssue(3);
-    expect(issue.state).toBe("closed");
-    expect(server.getPullRequests()).toHaveLength(1);
+    expect(server.isReviewThreadResolved(threadId)).toBe(true);
 
     const secondAttempt = await readRemoteBranchFile(
       remotePath,
@@ -255,5 +261,15 @@ describe("Phase 0 bootstrap factory", () => {
       "IMPLEMENTED.txt",
     );
     expect(secondAttempt).toContain("attempt 2");
+    expect(await countRemoteBranchCommits(remotePath, "symphony/3")).toBe(2);
+
+    server.setPullRequestCheckRuns("symphony/3", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(3);
+    expect(issue.state).toBe("closed");
   });
 });

--- a/tests/fixtures/fake-agent-flaky.sh
+++ b/tests/fixtures/fake-agent-flaky.sh
@@ -24,6 +24,9 @@ echo "implemented after retry ${SYMPHONY_ISSUE_IDENTIFIER} attempt ${SYMPHONY_RU
 git add .agent-prompt.txt IMPLEMENTED.txt "$STATE_FILE"
 git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} after retry"
 git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
+  -H 'content-type: application/json' \
+  -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
 
 gh pr create \
   --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \

--- a/tests/fixtures/fake-agent-pr-follow-up.sh
+++ b/tests/fixtures/fake-agent-pr-follow-up.sh
@@ -15,12 +15,10 @@ curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
   -H 'content-type: application/json' \
   -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
 
-if [[ "${SYMPHONY_RUN_ATTEMPT}" -lt 2 ]]; then
-  exit 0
+if [[ "${SYMPHONY_RUN_ATTEMPT}" -eq 1 ]]; then
+  gh pr create \
+    --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
+    --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER}" \
+    --base main \
+    --head "${SYMPHONY_BRANCH_NAME}"
 fi
-
-gh pr create \
-  --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
-  --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER}" \
-  --base main \
-  --head "${SYMPHONY_BRANCH_NAME}"

--- a/tests/fixtures/fake-agent-success.sh
+++ b/tests/fixtures/fake-agent-success.sh
@@ -11,6 +11,9 @@ echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER}" > IMPLEMENTED.txt
 git add .agent-prompt.txt IMPLEMENTED.txt
 git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER}"
 git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
+  -H 'content-type: application/json' \
+  -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
 
 gh pr create \
   --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -1,10 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { RunResult, RunSession } from "../../src/domain/run.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { GitHubBootstrapTracker } from "../../src/tracker/github-bootstrap.js";
 import { MockGitHubServer } from "../support/mock-github-server.js";
 
 const logger = new JsonLogger();
+
+function createTracker(server: MockGitHubServer): GitHubBootstrapTracker {
+  return new GitHubBootstrapTracker(
+    {
+      kind: "github-bootstrap",
+      repo: "sociotechnica-org/symphony-ts",
+      apiUrl: server.baseUrl,
+      readyLabel: "symphony:ready",
+      runningLabel: "symphony:running",
+      failedLabel: "symphony:failed",
+      successComment: "done",
+      reviewBotLogins: ["greptile[bot]", "bugbot[bot]"],
+    },
+    logger,
+  );
+}
 
 describe("GitHubBootstrapTracker", () => {
   let server: MockGitHubServer;
@@ -31,142 +46,138 @@ describe("GitHubBootstrapTracker", () => {
     await server.stop();
   });
 
-  it("claims, releases, and completes issues through the GitHub API", async () => {
-    const tracker = new GitHubBootstrapTracker(
-      {
-        kind: "github-bootstrap",
-        repo: "sociotechnica-org/symphony-ts",
-        apiUrl: server.baseUrl,
-        readyLabel: "symphony:ready",
-        runningLabel: "symphony:running",
-        failedLabel: "symphony:failed",
-        successComment: "done",
-      },
-      logger,
-    );
+  it("claims issues, keeps retries in running state, and only closes when the PR is ready", async () => {
+    const tracker = createTracker(server);
 
     await tracker.ensureLabels();
-    const eligible = await tracker.fetchEligibleIssues();
-    expect(eligible).toHaveLength(1);
+    const ready = await tracker.fetchReadyIssues();
+    expect(ready).toHaveLength(1);
+    expect(await tracker.fetchRunningIssues()).toHaveLength(0);
 
     const claimed = await tracker.claimIssue(7);
     expect(claimed?.labels).toContain("symphony:running");
+    expect(await tracker.fetchReadyIssues()).toHaveLength(0);
+    expect(await tracker.fetchRunningIssues()).toHaveLength(1);
 
-    await tracker.releaseIssue(7, "retry later");
+    await tracker.recordRetry(7, "retry later");
     expect(server.getIssue(7).labels.map((label) => label.name)).toContain(
-      "symphony:ready",
+      "symphony:running",
+    );
+    expect(server.getIssue(7).comments).toContain(
+      "Retry scheduled by Symphony: retry later",
     );
 
-    const runSession: RunSession = {
-      id: "sociotechnica-org/symphony-ts#7/attempt-1",
-      issue: (await tracker.claimIssue(7))!,
-      workspace: {
-        key: "sociotechnica-org_symphony-ts_7",
-        path: "/tmp/workspaces/7",
-        branchName: "symphony/7",
-        createdNow: true,
-      },
-      prompt: "prompt",
-      attempt: {
-        sequence: 1,
-      },
-    };
-    const runResult: RunResult = {
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-    };
     await server.recordPullRequest({
       title: "PR for issue 7",
       body: "",
       head: "symphony/7",
       base: "main",
     });
-    await tracker.completeRun(runSession, runResult);
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+
+    expect(
+      (await tracker.inspectPullRequestLifecycle(7, "symphony/7")).kind,
+    ).toBe("ready");
+
+    await tracker.completeIssue(7);
     const issue = server.getIssue(7);
     expect(issue.state).toBe("closed");
     expect(issue.comments).toContain("done");
   });
 
-  it("fails completion when no pull request exists for the run branch", async () => {
-    const tracker = new GitHubBootstrapTracker(
-      {
-        kind: "github-bootstrap",
-        repo: "sociotechnica-org/symphony-ts",
-        apiUrl: server.baseUrl,
-        readyLabel: "symphony:ready",
-        runningLabel: "symphony:running",
-        failedLabel: "symphony:failed",
-        successComment: "done",
-      },
-      logger,
+  it("reports a missing lifecycle when no PR exists for the branch", async () => {
+    const tracker = createTracker(server);
+    const lifecycle = await tracker.inspectPullRequestLifecycle(
+      7,
+      "symphony/7",
     );
 
-    const claimed = (await tracker.claimIssue(7))!;
-
-    await expect(
-      tracker.completeRun(
-        {
-          id: "sociotechnica-org/symphony-ts#7/attempt-1",
-          issue: claimed,
-          workspace: {
-            key: "sociotechnica-org_symphony-ts_7",
-            path: "/tmp/workspaces/7",
-            branchName: "symphony/7",
-            createdNow: true,
-          },
-          prompt: "prompt",
-          attempt: {
-            sequence: 1,
-          },
-        },
-        {
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          startedAt: new Date().toISOString(),
-          finishedAt: new Date().toISOString(),
-        },
-      ),
-    ).rejects.toThrow(/no pull request/i);
+    expect(lifecycle.kind).toBe("missing");
+    expect(lifecycle.summary).toMatch(/no open pull request/i);
   });
 
-  it("ensures labels only once across concurrent calls", async () => {
-    const tracker = new GitHubBootstrapTracker(
-      {
-        kind: "github-bootstrap",
-        repo: "sociotechnica-org/symphony-ts",
-        apiUrl: server.baseUrl,
-        readyLabel: "symphony:ready",
-        runningLabel: "symphony:running",
-        failedLabel: "symphony:failed",
-        successComment: "done",
-      },
-      logger,
+  it("reports awaiting-review while checks are pending", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "in_progress" },
+    ]);
+
+    const lifecycle = await tracker.inspectPullRequestLifecycle(
+      7,
+      "symphony/7",
     );
 
-    await Promise.all([tracker.ensureLabels(), tracker.ensureLabels()]);
+    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.pendingCheckNames).toEqual(["CI"]);
+  });
 
-    expect(server.countRequests("POST labels")).toBe(3);
+  it("detects actionable review feedback and resolves addressed review threads", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "failure" },
+    ]);
+    const threadId = server.addPullRequestReviewThread({
+      head: "symphony/7",
+      authorLogin: "greptile[bot]",
+      body: "Please fix this",
+      path: "src/index.ts",
+      line: 12,
+    });
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "bugbot[bot]",
+      body: "Another actionable issue",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    const lifecycle = await tracker.inspectPullRequestLifecycle(
+      7,
+      "symphony/7",
+    );
+
+    expect(lifecycle.kind).toBe("needs-follow-up");
+    expect(lifecycle.failingCheckNames).toEqual(["CI"]);
+    expect(lifecycle.unresolvedThreadIds).toEqual([threadId]);
+    expect(lifecycle.actionableReviewFeedback).toHaveLength(2);
+
+    await tracker.resolveReviewThreads(lifecycle.unresolvedThreadIds);
+    expect(server.isReviewThreadResolved(threadId)).toBe(true);
+
+    server.recordBranchPush(
+      "symphony/7",
+      new Date(Date.now() + 2_000).toISOString(),
+    );
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+
+    const refreshed = await tracker.inspectPullRequestLifecycle(
+      7,
+      "symphony/7",
+    );
+    expect(refreshed.kind).toBe("ready");
   });
 
   it("preserves labels added after claim when completing an issue", async () => {
-    const tracker = new GitHubBootstrapTracker(
-      {
-        kind: "github-bootstrap",
-        repo: "sociotechnica-org/symphony-ts",
-        apiUrl: server.baseUrl,
-        readyLabel: "symphony:ready",
-        runningLabel: "symphony:running",
-        failedLabel: "symphony:failed",
-        successComment: "done",
-      },
-      logger,
-    );
-
+    const tracker = createTracker(server);
     const claimed = (await tracker.claimIssue(7))!;
+
     server.setIssueLabels(7, [...claimed.labels, "external:keep"]);
     await server.recordPullRequest({
       title: "PR for issue 7",
@@ -174,30 +185,11 @@ describe("GitHubBootstrapTracker", () => {
       head: "symphony/7",
       base: "main",
     });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
 
-    await tracker.completeRun(
-      {
-        id: "sociotechnica-org/symphony-ts#7/attempt-1",
-        issue: claimed,
-        workspace: {
-          key: "sociotechnica-org_symphony-ts_7",
-          path: "/tmp/workspaces/7",
-          branchName: "symphony/7",
-          createdNow: true,
-        },
-        prompt: "prompt",
-        attempt: {
-          sequence: 1,
-        },
-      },
-      {
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-        startedAt: new Date().toISOString(),
-        finishedAt: new Date().toISOString(),
-      },
-    );
+    await tracker.completeIssue(7);
 
     expect(server.getIssue(7).labels.map((label) => label.name)).toContain(
       "external:keep",

--- a/tests/support/git.ts
+++ b/tests/support/git.ts
@@ -52,3 +52,18 @@ export async function readRemoteBranchFile(
   await execFileAsync("git", ["checkout", branchName], { cwd: checkoutDir });
   return await fs.readFile(path.join(checkoutDir, filePath), "utf8");
 }
+
+export async function countRemoteBranchCommits(
+  remotePath: string,
+  branchName: string,
+): Promise<number> {
+  const checkoutDir = await createTempDir("symphony-verify-");
+  await execFileAsync("git", ["clone", remotePath, checkoutDir]);
+  await execFileAsync("git", ["checkout", branchName], { cwd: checkoutDir });
+  const result = await execFileAsync(
+    "git",
+    ["rev-list", "--count", branchName, "^main"],
+    { cwd: checkoutDir },
+  );
+  return Number(result.stdout.trim());
+}

--- a/tests/support/git.ts
+++ b/tests/support/git.ts
@@ -62,7 +62,7 @@ export async function countRemoteBranchCommits(
   await execFileAsync("git", ["checkout", branchName], { cwd: checkoutDir });
   const result = await execFileAsync(
     "git",
-    ["rev-list", "--count", branchName, "^main"],
+    ["rev-list", "--count", branchName, "^origin/main"],
     { cwd: checkoutDir },
   );
   return Number(result.stdout.trim());

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -3,10 +3,55 @@ import { once } from "node:events";
 import { randomUUID } from "node:crypto";
 
 interface PullRequestRecord {
+  readonly number: number;
   readonly title: string;
   readonly body: string;
   readonly head: string;
   readonly base: string;
+  readonly html_url: string;
+  latestCommitAt: string | null;
+  readonly comments: MockPullRequestComment[];
+  readonly reviewThreads: MockReviewThread[];
+  checkRuns: MockCheckRun[];
+  statuses: MockCommitStatus[];
+}
+
+interface MockPullRequestComment {
+  readonly id: string;
+  readonly authorLogin: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+}
+
+interface MockReviewThread {
+  readonly id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  readonly comments: MockReviewComment[];
+}
+
+interface MockReviewComment {
+  readonly id: string;
+  readonly authorLogin: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+  readonly path: string | null;
+  readonly line: number | null;
+}
+
+interface MockCheckRun {
+  readonly name: string;
+  readonly status: string;
+  readonly conclusion: string | null;
+  readonly detailsUrl: string | null;
+}
+
+interface MockCommitStatus {
+  readonly context: string;
+  readonly state: string;
+  readonly targetUrl: string | null;
 }
 
 interface MockIssue {
@@ -50,10 +95,12 @@ async function readJson(request: IncomingMessage): Promise<unknown> {
 export class MockGitHubServer {
   readonly #issues = new Map<number, MockIssue>();
   readonly #labels = new Map<string, MockLabel>();
-  readonly #prs: PullRequestRecord[] = [];
+  readonly #prs = new Map<number, PullRequestRecord>();
   readonly #requestCounts = new Map<string, number>();
+  readonly #branchCommitTimes = new Map<string, string>();
   readonly #server = http.createServer(this.#handle.bind(this));
   #baseUrl = "";
+  #nextPrNumber = 1;
 
   async start(): Promise<void> {
     this.#server.listen(0, "127.0.0.1");
@@ -114,16 +161,169 @@ export class MockGitHubServer {
     issue.updated_at = new Date().toISOString();
   }
 
-  getPullRequests(): readonly PullRequestRecord[] {
-    return structuredClone(this.#prs);
+  getPullRequests(): ReadonlyArray<{
+    readonly title: string;
+    readonly body: string;
+    readonly head: string;
+    readonly base: string;
+  }> {
+    return [...this.#prs.values()].map((pullRequest) => ({
+      title: pullRequest.title,
+      body: pullRequest.body,
+      head: pullRequest.head,
+      base: pullRequest.base,
+    }));
+  }
+
+  getPullRequestByHead(head: string): PullRequestRecord {
+    const pullRequest = [...this.#prs.values()].find(
+      (entry) => entry.head === head,
+    );
+    if (!pullRequest) {
+      throw new Error(`Pull request for ${head} not found`);
+    }
+    return structuredClone(pullRequest);
   }
 
   countRequests(key: string): number {
     return this.#requestCounts.get(key) ?? 0;
   }
 
-  async recordPullRequest(pr: PullRequestRecord): Promise<void> {
-    this.#prs.push(pr);
+  async recordPullRequest(pr: {
+    title: string;
+    body: string;
+    head: string;
+    base: string;
+  }): Promise<void> {
+    const existing = [...this.#prs.values()].find(
+      (entry) => entry.head === pr.head,
+    );
+    if (existing) {
+      return;
+    }
+
+    const number = this.#nextPrNumber++;
+    const latestCommitAt =
+      this.#branchCommitTimes.get(pr.head) ?? new Date().toISOString();
+    this.#prs.set(number, {
+      number,
+      title: pr.title,
+      body: pr.body,
+      head: pr.head,
+      base: pr.base,
+      html_url: `${this.#baseUrl}/pulls/${number}`,
+      latestCommitAt,
+      comments: [],
+      reviewThreads: [],
+      checkRuns: [],
+      statuses: [],
+    });
+  }
+
+  recordBranchPush(head: string, committedAt = new Date().toISOString()): void {
+    this.#branchCommitTimes.set(head, committedAt);
+    const pullRequest = [...this.#prs.values()].find(
+      (entry) => entry.head === head,
+    );
+    if (pullRequest) {
+      pullRequest.latestCommitAt = committedAt;
+      pullRequest.checkRuns = pullRequest.checkRuns.map((checkRun) => ({
+        ...checkRun,
+        status: "in_progress",
+        conclusion: null,
+      }));
+      pullRequest.statuses = pullRequest.statuses.map((status) => ({
+        ...status,
+        state: "pending",
+      }));
+    }
+  }
+
+  setPullRequestCheckRuns(
+    head: string,
+    checkRuns: ReadonlyArray<{
+      name: string;
+      status: string;
+      conclusion?: string | null;
+      detailsUrl?: string | null;
+    }>,
+  ): void {
+    const pullRequest = this.#requirePullRequestByHead(head);
+    pullRequest.checkRuns = checkRuns.map((checkRun) => ({
+      name: checkRun.name,
+      status: checkRun.status,
+      conclusion: checkRun.conclusion ?? null,
+      detailsUrl: checkRun.detailsUrl ?? null,
+    }));
+  }
+
+  setPullRequestStatuses(
+    head: string,
+    statuses: ReadonlyArray<{
+      context: string;
+      state: string;
+      targetUrl?: string | null;
+    }>,
+  ): void {
+    const pullRequest = this.#requirePullRequestByHead(head);
+    pullRequest.statuses = statuses.map((status) => ({
+      context: status.context,
+      state: status.state,
+      targetUrl: status.targetUrl ?? null,
+    }));
+  }
+
+  addPullRequestComment(input: {
+    head: string;
+    authorLogin: string;
+    body: string;
+    createdAt?: string;
+  }): string {
+    const pullRequest = this.#requirePullRequestByHead(input.head);
+    const commentId = randomUUID();
+    pullRequest.comments.push({
+      id: commentId,
+      authorLogin: input.authorLogin,
+      body: input.body,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+      url: `${pullRequest.html_url}#issuecomment-${commentId}`,
+    });
+    return commentId;
+  }
+
+  addPullRequestReviewThread(input: {
+    head: string;
+    authorLogin: string;
+    body: string;
+    path?: string | null;
+    line?: number | null;
+    createdAt?: string;
+  }): string {
+    const pullRequest = this.#requirePullRequestByHead(input.head);
+    const threadId = randomUUID();
+    const commentId = randomUUID();
+    pullRequest.reviewThreads.push({
+      id: threadId,
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          id: commentId,
+          authorLogin: input.authorLogin,
+          body: input.body,
+          createdAt: input.createdAt ?? new Date().toISOString(),
+          url: `${pullRequest.html_url}#discussion_r${commentId}`,
+          path: input.path ?? null,
+          line: input.line ?? null,
+        },
+      ],
+    });
+    return threadId;
+  }
+
+  isReviewThreadResolved(threadId: string): boolean {
+    const thread = this.#findReviewThread(threadId);
+    return thread.isResolved;
   }
 
   async #handle(
@@ -134,9 +334,33 @@ export class MockGitHubServer {
     const method = request.method ?? "GET";
 
     if (method === "POST" && url.pathname === "/mock/prs") {
-      const body = (await readJson(request)) as PullRequestRecord;
-      this.#prs.push(body);
+      const body = (await readJson(request)) as {
+        title: string;
+        body: string;
+        head: string;
+        base: string;
+      };
+      await this.recordPullRequest(body);
       json(response, 201, { ok: true });
+      return;
+    }
+
+    if (method === "POST" && url.pathname === "/mock/branch-pushes") {
+      const body = (await readJson(request)) as {
+        head: string;
+        committed_at?: string;
+      };
+      this.recordBranchPush(body.head, body.committed_at);
+      json(response, 201, { ok: true });
+      return;
+    }
+
+    if (method === "POST" && url.pathname === "/graphql") {
+      const body = (await readJson(request)) as {
+        query: string;
+        variables: Record<string, unknown>;
+      };
+      await this.#handleGraphql(body, response);
       return;
     }
 
@@ -204,21 +428,55 @@ export class MockGitHubServer {
     if (method === "GET" && suffix === "pulls") {
       const head = url.searchParams.get("head");
       const state = url.searchParams.get("state") ?? "open";
-      const pulls = this.#prs
-        // The mock does not model PR lifecycle; stored PRs are treated as open.
+      const pulls = [...this.#prs.values()]
         .filter(() => state === "open" || state === "all")
         .filter((pull) =>
           head ? `${pathMatch[1]}:${pull.head}` === head : true,
         )
-        .map((pull, index) => ({
-          id: index + 1,
-          html_url: `${this.#baseUrl}/pulls/${index + 1}`,
+        .map((pull) => ({
+          number: pull.number,
+          html_url: pull.html_url,
           state: "open",
           head: {
             ref: pull.head,
           },
         }));
       json(response, 200, pulls);
+      return;
+    }
+
+    const checkRunsMatch = suffix.match(/^commits\/(.+)\/check-runs$/);
+    if (method === "GET" && checkRunsMatch) {
+      const head = decodeURIComponent(checkRunsMatch[1] ?? "");
+      const pullRequest = this.#requirePullRequestByHead(head);
+      json(response, 200, {
+        total_count: pullRequest.checkRuns.length,
+        check_runs: pullRequest.checkRuns.map((checkRun) => ({
+          name: checkRun.name,
+          status: checkRun.status,
+          conclusion: checkRun.conclusion,
+          details_url: checkRun.detailsUrl,
+        })),
+      });
+      return;
+    }
+
+    const statusMatch = suffix.match(/^commits\/(.+)\/status$/);
+    if (method === "GET" && statusMatch) {
+      const head = decodeURIComponent(statusMatch[1] ?? "");
+      const pullRequest = this.#requirePullRequestByHead(head);
+      json(response, 200, {
+        state: pullRequest.statuses.some((status) => status.state === "failure")
+          ? "failure"
+          : pullRequest.statuses.some((status) => status.state === "pending")
+            ? "pending"
+            : "success",
+        statuses: pullRequest.statuses.map((status) => ({
+          context: status.context,
+          state: status.state,
+          target_url: status.targetUrl,
+        })),
+      });
       return;
     }
 
@@ -267,5 +525,119 @@ export class MockGitHubServer {
     }
 
     json(response, 404, { message: "not found" });
+  }
+
+  async #handleGraphql(
+    body: { query: string; variables: Record<string, unknown> },
+    response: ServerResponse,
+  ): Promise<void> {
+    if (body.query.includes("PullRequestReviewState")) {
+      const number = Number(body.variables["number"]);
+      const pullRequest = this.#prs.get(number);
+      if (!pullRequest) {
+        json(response, 200, {
+          data: {
+            repository: {
+              pullRequest: null,
+            },
+          },
+        });
+        return;
+      }
+
+      json(response, 200, {
+        data: {
+          repository: {
+            pullRequest: {
+              commits: {
+                nodes:
+                  pullRequest.latestCommitAt === null
+                    ? []
+                    : [
+                        {
+                          commit: {
+                            committedDate: pullRequest.latestCommitAt,
+                          },
+                        },
+                      ],
+              },
+              comments: {
+                nodes: pullRequest.comments.map((comment) => ({
+                  id: comment.id,
+                  body: comment.body,
+                  createdAt: comment.createdAt,
+                  url: comment.url,
+                  author: {
+                    login: comment.authorLogin,
+                  },
+                })),
+              },
+              reviewThreads: {
+                nodes: pullRequest.reviewThreads.map((thread) => ({
+                  id: thread.id,
+                  isResolved: thread.isResolved,
+                  isOutdated: thread.isOutdated,
+                  comments: {
+                    nodes: thread.comments.map((comment) => ({
+                      id: comment.id,
+                      body: comment.body,
+                      createdAt: comment.createdAt,
+                      url: comment.url,
+                      path: comment.path,
+                      line: comment.line,
+                      author: {
+                        login: comment.authorLogin,
+                      },
+                    })),
+                  },
+                })),
+              },
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    if (body.query.includes("ResolveReviewThread")) {
+      const threadId = String(body.variables["threadId"]);
+      const thread = this.#findReviewThread(threadId);
+      thread.isResolved = true;
+      json(response, 200, {
+        data: {
+          resolveReviewThread: {
+            thread: {
+              id: thread.id,
+              isResolved: thread.isResolved,
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    json(response, 400, { errors: [{ message: "unsupported graphql query" }] });
+  }
+
+  #requirePullRequestByHead(head: string): PullRequestRecord {
+    const pullRequest = [...this.#prs.values()].find(
+      (entry) => entry.head === head,
+    );
+    if (!pullRequest) {
+      throw new Error(`Pull request for ${head} not found`);
+    }
+    return pullRequest;
+  }
+
+  #findReviewThread(threadId: string): MockReviewThread {
+    for (const pullRequest of this.#prs.values()) {
+      const thread = pullRequest.reviewThreads.find(
+        (entry) => entry.id === threadId,
+      );
+      if (thread) {
+        return thread;
+      }
+    }
+    throw new Error(`Review thread ${threadId} not found`);
   }
 }

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
+import type {
+  PullRequestLifecycle,
+  ReviewFeedback,
+} from "../../src/domain/pull-request.js";
 import type { RunResult, RunSession } from "../../src/domain/run.js";
 import type { PreparedWorkspace } from "../../src/domain/workspace.js";
 import type {
@@ -15,15 +19,12 @@ import type { WorkspaceManager } from "../../src/workspace/service.js";
 function createDeferred<T>(): {
   readonly promise: Promise<T>;
   resolve(value: T | PromiseLike<T>): void;
-  reject(reason?: unknown): void;
 } {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+  const promise = new Promise<T>((resolvePromise) => {
     resolve = resolvePromise;
-    reject = rejectPromise;
   });
-  return { promise, resolve, reject };
+  return { promise, resolve };
 }
 
 const baseConfig: ResolvedConfig = {
@@ -36,12 +37,13 @@ const baseConfig: ResolvedConfig = {
     runningLabel: "symphony:running",
     failedLabel: "symphony:failed",
     successComment: "done",
+    reviewBotLogins: ["greptile[bot]"],
   },
   polling: {
     intervalMs: 10,
     maxConcurrentRuns: 2,
     retry: {
-      maxAttempts: 1,
+      maxAttempts: 2,
       backoffMs: 0,
     },
   },
@@ -63,12 +65,16 @@ const baseConfig: ResolvedConfig = {
 };
 
 const staticPromptBuilder: PromptBuilder = {
-  async build({ issue }): Promise<string> {
-    return `Issue ${issue.identifier}`;
+  async build({ issue, attempt, pullRequest }): Promise<string> {
+    return JSON.stringify({
+      issue: issue.identifier,
+      attempt,
+      pullRequest: pullRequest?.kind ?? null,
+    });
   },
 };
 
-function createIssue(number: number): RuntimeIssue {
+function createIssue(number: number, label = "symphony:ready"): RuntimeIssue {
   const timestamp = new Date().toISOString();
   return {
     id: String(number),
@@ -76,11 +82,42 @@ function createIssue(number: number): RuntimeIssue {
     number,
     title: `Issue ${number}`,
     description: `Description ${number}`,
-    labels: ["symphony:ready"],
+    labels: [label],
     state: "open",
     url: `https://example.test/issues/${number}`,
     createdAt: timestamp,
     updatedAt: timestamp,
+  };
+}
+
+function lifecycle(
+  kind: PullRequestLifecycle["kind"],
+  branchName: string,
+  options?: {
+    failingCheckNames?: readonly string[];
+    pendingCheckNames?: readonly string[];
+    actionableReviewFeedback?: readonly ReviewFeedback[];
+    unresolvedThreadIds?: readonly string[];
+  },
+): PullRequestLifecycle {
+  return {
+    kind,
+    branchName,
+    pullRequest:
+      kind === "missing"
+        ? null
+        : {
+            number: 1,
+            url: `https://example.test/pulls/${branchName}`,
+            branchName,
+            latestCommitAt: new Date().toISOString(),
+          },
+    checks: [],
+    pendingCheckNames: options?.pendingCheckNames ?? [],
+    failingCheckNames: options?.failingCheckNames ?? [],
+    actionableReviewFeedback: options?.actionableReviewFeedback ?? [],
+    unresolvedThreadIds: options?.unresolvedThreadIds ?? [],
+    summary: `${kind} for ${branchName}`,
   };
 }
 
@@ -94,74 +131,117 @@ class NullLogger implements Logger {
   }
 }
 
-class CompletionLoggingFailingLogger extends NullLogger {
-  override info(message: string, _data?: Record<string, unknown>): void {
-    if (message === "Issue completed") {
-      throw new Error("logger failed");
+class SequencedTracker implements Tracker {
+  readonly readyIssues = new Map<number, RuntimeIssue>();
+  readonly runningIssues = new Map<number, RuntimeIssue>();
+  readonly lifecycleSequences = new Map<number, PullRequestLifecycle[]>();
+  readonly completed: number[] = [];
+  readonly retried: Array<{ issueNumber: number; reason: string }> = [];
+  readonly failed: Array<{ issueNumber: number; reason: string }> = [];
+  readonly resolvedThreadBatches: readonly string[][] = [];
+  ensureLabelsCalls = 0;
+
+  constructor(options: {
+    ready?: readonly RuntimeIssue[];
+    running?: readonly RuntimeIssue[];
+  }) {
+    for (const issue of options.ready ?? []) {
+      this.readyIssues.set(issue.number, issue);
+    }
+    for (const issue of options.running ?? []) {
+      this.runningIssues.set(issue.number, issue);
     }
   }
-}
 
-class StaticTracker implements Tracker {
-  readonly #issues: readonly RuntimeIssue[];
-  readonly completed: number[] = [];
-  readonly released: Array<{ issueNumber: number; reason: string }> = [];
-  readonly failed: Array<{ issueNumber: number; reason: string }> = [];
-  claimCalls = 0;
-
-  constructor(issues: readonly RuntimeIssue[]) {
-    this.#issues = issues;
+  setLifecycleSequence(
+    issueNumber: number,
+    sequence: readonly PullRequestLifecycle[],
+  ): void {
+    this.lifecycleSequences.set(issueNumber, [...sequence]);
   }
 
-  async ensureLabels(): Promise<void> {}
+  async ensureLabels(): Promise<void> {
+    this.ensureLabelsCalls += 1;
+  }
 
-  async fetchEligibleIssues(): Promise<readonly RuntimeIssue[]> {
-    return this.#issues;
+  async fetchReadyIssues(): Promise<readonly RuntimeIssue[]> {
+    return [...this.readyIssues.values()];
+  }
+
+  async fetchRunningIssues(): Promise<readonly RuntimeIssue[]> {
+    return [...this.runningIssues.values()];
   }
 
   async getIssue(issueNumber: number): Promise<RuntimeIssue> {
-    return this.#issues.find((issue) => issue.number === issueNumber)!;
+    return (this.readyIssues.get(issueNumber) ??
+      this.runningIssues.get(issueNumber))!;
   }
 
   async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
-    this.claimCalls += 1;
-    return await this.getIssue(issueNumber);
+    const issue = this.readyIssues.get(issueNumber);
+    if (!issue) {
+      return null;
+    }
+    this.readyIssues.delete(issueNumber);
+    const claimed = { ...issue, labels: ["symphony:running"] };
+    this.runningIssues.set(issueNumber, claimed);
+    return claimed;
   }
 
-  async completeRun(session: RunSession): Promise<void> {
-    this.completed.push(session.issue.number);
+  async inspectPullRequestLifecycle(
+    issueNumber: number,
+    _branchName: string,
+  ): Promise<PullRequestLifecycle> {
+    const sequence = this.lifecycleSequences.get(issueNumber);
+    if (!sequence || sequence.length === 0) {
+      throw new Error(`No lifecycle configured for issue ${issueNumber}`);
+    }
+    if (sequence.length === 1) {
+      return sequence[0]!;
+    }
+    return sequence.shift()!;
   }
 
-  async releaseIssue(issueNumber: number, reason: string): Promise<void> {
-    this.released.push({ issueNumber, reason });
+  async resolveReviewThreads(threadIds: readonly string[]): Promise<void> {
+    (this.resolvedThreadBatches as string[][]).push([...threadIds]);
+  }
+
+  async recordRetry(issueNumber: number, reason: string): Promise<void> {
+    this.retried.push({ issueNumber, reason });
+  }
+
+  async completeIssue(issueNumber: number): Promise<void> {
+    this.completed.push(issueNumber);
+    this.readyIssues.delete(issueNumber);
+    this.runningIssues.delete(issueNumber);
   }
 
   async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
     this.failed.push({ issueNumber, reason });
+    this.readyIssues.delete(issueNumber);
+    this.runningIssues.delete(issueNumber);
   }
 }
 
-class FlakyTracker extends StaticTracker {
-  attempts = 0;
-
+class FlakyTracker extends SequencedTracker {
   override async ensureLabels(): Promise<void> {
-    this.attempts += 1;
-    if (this.attempts === 1) {
+    await super.ensureLabels();
+    if (this.ensureLabelsCalls === 1) {
       throw new Error("transient label failure");
     }
   }
 }
 
-class ReleaseFailingTracker extends StaticTracker {
-  releaseAttempts = 0;
+class RetryRecordingFailingTracker extends SequencedTracker {
+  retryCalls = 0;
 
-  override async releaseIssue(
+  override async recordRetry(
     issueNumber: number,
     reason: string,
   ): Promise<void> {
-    this.releaseAttempts += 1;
-    await super.releaseIssue(issueNumber, reason);
-    throw new Error("release failed");
+    this.retryCalls += 1;
+    await super.recordRetry(issueNumber, reason);
+    throw new Error("retry bookkeeping failed");
   }
 }
 
@@ -228,9 +308,11 @@ class ConcurrencyRunner implements Runner {
 
 class RecordingRunner implements Runner {
   readonly sessionIds: string[] = [];
+  readonly attempts: number[] = [];
 
   async run(session: RunSession): Promise<RunResult> {
     this.sessionIds.push(session.id);
+    this.attempts.push(session.attempt.sequence);
     const timestamp = new Date().toISOString();
     return {
       exitCode: 0,
@@ -243,19 +325,28 @@ class RecordingRunner implements Runner {
 }
 
 describe("BootstrapOrchestrator", () => {
-  it("starts up to maxConcurrentRuns issues in parallel", async () => {
-    const tracker = new StaticTracker([
-      createIssue(1),
-      createIssue(2),
-      createIssue(3),
+  it("starts up to maxConcurrentRuns ready issues in parallel", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(1), createIssue(2), createIssue(3)],
+    });
+    tracker.setLifecycleSequence(1, [
+      lifecycle("missing", "symphony/1"),
+      lifecycle("ready", "symphony/1"),
     ]);
-    const workspace = new StaticWorkspaceManager();
+    tracker.setLifecycleSequence(2, [
+      lifecycle("missing", "symphony/2"),
+      lifecycle("ready", "symphony/2"),
+    ]);
+    tracker.setLifecycleSequence(3, [
+      lifecycle("missing", "symphony/3"),
+      lifecycle("ready", "symphony/3"),
+    ]);
     const runner = new ConcurrencyRunner();
     const orchestrator = new BootstrapOrchestrator(
       baseConfig,
       staticPromptBuilder,
       tracker,
-      workspace,
+      new StaticWorkspaceManager(),
       runner,
       new NullLogger(),
     );
@@ -273,22 +364,20 @@ describe("BootstrapOrchestrator", () => {
   });
 
   it("keeps polling after a transient poll-level failure", async () => {
-    const tracker = new FlakyTracker([createIssue(1)]);
-    const workspace = new StaticWorkspaceManager();
-    const runner = new RecordingRunner();
+    const tracker = new FlakyTracker({
+      ready: [createIssue(1)],
+    });
+    tracker.setLifecycleSequence(1, [
+      lifecycle("missing", "symphony/1"),
+      lifecycle("ready", "symphony/1"),
+    ]);
     const logger = new NullLogger();
     const orchestrator = new BootstrapOrchestrator(
-      {
-        ...baseConfig,
-        polling: {
-          ...baseConfig.polling,
-          intervalMs: 1,
-        },
-      },
+      { ...baseConfig, polling: { ...baseConfig.polling, intervalMs: 1 } },
       staticPromptBuilder,
       tracker,
-      workspace,
-      runner,
+      new StaticWorkspaceManager(),
+      new RecordingRunner(),
       logger,
     );
     const controller = new AbortController();
@@ -316,27 +405,68 @@ describe("BootstrapOrchestrator", () => {
 
     await loop;
 
-    expect(tracker.attempts).toBeGreaterThanOrEqual(2);
     expect(logger.errors).toContain("Poll cycle failed");
     expect(tracker.completed).toEqual([1]);
   });
 
-  it("does not retry or fail an issue after successful completion if cleanup fails", async () => {
-    const tracker = new StaticTracker([createIssue(1)]);
+  it("waits when a running PR only has pending checks", async () => {
+    const tracker = new SequencedTracker({
+      running: [createIssue(7, "symphony:running")],
+    });
+    tracker.setLifecycleSequence(7, [
+      lifecycle("awaiting-review", "symphony/7", {
+        pendingCheckNames: ["CI"],
+      }),
+    ]);
+    let runnerCalls = 0;
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        async run(): Promise<RunResult> {
+          runnerCalls += 1;
+          throw new Error("runner should not be called");
+        },
+      },
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(runnerCalls).toBe(0);
+    expect(tracker.completed).toEqual([]);
+    expect(tracker.retried).toEqual([]);
+  });
+
+  it("reruns a running PR when CI or review feedback is actionable and resolves review threads", async () => {
+    const tracker = new SequencedTracker({
+      running: [createIssue(8, "symphony:running")],
+    });
+    tracker.setLifecycleSequence(8, [
+      lifecycle("needs-follow-up", "symphony/8", {
+        failingCheckNames: ["CI"],
+        unresolvedThreadIds: ["thread-1"],
+        actionableReviewFeedback: [
+          {
+            id: "comment-1",
+            kind: "review-thread",
+            threadId: "thread-1",
+            authorLogin: "greptile[bot]",
+            body: "Fix this",
+            createdAt: new Date().toISOString(),
+            url: "https://example.test/thread/1",
+            path: "src/index.ts",
+            line: 10,
+          },
+        ],
+      }),
+      lifecycle("ready", "symphony/8"),
+    ]);
+    const runner = new RecordingRunner();
     const workspace = new CleanupFailingWorkspaceManager();
     const logger = new NullLogger();
-    const runner: Runner = {
-      async run(): Promise<RunResult> {
-        const timestamp = new Date().toISOString();
-        return {
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          startedAt: timestamp,
-          finishedAt: timestamp,
-        };
-      },
-    };
     const orchestrator = new BootstrapOrchestrator(
       {
         ...baseConfig,
@@ -354,16 +484,53 @@ describe("BootstrapOrchestrator", () => {
 
     await orchestrator.runOnce();
 
-    expect(tracker.completed).toEqual([1]);
-    expect(tracker.released).toEqual([]);
-    expect(tracker.failed).toEqual([]);
-    expect(workspace.cleaned).toEqual(["/tmp/workspaces/1"]);
+    expect(runner.attempts).toEqual([1]);
+    expect(tracker.resolvedThreadBatches).toEqual([["thread-1"]]);
+    expect(tracker.completed).toEqual([8]);
+    expect(workspace.cleaned).toEqual(["/tmp/workspaces/8"]);
     expect(logger.errors).toContain("Workspace cleanup failed");
   });
 
+  it("keeps the next run attempt when PR follow-up work appears after the initial PR open", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(9)],
+    });
+    tracker.setLifecycleSequence(9, [
+      lifecycle("missing", "symphony/9"),
+      lifecycle("awaiting-review", "symphony/9", {
+        pendingCheckNames: ["CI"],
+      }),
+      lifecycle("awaiting-review", "symphony/9", {
+        pendingCheckNames: ["CI"],
+      }),
+      lifecycle("needs-follow-up", "symphony/9", {
+        failingCheckNames: ["CI"],
+      }),
+      lifecycle("ready", "symphony/9"),
+    ]);
+    const runner = new RecordingRunner();
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      runner,
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    expect(runner.attempts).toEqual([1, 2]);
+    expect(tracker.completed).toEqual([9]);
+  });
+
   it("does not requeue a retrying issue before its backoff window expires", async () => {
-    const tracker = new StaticTracker([createIssue(1)]);
-    const workspace = new StaticWorkspaceManager();
+    const tracker = new SequencedTracker({
+      ready: [createIssue(10)],
+    });
+    tracker.setLifecycleSequence(10, [lifecycle("missing", "symphony/10")]);
     const runnerCalls: number[] = [];
     const runner: Runner = {
       async run(session): Promise<RunResult> {
@@ -391,7 +558,7 @@ describe("BootstrapOrchestrator", () => {
       },
       staticPromptBuilder,
       tracker,
-      workspace,
+      new StaticWorkspaceManager(),
       runner,
       new NullLogger(),
     );
@@ -400,62 +567,62 @@ describe("BootstrapOrchestrator", () => {
     await orchestrator.runOnce();
 
     expect(runnerCalls).toEqual([1]);
-    expect(tracker.claimCalls).toBe(1);
-    expect(tracker.released).toHaveLength(1);
+    expect(tracker.retried).toHaveLength(1);
     expect(tracker.failed).toEqual([]);
   });
 
-  it("does not invoke the unexpected failure path when retry scheduling fails", async () => {
-    const tracker = new ReleaseFailingTracker([createIssue(1)]);
-    const workspace = new StaticWorkspaceManager();
+  it("does not invoke the unexpected failure path when retry bookkeeping fails", async () => {
+    const tracker = new RetryRecordingFailingTracker({
+      ready: [createIssue(11)],
+    });
+    tracker.setLifecycleSequence(11, [lifecycle("missing", "symphony/11")]);
     const logger = new NullLogger();
-    const runner: Runner = {
-      async run(): Promise<RunResult> {
-        const timestamp = new Date().toISOString();
-        return {
-          exitCode: 17,
-          stdout: "",
-          stderr: "simulated failure",
-          startedAt: timestamp,
-          finishedAt: timestamp,
-        };
-      },
-    };
     const orchestrator = new BootstrapOrchestrator(
-      {
-        ...baseConfig,
-        polling: {
-          ...baseConfig.polling,
-          retry: {
-            maxAttempts: 2,
-            backoffMs: 0,
-          },
-        },
-      },
+      baseConfig,
       staticPromptBuilder,
       tracker,
-      workspace,
-      runner,
+      new StaticWorkspaceManager(),
+      {
+        async run(): Promise<RunResult> {
+          const timestamp = new Date().toISOString();
+          return {
+            exitCode: 17,
+            stdout: "",
+            stderr: "simulated failure",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      },
       logger,
     );
 
     await orchestrator.runOnce();
 
-    expect(tracker.releaseAttempts).toBe(1);
-    expect(tracker.released).toHaveLength(1);
-    expect(tracker.failed).toEqual([]);
+    expect(tracker.retryCalls).toBe(1);
+    expect(tracker.retried).toHaveLength(1);
     expect(logger.errors).toContain("Issue run failed");
     expect(logger.errors).toContain("Failure handling failed");
   });
 
   it("generates unique run session ids across orchestrator instances", async () => {
-    const issue = createIssue(1);
+    const issue = createIssue(12);
+    const firstTracker = new SequencedTracker({ ready: [issue] });
+    const secondTracker = new SequencedTracker({ ready: [issue] });
+    firstTracker.setLifecycleSequence(12, [
+      lifecycle("missing", "symphony/12"),
+      lifecycle("ready", "symphony/12"),
+    ]);
+    secondTracker.setLifecycleSequence(12, [
+      lifecycle("missing", "symphony/12"),
+      lifecycle("ready", "symphony/12"),
+    ]);
     const runner = new RecordingRunner();
 
     const first = new BootstrapOrchestrator(
       baseConfig,
       staticPromptBuilder,
-      new StaticTracker([issue]),
+      firstTracker,
       new StaticWorkspaceManager(),
       runner,
       new NullLogger(),
@@ -463,7 +630,7 @@ describe("BootstrapOrchestrator", () => {
     const second = new BootstrapOrchestrator(
       baseConfig,
       staticPromptBuilder,
-      new StaticTracker([issue]),
+      secondTracker,
       new StaticWorkspaceManager(),
       runner,
       new NullLogger(),
@@ -474,41 +641,11 @@ describe("BootstrapOrchestrator", () => {
 
     expect(runner.sessionIds).toHaveLength(2);
     expect(runner.sessionIds[0]).toMatch(
-      /^sociotechnica-org\/symphony-ts#1\/attempt-1-/,
+      /^sociotechnica-org\/symphony-ts#12\/attempt-1-/,
     );
     expect(runner.sessionIds[1]).toMatch(
-      /^sociotechnica-org\/symphony-ts#1\/attempt-1-/,
+      /^sociotechnica-org\/symphony-ts#12\/attempt-1-/,
     );
     expect(new Set(runner.sessionIds).size).toBe(2);
-  });
-
-  it("does not retry or fail an issue if completion logging throws", async () => {
-    const tracker = new StaticTracker([createIssue(1)]);
-    const workspace = new StaticWorkspaceManager();
-    const runner: Runner = {
-      async run(): Promise<RunResult> {
-        const timestamp = new Date().toISOString();
-        return {
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          startedAt: timestamp,
-          finishedAt: timestamp,
-        };
-      },
-    };
-    const orchestrator = new BootstrapOrchestrator(
-      baseConfig,
-      staticPromptBuilder,
-      tracker,
-      workspace,
-      runner,
-      new CompletionLoggingFailingLogger(),
-    );
-
-    await expect(orchestrator.runOnce()).resolves.toBeUndefined();
-    expect(tracker.completed).toEqual([1]);
-    expect(tracker.released).toEqual([]);
-    expect(tracker.failed).toEqual([]);
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -21,6 +21,8 @@ tracker:
   running_label: symphony:running
   failed_label: symphony:failed
   success_comment: done
+  review_bot_logins:
+    - greptile[bot]
 polling:
   interval_ms: 1000
   max_concurrent_runs: 1
@@ -65,6 +67,7 @@ Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
         updatedAt: "2026-01-01T00:00:00.000Z",
       },
       attempt: null,
+      pullRequest: null,
     });
     expect(rendered).toContain("repo#1");
     expect(rendered).toContain("sociotechnica-org/symphony-ts");


### PR DESCRIPTION
Closes #16\n\n## Summary\n- add explicit PR lifecycle modeling and GitHub tracker support for PR checks, review threads, and actionable bot feedback\n- keep running issues alive through CI/review, rerun the same branch when follow-up work is needed, and only complete when the PR is merge-ready\n- extend the mock GitHub harness and e2e coverage for PR-open, CI-fail, review-feedback, follow-up-push, and merge-ready paths\n\n## Validation\n- pnpm format:check\n- pnpm lint\n- pnpm typecheck\n- pnpm test