### PR TITLE
Add minimal factory status surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Today, `symphony-ts` can:
 - recover orphaned `symphony:running` issues after local worker or agent loss
 - close the issue only after the PR is merge-ready
 - retry failed runs locally
+- emit a local factory status snapshot and render it in the terminal
 
 This is already being used to build `symphony-ts` itself.
 
@@ -112,6 +113,18 @@ Run continuously:
 pnpm tsx bin/symphony.ts run
 ```
 
+Inspect the latest local factory status:
+
+```bash
+pnpm tsx bin/symphony.ts status
+```
+
+Print the machine-readable snapshot:
+
+```bash
+pnpm tsx bin/symphony.ts status --json
+```
+
 By default, the checked-in `WORKFLOW.md` targets:
 
 - repo: `sociotechnica-org/symphony-ts`
@@ -174,6 +187,10 @@ pnpm tsx bin/symphony.ts run
 ```
 
 In continuous mode, Symphony will keep polling for additional ready issues.
+
+During or after a run, Symphony writes the latest derived status snapshot to `.tmp/status.json`.
+The `status` CLI reads that file and renders either a simple terminal view or the raw JSON contract
+for future tooling.
 
 ### 5. Watch the issue lifecycle
 

--- a/docs/plans/031-minimal-factory-status-surface/plan.md
+++ b/docs/plans/031-minimal-factory-status-surface/plan.md
@@ -1,0 +1,297 @@
+# Phase 1.3.3 Technical Plan: Minimal Factory Status Surface
+
+## Goal
+
+Add a minimal operator-facing factory status surface that lets a human inspect current Symphony activity locally without reading structured logs by hand.
+
+The first slice should establish one authoritative runtime snapshot contract and expose it through:
+
+1. a machine-readable local snapshot, and
+2. one simple human-readable terminal view.
+
+## Scope
+
+Required outcomes for issue `#31`:
+
+1. define a canonical runtime status snapshot owned by the runtime rather than by a separate UI model
+2. capture enough live factory state to answer basic operator questions about what Symphony is doing
+3. expose a local machine-readable snapshot that later TUI or web surfaces can reuse
+4. expose one synchronous terminal-oriented status command for immediate human use
+5. cover the snapshot and terminal output with tests that reflect real orchestration state
+
+## Non-Goals
+
+This issue does not include:
+
+1. a long-running interactive TUI
+2. a web dashboard or HTTP server
+3. operator controls such as retry, pause, cancel, or claim
+4. historical analytics or persisted time-series metrics
+5. a second state model derived from `.ralph` notes or other operator context files
+6. deep Codex token/rate-limit accounting beyond what the current TypeScript runtime actually tracks
+
+## Product Constraints
+
+This plan follows the issue decisions already recorded on GitHub:
+
+1. terminal-first before any web UI
+2. one canonical machine-readable snapshot first
+3. read-only human surface in v1
+4. source of truth is runtime state, not notes files
+5. local-only first slice
+6. minimum useful fields include factory health, worker/session info, active issue, counts, active PR summary, checks/review summary, runner presence, last update time, and blocked reason
+
+## Current Gaps
+
+Today the runtime has no direct operator visibility surface beyond logs:
+
+1. the orchestrator keeps dispatch and retry state in memory, but does not expose a synchronous runtime snapshot
+2. active run ownership is partly durable through issue leases, but there is no operator-readable synthesis of owner PID, runner PID, session id, or workspace path
+3. PR lifecycle state is only visible indirectly through logs and issue/PR inspection
+4. the CLI only supports `run`, so there is no first-class way to inspect current factory state locally
+5. there is no single contract that a future TUI or web UI could consume without re-reading coordination files directly
+
+## Architecture Boundaries
+
+### Config / Workflow
+
+Belongs here:
+
+- CLI option parsing for a status command and optional output path overrides
+- any explicit workflow/config needed for status file placement if the current runtime needs it
+
+Does not belong here:
+
+- live snapshot assembly
+- tracker or orchestration policy
+
+### Tracker
+
+Belongs here:
+
+- returning normalized issue and pull-request lifecycle data already needed for runtime decisions
+
+Does not belong here:
+
+- formatting status output
+- persisting operator-facing snapshots
+- keeping separate UI-only state
+
+### Workspace
+
+Belongs here:
+
+- deterministic workspace paths already used by the runtime
+
+Does not belong here:
+
+- rendering status
+- synthesizing orchestration summaries
+
+### Runner
+
+Belongs here:
+
+- spawned process metadata and run session result details already observable through the runner contract
+
+Does not belong here:
+
+- deciding what counts as factory health
+- maintaining a dashboard-specific session model
+
+### Orchestrator
+
+Belongs here:
+
+- owning the authoritative runtime snapshot
+- combining current in-memory state, durable lease state, and tracker-derived follow-up state into one read model
+- updating snapshot state on meaningful transitions
+
+Does not belong here:
+
+- terminal formatting details beyond emitting the snapshot contract
+- tracker-specific presentation quirks
+
+### Observability
+
+Belongs here:
+
+- snapshot types and assembly helpers
+- local snapshot persistence
+- terminal rendering from the canonical snapshot
+
+Does not belong here:
+
+- dispatch decisions
+- retry policy
+- tracker mutation logic
+
+## Canonical Snapshot Contract
+
+Introduce one synchronous factory snapshot that is cheap to compute and stable enough for later reuse.
+
+### Top-Level Shape
+
+The first slice should include:
+
+1. factory summary
+2. worker identity and liveness metadata
+3. active run rows
+4. retry queue rows
+5. aggregate issue counts relevant to the local operator
+6. last runtime action
+
+### Factory Summary
+
+Minimum fields:
+
+- `generatedAt`
+- `factoryState` (`idle`, `running`, or `blocked`)
+- `worker`
+  - `instanceId`
+  - `pid`
+  - `startedAt`
+  - `pollIntervalMs`
+  - `maxConcurrentRuns`
+- `counts`
+  - `ready`
+  - `running`
+  - `failed`
+  - `activeLocalRuns`
+- `lastAction`
+  - normalized action kind
+  - short summary
+  - timestamp
+  - issue number when applicable
+
+### Active Run Rows
+
+Each running row should expose the minimum operator-useful facts already owned by the runtime:
+
+- issue number / identifier / title
+- current run sequence
+- source (`ready` vs `running`)
+- workspace path
+- branch name
+- run session id
+- owner PID
+- runner PID
+- started at / latest update at
+- current status summary
+- active PR summary when known
+- checks summary when known
+- review summary when known
+- blocked reason when applicable
+
+### Retry Rows
+
+Each retry row should include:
+
+- issue number / identifier
+- next attempt number
+- due at timestamp
+- last error summary
+
+## Runtime State Model
+
+This feature should not invent a parallel orchestration model. Instead it should expose a read model over existing runtime state plus a few explicit observability fields.
+
+### New Explicit State
+
+Add a focused runtime-status state module that records:
+
+1. worker start time
+2. last meaningful orchestrator action
+3. active run metadata keyed by issue number
+4. most recent observed PR lifecycle summary per issue
+5. latest tracker counts observed during polling
+
+The existing orchestrator state for running issues, retries, follow-up budgets, and run abort controllers remains authoritative for coordination.
+
+### Allowed Transition Updates
+
+The observability state should update on:
+
+1. poll start and poll result
+2. issue claim or running-issue resume
+3. run start
+4. runner spawn
+5. lifecycle observation while awaiting review or needing follow-up
+6. retry scheduling
+7. completion
+8. failure
+9. recovery/orphan reconciliation decisions
+
+## Failure-Class Matrix
+
+| Observed condition                               | Local facts available                                       | Tracker facts available                      | Expected status behavior                                                                                  |
+| ------------------------------------------------ | ----------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Factory is idle with no local runs               | no active run rows, no due retries                          | ready/running counts may be zero or non-zero | snapshot reports `idle` and last poll result                                                              |
+| Run is active with spawned runner                | active run metadata, owner PID, runner PID                  | issue and PR lifecycle                       | snapshot row reports runner presence and current PR/check summary                                         |
+| Issue is running but awaiting CI or human review | no active local runner, lifecycle cached as awaiting review | PR lifecycle says waiting                    | snapshot reports issue under active/blocked surface with blocked reason and last action `awaiting-review` |
+| Retry is scheduled after failure                 | retry queue entry present                                   | tracker still has running issue              | snapshot reports retry row with due time and error summary                                                |
+| Orphan reconciliation finds stale ownership      | lease reconciliation says stale or invalid                  | running issue still present                  | snapshot last action records recovery decision; no hidden UI-only repair state                            |
+| Snapshot write or render fails                   | runtime still has in-memory snapshot                        | tracker facts unchanged                      | emit warning log; orchestration continues because status surface is optional                              |
+
+## Storage / Persistence Contract
+
+The first slice should persist one local JSON snapshot file, for example under `.tmp/status.json`.
+
+Rules:
+
+1. the file is a derived view, not authoritative runtime state
+2. writes should be atomic enough that readers do not see truncated JSON
+3. missing or stale snapshot files are acceptable outside a running worker and should be presented clearly by the CLI
+4. the terminal view should prefer reading the current in-process snapshot when invoked inside the worker path, but the local JSON file is the stable interoperability contract for later surfaces
+
+## Observability Requirements
+
+1. logs remain structured and separate from the status surface
+2. snapshot generation must be cheap enough to run on every meaningful runtime transition and at least once per poll
+3. the human-readable view must be synchronous and readable in a normal terminal without extra dependencies
+4. the status contract should leave room for richer fields later without breaking the v1 meaning of the existing ones
+
+## Implementation Steps
+
+1. add explicit runtime status domain types for factory snapshot, run rows, retry rows, and last action
+2. add a focused observability/status module that can build and atomically write the JSON snapshot
+3. extend orchestrator runtime state with the minimum observability metadata needed for the snapshot
+4. update orchestrator transitions to record last action, active run summaries, lifecycle observations, and tracker counts
+5. expose a snapshot reader and simple terminal renderer for a new CLI status command
+6. document the local status workflow in `README.md`
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. snapshot builder returns the expected machine-readable shape for idle, running, awaiting-review, and retrying states
+2. terminal renderer includes worker, issue, PR, checks, review, and last-action summaries without depending on logs
+3. snapshot writer handles atomic rewrite behavior and stable serialization
+
+### Integration
+
+1. CLI status command renders the local snapshot when the JSON file exists
+2. CLI status command returns valid JSON when asked for machine-readable output
+3. CLI status command handles missing snapshot files with a clear operator-facing message
+
+### End-to-End
+
+1. after a factory poll claims and starts one issue, a human can inspect the status locally and see the active issue, branch, workspace, and runner/session info
+2. after a PR opens and the runtime is waiting on checks or review, the status view shows the active PR summary plus blocked reason without needing log inspection
+3. after a failed attempt schedules a retry, the status view shows the retry row and next attempt timing
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. the runtime emits one canonical machine-readable status snapshot from authoritative runtime state
+2. a local operator can run one CLI command to inspect the current factory state without parsing logs
+3. the status includes worker/session info, active issue, active PR, checks/review state, and last action
+4. tests cover idle, active, waiting, and retrying status scenarios
+5. the design leaves room for a future richer TUI or web UI without redefining the state contract
+
+## Decision Notes
+
+1. Use a derived JSON snapshot file rather than an always-live terminal process as the first reusable contract. This keeps the initial slice small and future-UI-friendly.
+2. Keep status state inside orchestrator-owned observability structures rather than re-reading logs or tracker data ad hoc in the CLI. This preserves one source of truth.
+3. Treat waiting-for-review/checks as visible factory activity even when no agent subprocess is currently running. For the operator, that issue is still the active factory work item.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -65,13 +65,13 @@ export function parseArgs(argv: readonly string[]): CliArgs {
 export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseArgs(argv);
   if (args.command === "status") {
+    const effectiveWorkflowPath =
+      args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md");
     const statusFilePath =
       args.statusFilePath ??
-      (await resolveStatusFilePath(
-        args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md"),
-      ).catch((error) => {
+      (await resolveStatusFilePath(effectiveWorkflowPath).catch((error) => {
         throw new Error(
-          `Could not determine status file path from workflow at ${args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md")}. Use --status-file <path> to specify the snapshot location directly.`,
+          `Could not determine status file path from workflow at ${effectiveWorkflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
           { cause: error as Error },
         );
       }));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,7 @@ export type CliArgs =
   | {
       readonly command: "status";
       readonly format: "human" | "json";
-      readonly workflowPath: string;
+      readonly workflowPath: string | null;
       readonly statusFilePath: string | null;
     };
 
@@ -40,12 +40,16 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   }
 
   if (command === "status") {
-    const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
     const statusFilePath = readOptionValue(args, "--status-file");
+    const workflowPath =
+      statusFilePath === null ? readOptionValue(args, "--workflow") : null;
     return {
       command: "status",
       format: args.includes("--json") ? "json" : "human",
-      workflowPath: path.resolve(process.cwd(), workflowPath),
+      workflowPath:
+        workflowPath === null
+          ? null
+          : path.resolve(process.cwd(), workflowPath),
       statusFilePath:
         statusFilePath !== null
           ? path.resolve(process.cwd(), statusFilePath)
@@ -63,9 +67,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   if (args.command === "status") {
     const statusFilePath =
       args.statusFilePath ??
-      (await resolveStatusFilePath(args.workflowPath).catch((error) => {
+      (await resolveStatusFilePath(
+        args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md"),
+      ).catch((error) => {
         throw new Error(
-          `Could not determine status file path from workflow at ${args.workflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
+          `Could not determine status file path from workflow at ${args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md")}. Use --status-file <path> to specify the snapshot location directly.`,
           { cause: error as Error },
         );
       }));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,10 +29,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   const args = argv.slice(2);
   const command = args[0];
   const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
-  const resolvedWorkflowPath = path.resolve(
-    process.cwd(),
-    workflowPath ?? "WORKFLOW.md",
-  );
+  const resolvedWorkflowPath = path.resolve(process.cwd(), workflowPath);
 
   if (command === "run") {
     return {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,7 +61,13 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseArgs(argv);
   if (args.command === "status") {
     const statusFilePath =
-      args.statusFilePath ?? (await resolveStatusFilePath(args.workflowPath));
+      args.statusFilePath ??
+      (await resolveStatusFilePath(args.workflowPath).catch((error) => {
+        throw new Error(
+          `Could not determine status file path from workflow at ${args.workflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
+          { cause: error as Error },
+        );
+      }));
     let snapshot;
     try {
       snapshot = await readFactoryStatusSnapshot(statusFilePath);
@@ -70,6 +76,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
       if (code === "ENOENT") {
         throw new Error(
           `No factory status snapshot found at ${statusFilePath}. Start Symphony with 'symphony run' first.`,
+          { cause: error as Error },
         );
       }
       throw error;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,36 +1,98 @@
 import path from "node:path";
 import { createPromptBuilder, loadWorkflow } from "../config/workflow.js";
 import { JsonLogger } from "../observability/logger.js";
+import {
+  deriveStatusFilePath,
+  isProcessAlive,
+  readFactoryStatusSnapshot,
+  renderFactoryStatusSnapshot,
+} from "../observability/status.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
 import { LocalRunner } from "../runner/local.js";
 import { GitHubBootstrapTracker } from "../tracker/github-bootstrap.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
 
-export interface CliArgs {
-  readonly command: "run";
-  readonly once: boolean;
-  readonly workflowPath: string;
-}
+export type CliArgs =
+  | {
+      readonly command: "run";
+      readonly once: boolean;
+      readonly workflowPath: string;
+    }
+  | {
+      readonly command: "status";
+      readonly format: "human" | "json";
+      readonly workflowPath: string;
+      readonly statusFilePath: string | null;
+    };
 
 export function parseArgs(argv: readonly string[]): CliArgs {
   const args = argv.slice(2);
   const command = args[0];
-  if (command !== "run") {
-    throw new Error("Usage: symphony run [--once] [--workflow <path>]");
-  }
-  const once = args.includes("--once");
   const workflowIndex = args.findIndex((arg) => arg === "--workflow");
   const workflowPath =
     workflowIndex >= 0 ? args[workflowIndex + 1] : "WORKFLOW.md";
-  return {
-    command: "run",
-    once,
-    workflowPath: path.resolve(process.cwd(), workflowPath ?? "WORKFLOW.md"),
-  };
+  const resolvedWorkflowPath = path.resolve(
+    process.cwd(),
+    workflowPath ?? "WORKFLOW.md",
+  );
+
+  if (command === "run") {
+    return {
+      command: "run",
+      once: args.includes("--once"),
+      workflowPath: resolvedWorkflowPath,
+    };
+  }
+
+  if (command === "status") {
+    const statusFileIndex = args.findIndex((arg) => arg === "--status-file");
+    return {
+      command: "status",
+      format: args.includes("--json") ? "json" : "human",
+      workflowPath: resolvedWorkflowPath,
+      statusFilePath:
+        statusFileIndex >= 0
+          ? path.resolve(
+              process.cwd(),
+              args[statusFileIndex + 1] ?? ".tmp/status.json",
+            )
+          : null,
+    };
+  }
+
+  throw new Error(
+    "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
+  );
 }
 
 export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseArgs(argv);
+  if (args.command === "status") {
+    const statusFilePath =
+      args.statusFilePath ?? (await resolveStatusFilePath(args.workflowPath));
+    let snapshot;
+    try {
+      snapshot = await readFactoryStatusSnapshot(statusFilePath);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        throw new Error(
+          `No factory status snapshot found at ${statusFilePath}. Start Symphony with 'symphony run' first.`,
+        );
+      }
+      throw error;
+    }
+    const output =
+      args.format === "json"
+        ? `${JSON.stringify(snapshot, null, 2)}\n`
+        : `${renderFactoryStatusSnapshot(snapshot, {
+            workerAlive: isProcessAlive(snapshot.worker.pid),
+            statusFilePath,
+          })}\n`;
+    process.stdout.write(output);
+    return;
+  }
+
   const logger = new JsonLogger();
   const workflow = await loadWorkflow(args.workflowPath);
   const promptBuilder = createPromptBuilder(workflow);
@@ -59,4 +121,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   process.on("SIGINT", () => abortController.abort());
   process.on("SIGTERM", () => abortController.abort());
   await orchestrator.runLoop(abortController.signal);
+}
+
+async function resolveStatusFilePath(workflowPath: string): Promise<string> {
+  const workflow = await loadWorkflow(workflowPath);
+  return deriveStatusFilePath(workflow.config.workspace.root);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,9 +28,7 @@ export type CliArgs =
 export function parseArgs(argv: readonly string[]): CliArgs {
   const args = argv.slice(2);
   const command = args[0];
-  const workflowIndex = args.findIndex((arg) => arg === "--workflow");
-  const workflowPath =
-    workflowIndex >= 0 ? args[workflowIndex + 1] : "WORKFLOW.md";
+  const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
   const resolvedWorkflowPath = path.resolve(
     process.cwd(),
     workflowPath ?? "WORKFLOW.md",
@@ -45,17 +43,14 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   }
 
   if (command === "status") {
-    const statusFileIndex = args.findIndex((arg) => arg === "--status-file");
+    const statusFilePath = readOptionValue(args, "--status-file");
     return {
       command: "status",
       format: args.includes("--json") ? "json" : "human",
       workflowPath: resolvedWorkflowPath,
       statusFilePath:
-        statusFileIndex >= 0
-          ? path.resolve(
-              process.cwd(),
-              args[statusFileIndex + 1] ?? ".tmp/status.json",
-            )
+        statusFilePath !== null
+          ? path.resolve(process.cwd(), statusFilePath)
           : null,
     };
   }
@@ -126,4 +121,16 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 async function resolveStatusFilePath(workflowPath: string): Promise<string> {
   const workflow = await loadWorkflow(workflowPath);
   return deriveStatusFilePath(workflow.config.workspace.root);
+}
+
+function readOptionValue(args: readonly string[], flag: string): string | null {
+  const index = args.findIndex((arg) => arg === flag);
+  if (index < 0) {
+    return null;
+  }
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,7 +79,10 @@ export async function runCli(argv: readonly string[]): Promise<void> {
           { cause: error as Error },
         );
       }
-      throw error;
+      throw new Error(
+        `Failed to read factory status snapshot at ${statusFilePath}. The file may be corrupt; re-running 'symphony run' will regenerate it.`,
+        { cause: error as Error },
+      );
     }
     const output =
       args.format === "json"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { createPromptBuilder, loadWorkflow } from "../config/workflow.js";
 import { JsonLogger } from "../observability/logger.js";
@@ -28,23 +29,23 @@ export type CliArgs =
 export function parseArgs(argv: readonly string[]): CliArgs {
   const args = argv.slice(2);
   const command = args[0];
-  const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
-  const resolvedWorkflowPath = path.resolve(process.cwd(), workflowPath);
 
   if (command === "run") {
+    const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
     return {
       command: "run",
       once: args.includes("--once"),
-      workflowPath: resolvedWorkflowPath,
+      workflowPath: path.resolve(process.cwd(), workflowPath),
     };
   }
 
   if (command === "status") {
+    const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
     const statusFilePath = readOptionValue(args, "--status-file");
     return {
       command: "status",
       format: args.includes("--json") ? "json" : "human",
-      workflowPath: resolvedWorkflowPath,
+      workflowPath: path.resolve(process.cwd(), workflowPath),
       statusFilePath:
         statusFilePath !== null
           ? path.resolve(process.cwd(), statusFilePath)
@@ -69,7 +70,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         );
       }));
     let snapshot;
+    let rawSnapshot = "";
     try {
+      rawSnapshot = await fs.readFile(statusFilePath, "utf8");
       snapshot = await readFactoryStatusSnapshot(statusFilePath);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
@@ -86,7 +89,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     }
     const output =
       args.format === "json"
-        ? `${JSON.stringify(snapshot, null, 2)}\n`
+        ? rawSnapshot
         : `${renderFactoryStatusSnapshot(snapshot, {
             workerAlive: isProcessAlive(snapshot.worker.pid),
             statusFilePath,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ import { JsonLogger } from "../observability/logger.js";
 import {
   deriveStatusFilePath,
   isProcessAlive,
-  readFactoryStatusSnapshot,
+  parseFactoryStatusSnapshotContent,
   renderFactoryStatusSnapshot,
 } from "../observability/status.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
@@ -73,7 +73,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     let rawSnapshot = "";
     try {
       rawSnapshot = await fs.readFile(statusFilePath, "utf8");
-      snapshot = await readFactoryStatusSnapshot(statusFilePath);
+      snapshot = parseFactoryStatusSnapshotContent(rawSnapshot, statusFilePath);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -44,6 +44,12 @@ export class RunnerAbortedError extends SymphonyError {
   }
 }
 
+export class ObservabilityError extends SymphonyError {
+  constructor(message: string, options?: ErrorOptions) {
+    super("observability_error", message, options);
+  }
+}
+
 export class OrchestratorError extends SymphonyError {
   constructor(message: string, options?: ErrorOptions) {
     super("orchestrator_error", message, options);

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -7,6 +7,7 @@ export interface WorkspacePreparationRequest {
 export interface PreparedWorkspace {
   readonly key: string;
   readonly path: string;
+  /** Canonical issue branch checked out for the run. */
   readonly branchName: string;
   readonly createdNow: boolean;
 }

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -1,0 +1,249 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type FactoryState = "idle" | "running" | "blocked";
+
+export type FactoryIssueStatus =
+  | "queued"
+  | "preparing"
+  | "running"
+  | "awaiting-review"
+  | "needs-follow-up";
+
+export interface FactoryWorkerSnapshot {
+  readonly instanceId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly pollIntervalMs: number;
+  readonly maxConcurrentRuns: number;
+}
+
+export interface FactoryStatusCounts {
+  readonly ready: number;
+  readonly running: number;
+  readonly failed: number;
+  readonly activeLocalRuns: number;
+  readonly retries: number;
+}
+
+export interface FactoryStatusAction {
+  readonly kind: string;
+  readonly summary: string;
+  readonly at: string;
+  readonly issueNumber: number | null;
+}
+
+export interface FactoryPullRequestStatus {
+  readonly number: number;
+  readonly url: string;
+  readonly latestCommitAt: string | null;
+}
+
+export interface FactoryCheckStatus {
+  readonly pendingNames: readonly string[];
+  readonly failingNames: readonly string[];
+}
+
+export interface FactoryReviewStatus {
+  readonly actionableCount: number;
+  readonly unresolvedThreadCount: number;
+}
+
+export interface FactoryActiveIssueSnapshot {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly source: "ready" | "running";
+  readonly runSequence: number;
+  readonly status: FactoryIssueStatus;
+  readonly summary: string;
+  readonly workspacePath: string | null;
+  readonly branchName: string;
+  readonly runSessionId: string | null;
+  readonly ownerPid: number | null;
+  readonly runnerPid: number | null;
+  readonly startedAt: string | null;
+  readonly updatedAt: string;
+  readonly pullRequest: FactoryPullRequestStatus | null;
+  readonly checks: FactoryCheckStatus;
+  readonly review: FactoryReviewStatus;
+  readonly blockedReason: string | null;
+}
+
+export interface FactoryRetrySnapshot {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly nextAttempt: number;
+  readonly dueAt: string;
+  readonly lastError: string;
+}
+
+export interface FactoryStatusSnapshot {
+  readonly version: 1;
+  readonly generatedAt: string;
+  readonly factoryState: FactoryState;
+  readonly worker: FactoryWorkerSnapshot;
+  readonly counts: FactoryStatusCounts;
+  readonly lastAction: FactoryStatusAction | null;
+  readonly activeIssues: readonly FactoryActiveIssueSnapshot[];
+  readonly retries: readonly FactoryRetrySnapshot[];
+}
+
+export function deriveStatusFilePath(workspaceRoot: string): string {
+  return path.resolve(workspaceRoot, "..", "status.json");
+}
+
+export async function writeFactoryStatusSnapshot(
+  filePath: string,
+  snapshot: FactoryStatusSnapshot,
+): Promise<void> {
+  const directory = path.dirname(filePath);
+  const temporaryPath = path.join(
+    directory,
+    `.status.${process.pid.toString()}.tmp`,
+  );
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(
+    temporaryPath,
+    `${JSON.stringify(snapshot, null, 2)}\n`,
+    "utf8",
+  );
+  await fs.rename(temporaryPath, filePath);
+}
+
+export async function readFactoryStatusSnapshot(
+  filePath: string,
+): Promise<FactoryStatusSnapshot> {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw) as FactoryStatusSnapshot;
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "EPERM";
+  }
+}
+
+export function renderFactoryStatusSnapshot(
+  snapshot: FactoryStatusSnapshot,
+  options?: {
+    readonly workerAlive?: boolean;
+    readonly statusFilePath?: string;
+  },
+): string {
+  const lines: string[] = [];
+  const workerAlive = options?.workerAlive;
+  const workerState =
+    workerAlive === undefined
+      ? snapshot.factoryState
+      : workerAlive
+        ? "online"
+        : "offline";
+
+  lines.push(`Factory: ${snapshot.factoryState}`);
+  lines.push(
+    `Worker: ${workerState} pid=${snapshot.worker.pid.toString()} instance=${snapshot.worker.instanceId}`,
+  );
+  lines.push(
+    `Started: ${snapshot.worker.startedAt}  Snapshot: ${snapshot.generatedAt}`,
+  );
+  lines.push(
+    `Counts: ready=${snapshot.counts.ready.toString()} running=${snapshot.counts.running.toString()} failed=${snapshot.counts.failed.toString()} local=${snapshot.counts.activeLocalRuns.toString()} retries=${snapshot.counts.retries.toString()}`,
+  );
+  lines.push(
+    `Polling: every ${snapshot.worker.pollIntervalMs.toString()}ms, max concurrency ${snapshot.worker.maxConcurrentRuns.toString()}`,
+  );
+  if (options?.statusFilePath) {
+    lines.push(`Snapshot file: ${options.statusFilePath}`);
+  }
+
+  if (snapshot.lastAction === null) {
+    lines.push("Last action: none");
+  } else {
+    const issueSuffix =
+      snapshot.lastAction.issueNumber === null
+        ? ""
+        : ` issue #${snapshot.lastAction.issueNumber.toString()}`;
+    lines.push(
+      `Last action: ${snapshot.lastAction.kind}${issueSuffix} at ${snapshot.lastAction.at} - ${snapshot.lastAction.summary}`,
+    );
+  }
+
+  if (workerAlive === false) {
+    lines.push(
+      "Warning: worker PID is not running; this snapshot may be stale.",
+    );
+  }
+
+  lines.push("");
+  lines.push("Active issues:");
+  if (snapshot.activeIssues.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const issue of snapshot.activeIssues) {
+      lines.push(
+        `  #${issue.issueNumber.toString()} ${issue.title} [${issue.status}]`,
+      );
+      lines.push(`    Summary: ${issue.summary}`);
+      lines.push(`    Branch: ${issue.branchName}`);
+      lines.push(
+        `    Source: ${issue.source} attempt=${issue.runSequence.toString()}`,
+      );
+      lines.push(
+        `    Workspace: ${issue.workspacePath ?? "n/a"}  Session: ${issue.runSessionId ?? "n/a"}`,
+      );
+      lines.push(
+        `    PIDs: owner=${issue.ownerPid?.toString() ?? "n/a"} runner=${issue.runnerPid?.toString() ?? "n/a"}`,
+      );
+      lines.push(
+        `    Updated: ${issue.updatedAt}${issue.startedAt === null ? "" : `  Started: ${issue.startedAt}`}`,
+      );
+      if (issue.pullRequest !== null) {
+        lines.push(
+          `    PR: #${issue.pullRequest.number.toString()} ${issue.pullRequest.url}`,
+        );
+      } else {
+        lines.push("    PR: none");
+      }
+      lines.push(
+        `    Checks: pending=${issue.checks.pendingNames.length.toString()} failing=${issue.checks.failingNames.length.toString()}`,
+      );
+      if (issue.checks.pendingNames.length > 0) {
+        lines.push(
+          `    Pending checks: ${issue.checks.pendingNames.join(", ")}`,
+        );
+      }
+      if (issue.checks.failingNames.length > 0) {
+        lines.push(
+          `    Failing checks: ${issue.checks.failingNames.join(", ")}`,
+        );
+      }
+      lines.push(
+        `    Review: actionable=${issue.review.actionableCount.toString()} unresolved_threads=${issue.review.unresolvedThreadCount.toString()}`,
+      );
+      if (issue.blockedReason !== null) {
+        lines.push(`    Blocked: ${issue.blockedReason}`);
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push("Retries:");
+  if (snapshot.retries.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const retry of snapshot.retries) {
+      lines.push(
+        `  #${retry.issueNumber.toString()} ${retry.title} attempt ${retry.nextAttempt.toString()} at ${retry.dueAt}`,
+      );
+      lines.push(`    Error: ${retry.lastError}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -447,7 +447,7 @@ function parsePullRequest(
   filePath: string,
   field: string,
 ): FactoryPullRequestStatus | null {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return null;
   }
   const pullRequest = expectObject(value, filePath, field);

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -125,6 +125,13 @@ export async function readFactoryStatusSnapshot(
   filePath: string,
 ): Promise<FactoryStatusSnapshot> {
   const raw = await fs.readFile(filePath, "utf8");
+  return parseFactoryStatusSnapshotContent(raw, filePath);
+}
+
+export function parseFactoryStatusSnapshotContent(
+  raw: string,
+  filePath: string,
+): FactoryStatusSnapshot {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw) as unknown;

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -113,7 +113,12 @@ export async function writeFactoryStatusSnapshot(
     `${JSON.stringify(snapshot, null, 2)}\n`,
     "utf8",
   );
-  await fs.rename(temporaryPath, filePath);
+  try {
+    await fs.rename(temporaryPath, filePath);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function readFactoryStatusSnapshot(
@@ -157,11 +162,7 @@ export function renderFactoryStatusSnapshot(
   const lines: string[] = [];
   const workerAlive = options?.workerAlive;
   const workerState =
-    workerAlive === undefined
-      ? snapshot.factoryState
-      : workerAlive
-        ? "online"
-        : "offline";
+    workerAlive === undefined ? "unknown" : workerAlive ? "online" : "offline";
 
   lines.push(`Factory: ${snapshot.factoryState}`);
   lines.push(

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
 
 export type FactoryState = "idle" | "running" | "blocked";
 
@@ -116,7 +117,18 @@ export async function readFactoryStatusSnapshot(
   filePath: string,
 ): Promise<FactoryStatusSnapshot> {
   const raw = await fs.readFile(filePath, "utf8");
-  return JSON.parse(raw) as FactoryStatusSnapshot;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new ObservabilityError(
+      `Failed to parse factory status snapshot at ${filePath}`,
+      {
+        cause: error as Error,
+      },
+    );
+  }
+  return parseFactoryStatusSnapshot(parsed, filePath);
 }
 
 export function isProcessAlive(pid: number): boolean {
@@ -246,4 +258,372 @@ export function renderFactoryStatusSnapshot(
   }
 
   return lines.join("\n");
+}
+
+function parseFactoryStatusSnapshot(
+  value: unknown,
+  filePath: string,
+): FactoryStatusSnapshot {
+  const snapshot = expectObject(value, filePath, "snapshot");
+  const version = expectInteger(snapshot.version, filePath, "version");
+  if (version !== 1) {
+    throw new ObservabilityError(
+      `Unsupported factory status snapshot version at ${filePath}: expected 1, received ${version.toString()}`,
+    );
+  }
+
+  return {
+    version: 1,
+    generatedAt: expectString(snapshot.generatedAt, filePath, "generatedAt"),
+    factoryState: expectEnum(
+      snapshot.factoryState,
+      ["idle", "running", "blocked"],
+      filePath,
+      "factoryState",
+    ),
+    worker: parseWorkerSnapshot(snapshot.worker, filePath),
+    counts: parseCountsSnapshot(snapshot.counts, filePath),
+    lastAction: parseLastAction(snapshot.lastAction, filePath),
+    activeIssues: expectArray(
+      snapshot.activeIssues,
+      filePath,
+      "activeIssues",
+      (entry, index) =>
+        parseActiveIssue(entry, filePath, `activeIssues[${index.toString()}]`),
+    ),
+    retries: expectArray(
+      snapshot.retries,
+      filePath,
+      "retries",
+      (entry, index) =>
+        parseRetry(entry, filePath, `retries[${index.toString()}]`),
+    ),
+  };
+}
+
+function parseWorkerSnapshot(
+  value: unknown,
+  filePath: string,
+): FactoryWorkerSnapshot {
+  const worker = expectObject(value, filePath, "worker");
+  return {
+    instanceId: expectString(worker.instanceId, filePath, "worker.instanceId"),
+    pid: expectInteger(worker.pid, filePath, "worker.pid"),
+    startedAt: expectString(worker.startedAt, filePath, "worker.startedAt"),
+    pollIntervalMs: expectInteger(
+      worker.pollIntervalMs,
+      filePath,
+      "worker.pollIntervalMs",
+    ),
+    maxConcurrentRuns: expectInteger(
+      worker.maxConcurrentRuns,
+      filePath,
+      "worker.maxConcurrentRuns",
+    ),
+  };
+}
+
+function parseCountsSnapshot(
+  value: unknown,
+  filePath: string,
+): FactoryStatusCounts {
+  const counts = expectObject(value, filePath, "counts");
+  return {
+    ready: expectInteger(counts.ready, filePath, "counts.ready"),
+    running: expectInteger(counts.running, filePath, "counts.running"),
+    failed: expectInteger(counts.failed, filePath, "counts.failed"),
+    activeLocalRuns: expectInteger(
+      counts.activeLocalRuns,
+      filePath,
+      "counts.activeLocalRuns",
+    ),
+    retries: expectInteger(counts.retries, filePath, "counts.retries"),
+  };
+}
+
+function parseLastAction(
+  value: unknown,
+  filePath: string,
+): FactoryStatusAction | null {
+  if (value === null) {
+    return null;
+  }
+  const action = expectObject(value, filePath, "lastAction");
+  return {
+    kind: expectString(action.kind, filePath, "lastAction.kind"),
+    summary: expectString(action.summary, filePath, "lastAction.summary"),
+    at: expectString(action.at, filePath, "lastAction.at"),
+    issueNumber: expectNullableInteger(
+      action.issueNumber,
+      filePath,
+      "lastAction.issueNumber",
+    ),
+  };
+}
+
+function parseActiveIssue(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryActiveIssueSnapshot {
+  const issue = expectObject(value, filePath, field);
+  return {
+    issueNumber: expectInteger(
+      issue.issueNumber,
+      filePath,
+      `${field}.issueNumber`,
+    ),
+    issueIdentifier: expectString(
+      issue.issueIdentifier,
+      filePath,
+      `${field}.issueIdentifier`,
+    ),
+    title: expectString(issue.title, filePath, `${field}.title`),
+    source: expectEnum(
+      issue.source,
+      ["ready", "running"],
+      filePath,
+      `${field}.source`,
+    ),
+    runSequence: expectInteger(
+      issue.runSequence,
+      filePath,
+      `${field}.runSequence`,
+    ),
+    status: expectEnum(
+      issue.status,
+      ["queued", "preparing", "running", "awaiting-review", "needs-follow-up"],
+      filePath,
+      `${field}.status`,
+    ),
+    summary: expectString(issue.summary, filePath, `${field}.summary`),
+    workspacePath: expectNullableString(
+      issue.workspacePath,
+      filePath,
+      `${field}.workspacePath`,
+    ),
+    branchName: expectString(issue.branchName, filePath, `${field}.branchName`),
+    runSessionId: expectNullableString(
+      issue.runSessionId,
+      filePath,
+      `${field}.runSessionId`,
+    ),
+    ownerPid: expectNullableInteger(
+      issue.ownerPid,
+      filePath,
+      `${field}.ownerPid`,
+    ),
+    runnerPid: expectNullableInteger(
+      issue.runnerPid,
+      filePath,
+      `${field}.runnerPid`,
+    ),
+    startedAt: expectNullableString(
+      issue.startedAt,
+      filePath,
+      `${field}.startedAt`,
+    ),
+    updatedAt: expectString(issue.updatedAt, filePath, `${field}.updatedAt`),
+    pullRequest: parsePullRequest(
+      issue.pullRequest,
+      filePath,
+      `${field}.pullRequest`,
+    ),
+    checks: parseCheckStatus(issue.checks, filePath, `${field}.checks`),
+    review: parseReviewStatus(issue.review, filePath, `${field}.review`),
+    blockedReason: expectNullableString(
+      issue.blockedReason,
+      filePath,
+      `${field}.blockedReason`,
+    ),
+  };
+}
+
+function parsePullRequest(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryPullRequestStatus | null {
+  if (value === null) {
+    return null;
+  }
+  const pullRequest = expectObject(value, filePath, field);
+  return {
+    number: expectInteger(pullRequest.number, filePath, `${field}.number`),
+    url: expectString(pullRequest.url, filePath, `${field}.url`),
+    latestCommitAt: expectNullableString(
+      pullRequest.latestCommitAt,
+      filePath,
+      `${field}.latestCommitAt`,
+    ),
+  };
+}
+
+function parseCheckStatus(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryCheckStatus {
+  const checks = expectObject(value, filePath, field);
+  return {
+    pendingNames: expectStringArray(
+      checks.pendingNames,
+      filePath,
+      `${field}.pendingNames`,
+    ),
+    failingNames: expectStringArray(
+      checks.failingNames,
+      filePath,
+      `${field}.failingNames`,
+    ),
+  };
+}
+
+function parseReviewStatus(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryReviewStatus {
+  const review = expectObject(value, filePath, field);
+  return {
+    actionableCount: expectInteger(
+      review.actionableCount,
+      filePath,
+      `${field}.actionableCount`,
+    ),
+    unresolvedThreadCount: expectInteger(
+      review.unresolvedThreadCount,
+      filePath,
+      `${field}.unresolvedThreadCount`,
+    ),
+  };
+}
+
+function parseRetry(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryRetrySnapshot {
+  const retry = expectObject(value, filePath, field);
+  return {
+    issueNumber: expectInteger(
+      retry.issueNumber,
+      filePath,
+      `${field}.issueNumber`,
+    ),
+    issueIdentifier: expectString(
+      retry.issueIdentifier,
+      filePath,
+      `${field}.issueIdentifier`,
+    ),
+    title: expectString(retry.title, filePath, `${field}.title`),
+    nextAttempt: expectInteger(
+      retry.nextAttempt,
+      filePath,
+      `${field}.nextAttempt`,
+    ),
+    dueAt: expectString(retry.dueAt, filePath, `${field}.dueAt`),
+    lastError: expectString(retry.lastError, filePath, `${field}.lastError`),
+  };
+}
+
+function expectObject(
+  value: unknown,
+  filePath: string,
+  field: string,
+): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidSnapshot(filePath, `expected ${field} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectString(value: unknown, filePath: string, field: string): string {
+  if (typeof value !== "string") {
+    throw invalidSnapshot(filePath, `expected ${field} to be a string`);
+  }
+  return value;
+}
+
+function expectNullableString(
+  value: unknown,
+  filePath: string,
+  field: string,
+): string | null {
+  if (value === null) {
+    return null;
+  }
+  return expectString(value, filePath, field);
+}
+
+function expectInteger(
+  value: unknown,
+  filePath: string,
+  field: string,
+): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw invalidSnapshot(filePath, `expected ${field} to be an integer`);
+  }
+  return value;
+}
+
+function expectNullableInteger(
+  value: unknown,
+  filePath: string,
+  field: string,
+): number | null {
+  if (value === null) {
+    return null;
+  }
+  return expectInteger(value, filePath, field);
+}
+
+function expectStringArray(
+  value: unknown,
+  filePath: string,
+  field: string,
+): readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw invalidSnapshot(filePath, `expected ${field} to be a string array`);
+  }
+  return value;
+}
+
+function expectArray<T>(
+  value: unknown,
+  filePath: string,
+  field: string,
+  parseEntry: (entry: unknown, index: number) => T,
+): readonly T[] {
+  if (!Array.isArray(value)) {
+    throw invalidSnapshot(filePath, `expected ${field} to be an array`);
+  }
+  return value.map((entry, index) => parseEntry(entry, index));
+}
+
+function expectEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  filePath: string,
+  field: string,
+): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw invalidSnapshot(
+      filePath,
+      `expected ${field} to be one of ${allowed.join(", ")}`,
+    );
+  }
+  return value as T;
+}
+
+function invalidSnapshot(
+  filePath: string,
+  message: string,
+): ObservabilityError {
+  return new ObservabilityError(
+    `Invalid factory status snapshot at ${filePath}: ${message}`,
+  );
 }

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -348,7 +348,7 @@ function parseLastAction(
   value: unknown,
   filePath: string,
 ): FactoryStatusAction | null {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return null;
   }
   const action = expectObject(value, filePath, "lastAction");
@@ -553,7 +553,7 @@ function expectNullableString(
   filePath: string,
   field: string,
 ): string | null {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return null;
   }
   return expectString(value, filePath, field);
@@ -575,7 +575,7 @@ function expectNullableInteger(
   filePath: string,
   field: string,
 ): number | null {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return null;
   }
   return expectInteger(value, filePath, field);

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -94,7 +94,11 @@ export interface FactoryStatusSnapshot {
 }
 
 export function deriveStatusFilePath(workspaceRoot: string): string {
-  return path.resolve(workspaceRoot, "..", "status.json");
+  const parent = path.dirname(workspaceRoot);
+  if (parent === workspaceRoot) {
+    return path.join(workspaceRoot, "status.json");
+  }
+  return path.join(parent, "status.json");
 }
 
 export async function writeFactoryStatusSnapshot(

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
 
+let snapshotWriteSequence = 0;
+
 export type FactoryState = "idle" | "running" | "blocked";
 
 export type FactoryIssueStatus =
@@ -102,8 +104,9 @@ export async function writeFactoryStatusSnapshot(
   const directory = path.dirname(filePath);
   const temporaryPath = path.join(
     directory,
-    `.status.${process.pid.toString()}.tmp`,
+    `.status.${process.pid.toString()}.${snapshotWriteSequence.toString()}.tmp`,
   );
+  snapshotWriteSequence += 1;
   await fs.mkdir(directory, { recursive: true });
   await fs.writeFile(
     temporaryPath,

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -135,6 +135,9 @@ export async function readFactoryStatusSnapshot(
 }
 
 export function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) {
+    return false;
+  }
   try {
     process.kill(pid, 0);
     return true;
@@ -311,7 +314,7 @@ function parseWorkerSnapshot(
   const worker = expectObject(value, filePath, "worker");
   return {
     instanceId: expectString(worker.instanceId, filePath, "worker.instanceId"),
-    pid: expectInteger(worker.pid, filePath, "worker.pid"),
+    pid: expectPositiveInteger(worker.pid, filePath, "worker.pid"),
     startedAt: expectString(worker.startedAt, filePath, "worker.startedAt"),
     pollIntervalMs: expectInteger(
       worker.pollIntervalMs,
@@ -568,6 +571,21 @@ function expectInteger(
     throw invalidSnapshot(filePath, `expected ${field} to be an integer`);
   }
   return value;
+}
+
+function expectPositiveInteger(
+  value: unknown,
+  filePath: string,
+  field: string,
+): number {
+  const integer = expectInteger(value, filePath, field);
+  if (integer <= 0) {
+    throw invalidSnapshot(
+      filePath,
+      `expected ${field} to be a positive integer`,
+    );
+  }
+  return integer;
 }
 
 function expectNullableInteger(

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -22,10 +22,13 @@ export interface FactoryWorkerSnapshot {
 }
 
 export interface FactoryStatusCounts {
+  /** Tracker-level label counts refreshed from the tracker on each poll. */
   readonly ready: number;
   readonly running: number;
   readonly failed: number;
+  /** Local process state for the current factory instance. */
   readonly activeLocalRuns: number;
+  /** Local in-memory retry queue size, not a tracker-level label count. */
   readonly retries: number;
 }
 

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -186,7 +186,7 @@ export function renderFactoryStatusSnapshot(
     `Started: ${snapshot.worker.startedAt}  Snapshot: ${snapshot.generatedAt}`,
   );
   lines.push(
-    `Counts: ready=${snapshot.counts.ready.toString()} running=${snapshot.counts.running.toString()} failed=${snapshot.counts.failed.toString()} local=${snapshot.counts.activeLocalRuns.toString()} retries=${snapshot.counts.retries.toString()}`,
+    `Counts: ready=${snapshot.counts.ready.toString()} tracker_running=${snapshot.counts.running.toString()} failed=${snapshot.counts.failed.toString()} local=${snapshot.counts.activeLocalRuns.toString()} retries=${snapshot.counts.retries.toString()}`,
   );
   lines.push(
     `Polling: every ${snapshot.worker.pollIntervalMs.toString()}ms, max concurrency ${snapshot.worker.maxConcurrentRuns.toString()}`,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -258,6 +258,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         ready: -1,
         running: 1,
       });
+      upsertActiveIssue(this.#state.status, claimed, {
+        source: "ready",
+        runSequence: attempt,
+        branchName: this.#branchName(claimed.number),
+        status: "queued",
+        summary: `Claimed ${claimed.identifier}`,
+        ownerPid: process.pid,
+      });
       noteStatusAction(this.#state.status, {
         kind: "issue-claimed",
         summary: `Claimed ${claimed.identifier}`,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -90,7 +90,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       await Promise.all([
         this.#tracker.fetchReadyIssues(),
         this.#tracker.fetchRunningIssues(),
-        this.#tracker.fetchFailedIssues(),
+        this.#fetchFailedCandidatesForStatus(),
       ]);
     setTrackerIssueCounts(this.#state.status, {
       ready: readyCandidates.length,
@@ -850,6 +850,17 @@ export class BootstrapOrchestrator implements Orchestrator {
         statusFilePath: this.#statusFilePath,
         error: this.#normalizeFailure(error as Error),
       });
+    }
+  }
+
+  async #fetchFailedCandidatesForStatus(): Promise<readonly RuntimeIssue[]> {
+    try {
+      return await this.#tracker.fetchFailedIssues();
+    } catch (error) {
+      this.#logger.warn("Failed to fetch failed issues for status snapshot", {
+        error: this.#normalizeFailure(error as Error),
+      });
+      return [];
     }
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -97,6 +97,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       running: runningCandidates.length,
       failed: failedCandidates.length,
     });
+    this.#pruneStaleActiveIssues(readyCandidates, runningCandidates);
     await this.#reconcileRunningIssueOwnership(runningCandidates);
     const dueRetries = this.#collectDueRetries();
     const queue = this.#mergeQueue(
@@ -254,10 +255,6 @@ export class BootstrapOrchestrator implements Orchestrator {
         await this.#persistStatusSnapshot();
         return;
       }
-      adjustTrackerIssueCounts(this.#state.status, {
-        ready: -1,
-        running: 1,
-      });
       upsertActiveIssue(this.#state.status, claimed, {
         source: "ready",
         runSequence: attempt,
@@ -265,6 +262,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         status: "queued",
         summary: `Claimed ${claimed.identifier}`,
         ownerPid: process.pid,
+      });
+      adjustTrackerIssueCounts(this.#state.status, {
+        ready: -1,
+        running: 1,
       });
       noteStatusAction(this.#state.status, {
         kind: "issue-claimed",
@@ -629,6 +630,25 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber,
       });
       await this.#persistStatusSnapshot();
+    }
+  }
+
+  #pruneStaleActiveIssues(
+    readyIssues: readonly RuntimeIssue[],
+    runningIssues: readonly RuntimeIssue[],
+  ): void {
+    const retainedIssueNumbers = new Set<number>([
+      ...readyIssues.map((issue) => issue.number),
+      ...runningIssues.map((issue) => issue.number),
+      ...this.#state.runningIssueNumbers,
+      ...this.#state.retries.keys(),
+    ]);
+
+    for (const issueNumber of this.#state.status.activeIssues.keys()) {
+      if (retainedIssueNumbers.has(issueNumber)) {
+        continue;
+      }
+      clearActiveIssue(this.#state.status, issueNumber);
     }
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -816,6 +816,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber,
       at: event.spawnedAt,
     });
+    // The runner onSpawn callback is synchronous; snapshot persistence is optional.
     void this.#persistStatusSnapshot();
     this.#logger.info("Runner process attached to active issue", {
       issueNumber,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -324,6 +324,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     initialLifecycle?: PullRequestLifecycle,
   ): Promise<void> {
     const branchName = this.#branchName(issue.number);
+    const issueSource = initialLifecycle === undefined ? "running" : "ready";
     const lifecycle =
       initialLifecycle ?? (await this.#refreshLifecycle(branchName));
 
@@ -337,7 +338,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       noteLifecycleForIssue(
         this.#state.status,
         issue,
-        initialLifecycle === undefined ? "running" : "ready",
+        issueSource,
         attempt,
         branchName,
         lifecycle,
@@ -359,6 +360,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issue,
       attempt,
       lockDir,
+      issueSource,
       lifecycle.kind === "missing" ? null : lifecycle,
     );
   }
@@ -367,10 +369,11 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     lockDir: string,
+    source: "ready" | "running",
     pullRequest: PullRequestLifecycle | null,
   ): Promise<void> {
     upsertActiveIssue(this.#state.status, issue, {
-      source: pullRequest === null ? "ready" : "running",
+      source,
       runSequence: attempt,
       branchName: this.#branchName(issue.number),
       status: "preparing",
@@ -393,7 +396,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     });
     const session = this.#createRunSession(issue, workspace, prompt, attempt);
     upsertActiveIssue(this.#state.status, issue, {
-      source: pullRequest === null ? "ready" : "running",
+      source,
       runSequence: attempt,
       branchName: workspace.branchName,
       status: "running",
@@ -483,7 +486,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       noteLifecycleForIssue(
         this.#state.status,
         issue,
-        pullRequest === null ? "ready" : "running",
+        source,
         attempt,
         workspace.branchName,
         nextLifecycle,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -324,7 +324,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     initialLifecycle?: PullRequestLifecycle,
   ): Promise<void> {
     const branchName = this.#branchName(issue.number);
-    const issueSource = initialLifecycle === undefined ? "running" : "ready";
+    const issueSource = initialLifecycle !== undefined ? "ready" : "running";
     const lifecycle =
       initialLifecycle ?? (await this.#refreshLifecycle(branchName));
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -6,6 +6,10 @@ import type { RetryState } from "../domain/retry.js";
 import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
 import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import {
+  deriveStatusFilePath,
+  writeFactoryStatusSnapshot,
+} from "../observability/status.js";
 import type { Runner } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
@@ -18,6 +22,15 @@ import {
 } from "./follow-up-state.js";
 import { LocalIssueLeaseManager } from "./issue-lease.js";
 import { createOrchestratorState } from "./state.js";
+import {
+  adjustTrackerIssueCounts,
+  buildFactoryStatusSnapshot,
+  clearActiveIssue,
+  noteLifecycleForIssue,
+  noteStatusAction,
+  setTrackerIssueCounts,
+  upsertActiveIssue,
+} from "./status-state.js";
 
 export interface Orchestrator {
   runOnce(): Promise<void>;
@@ -40,6 +53,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #state = createOrchestratorState();
   readonly #instanceId = randomUUID();
   readonly #leaseManager: LocalIssueLeaseManager;
+  readonly #statusFilePath: string;
   #shutdownSignal: AbortSignal | undefined;
 
   constructor(
@@ -60,15 +74,29 @@ export class BootstrapOrchestrator implements Orchestrator {
       config.workspace.root,
       logger,
     );
+    this.#statusFilePath = deriveStatusFilePath(config.workspace.root);
   }
 
   async runOnce(): Promise<void> {
+    noteStatusAction(this.#state.status, {
+      kind: "poll-started",
+      summary: "Polling tracker for ready and running issues",
+      issueNumber: null,
+    });
+    await this.#persistStatusSnapshot();
     await this.#tracker.ensureLabels();
     this.#logger.info("Poll started");
-    const [readyCandidates, runningCandidates] = await Promise.all([
-      this.#tracker.fetchReadyIssues(),
-      this.#tracker.fetchRunningIssues(),
-    ]);
+    const [readyCandidates, runningCandidates, failedCandidates] =
+      await Promise.all([
+        this.#tracker.fetchReadyIssues(),
+        this.#tracker.fetchRunningIssues(),
+        this.#tracker.fetchFailedIssues(),
+      ]);
+    setTrackerIssueCounts(this.#state.status, {
+      ready: readyCandidates.length,
+      running: runningCandidates.length,
+      failed: failedCandidates.length,
+    });
     await this.#reconcileRunningIssueOwnership(runningCandidates);
     const dueRetries = this.#collectDueRetries();
     const queue = this.#mergeQueue(
@@ -82,9 +110,16 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#logger.info("Poll candidates fetched", {
       readyCount: readyCandidates.length,
       runningCount: runningCandidates.length,
+      failedCount: failedCandidates.length,
       candidateCount: queue.length,
       availableSlots,
     });
+    noteStatusAction(this.#state.status, {
+      kind: "poll-fetched",
+      summary: `Found ${readyCandidates.length.toString()} ready, ${runningCandidates.length.toString()} running, ${failedCandidates.length.toString()} failed issues`,
+      issueNumber: null,
+    });
+    await this.#persistStatusSnapshot();
 
     if (availableSlots <= 0) {
       return;
@@ -211,8 +246,24 @@ export class BootstrapOrchestrator implements Orchestrator {
         this.#logger.info("Issue was no longer claimable", {
           issueNumber: issue.number,
         });
+        noteStatusAction(this.#state.status, {
+          kind: "claim-skipped",
+          summary: `Issue #${issue.number.toString()} was no longer claimable`,
+          issueNumber: issue.number,
+        });
+        await this.#persistStatusSnapshot();
         return;
       }
+      adjustTrackerIssueCounts(this.#state.status, {
+        ready: -1,
+        running: 1,
+      });
+      noteStatusAction(this.#state.status, {
+        kind: "issue-claimed",
+        summary: `Claimed ${claimed.identifier}`,
+        issueNumber: claimed.number,
+      });
+      await this.#persistStatusSnapshot();
       await this.#processClaimedIssue(
         claimed,
         attempt,
@@ -227,6 +278,20 @@ export class BootstrapOrchestrator implements Orchestrator {
     attempt: number,
   ): Promise<void> {
     await this.#withIssueLease(issue, attempt, async (lockDir) => {
+      upsertActiveIssue(this.#state.status, issue, {
+        source: "running",
+        runSequence: attempt,
+        branchName: this.#branchName(issue.number),
+        status: "queued",
+        summary: `Inspecting ${issue.identifier}`,
+        ownerPid: process.pid,
+      });
+      noteStatusAction(this.#state.status, {
+        kind: "issue-resumed",
+        summary: `Inspecting running issue ${issue.identifier}`,
+        issueNumber: issue.number,
+      });
+      await this.#persistStatusSnapshot();
       await this.#processClaimedIssue(issue, attempt, lockDir);
     });
   }
