### PR TITLE
docs: add symphony planning skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,34 @@ src/workspace/  workspace lifecycle and hooks
 - Keep coordination infrastructure such as leases, lock recovery, and temp cleanup in focused modules rather than inline branches.
 - Prefer test builders and helpers over repeated ad hoc setup for snapshots, fixtures, temp roots, and cleanup.
 
+## Skills Policy
+
+`WORKFLOW.md`, `AGENTS.md`, and in-repo skills serve different roles.
+
+- `WORKFLOW.md` is the repository runtime contract. It should define the required worker process and completion behavior.
+- `AGENTS.md` is the repository engineering policy. It should define enduring design, testing, review, and architecture expectations.
+- skills are specialized guides for recurring kinds of work. They may add detailed method, but they should not be the only place where required correctness rules live.
+
+Use this rule of thumb:
+
+- if behavior is required for every worker run, put it in `WORKFLOW.md` or `AGENTS.md`
+- if guidance is specialized to a type of task, put it in a skill
+- if behavior is part of runtime correctness, put it in code and tests, not only in prompts
+
+For this repo, skills should stay small in number and high in leverage. Prefer checked-in skills that help Symphony build Symphony without making the repository depend on hidden prompt state.
+
+## Architecture Principles
+
+- Normalize external inputs at the boundary before orchestration logic uses them.
+- Separate transport, normalization, and policy whenever an adapter talks to an external system.
+- Make runtime state explicit when behavior depends on multiple counters, stages, or recovery paths.
+- Do not overload one counter to mean prompt sequence, retry budget, and follow-up budget at the same time.
+- Isolate coordination infrastructure such as leases, lock recovery, and durable runtime ownership into focused modules.
+- Prefer pure policy functions over inline branching when lifecycle or recovery decisions can be expressed over normalized internal state.
+- Use small test builders/helpers when repeated orchestration fixtures start to accumulate.
+
+When review feedback clusters repeatedly in the same files or around the same themes, treat that as a sign the decomposition is wrong. Prefer a structural refactor before continuing with more patch-on-patch fixes.
+
 ## Issue Workflow
 
 For any GitHub issue assigned for implementation:
@@ -125,6 +153,8 @@ Every PR should:
 3. and remain traceable back to the plan and issue discussion.
 
 Prefer smaller reviewable slices over oversized PRs when the work can be split without losing end-to-end integrity.
+
+For orchestration-heavy work, prefer splitting large changes into smaller PRs along stable architectural seams rather than combining tracker policy, orchestrator state, runner behavior, test harness changes, and docs into one review surface. Each PR should either complete one usable vertical slice or land inert, well-tested plumbing that reduces risk for the next slice.
 
 ## Related Bugs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,18 +81,6 @@ Use this rule of thumb:
 
 For this repo, skills should stay small in number and high in leverage. Prefer checked-in skills that help Symphony build Symphony without making the repository depend on hidden prompt state.
 
-## Architecture Principles
-
-- Normalize external inputs at the boundary before orchestration logic uses them.
-- Separate transport, normalization, and policy whenever an adapter talks to an external system.
-- Make runtime state explicit when behavior depends on multiple counters, stages, or recovery paths.
-- Do not overload one counter to mean prompt sequence, retry budget, and follow-up budget at the same time.
-- Isolate coordination infrastructure such as leases, lock recovery, and durable runtime ownership into focused modules.
-- Prefer pure policy functions over inline branching when lifecycle or recovery decisions can be expressed over normalized internal state.
-- Use small test builders/helpers when repeated orchestration fixtures start to accumulate.
-
-When review feedback clusters repeatedly in the same files or around the same themes, treat that as a sign the decomposition is wrong. Prefer a structural refactor before continuing with more patch-on-patch fixes.
-
 ## Issue Workflow
 
 For any GitHub issue assigned for implementation:
