### PR TITLE
fix: recognize active review bots

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -10,6 +10,8 @@ tracker:
   review_bot_logins:
     - greptile[bot]
     - bugbot[bot]
+    - greptile-apps
+    - cursor
 polling:
   interval_ms: 30000
   max_concurrent_runs: 1


### PR DESCRIPTION
## Summary
- add the actual current automated review authors to `tracker.review_bot_logins`
- let the factory treat Greptile and Cursor review threads as bot-actionable follow-up

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- codex review --base origin/main