@@ -248,6 +313,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     } finally {
       this.#state.runningIssueNumbers.delete(issue.number);
       await this.#leaseManager.release(lease);
+      await this.#persistStatusSnapshot();
     }
   }
 
@@ -268,10 +334,24 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
 
     if (lifecycle.kind === "awaiting-review") {
+      noteLifecycleForIssue(
+        this.#state.status,
+        issue,
+        "running",
+        attempt,
+        branchName,
+        lifecycle,
+      );
       this.#logger.info("Issue remains in PR review", {
         issueNumber: issue.number,
         summary: lifecycle.summary,
       });
+      noteStatusAction(this.#state.status, {
+        kind: "awaiting-review",
+        summary: lifecycle.summary,
+        issueNumber: issue.number,
+      });
+      await this.#persistStatusSnapshot();
       return;
     }
 
@@ -289,6 +369,22 @@ export class BootstrapOrchestrator implements Orchestrator {
     lockDir: string,
     pullRequest: PullRequestLifecycle | null,
   ): Promise<void> {
+    upsertActiveIssue(this.#state.status, issue, {
+      source: pullRequest === null ? "ready" : "running",
+      runSequence: attempt,
+      branchName: this.#branchName(issue.number),
+      status: "preparing",
+      summary: `Preparing workspace for ${issue.identifier}`,
+      ownerPid: process.pid,
+      runnerPid: null,
+      blockedReason: null,
+    });
+    noteStatusAction(this.#state.status, {
+      kind: "run-preparing",
+      summary: `Preparing workspace for ${issue.identifier}`,
+      issueNumber: issue.number,
+    });
+    await this.#persistStatusSnapshot();
     const workspace = await this.#workspaceManager.prepareWorkspace({ issue });
     const prompt = await this.#promptBuilder.build({
       issue,