@@ -168,7 +156,7 @@ Implementation work is not complete when the code compiles locally. It is comple
 
 1. plan exists,
 2. implementation is complete,
-3. `/review` has been run and all self-review findings have been fixed,
+3. `codex review --base origin/main` has been run and all self-review findings have been fixed,
 4. formatting, lint, typecheck, and all tests are passing,
 5. a PR is created,
 6. PR CI is watched until it passes,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,8 @@ After opening a PR:
 
 Greptile review feedback is part of the required review loop and must be explicitly handled.
 
+If a CI or automated review check remains in a non-terminal state for more than 30 minutes without progress, treat it as blocked infrastructure rather than silent success. Comment on the issue or PR with the blocked check name and wait for human guidance before proceeding.
+
 ## Execution Bias
 
 In general, keep working through the task until the full delivery loop is finished.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The checked-in `WORKFLOW.md` should point at:
 
 - `tracker.repo: sociotechnica-org/symphony-ts`
 - `workspace.repo_url: git@github.com:sociotechnica-org/symphony-ts.git`
-- `agent.command: codex exec --dangerously-bypass-approvals-and-sandbox -C . -`
+- `agent.command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`
 
 That means the local orchestrator will poll the real `symphony-ts` GitHub repo and create issue branches inside local workspaces cloned from that same repository.
 
@@ -240,7 +240,7 @@ Key fields in the current workflow:
 The checked-in default runner command is:
 
 ```bash
-codex exec --dangerously-bypass-approvals-and-sandbox -C . -
+codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
 ```
 
 ## Development

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -65,7 +65,7 @@ Rules:
 5. Comment on the GitHub issue when the plan is ready for review.
 6. If explicitly instructed not to wait for human feedback, continue directly from plan into implementation.
 7. Implement the issue completely, including docs and tests required by the repo process.
-8. Run `/review` on your changes and fix the findings before opening a PR.
+8. Run `codex review --base origin/main` on your changes and fix the findings before opening a PR.
 9. Run the relevant local checks before finishing.
 10. Open a pull request against `main` in `{{ config.tracker.repo }}` and reference the issue in the PR body.
 11. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -25,7 +25,7 @@ workspace:
 hooks:
   after_create: []
 agent:
-  command: codex exec --dangerously-bypass-approvals-and-sandbox -C . -
+  command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
   prompt_transport: stdin
   timeout_ms: 1800000
   env:
@@ -58,12 +58,16 @@ Pull Request State:
 
 Rules:
 
-1. Work only inside this repository clone.
-2. Create or reuse the issue branch for this work.
-3. Implement the issue completely.
-4. Run the relevant checks before finishing.
-5. Open a pull request against `main` in `{{ config.tracker.repo }}`.
-6. Reference the issue in the PR body.
-7. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.
-8. Do not treat "PR opened" as complete; keep going until the PR is green and actionable review feedback is resolved.
-9. Leave the workspace in a git state that can be inspected if the run fails.
+1. Read `AGENTS.md`, `README.md`, and the relevant docs before making changes.
+2. Work only inside this repository clone.
+3. Create or reuse the issue branch for this work.
+4. For implementation issues, read `skills/symphony-plan/SKILL.md` and use it to create or update `docs/plans/<issue-number>-<task-name>/plan.md` before substantial code changes.
+5. Comment on the GitHub issue when the plan is ready for review.
+6. If explicitly instructed not to wait for human feedback, continue directly from plan into implementation.
+7. Implement the issue completely, including docs and tests required by the repo process.
+8. Run `/review` on your changes and fix the findings before opening a PR.
+9. Run the relevant local checks before finishing.
+10. Open a pull request against `main` in `{{ config.tracker.repo }}` and reference the issue in the PR body.
+11. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.
+12. Monitor CI and automated review feedback, address follow-up comments, and do not treat the CI/review stage as complete until all checks pass and all actionable comments are resolved, unless blocked by an external stuck check.
+13. Leave the workspace in a git state that can be inspected if the run fails.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -61,7 +61,7 @@ Rules:
 1. Read `AGENTS.md`, `README.md`, and the relevant docs before making changes.
 2. Work only inside this repository clone.
 3. Create or reuse the issue branch for this work.