@@ -296,6 +392,42 @@ export class BootstrapOrchestrator implements Orchestrator {
       pullRequest,
     });
     const session = this.#createRunSession(issue, workspace, prompt, attempt);
+    upsertActiveIssue(this.#state.status, issue, {
+      source: pullRequest === null ? "ready" : "running",
+      runSequence: attempt,
+      branchName: workspace.branchName,
+      status: "running",
+      summary: `Running ${issue.identifier}`,
+      workspacePath: workspace.path,
+      runSessionId: session.id,
+      ownerPid: process.pid,
+      runnerPid: null,
+      startedAt: new Date().toISOString(),
+      pullRequest:
+        pullRequest?.pullRequest === undefined ||
+        pullRequest.pullRequest === null
+          ? null
+          : {
+              number: pullRequest.pullRequest.number,
+              url: pullRequest.pullRequest.url,
+              latestCommitAt: pullRequest.pullRequest.latestCommitAt,
+            },
+      checks: {
+        pendingNames: pullRequest?.pendingCheckNames ?? [],
+        failingNames: pullRequest?.failingCheckNames ?? [],
+      },
+      review: {
+        actionableCount: pullRequest?.actionableReviewFeedback.length ?? 0,
+        unresolvedThreadCount: pullRequest?.unresolvedThreadIds.length ?? 0,
+      },
+      blockedReason: null,
+    });
+    noteStatusAction(this.#state.status, {
+      kind: "run-started",
+      summary: `Started agent run for ${issue.identifier}`,
+      issueNumber: issue.number,
+    });
+    await this.#persistStatusSnapshot();
     await this.#leaseManager.recordRun(lockDir, session);
     const abortController = new AbortController();
     const shutdownSignal = this.#shutdownSignal;
@@ -348,6 +480,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         return;
       }
 
+      noteLifecycleForIssue(
+        this.#state.status,
+        issue,
+        pullRequest === null ? "ready" : "running",
+        attempt,
+        workspace.branchName,
+        nextLifecycle,
+      );
       this.#logger.info("Issue remains in PR lifecycle", {
         issueNumber: issue.number,
         branchName: workspace.branchName,
@@ -355,6 +495,12 @@ export class BootstrapOrchestrator implements Orchestrator {
         lifecycle: nextLifecycle.kind,
         summary: nextLifecycle.summary,
       });
+      noteStatusAction(this.#state.status, {
+        kind: nextLifecycle.kind,
+        summary: nextLifecycle.summary,
+        issueNumber: issue.number,
+      });
+      await this.#persistStatusSnapshot();
 
       const decision = noteLifecycleObservation(
         this.#state.followUp,
@@ -382,7 +528,17 @@ export class BootstrapOrchestrator implements Orchestrator {
     await this.#tracker.completeIssue(issueNumber);
     this.#state.retries.delete(issueNumber);
     clearFollowUpRuntimeState(this.#state.followUp, issueNumber);
+    clearActiveIssue(this.#state.status, issueNumber);
+    adjustTrackerIssueCounts(this.#state.status, {
+      running: -1,
+    });
     this.#logger.info("Issue completed", { issueNumber });
+    noteStatusAction(this.#state.status, {
+      kind: "issue-completed",
+      summary: `Completed issue #${issueNumber.toString()}`,
+      issueNumber,
+    });
+    await this.#persistStatusSnapshot();
   }
 
   async #cleanupIssueWorkspaceIfNeeded(issue: RuntimeIssue): Promise<void> {
@@ -456,6 +612,12 @@ export class BootstrapOrchestrator implements Orchestrator {
         runnerPid: snapshot.runnerPid,
         runSessionId: snapshot.record?.runSessionId ?? null,
       });