-4. For implementation issues, read `skills/symphony-plan/SKILL.md` and use it to create or update `docs/plans/<issue-number>-<task-name>/plan.md` before substantial code changes.
+4. Read `skills/symphony-plan/SKILL.md` and use it to create or update `docs/plans/<issue-number>-<task-name>/plan.md` before substantial code changes.
 5. Comment on the GitHub issue when the plan is ready for review.
 6. If explicitly instructed not to wait for human feedback, continue directly from plan into implementation.
 7. Implement the issue completely, including docs and tests required by the repo process.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -69,5 +69,5 @@ Rules:
 9. Run the relevant local checks before finishing.
 10. Open a pull request against `main` in `{{ config.tracker.repo }}` and reference the issue in the PR body.
 11. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.
-12. Monitor CI and automated review feedback, address follow-up comments, and do not treat the CI/review stage as complete until all checks pass and all actionable comments are resolved, unless blocked by an external stuck check.
+12. Monitor CI and automated review feedback, address follow-up comments, and do not treat the CI/review stage as complete until all checks pass and all actionable comments are resolved. If a CI or automated review check remains in a non-terminal state for more than 30 minutes without progress, comment on the issue describing the blocked check and wait for human guidance before proceeding.
 13. Leave the workspace in a git state that can be inspected if the run fails.

--- a/skills/symphony-plan/SKILL.md
+++ b/skills/symphony-plan/SKILL.md
@@ -30,7 +30,7 @@ When relevant to the issue, also consult:
 
 1. the local Symphony spec checkout, if available locally, for example the sibling `../symphony/` checkout
 2. the Elixir reference implementation, if available locally, for example under `../symphony/elixir/`
-3. the Harness engineering principles already discussed in this repo
+3. the Harness engineering principles in `docs/golden-principles.md`
 
 ## Planning Standard
 