+      noteStatusAction(this.#state.status, {
+        kind: "ownership-recovered",
+        summary: `Recovered stale ownership for issue #${issueNumber.toString()}`,
+        issueNumber,
+      });
+      await this.#persistStatusSnapshot();
     }
   }
 
@@ -507,6 +669,12 @@ export class BootstrapOrchestrator implements Orchestrator {
       workspacePath: session.workspace.path,
       runSessionId: session.id,
     });
+    noteStatusAction(this.#state.status, {
+      kind: "run-failed",
+      summary: message,
+      issueNumber: session.issue.number,
+    });
+    await this.#persistStatusSnapshot();
     await this.#scheduleRetryOrFailSafely(session.issue, attempt, message);
   }
 
@@ -521,6 +689,12 @@ export class BootstrapOrchestrator implements Orchestrator {
       attempt,
       error: message,
     });
+    noteStatusAction(this.#state.status, {
+      kind: "unexpected-failure",
+      summary: message,
+      issueNumber: issue.number,
+    });
+    await this.#persistStatusSnapshot();
     await this.#scheduleRetryOrFailSafely(issue, attempt, message);
   }
 
@@ -563,6 +737,15 @@ export class BootstrapOrchestrator implements Orchestrator {
           message,
         ),
       );
+      clearActiveIssue(this.#state.status, issue.number);
+      noteStatusAction(this.#state.status, {
+        kind: "retry-scheduled",
+        summary: `Retry ${this.#state.retries
+          .get(issue.number)!
+          .nextAttempt.toString()} scheduled for ${issue.identifier}`,
+        issueNumber: issue.number,
+      });
+      await this.#persistStatusSnapshot();
       return;
     }
     await this.#failIssue(issue.number, message);
@@ -572,6 +755,17 @@ export class BootstrapOrchestrator implements Orchestrator {
     await this.#tracker.markIssueFailed(issueNumber, message);
     this.#state.retries.delete(issueNumber);
     clearFollowUpRuntimeState(this.#state.followUp, issueNumber);
+    clearActiveIssue(this.#state.status, issueNumber);
+    adjustTrackerIssueCounts(this.#state.status, {
+      running: -1,
+      failed: 1,
+    });
+    noteStatusAction(this.#state.status, {
+      kind: "issue-failed",
+      summary: message,
+      issueNumber,
+    });
+    await this.#persistStatusSnapshot();
   }
 
   #followUpFailureMessage(lifecycle: PullRequestLifecycle): string {
@@ -608,6 +802,21 @@ export class BootstrapOrchestrator implements Orchestrator {
     event: RunSpawnEvent,
   ): void {
     this.#leaseManager.recordRunnerSpawn(lockDir, event);
+    const entry = this.#state.status.activeIssues.get(issueNumber);
+    if (entry) {
+      this.#state.status.activeIssues.set(issueNumber, {
+        ...entry,
+        runnerPid: event.pid,
+        updatedAt: event.spawnedAt,
+      });
+    }
+    noteStatusAction(this.#state.status, {
+      kind: "runner-spawned",
+      summary: `Runner PID ${event.pid.toString()} attached`,
+      issueNumber,
+      at: event.spawnedAt,
+    });
+    void this.#persistStatusSnapshot();
     this.#logger.info("Runner process attached to active issue", {
       issueNumber,
       runnerPid: event.pid,
@@ -618,6 +827,28 @@ export class BootstrapOrchestrator implements Orchestrator {
   #abortActiveRuns(): void {
     for (const controller of this.#state.runAbortControllers.values()) {
       controller.abort();
+    }
+  }
+
+  async #persistStatusSnapshot(): Promise<void> {
+    try {
+      await writeFactoryStatusSnapshot(
+        this.#statusFilePath,
+        buildFactoryStatusSnapshot({
+          state: this.#state.status,
+          instanceId: this.#instanceId,
+          workerPid: process.pid,
+          pollIntervalMs: this.#config.polling.intervalMs,
+          maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
+          activeLocalRuns: this.#state.runningIssueNumbers.size,
+          retries: this.#state.retries,
+        }),
+      );
+    } catch (error) {
+      this.#logger.warn("Failed to write status snapshot", {
+        statusFilePath: this.#statusFilePath,
+        error: this.#normalizeFailure(error as Error),
+      });
     }
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -337,7 +337,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       noteLifecycleForIssue(
         this.#state.status,
         issue,
-        "running",
+        initialLifecycle === undefined ? "running" : "ready",
         attempt,
         branchName,
         lifecycle,

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -3,12 +3,17 @@ import {
   createFollowUpRuntimeState,
   type FollowUpRuntimeState,
 } from "./follow-up-state.js";
+import {
+  createRuntimeStatusState,
+  type RuntimeStatusState,
+} from "./status-state.js";
 
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
   readonly runAbortControllers: Map<number, AbortController>;
   readonly retries: Map<number, RetryState>;
   readonly followUp: FollowUpRuntimeState;
+  readonly status: RuntimeStatusState;
 }
 
 export function createOrchestratorState(): OrchestratorState {
@@ -17,5 +22,6 @@ export function createOrchestratorState(): OrchestratorState {
     runAbortControllers: new Map<number, AbortController>(),
     retries: new Map<number, RetryState>(),
     followUp: createFollowUpRuntimeState(),
+    status: createRuntimeStatusState(),
   };
 }

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -15,7 +15,7 @@ export interface TrackerIssueCounts {
   failed: number;
 }
 
-interface RuntimeActiveIssueState extends FactoryActiveIssueSnapshot {}
+type RuntimeActiveIssueState = FactoryActiveIssueSnapshot;
 
 export interface RuntimeStatusState {
   readonly workerStartedAt: string;

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -10,16 +10,16 @@ import type {
 } from "../observability/status.js";
 
 export interface TrackerIssueCounts {
-  ready: number;
-  running: number;
-  failed: number;
+  readonly ready: number;
+  readonly running: number;
+  readonly failed: number;
 }
 
 type RuntimeActiveIssueState = FactoryActiveIssueSnapshot;
 
 export interface RuntimeStatusState {
   readonly workerStartedAt: string;
-  readonly trackerCounts: TrackerIssueCounts;
+  trackerCounts: TrackerIssueCounts;
   readonly activeIssues: Map<number, RuntimeActiveIssueState>;
   lastAction: FactoryStatusAction | null;
 }
@@ -53,33 +53,31 @@ export function setTrackerIssueCounts(
   state: RuntimeStatusState,
   counts: TrackerIssueCounts,
 ): void {
-  state.trackerCounts.ready = counts.ready;
-  state.trackerCounts.running = counts.running;
-  state.trackerCounts.failed = counts.failed;
+  state.trackerCounts = {
+    ready: counts.ready,
+    running: counts.running,
+    failed: counts.failed,
+  };
 }
 
 export function adjustTrackerIssueCounts(
   state: RuntimeStatusState,
   change: Partial<Record<keyof TrackerIssueCounts, number>>,
 ): void {
-  if (change.ready !== undefined) {
-    state.trackerCounts.ready = Math.max(
-      0,
-      state.trackerCounts.ready + change.ready,
-    );
-  }
-  if (change.running !== undefined) {
-    state.trackerCounts.running = Math.max(
-      0,
-      state.trackerCounts.running + change.running,
-    );
-  }
-  if (change.failed !== undefined) {
-    state.trackerCounts.failed = Math.max(
-      0,
-      state.trackerCounts.failed + change.failed,
-    );
-  }
+  state.trackerCounts = {
+    ready:
+      change.ready === undefined
+        ? state.trackerCounts.ready
+        : Math.max(0, state.trackerCounts.ready + change.ready),
+    running:
+      change.running === undefined
+        ? state.trackerCounts.running
+        : Math.max(0, state.trackerCounts.running + change.running),
+    failed:
+      change.failed === undefined
+        ? state.trackerCounts.failed
+        : Math.max(0, state.trackerCounts.failed + change.failed),
+  };
 }
 
 export function upsertActiveIssue(

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -103,14 +103,32 @@ export function upsertActiveIssue(
     runSequence: update.runSequence,
     status: update.status,
     summary: update.summary,
-    workspacePath: update.workspacePath ?? existing?.workspacePath ?? null,
+    workspacePath:
+      update.workspacePath === undefined
+        ? (existing?.workspacePath ?? null)
+        : update.workspacePath,
     branchName: update.branchName,
-    runSessionId: update.runSessionId ?? existing?.runSessionId ?? null,
-    ownerPid: update.ownerPid ?? existing?.ownerPid ?? null,
-    runnerPid: update.runnerPid ?? existing?.runnerPid ?? null,
-    startedAt: update.startedAt ?? existing?.startedAt ?? null,
+    runSessionId:
+      update.runSessionId === undefined
+        ? (existing?.runSessionId ?? null)
+        : update.runSessionId,
+    ownerPid:
+      update.ownerPid === undefined
+        ? (existing?.ownerPid ?? null)
+        : update.ownerPid,
+    runnerPid:
+      update.runnerPid === undefined
+        ? (existing?.runnerPid ?? null)
+        : update.runnerPid,
+    startedAt:
+      update.startedAt === undefined
+        ? (existing?.startedAt ?? null)
+        : update.startedAt,
     updatedAt,
-    pullRequest: update.pullRequest ?? existing?.pullRequest ?? null,
+    pullRequest:
+      update.pullRequest === undefined
+        ? (existing?.pullRequest ?? null)
+        : update.pullRequest,
     checks: update.checks ??
       existing?.checks ?? { pendingNames: [], failingNames: [] },
     review: update.review ??

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -1,0 +1,245 @@
+import type { RuntimeIssue } from "../domain/issue.js";
+import type { PullRequestLifecycle } from "../domain/pull-request.js";
+import type { RetryState } from "../domain/retry.js";
+import type {
+  FactoryActiveIssueSnapshot,
+  FactoryIssueStatus,
+  FactoryState,
+  FactoryStatusAction,
+  FactoryStatusSnapshot,
+} from "../observability/status.js";
+
+export interface TrackerIssueCounts {
+  ready: number;
+  running: number;
+  failed: number;
+}
+
+interface RuntimeActiveIssueState extends FactoryActiveIssueSnapshot {
+  readonly title: string;
+}
+
+export interface RuntimeStatusState {
+  readonly workerStartedAt: string;
+  readonly trackerCounts: TrackerIssueCounts;
+  readonly activeIssues: Map<number, RuntimeActiveIssueState>;
+  lastAction: FactoryStatusAction | null;
+}
+
+export function createRuntimeStatusState(): RuntimeStatusState {
+  return {
+    workerStartedAt: new Date().toISOString(),
+    trackerCounts: {
+      ready: 0,
+      running: 0,
+      failed: 0,
+    },
+    activeIssues: new Map<number, RuntimeActiveIssueState>(),
+    lastAction: null,
+  };
+}
+
+export function noteStatusAction(
+  state: RuntimeStatusState,
+  action: Omit<FactoryStatusAction, "at"> & { readonly at?: string },
+): void {
+  state.lastAction = {
+    kind: action.kind,
+    summary: action.summary,
+    issueNumber: action.issueNumber,
+    at: action.at ?? new Date().toISOString(),
+  };
+}
+
+export function setTrackerIssueCounts(
+  state: RuntimeStatusState,
+  counts: TrackerIssueCounts,
+): void {
+  state.trackerCounts.ready = counts.ready;
+  state.trackerCounts.running = counts.running;
+  state.trackerCounts.failed = counts.failed;
+}
+
+export function adjustTrackerIssueCounts(
+  state: RuntimeStatusState,
+  change: Partial<Record<keyof TrackerIssueCounts, number>>,
+): void {
+  if (change.ready !== undefined) {
+    state.trackerCounts.ready = Math.max(
+      0,
+      state.trackerCounts.ready + change.ready,
+    );
+  }
+  if (change.running !== undefined) {
+    state.trackerCounts.running = Math.max(
+      0,
+      state.trackerCounts.running + change.running,
+    );
+  }
+  if (change.failed !== undefined) {
+    state.trackerCounts.failed = Math.max(
+      0,
+      state.trackerCounts.failed + change.failed,
+    );
+  }
+}
+
+export function upsertActiveIssue(
+  state: RuntimeStatusState,
+  issue: RuntimeIssue,
+  update: Partial<RuntimeActiveIssueState> & {
+    readonly source: "ready" | "running";
+    readonly runSequence: number;
+    readonly branchName: string;
+    readonly status: FactoryIssueStatus;
+    readonly summary: string;
+  },
+): void {
+  const existing = state.activeIssues.get(issue.number);
+  const updatedAt = update.updatedAt ?? new Date().toISOString();
+  state.activeIssues.set(issue.number, {
+    issueNumber: issue.number,
+    issueIdentifier: issue.identifier,
+    title: issue.title,
+    source: update.source,
+    runSequence: update.runSequence,
+    status: update.status,
+    summary: update.summary,
+    workspacePath: update.workspacePath ?? existing?.workspacePath ?? null,
+    branchName: update.branchName,
+    runSessionId: update.runSessionId ?? existing?.runSessionId ?? null,
+    ownerPid: update.ownerPid ?? existing?.ownerPid ?? null,
+    runnerPid: update.runnerPid ?? existing?.runnerPid ?? null,
+    startedAt: update.startedAt ?? existing?.startedAt ?? null,
+    updatedAt,
+    pullRequest: update.pullRequest ?? existing?.pullRequest ?? null,
+    checks: update.checks ??
+      existing?.checks ?? { pendingNames: [], failingNames: [] },
+    review: update.review ??
+      existing?.review ?? { actionableCount: 0, unresolvedThreadCount: 0 },
+    blockedReason:
+      update.blockedReason === undefined
+        ? (existing?.blockedReason ?? null)
+        : update.blockedReason,
+  });
+}
+
+export function noteLifecycleForIssue(
+  state: RuntimeStatusState,
+  issue: RuntimeIssue,
+  source: "ready" | "running",
+  runSequence: number,
+  branchName: string,
+  lifecycle: PullRequestLifecycle,
+): void {
+  upsertActiveIssue(state, issue, {
+    source,
+    runSequence,
+    branchName,
+    status:
+      lifecycle.kind === "needs-follow-up"
+        ? "needs-follow-up"
+        : lifecycle.kind === "awaiting-review"
+          ? "awaiting-review"
+          : "queued",
+    summary: lifecycle.summary,
+    pullRequest:
+      lifecycle.pullRequest === null
+        ? null
+        : {
+            number: lifecycle.pullRequest.number,
+            url: lifecycle.pullRequest.url,
+            latestCommitAt: lifecycle.pullRequest.latestCommitAt,
+          },
+    checks: {
+      pendingNames: lifecycle.pendingCheckNames,
+      failingNames: lifecycle.failingCheckNames,
+    },
+    review: {
+      actionableCount: lifecycle.actionableReviewFeedback.length,
+      unresolvedThreadCount: lifecycle.unresolvedThreadIds.length,
+    },
+    blockedReason:
+      lifecycle.kind === "awaiting-review" ||
+      lifecycle.kind === "needs-follow-up"
+        ? lifecycle.summary
+        : null,
+  });
+}
+
+export function clearActiveIssue(
+  state: RuntimeStatusState,
+  issueNumber: number,
+): void {
+  state.activeIssues.delete(issueNumber);
+}
+
+export function buildFactoryStatusSnapshot(input: {
+  readonly state: RuntimeStatusState;
+  readonly instanceId: string;
+  readonly workerPid: number;
+  readonly pollIntervalMs: number;
+  readonly maxConcurrentRuns: number;
+  readonly activeLocalRuns: number;
+  readonly retries: ReadonlyMap<number, RetryState>;
+}): FactoryStatusSnapshot {
+  const activeIssues = [...input.state.activeIssues.values()].sort(
+    (left, right) => left.issueNumber - right.issueNumber,
+  );
+  const retries = [...input.retries.values()]
+    .sort((left, right) => left.issue.number - right.issue.number)
+    .map((retry) => ({
+      issueNumber: retry.issue.number,
+      issueIdentifier: retry.issue.identifier,
+      title: retry.issue.title,
+      nextAttempt: retry.nextAttempt,
+      dueAt: new Date(retry.dueAt).toISOString(),
+      lastError: retry.lastError,
+    }));
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    factoryState: resolveFactoryState(
+      activeIssues,
+      input.activeLocalRuns,
+      retries.length,
+    ),
+    worker: {
+      instanceId: input.instanceId,
+      pid: input.workerPid,
+      startedAt: input.state.workerStartedAt,
+      pollIntervalMs: input.pollIntervalMs,
+      maxConcurrentRuns: input.maxConcurrentRuns,
+    },
+    counts: {
+      ready: input.state.trackerCounts.ready,
+      running: input.state.trackerCounts.running,
+      failed: input.state.trackerCounts.failed,
+      activeLocalRuns: input.activeLocalRuns,
+      retries: retries.length,
+    },
+    lastAction: input.state.lastAction,
+    activeIssues,
+    retries,
+  };
+}
+
+function resolveFactoryState(
+  activeIssues: readonly RuntimeActiveIssueState[],
+  activeLocalRuns: number,
+  retryCount: number,
+): FactoryState {
+  if (
+    activeLocalRuns > 0 ||
+    activeIssues.some((issue) =>
+      ["queued", "preparing", "running"].includes(issue.status),
+    )
+  ) {
+    return "running";
+  }
+  if (activeIssues.length > 0 || retryCount > 0) {
+    return "blocked";
+  }
+  return "idle";
+}

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -15,9 +15,7 @@ export interface TrackerIssueCounts {
   failed: number;
 }
 
-interface RuntimeActiveIssueState extends FactoryActiveIssueSnapshot {
-  readonly title: string;
-}
+interface RuntimeActiveIssueState extends FactoryActiveIssueSnapshot {}
 
 export interface RuntimeStatusState {
   readonly workerStartedAt: string;

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -42,6 +42,10 @@ export class GitHubBootstrapTracker implements Tracker {
     return await this.#client.fetchIssuesByLabel(this.#config.runningLabel);
   }
 
+  async fetchFailedIssues(): Promise<readonly RuntimeIssue[]> {
+    return await this.#client.fetchIssuesByLabel(this.#config.failedLabel);
+  }
+
   async getIssue(issueNumber: number): Promise<RuntimeIssue> {
     return await this.#client.getIssue(issueNumber);
   }

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -5,6 +5,7 @@ export interface Tracker {
   ensureLabels(): Promise<void>;
   fetchReadyIssues(): Promise<readonly RuntimeIssue[]>;
   fetchRunningIssues(): Promise<readonly RuntimeIssue[]>;
+  fetchFailedIssues(): Promise<readonly RuntimeIssue[]>;
   getIssue(issueNumber: number): Promise<RuntimeIssue>;
   claimIssue(issueNumber: number): Promise<RuntimeIssue | null>;
   inspectIssueHandoff(branchName: string): Promise<PullRequestLifecycle>;

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -7,6 +7,7 @@ import {
   loadWorkflow,
 } from "../../src/config/workflow.js";
 import { JsonLogger } from "../../src/observability/logger.js";
+import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import { LocalRunner } from "../../src/runner/local.js";
 import { GitHubBootstrapTracker } from "../../src/tracker/github-bootstrap.js";
@@ -156,6 +157,20 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       "symphony:running",
     );
     expect(server.getPullRequests()).toHaveLength(1);
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.factoryState).toBe("blocked");
+    expect(status.counts.running).toBe(1);
+    expect(status.lastAction?.kind).toBe("awaiting-review");
+    expect(status.activeIssues).toHaveLength(1);
+    expect(status.activeIssues[0]).toMatchObject({
+      issueNumber: 1,
+      status: "awaiting-review",
+      branchName: "symphony/1",
+    });
+    expect(status.activeIssues[0]?.pullRequest?.number).toBe(1);
+    expect(status.activeIssues[0]?.checks.pendingNames).toEqual([]);
 
     server.setPullRequestCheckRuns("symphony/1", [
       { name: "CI", status: "completed", conclusion: "success" },

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -111,6 +111,14 @@ describe("parseArgs", () => {
       parseArgs(["node", "symphony", "run", "--workflow"]),
     ).toThrowError("Missing value for --workflow");
   });
+
+  it("shows usage for unknown commands before parsing workflow options", () => {
+    expect(() =>
+      parseArgs(["node", "symphony", "deploy", "--workflow"]),
+    ).toThrowError(
+      "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
+    );
+  });
 });
 
 describe("runCli status", () => {
@@ -149,13 +157,31 @@ describe("runCli status", () => {
     const tempDir = await createTempDir("symphony-cli-status-json-");
     const workflowPath = await writeWorkflow(tempDir);
     const statusPath = path.join(tempDir, ".tmp", "status.json");
-    const snapshot = createSnapshot();
+    const rawSnapshot = `{
+  "version": 1,
+  "generatedAt": "2026-03-06T12:00:00.000Z",
+  "factoryState": "idle",
+  "worker": {
+    "instanceId": "worker-1",
+    "pid": ${process.pid},
+    "startedAt": "2026-03-06T11:59:00.000Z",
+    "pollIntervalMs": 1000,
+    "maxConcurrentRuns": 1
+  },
+  "counts": {
+    "ready": 0,
+    "running": 0,
+    "failed": 0,
+    "activeLocalRuns": 0,
+    "retries": 0
+  },
+  "lastAction": null,
+  "activeIssues": [],
+  "retries": []
+}
+`;
     await fs.mkdir(path.dirname(statusPath), { recursive: true });
-    await fs.writeFile(
-      statusPath,
-      `${JSON.stringify(snapshot, null, 2)}\n`,
-      "utf8",
-    );
+    await fs.writeFile(statusPath, rawSnapshot, "utf8");
 
     const chunks: string[] = [];
     vi.spyOn(process.stdout, "write").mockImplementation(((
@@ -180,7 +206,7 @@ describe("runCli status", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
 
-    expect(JSON.parse(chunks.join(""))).toEqual(snapshot);
+    expect(chunks.join("")).toBe(rawSnapshot);
   });
 
   it("fails with a clear message when the snapshot is missing", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,16 +1,196 @@
-import { describe, expect, it } from "vitest";
-import { parseArgs } from "../../src/cli/index.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseArgs, runCli } from "../../src/cli/index.js";
+import type { FactoryStatusSnapshot } from "../../src/observability/status.js";
+import { createTempDir } from "../support/git.js";
+
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+function createWorkflow(rootDir: string): string {
+  return path.join(rootDir, "WORKFLOW.md");
+}
+
+async function writeWorkflow(rootDir: string): Promise<string> {
+  const workflowPath = createWorkflow(rootDir);
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://example.test
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  review_bot_logins: []
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: /tmp/repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
+function createSnapshot(): FactoryStatusSnapshot {
+  return {
+    version: 1,
+    generatedAt: "2026-03-06T12:00:00.000Z",
+    factoryState: "idle",
+    worker: {
+      instanceId: "worker-1",
+      pid: process.pid,
+      startedAt: "2026-03-06T11:59:00.000Z",
+      pollIntervalMs: 1000,
+      maxConcurrentRuns: 1,
+    },
+    counts: {
+      ready: 0,
+      running: 0,
+      failed: 0,
+      activeLocalRuns: 0,
+      retries: 0,
+    },
+    lastAction: null,
+    activeIssues: [],
+    retries: [],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("parseArgs", () => {
   it("parses the run command", () => {
     const args = parseArgs(["node", "symphony", "run", "--once"]);
     expect(args.command).toBe("run");
+    if (args.command !== "run") {
+      throw new Error("expected run command");
+    }
     expect(args.once).toBe(true);
   });
 
   it("fails when the run command is missing", () => {
     expect(() => parseArgs(["node", "symphony"])).toThrowError(
-      "Usage: symphony run [--once] [--workflow <path>]",
+      "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
     );
+  });
+
+  it("parses the status command", () => {
+    const args = parseArgs(["node", "symphony", "status", "--json"]);
+    expect(args).toMatchObject({
+      command: "status",
+      format: "json",
+    });
+  });
+});
+
+describe("runCli status", () => {
+  it("renders the human-readable status view from the workflow-derived snapshot path", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const statusPath = path.join(tempDir, ".tmp", "status.json");
+    await fs.mkdir(path.dirname(statusPath), { recursive: true });
+    await fs.writeFile(
+      statusPath,
+      `${JSON.stringify(createSnapshot(), null, 2)}\n`,
+      "utf8",
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      return originalStdoutWrite(chunk);
+    }) as typeof process.stdout.write);
+    const chunks: string[] = [];
+    writeSpy.mockImplementation(((chunk: string | Uint8Array) => {
+      chunks.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    try {
+      await runCli(["node", "symphony", "status", "--workflow", workflowPath]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(chunks.join("")).toContain("Factory: idle");
+    expect(chunks.join("")).toContain(`Snapshot file: ${statusPath}`);
+  });
+
+  it("renders JSON when requested", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-json-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const statusPath = path.join(tempDir, ".tmp", "status.json");
+    const snapshot = createSnapshot();
+    await fs.mkdir(path.dirname(statusPath), { recursive: true });
+    await fs.writeFile(
+      statusPath,
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      "utf8",
+    );
+
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      chunks.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    try {
+      await runCli([
+        "node",
+        "symphony",
+        "status",
+        "--json",
+        "--workflow",
+        workflowPath,
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(JSON.parse(chunks.join(""))).toEqual(snapshot);
+  });
+
+  it("fails with a clear message when the snapshot is missing", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-missing-");
+    const workflowPath = await writeWorkflow(tempDir);
+
+    try {
+      await expect(
+        runCli(["node", "symphony", "status", "--workflow", workflowPath]),
+      ).rejects.toThrowError(
+        `No factory status snapshot found at ${path.join(tempDir, ".tmp", "status.json")}. Start Symphony with 'symphony run' first.`,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -198,6 +198,24 @@ describe("runCli status", () => {
     }
   });
 
+  it("fails with guidance when the snapshot file is invalid", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-invalid-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const statusPath = path.join(tempDir, ".tmp", "status.json");
+    await fs.mkdir(path.dirname(statusPath), { recursive: true });
+    await fs.writeFile(statusPath, "{ invalid json\n", "utf8");
+
+    try {
+      await expect(
+        runCli(["node", "symphony", "status", "--workflow", workflowPath]),
+      ).rejects.toThrowError(
+        `Failed to read factory status snapshot at ${statusPath}. The file may be corrupt; re-running 'symphony run' will regenerate it.`,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails with guidance when the workflow cannot determine the status path", async () => {
     const tempDir = await createTempDir(
       "symphony-cli-status-workflow-missing-",

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -5,8 +5,6 @@ import { parseArgs, runCli } from "../../src/cli/index.js";
 import type { FactoryStatusSnapshot } from "../../src/observability/status.js";
 import { createTempDir } from "../support/git.js";
 
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-
 function createWorkflow(rootDir: string): string {
   return path.join(rootDir, "WORKFLOW.md");
 }
@@ -127,13 +125,10 @@ describe("runCli status", () => {
       "utf8",
     );
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
       chunk: string | Uint8Array,
     ) => {
-      return originalStdoutWrite(chunk);
-    }) as typeof process.stdout.write);
-    const chunks: string[] = [];
-    writeSpy.mockImplementation(((chunk: string | Uint8Array) => {
       chunks.push(
         typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
       );

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -104,6 +104,15 @@ describe("parseArgs", () => {
       format: "json",
     });
   });
+
+  it("fails when a value flag is missing its argument", () => {
+    expect(() =>
+      parseArgs(["node", "symphony", "status", "--status-file", "--json"]),
+    ).toThrowError("Missing value for --status-file");
+    expect(() =>
+      parseArgs(["node", "symphony", "run", "--workflow"]),
+    ).toThrowError("Missing value for --workflow");
+  });
 });
 
 describe("runCli status", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -258,4 +258,40 @@ describe("runCli status", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("ignores malformed --workflow when --status-file is provided", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-explicit-file-");
+    const statusPath = path.join(tempDir, "status.json");
+    await fs.writeFile(
+      statusPath,
+      `${JSON.stringify(createSnapshot(), null, 2)}\n`,
+      "utf8",
+    );
+
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      chunks.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    try {
+      await runCli([
+        "node",
+        "symphony",
+        "status",
+        "--status-file",
+        statusPath,
+        "--workflow",
+        "--json",
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(chunks.join("")).toContain('"factoryState": "idle"');
+  });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -197,4 +197,21 @@ describe("runCli status", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("fails with guidance when the workflow cannot determine the status path", async () => {
+    const tempDir = await createTempDir(
+      "symphony-cli-status-workflow-missing-",
+    );
+    const workflowPath = path.join(tempDir, "WORKFLOW.md");
+
+    try {
+      await expect(
+        runCli(["node", "symphony", "status", "--workflow", workflowPath]),
+      ).rejects.toThrowError(
+        `Could not determine status file path from workflow at ${workflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -10,6 +10,10 @@ import type {
 } from "../../src/domain/workflow.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
+import {
+  deriveStatusFilePath,
+  readFactoryStatusSnapshot,
+} from "../../src/observability/status.js";
 import type { Logger } from "../../src/observability/logger.js";
 import type { Runner } from "../../src/runner/service.js";
 import type { Tracker } from "../../src/tracker/service.js";
@@ -483,6 +487,46 @@ describe("BootstrapOrchestrator", () => {
     expect(runnerCalls).toBe(0);
     expect(tracker.completed).toEqual([]);
     expect(tracker.retried).toEqual([]);
+  });
+
+  it("preserves the running source when a running issue has no PR yet", async () => {
+    const tempRoot = await createTempDir("symphony-running-source-test-");
+    try {
+      const tracker = new SequencedTracker({
+        running: [createIssue(79, "symphony:running")],
+      });
+      tracker.setLifecycleSequence(79, [
+        lifecycle("missing", "symphony/79"),
+        lifecycle("awaiting-review", "symphony/79", {
+          pendingCheckNames: ["CI"],
+        }),
+      ]);
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        new RecordingRunner(),
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(snapshot.activeIssues).toHaveLength(1);
+      expect(snapshot.activeIssues[0]?.source).toBe("running");
+      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-review");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("skips a running issue that is already leased by another local worker", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -662,6 +662,48 @@ describe("BootstrapOrchestrator", () => {
     expect(logger.errors).not.toContain("Poll cycle failed");
   });
 
+  it("prunes stale active issues that no longer appear in tracker state", async () => {
+    const tempRoot = await createTempDir("symphony-status-prune-test-");
+    try {
+      const issue = createIssue(72, "symphony:running");
+      const tracker = new SequencedTracker({
+        running: [issue],
+      });
+      tracker.setLifecycleSequence(72, [
+        lifecycle("awaiting-review", "symphony/72"),
+      ]);
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        new RecordingRunner(),
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      tracker.runningIssues.clear();
+
+      await orchestrator.runOnce();
+
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(snapshot.activeIssues).toHaveLength(0);
+      expect(snapshot.counts.running).toBe(0);
+      expect(snapshot.factoryState).toBe("idle");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps an existing issue lease when pid probing returns EPERM", async () => {
     const tempRoot = await createTempDir("symphony-stale-lease-eperm-test-");
     const tracker = new SequencedTracker({

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -96,6 +96,7 @@ class NullLogger implements Logger {
 class SequencedTracker implements Tracker {
   readonly readyIssues = new Map<number, RuntimeIssue>();
   readonly runningIssues = new Map<number, RuntimeIssue>();
+  readonly failedIssues = new Map<number, RuntimeIssue>();
   readonly lifecycleSequences = new Map<number, PullRequestLifecycle[]>();
   readonly completed: number[] = [];
   readonly retried: Array<{ issueNumber: number; reason: string }> = [];
@@ -132,6 +133,10 @@ class SequencedTracker implements Tracker {
 
   async fetchRunningIssues(): Promise<readonly RuntimeIssue[]> {
     return [...this.runningIssues.values()];
+  }
+
+  async fetchFailedIssues(): Promise<readonly RuntimeIssue[]> {
+    return [...this.failedIssues.values()];
   }
 
   async getIssue(issueNumber: number): Promise<RuntimeIssue> {
@@ -196,6 +201,10 @@ class SequencedTracker implements Tracker {
     this.failed.push({ issueNumber, reason });
     this.readyIssues.delete(issueNumber);
     this.runningIssues.delete(issueNumber);
+    this.failedIssues.set(
+      issueNumber,
+      createIssue(issueNumber, "symphony:failed"),
+    );
   }
 }
 

--- a/tests/unit/status-state.test.ts
+++ b/tests/unit/status-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeIssue } from "../../src/domain/issue.js";
+import {
+  createRuntimeStatusState,
+  upsertActiveIssue,
+} from "../../src/orchestrator/status-state.js";
+
+const issue: RuntimeIssue = {
+  id: "issue-12",
+  identifier: "sociotechnica-org/symphony-ts#12",
+  number: 12,
+  title: "Expose factory status",
+  description: "desc",
+  labels: ["symphony:running"],
+  state: "open",
+  url: "https://example.test/issues/12",
+  createdAt: "2026-03-06T11:00:00.000Z",
+  updatedAt: "2026-03-06T11:00:00.000Z",
+};
+
+describe("upsertActiveIssue", () => {
+  it("resets nullable fields when an explicit null update is provided", () => {
+    const state = createRuntimeStatusState();
+
+    upsertActiveIssue(state, issue, {
+      source: "running",
+      runSequence: 1,
+      branchName: "symphony/12",
+      status: "running",
+      summary: "Running issue",
+      workspacePath: "/tmp/workspaces/12",
+      runSessionId: "session-1",
+      ownerPid: 111,
+      runnerPid: 222,
+      startedAt: "2026-03-06T11:01:00.000Z",
+      pullRequest: {
+        number: 12,
+        url: "https://example.test/pulls/12",
+        latestCommitAt: "2026-03-06T11:02:00.000Z",
+      },
+      blockedReason: "Waiting on review",
+    });
+
+    upsertActiveIssue(state, issue, {
+      source: "running",
+      runSequence: 2,
+      branchName: "symphony/12",
+      status: "preparing",
+      summary: "Preparing rerun",
+      workspacePath: null,
+      runSessionId: null,
+      ownerPid: null,
+      runnerPid: null,
+      startedAt: null,
+      pullRequest: null,
+      blockedReason: null,
+    });
+
+    expect(state.activeIssues.get(issue.number)).toMatchObject({
+      workspacePath: null,
+      runSessionId: null,
+      ownerPid: null,
+      runnerPid: null,
+      startedAt: null,
+      pullRequest: null,
+      blockedReason: null,
+    });
+  });
+});

--- a/tests/unit/status-state.test.ts
+++ b/tests/unit/status-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
 import {
+  adjustTrackerIssueCounts,
   createRuntimeStatusState,
+  setTrackerIssueCounts,
   upsertActiveIssue,
 } from "../../src/orchestrator/status-state.js";
 
@@ -19,6 +21,30 @@ const issue: RuntimeIssue = {
 };
 
 describe("upsertActiveIssue", () => {
+  it("reassigns tracker counts through the helper functions", () => {
+    const state = createRuntimeStatusState();
+    const firstCounts = state.trackerCounts;
+
+    setTrackerIssueCounts(state, {
+      ready: 3,
+      running: 2,
+      failed: 1,
+    });
+    const secondCounts = state.trackerCounts;
+    adjustTrackerIssueCounts(state, {
+      ready: -1,
+      running: 1,
+    });
+
+    expect(firstCounts).not.toBe(secondCounts);
+    expect(secondCounts).not.toBe(state.trackerCounts);
+    expect(state.trackerCounts).toEqual({
+      ready: 2,
+      running: 3,
+      failed: 1,
+    });
+  });
+
   it("resets nullable fields when an explicit null update is provided", () => {
     const state = createRuntimeStatusState();
 

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -179,6 +179,7 @@ describe("factory status helpers", () => {
           {
             ...baseSnapshot.activeIssues[0],
             startedAt: undefined,
+            pullRequest: undefined,
             blockedReason: undefined,
           },
         ],
@@ -194,6 +195,7 @@ describe("factory status helpers", () => {
         activeIssues: [
           {
             startedAt: null,
+            pullRequest: null,
             blockedReason: null,
           },
         ],

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   deriveStatusFilePath,
   isProcessAlive,
@@ -115,6 +115,28 @@ describe("factory status helpers", () => {
       await writeFactoryStatusSnapshot(filePath, second);
       expect(await readFactoryStatusSnapshot(filePath)).toEqual(second);
     } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up the temporary file when rename fails", async () => {
+    const tempDir = await createTempDir("symphony-status-rename-failure-");
+    const filePath = path.join(tempDir, "status.json");
+    const snapshot = createSnapshot();
+    const rename = vi
+      .spyOn(fs, "rename")
+      .mockRejectedValueOnce(
+        Object.assign(new Error("rename failed"), { code: "EPERM" }),
+      );
+
+    try {
+      await expect(
+        writeFactoryStatusSnapshot(filePath, snapshot),
+      ).rejects.toThrow("rename failed");
+      const entries = await fs.readdir(tempDir);
+      expect(entries).toEqual([]);
+    } finally {
+      rename.mockRestore();
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
@@ -252,5 +274,11 @@ describe("factory status helpers", () => {
     expect(output).toContain("Pending checks: CI");
     expect(output).toContain("Retries:");
     expect(output).toContain("#9 Retry a failed run attempt 2");
+  });
+
+  it("renders worker state as unknown when liveness is omitted", () => {
+    const output = renderFactoryStatusSnapshot(createSnapshot());
+
+    expect(output).toContain("Worker: unknown");
   });
 });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -166,6 +166,43 @@ describe("factory status helpers", () => {
     }
   });
 
+  it("treats omitted nullable fields as null while reading the snapshot", async () => {
+    const tempDir = await createTempDir("symphony-status-nullable-test-");
+    const filePath = path.join(tempDir, "status.json");
+
+    try {
+      const baseSnapshot = createSnapshot();
+      const snapshot = {
+        ...baseSnapshot,
+        lastAction: undefined,
+        activeIssues: [
+          {
+            ...baseSnapshot.activeIssues[0],
+            startedAt: undefined,
+            blockedReason: undefined,
+          },
+        ],
+      };
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify(snapshot, null, 2)}\n`,
+        "utf8",
+      );
+
+      await expect(readFactoryStatusSnapshot(filePath)).resolves.toMatchObject({
+        lastAction: null,
+        activeIssues: [
+          {
+            startedAt: null,
+            blockedReason: null,
+          },
+        ],
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a terminal-friendly view from the snapshot", () => {
     const output = renderFactoryStatusSnapshot(createSnapshot(), {
       workerAlive: true,

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -271,7 +271,7 @@ describe("factory status helpers", () => {
     expect(output).toContain("Factory: blocked");
     expect(output).toContain("Worker: online");
     expect(output).toContain(
-      "Counts: ready=1 running=2 failed=0 local=0 retries=1",
+      "Counts: ready=1 tracker_running=2 failed=0 local=0 retries=1",
     );
     expect(output).toContain("#12 Expose factory status [awaiting-review]");
     expect(output).toContain("PR: #12 https://example.test/pr/12");

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -118,6 +118,54 @@ describe("factory status helpers", () => {
     }
   });
 
+  it("fails clearly when the snapshot version is unsupported", async () => {
+    const tempDir = await createTempDir("symphony-status-version-test-");
+    const filePath = path.join(tempDir, "status.json");
+
+    try {
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({ ...createSnapshot(), version: 2 }, null, 2)}\n`,
+        "utf8",
+      );
+
+      await expect(readFactoryStatusSnapshot(filePath)).rejects.toThrowError(
+        `Unsupported factory status snapshot version at ${filePath}: expected 1, received 2`,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails clearly when required snapshot fields are invalid", async () => {
+    const tempDir = await createTempDir("symphony-status-invalid-test-");
+    const filePath = path.join(tempDir, "status.json");
+
+    try {
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify(
+          {
+            ...createSnapshot(),
+            worker: {
+              ...createSnapshot().worker,
+              pid: "not-a-pid",
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      await expect(readFactoryStatusSnapshot(filePath)).rejects.toThrowError(
+        `Invalid factory status snapshot at ${filePath}: expected worker.pid to be an integer`,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a terminal-friendly view from the snapshot", () => {
     const output = renderFactoryStatusSnapshot(createSnapshot(), {
       workerAlive: true,

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -93,6 +93,10 @@ describe("factory status helpers", () => {
     );
   });
 
+  it("keeps the status file within the workspace root when given a filesystem root", () => {
+    expect(deriveStatusFilePath("/")).toBe(path.join("/", "status.json"));
+  });
+
   it("writes and reads the JSON snapshot contract", async () => {
     const tempDir = await createTempDir("symphony-status-test-");
     const filePath = path.join(tempDir, "status.json");

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deriveStatusFilePath,
+  readFactoryStatusSnapshot,
+  renderFactoryStatusSnapshot,
+  writeFactoryStatusSnapshot,
+  type FactoryStatusSnapshot,
+} from "../../src/observability/status.js";
+import { createTempDir } from "../support/git.js";
+
+function createSnapshot(
+  overrides?: Partial<FactoryStatusSnapshot>,
+): FactoryStatusSnapshot {
+  return {
+    version: 1,
+    generatedAt: "2026-03-06T12:00:00.000Z",
+    factoryState: "blocked",
+    worker: {
+      instanceId: "worker-123",
+      pid: process.pid,
+      startedAt: "2026-03-06T11:59:00.000Z",
+      pollIntervalMs: 5000,
+      maxConcurrentRuns: 1,
+    },
+    counts: {
+      ready: 1,
+      running: 2,
+      failed: 0,
+      activeLocalRuns: 0,
+      retries: 1,
+    },
+    lastAction: {
+      kind: "awaiting-review",
+      summary: "Waiting for PR checks to appear on https://example.test/pr/12",
+      at: "2026-03-06T12:00:00.000Z",
+      issueNumber: 12,
+    },
+    activeIssues: [
+      {
+        issueNumber: 12,
+        issueIdentifier: "sociotechnica-org/symphony-ts#12",
+        title: "Expose factory status",
+        source: "running",
+        runSequence: 2,
+        status: "awaiting-review",
+        summary:
+          "Waiting for PR checks to appear on https://example.test/pr/12",
+        workspacePath: "/tmp/workspaces/12",
+        branchName: "symphony/12",
+        runSessionId: "session-12",
+        ownerPid: process.pid,
+        runnerPid: null,
+        startedAt: "2026-03-06T11:58:00.000Z",
+        updatedAt: "2026-03-06T12:00:00.000Z",
+        pullRequest: {
+          number: 12,
+          url: "https://example.test/pr/12",
+          latestCommitAt: "2026-03-06T11:59:30.000Z",
+        },
+        checks: {
+          pendingNames: ["CI"],
+          failingNames: [],
+        },
+        review: {
+          actionableCount: 0,
+          unresolvedThreadCount: 0,
+        },
+        blockedReason:
+          "Waiting for PR checks to appear on https://example.test/pr/12",
+      },
+    ],
+    retries: [
+      {
+        issueNumber: 9,
+        issueIdentifier: "sociotechnica-org/symphony-ts#9",
+        title: "Retry a failed run",
+        nextAttempt: 2,
+        dueAt: "2026-03-06T12:05:00.000Z",
+        lastError: "Runner exited with 1",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("factory status helpers", () => {
+  it("derives the shared status file from the workspace root", () => {
+    expect(deriveStatusFilePath("/tmp/repo/.tmp/workspaces")).toBe(
+      path.resolve("/tmp/repo/.tmp/status.json"),
+    );
+  });
+
+  it("writes and reads the JSON snapshot contract", async () => {
+    const tempDir = await createTempDir("symphony-status-test-");
+    const filePath = path.join(tempDir, "status.json");
+
+    try {
+      const first = createSnapshot();
+      await writeFactoryStatusSnapshot(filePath, first);
+      expect(await readFactoryStatusSnapshot(filePath)).toEqual(first);
+
+      const second = createSnapshot({
+        factoryState: "idle",
+        counts: {
+          ready: 0,
+          running: 0,
+          failed: 1,
+          activeLocalRuns: 0,
+          retries: 0,
+        },
+      });
+      await writeFactoryStatusSnapshot(filePath, second);
+      expect(await readFactoryStatusSnapshot(filePath)).toEqual(second);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders a terminal-friendly view from the snapshot", () => {
+    const output = renderFactoryStatusSnapshot(createSnapshot(), {
+      workerAlive: true,
+      statusFilePath: "/tmp/status.json",
+    });
+
+    expect(output).toContain("Factory: blocked");
+    expect(output).toContain("Worker: online");
+    expect(output).toContain(
+      "Counts: ready=1 running=2 failed=0 local=0 retries=1",
+    );
+    expect(output).toContain("#12 Expose factory status [awaiting-review]");
+    expect(output).toContain("PR: #12 https://example.test/pr/12");
+    expect(output).toContain("Pending checks: CI");
+    expect(output).toContain("Retries:");
+    expect(output).toContain("#9 Retry a failed run attempt 2");
+  });
+});

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   deriveStatusFilePath,
+  isProcessAlive,
   readFactoryStatusSnapshot,
   renderFactoryStatusSnapshot,
   writeFactoryStatusSnapshot,
@@ -161,6 +162,36 @@ describe("factory status helpers", () => {
       await expect(readFactoryStatusSnapshot(filePath)).rejects.toThrowError(
         `Invalid factory status snapshot at ${filePath}: expected worker.pid to be an integer`,
       );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats non-positive pids as invalid and offline", async () => {
+    const tempDir = await createTempDir("symphony-status-pid-test-");
+    const filePath = path.join(tempDir, "status.json");
+
+    try {
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify(
+          {
+            ...createSnapshot(),
+            worker: {
+              ...createSnapshot().worker,
+              pid: 0,
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      await expect(readFactoryStatusSnapshot(filePath)).rejects.toThrowError(
+        `Invalid factory status snapshot at ${filePath}: expected worker.pid to be a positive integer`,
+      );
+      expect(isProcessAlive(0)).toBe(false);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #31

## Summary
- add a canonical local factory status snapshot and write it under `.tmp/status.json` from orchestrator-owned runtime state
- add a read-only `status` CLI command with human-readable and JSON output
- cover the snapshot/status path with unit and end-to-end tests

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm format:check