--- a/skills/symphony-plan/SKILL.md
+++ b/skills/symphony-plan/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: symphony-plan
+description: Create or refine implementation plans for Symphony issues in a way that stays close to the Symphony spec, preserves clean architectural layers, and reduces review churn.
+---
+
+# Symphony Plan
+
+Use this skill before substantial implementation work on a Symphony issue.
+
+The goal is not just to write a task list. The goal is to produce a plan that:
+
+- stays aligned with the Symphony spec,
+- preserves the intended layers of the system,
+- makes failure and recovery behavior explicit,
+- and reduces the chance of patch-on-patch review churn later.
+
+## Sources Of Truth
+
+Read only what is needed, but do not plan blind.
+
+Required sources:
+
+1. `AGENTS.md`
+2. `README.md`
+3. relevant files under `docs/`
+4. the existing implementation around the affected layers
+5. the issue text and comments
+
+When relevant to the issue, also consult:
+
+1. the local Symphony spec checkout
+2. the Elixir reference implementation
+3. the Harness engineering principles already discussed in this repo
+
+## Planning Standard
+
+Every substantial implementation plan should cover:
+
+1. goal
+2. scope
+3. non-goals
+4. current gaps
+5. architecture boundaries
+6. runtime state model or state machine, if behavior is stateful
+7. failure-class matrix, if recovery or retries are involved
+8. storage or persistence contract, if durable state is involved
+9. observability requirements
+10. implementation steps
+11. tests and named acceptance scenarios
+12. exit criteria
+13. decision notes when a boundary or tradeoff needs explicit rationale
+
+Do not stop at generic implementation bullets if the feature changes orchestration behavior.
+
+## Layering Rules
+
+Plans must preserve the intended system boundaries.
+
+Spell out what belongs in each layer:
+
+- config/workflow
+- tracker
+- workspace
+- runner
+- orchestrator
+- observability
+
+Also spell out what does not belong in a layer.
+
+Examples:
+
+- tracker-specific API quirks should not leak into orchestrator policy
+- transport, normalization, and policy should not be mixed in one module
+- leases and lock recovery should not live inline inside large coordinator branches
+- runtime state should not be represented as a few loose maps if the behavior is stateful enough to deserve explicit transitions
+
+## Harness-Oriented Principles
+
+Use the same principles that make agent-built systems easier to maintain:
+
+1. keep the system of record inside the repo
+2. prefer explicit contracts over implicit behavior
+3. make the happy path real, not simulated
+4. keep code and plans legible to future agents
+5. avoid cleverness that hides state or ownership
+6. choose small modules with obvious ownership
+
+If the plan would produce a large hot file with transport, policy, and state transitions mixed together, the plan is not ready yet.
+
+## State And Recovery Planning
+
+If the issue changes long-running orchestration, retries, review loops, ownership, or recovery:
+
+1. name the states explicitly
+2. name the allowed transitions
+3. distinguish counters that mean different things
+4. define which states are healthy waiting vs broken/orphaned
+5. define what facts the system uses to decide between wait, rerun, fail, or complete
+
+Do not let run sequence, retry budget, waiting state, and recovery state blur together.
+
+## Failure-Class Matrix
+
+For features involving recovery, reconciliation, subprocesses, trackers, or CI/review loops, include a small matrix of:
+
+- observed condition
+- local facts available
+- normalized tracker facts available
+- expected decision
+
+Examples:
+
+- local process dead, no PR
+- local process dead, PR awaiting review
+- tracker says running, no local state
+- stale lease with live process
+- stale lease with dead process
+
+This is one of the best ways to avoid repetitive review comments later.
+
+## Tests And Acceptance Scenarios
+
+Do not just say "add tests."
+
+Name the exact scenarios that prove the feature works.
+
+For orchestration changes, plans should usually include:
+
+- unit coverage for pure policy/state transitions
+- integration coverage for adapter/runtime interaction
+- end-to-end coverage for the real user-visible failure mode
+
+Name the end-to-end scenarios explicitly.
+
+## Review-Churn Trigger
+
+If you find yourself planning a change that would patch a large existing file in several unrelated places, stop and reconsider the decomposition.
+
+If likely review comments would cluster around:
+
+- nullability and boundary parsing
+- stale state handling
+- mixed transport/policy logic
+- hidden counters or budgets
+- test harness cleanup
+
+then the plan should include a small structural refactor up front rather than deferring it to code review.
+
+## Plan Output
+
+Write the plan to:
+
+- `docs/plans/<issue-number>-<task-name>/plan.md`
+
+Use a stable, descriptive directory name.
+
+After writing the plan:
+
+1. sanity-check that it matches the issue
+2. sanity-check that boundaries are explicit
+3. comment on the issue that the plan is ready
+
+If implementation is explicitly allowed to continue without waiting, continue from the plan.

--- a/skills/symphony-plan/SKILL.md
+++ b/skills/symphony-plan/SKILL.md
@@ -28,8 +28,8 @@ Required sources:
 
 When relevant to the issue, also consult:
 
-1. the local Symphony spec checkout
-2. the Elixir reference implementation
+1. the local Symphony spec checkout, if available locally, for example the sibling `../symphony/` checkout
+2. the Elixir reference implementation, if available locally, for example under `../symphony/elixir/`
 3. the Harness engineering principles already discussed in this repo
 
 ## Planning Standard


### PR DESCRIPTION
## Summary
- add a checked-in `symphony-plan` skill for implementation planning
- require workers to use it from `WORKFLOW.md`
- encode architecture principles in `AGENTS.md`
- ignore `.ralph/` in the root checkout

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- codex review --base main
