### PR TITLE
Fix awaiting human plan review handoff

### DIFF
--- a/docs/plans/042-awaiting-human-plan-review-bug/plan.md
+++ b/docs/plans/042-awaiting-human-plan-review-bug/plan.md
@@ -1,0 +1,119 @@
+# Bug: Do Not Fail Runs While Waiting For Human Plan Review
+
+## Objective
+
+Teach the GitHub bootstrap runtime to treat `plan-ready -> awaiting human review` as a valid pre-PR handoff state so the factory waits instead of retrying/failing when a worker intentionally stops after plan creation.
+
+## Scope
+
+- detect plan-review handoff state from issue comments when no PR exists for an issue branch
+- represent that handoff as a normalized runtime lifecycle state
+- keep the orchestrator in a waiting state instead of retry/fail for that handoff
+- resume issue execution when issue comments indicate `approved`, `waived`, or `changes-requested`
+- surface the waiting state in factory status/observability
+- cover the behavior with unit and integration tests using the mock GitHub server
+
+## Non-goals
+
+- redesigning the broader PR lifecycle loop
+- adding richer human-facing comment templates or acknowledgement comments
+- changing the plan-review policy itself
+- Beads-specific workflow behavior
+
+## Current Gap
+
+The runtime still treats a successful worker run with no PR as failure. That matched the pre-plan-review workflow but now breaks valid `plan-ready` handoffs. Issue `#32` proved the live gap: the worker wrote a plan, requested human review, then the runtime retried and failed with `No open pull request found for symphony/32`.
+
+## Spec / Layer Mapping
+
+- Policy: plan review as a valid handoff already lives in `WORKFLOW.md`, `AGENTS.md`, and `skills/symphony-plan/SKILL.md`
+- Configuration: no config schema changes expected
+- Coordination: orchestrator must recognize and wait on a valid pre-PR handoff instead of treating it as failure
+- Execution: worker reruns should resume only after explicit approval, waiver, or requested revisions
+- Integration: GitHub tracker adapter must read issue comments as tracker-side handoff input while GitHub remains the tracker
+- Observability: status snapshot must surface the plan-review waiting state distinctly from active execution and PR review
+
+## Architecture Boundaries
+
+- tracker transport: fetch issue comments from GitHub REST separately from PR transport
+- tracker normalization/policy: parse issue comments into normalized plan-review handoff state in focused modules instead of embedding ad hoc string checks in orchestrator code
+- orchestrator: consume the normalized handoff state and wait; do not parse GitHub comment bodies directly
+- observability: reflect the new waiting state without coupling status rendering to comment parsing rules
+
+## Slice Strategy
+
+This issue should fit in one reviewable PR because it is a narrow runtime-correctness seam:
+
+1. add a normalized pre-PR plan-review lifecycle path
+2. integrate it into the existing tracker/orchestrator handoff flow
+3. add focused tests for the exact failure mode from `#32`
+
+The richer human-facing protocol and acknowledgement loop are deferred to `#48`.
+
+## Runtime State Machine And Failure Matrix
+
+### States touched
+
+- `missing`
+- `awaiting-plan-review` (new)
+- `awaiting-review`
+- `needs-follow-up`
+- `ready`
+
+### Allowed transitions introduced
+
+- successful run with no PR + latest relevant comment is `Plan status: plan-ready` -> `awaiting-plan-review`
+- `awaiting-plan-review` + later `Plan review: approved` -> rerun issue without failing on missing PR
+- `awaiting-plan-review` + later `Plan review: waived` -> rerun issue without failing on missing PR
+- `awaiting-plan-review` + later `Plan review: changes-requested` -> rerun issue to revise the plan
+
+### Failure classes
+
+| Scenario                                             | Evidence                                                           | Expected behavior                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------- |
+| No PR exists and no valid plan-review handoff exists | no PR, no relevant issue comment state                             | keep existing failure behavior                    |
+| Worker stopped at plan-ready                         | no PR, latest relevant comment is `Plan status: plan-ready`        | wait in `awaiting-plan-review`; do not retry/fail |
+| Human approved/waived after plan-ready               | no PR, latest relevant comment is `Plan review: approved/waived`   | rerun issue; do not fail                          |
+| Human requested plan changes                         | no PR, latest relevant comment is `Plan review: changes-requested` | rerun issue to revise plan                        |
+
+## Implementation Steps
+
+1. Add a plan-review comment parser and normalized handoff evaluator in the tracker layer.
+2. Extend GitHub transport to fetch issue comments with enough metadata for ordering.
+3. Extend the lifecycle kind/status model with `awaiting-plan-review`.
+4. Update the GitHub bootstrap tracker so missing-PR cases consult plan-review handoff state before returning `missing`.
+5. Update orchestrator/status handling to treat `awaiting-plan-review` as a valid waiting state.
+6. Add integration tests for:
+   - plan-ready handoff waits
+   - approved resumes
+   - changes-requested resumes
+7. Add orchestrator/unit tests for the live `#32` failure mode.
+
+## Tests And Acceptance Scenarios
+
+- unit tests for plan-review comment parsing and ordering
+- integration tests for tracker handoff classification when no PR exists
+- orchestrator unit test proving a successful run can stop at plan review without failure
+- full repo gate: `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test`
+
+## Observability
+
+- status snapshot should expose `awaiting-plan-review` distinctly
+- last action summary should reflect plan-review waiting rather than missing PR failure
+
+## Exit Criteria
+
+- a worker that stops at `plan-ready` without opening a PR is left waiting, not failed
+- approval/waiver/changes-requested comments cause the issue to resume instead of failing on missing PR
+- the status snapshot shows the waiting state distinctly
+- the live `#32` failure mode is covered by tests
+
+## Deferred Work
+
+- human-facing plan-review templates and acknowledgement comments (`#48`)
+- Beads-native plan-review state model
+- any broader redesign of issue reporting or PR review flow
+
+## Revision Log
+
+- 2026-03-07: Initial plan for runtime support of pre-PR plan-review handoff.

--- a/src/domain/pull-request.ts
+++ b/src/domain/pull-request.ts
@@ -1,5 +1,6 @@
 export type PullRequestLifecycleKind =
   | "missing"
+  | "awaiting-plan-review"
   | "awaiting-review"
   | "needs-follow-up"
   | "ready";

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -10,6 +10,7 @@ export type FactoryIssueStatus =
   | "queued"
   | "preparing"
   | "running"
+  | "awaiting-plan-review"
   | "awaiting-review"
   | "needs-follow-up";
 
@@ -413,7 +414,14 @@ function parseActiveIssue(
     ),
     status: expectEnum(
       issue.status,
-      ["queued", "preparing", "running", "awaiting-review", "needs-follow-up"],
+      [
+        "queued",
+        "preparing",
+        "running",
+        "awaiting-plan-review",
+        "awaiting-review",
+        "needs-follow-up",
+      ],
       filePath,
       `${field}.status`,
     ),

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -343,7 +343,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       return;
     }
 
-    if (lifecycle.kind === "awaiting-review") {
+    if (
+      lifecycle.kind === "awaiting-review" ||
+      lifecycle.kind === "awaiting-plan-review"
+    ) {
       noteLifecycleForIssue(
         this.#state.status,
         issue,
@@ -352,12 +355,12 @@ export class BootstrapOrchestrator implements Orchestrator {
         branchName,
         lifecycle,
       );
-      this.#logger.info("Issue remains in PR review", {
+      this.#logger.info("Issue remains in handoff review", {
         issueNumber: issue.number,
         summary: lifecycle.summary,
       });
       noteStatusAction(this.#state.status, {
-        kind: "awaiting-review",
+        kind: lifecycle.kind,
         summary: lifecycle.summary,
         issueNumber: issue.number,
       });

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -153,9 +153,11 @@ export function noteLifecycleForIssue(
     status:
       lifecycle.kind === "needs-follow-up"
         ? "needs-follow-up"
-        : lifecycle.kind === "awaiting-review"
-          ? "awaiting-review"
-          : "queued",
+        : lifecycle.kind === "awaiting-plan-review"
+          ? "awaiting-plan-review"
+          : lifecycle.kind === "awaiting-review"
+            ? "awaiting-review"
+            : "queued",
     summary: lifecycle.summary,
     pullRequest:
       lifecycle.pullRequest === null
@@ -174,6 +176,7 @@ export function noteLifecycleForIssue(
       unresolvedThreadCount: lifecycle.unresolvedThreadIds.length,
     },
     blockedReason:
+      lifecycle.kind === "awaiting-plan-review" ||
       lifecycle.kind === "awaiting-review" ||
       lifecycle.kind === "needs-follow-up"
         ? lifecycle.summary

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -123,8 +123,10 @@ export class GitHubBootstrapTracker implements Tracker {
       return null;
     }
 
-    const issue = await this.getIssue(issueNumber);
-    const comments = await this.#client.getIssueComments(issueNumber);
+    const [issue, comments] = await Promise.all([
+      this.getIssue(issueNumber),
+      this.#client.getIssueComments(issueNumber),
+    ]);
     return evaluatePlanReviewLifecycle(
       branchName,
       issue.url,

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -143,6 +143,10 @@ export class GitHubBootstrapTracker implements Tracker {
   #issueNumberFromBranchName(branchName: string): number | null {
     const match = branchName.match(/(\d+)$/u);
     if (!match || !match[1]) {
+      this.#logger.warn(
+        "Could not extract issue number from branch name; skipping plan-review check",
+        { branchName },
+      );
       return null;
     }
     return Number(match[1]);

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -18,6 +18,13 @@ export class GitHubBootstrapTracker implements Tracker {
   readonly #client: GitHubClient;
   #ensureLabelsPromise: Promise<void> | null = null;
   readonly #noCheckObservations = new Map<string, NoCheckObservation>();
+  readonly #planReviewObservations = new Map<
+    string,
+    {
+      readonly issueUpdatedAt: string;
+      readonly lifecycle: PullRequestLifecycle;
+    }
+  >();
 
   constructor(config: TrackerConfig, logger: Logger) {
     this.#config = config;
@@ -78,6 +85,9 @@ export class GitHubBootstrapTracker implements Tracker {
       this.#noCheckObservations.delete(branchName);
       const planReviewLifecycle =
         await this.#inspectPlanReviewHandoff(branchName);
+      if (planReviewLifecycle === null) {
+        this.#planReviewObservations.delete(branchName);
+      }
       return planReviewLifecycle ?? missingPullRequestLifecycle(branchName);
     }
 
@@ -85,6 +95,7 @@ export class GitHubBootstrapTracker implements Tracker {
       this.#client.getChecks(pullRequest.head.sha),
       this.#client.getPullRequestReviewState(pullRequest.number),
     ]);
+    this.#planReviewObservations.delete(branchName);
     const snapshot = createPullRequestSnapshot({
       branchName,
       pullRequest,
@@ -123,11 +134,17 @@ export class GitHubBootstrapTracker implements Tracker {
       return null;
     }
 
-    const [issue, comments] = await Promise.all([
-      this.getIssue(issueNumber),
-      this.#client.getIssueComments(issueNumber),
-    ]);
-    return evaluatePlanReviewLifecycle(
+    const issue = await this.getIssue(issueNumber);
+    const observation = this.#planReviewObservations.get(branchName);
+    if (
+      observation !== undefined &&
+      observation.issueUpdatedAt === issue.updatedAt
+    ) {
+      return observation.lifecycle;
+    }
+
+    const comments = await this.#client.getIssueComments(issueNumber);
+    const lifecycle = evaluatePlanReviewLifecycle(
       branchName,
       issue.url,
       comments.map((comment) => ({
@@ -138,6 +155,15 @@ export class GitHubBootstrapTracker implements Tracker {
         authorLogin: comment.user?.login ?? null,
       })),
     );
+    if (lifecycle?.kind === "awaiting-plan-review") {
+      this.#planReviewObservations.set(branchName, {
+        issueUpdatedAt: issue.updatedAt,
+        lifecycle,
+      });
+    } else {
+      this.#planReviewObservations.delete(branchName);
+    }
+    return lifecycle;
   }
 
   #issueNumberFromBranchName(branchName: string): number | null {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -3,6 +3,7 @@ import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { TrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { GitHubClient } from "./github-client.js";
+import { evaluatePlanReviewLifecycle } from "./plan-review-policy.js";
 import {
   evaluatePullRequestLifecycle,
   missingPullRequestLifecycle,
@@ -75,7 +76,9 @@ export class GitHubBootstrapTracker implements Tracker {
     const pullRequest = await this.#client.findOpenPullRequest(branchName);
     if (pullRequest === null) {
       this.#noCheckObservations.delete(branchName);
-      return missingPullRequestLifecycle(branchName);
+      const planReviewLifecycle =
+        await this.#inspectPlanReviewHandoff(branchName);
+      return planReviewLifecycle ?? missingPullRequestLifecycle(branchName);
     }
 
     const [checks, reviewStateData] = await Promise.all([
@@ -110,6 +113,37 @@ export class GitHubBootstrapTracker implements Tracker {
     }
 
     return await this.inspectIssueHandoff(branchName);
+  }
+
+  async #inspectPlanReviewHandoff(
+    branchName: string,
+  ): Promise<PullRequestLifecycle | null> {
+    const issueNumber = this.#issueNumberFromBranchName(branchName);
+    if (issueNumber === null) {
+      return null;
+    }
+
+    const issue = await this.getIssue(issueNumber);
+    const comments = await this.#client.getIssueComments(issueNumber);
+    return evaluatePlanReviewLifecycle(
+      branchName,
+      issue.url,
+      comments.map((comment) => ({
+        id: comment.id,
+        body: comment.body,
+        createdAt: comment.created_at,
+        url: comment.html_url,
+        authorLogin: comment.user?.login ?? null,
+      })),
+    );
+  }
+
+  #issueNumberFromBranchName(branchName: string): number | null {
+    const match = branchName.match(/(\d+)$/u);
+    if (!match || !match[1]) {
+      return null;
+    }
+    return Number(match[1]);
   }
 
   async recordRetry(issueNumber: number, reason: string): Promise<void> {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -22,7 +22,7 @@ export class GitHubBootstrapTracker implements Tracker {
     string,
     {
       readonly issueUpdatedAt: string;
-      readonly lifecycle: PullRequestLifecycle;
+      readonly lifecycle: PullRequestLifecycle | null;
     }
   >();
 
@@ -85,9 +85,6 @@ export class GitHubBootstrapTracker implements Tracker {
       this.#noCheckObservations.delete(branchName);
       const planReviewLifecycle =
         await this.#inspectPlanReviewHandoff(branchName);
-      if (planReviewLifecycle === null) {
-        this.#planReviewObservations.delete(branchName);
-      }
       return planReviewLifecycle ?? missingPullRequestLifecycle(branchName);
     }
 
@@ -155,14 +152,10 @@ export class GitHubBootstrapTracker implements Tracker {
         authorLogin: comment.user?.login ?? null,
       })),
     );
-    if (lifecycle?.kind === "awaiting-plan-review") {
-      this.#planReviewObservations.set(branchName, {
-        issueUpdatedAt: issue.updatedAt,
-        lifecycle,
-      });
-    } else {
-      this.#planReviewObservations.delete(branchName);
-    }
+    this.#planReviewObservations.set(branchName, {
+      issueUpdatedAt: issue.updatedAt,
+      lifecycle,
+    });
     return lifecycle;
   }
 

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -25,6 +25,16 @@ interface GitHubLabelResponse {
   readonly name: string;
 }
 
+export interface GitHubIssueCommentResponse {
+  readonly id: number;
+  readonly body: string;
+  readonly created_at: string;
+  readonly html_url: string;
+  readonly user: {
+    readonly login: string;
+  } | null;
+}
+
 export interface GitHubPullRequestResponse {
   readonly number: number;
   readonly html_url: string;
@@ -408,6 +418,15 @@ export class GitHubClient {
       "POST",
       this.#issuePath(`issues/${issueNumber}/comments`),
       { body },
+    );
+  }
+
+  async getIssueComments(
+    issueNumber: number,
+  ): Promise<readonly GitHubIssueCommentResponse[]> {
+    return await this.#request<GitHubIssueCommentResponse[]>(
+      "GET",
+      this.#issuePath(`issues/${issueNumber}/comments`),
     );
   }
 

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -424,10 +424,22 @@ export class GitHubClient {
   async getIssueComments(
     issueNumber: number,
   ): Promise<readonly GitHubIssueCommentResponse[]> {
-    return await this.#request<GitHubIssueCommentResponse[]>(
-      "GET",
-      this.#issuePath(`issues/${issueNumber}/comments`),
-    );
+    const comments: GitHubIssueCommentResponse[] = [];
+    let page = 1;
+
+    for (;;) {
+      const currentPage = await this.#request<GitHubIssueCommentResponse[]>(
+        "GET",
+        this.#issuePath(
+          `issues/${issueNumber}/comments?per_page=100&page=${page.toString()}`,
+        ),
+      );
+      comments.push(...currentPage);
+      if (currentPage.length < 100) {
+        return comments;
+      }
+      page += 1;
+    }
   }
 
   async findOpenPullRequest(

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -1,0 +1,79 @@
+import type { PullRequestLifecycle } from "../domain/pull-request.js";
+
+export interface IssueCommentSnapshot {
+  readonly id: number;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+  readonly authorLogin: string | null;
+}
+
+type PlanReviewSignal =
+  | "plan-ready"
+  | "changes-requested"
+  | "approved"
+  | "waived";
+
+interface ParsedPlanReviewComment {
+  readonly signal: PlanReviewSignal;
+  readonly comment: IssueCommentSnapshot;
+}
+
+function parsePlanReviewComment(
+  comment: IssueCommentSnapshot,
+): ParsedPlanReviewComment | null {
+  const firstLine = comment.body
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find((line) => line !== "");
+
+  if (!firstLine) {
+    return null;
+  }
+
+  const normalized = firstLine.toLowerCase();
+  if (normalized === "plan status: plan-ready") {
+    return { signal: "plan-ready", comment };
+  }
+  if (normalized === "plan review: changes-requested") {
+    return { signal: "changes-requested", comment };
+  }
+  if (normalized === "plan review: approved") {
+    return { signal: "approved", comment };
+  }
+  if (normalized === "plan review: waived") {
+    return { signal: "waived", comment };
+  }
+
+  return null;
+}
+
+export function evaluatePlanReviewLifecycle(
+  branchName: string,
+  issueUrl: string,
+  comments: readonly IssueCommentSnapshot[],
+): PullRequestLifecycle | null {
+  const latestSignal = comments
+    .map(parsePlanReviewComment)
+    .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
+    .sort((left, right) =>
+      left.comment.createdAt.localeCompare(right.comment.createdAt),
+    )
+    .at(-1);
+
+  if (!latestSignal || latestSignal.signal !== "plan-ready") {
+    return null;
+  }
+
+  return {
+    kind: "awaiting-plan-review",
+    branchName,
+    pullRequest: null,
+    checks: [],
+    pendingCheckNames: [],
+    failingCheckNames: [],
+    actionableReviewFeedback: [],
+    unresolvedThreadIds: [],
+    summary: `Waiting for human plan review on ${issueUrl}`,
+  };
+}

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -56,11 +56,12 @@ export function evaluatePlanReviewLifecycle(
   const latestSignal = comments
     .map(parsePlanReviewComment)
     .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
-    .sort(
-      (left, right) =>
+    .sort((left, right) => {
+      const timeDiff =
         Date.parse(left.comment.createdAt) -
-        Date.parse(right.comment.createdAt),
-    )
+        Date.parse(right.comment.createdAt);
+      return timeDiff !== 0 ? timeDiff : left.comment.id - right.comment.id;
+    })
     .at(-1);
 
   if (!latestSignal || latestSignal.signal !== "plan-ready") {

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -56,14 +56,20 @@ export function evaluatePlanReviewLifecycle(
   const latestSignal = comments
     .map(parsePlanReviewComment)
     .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
-    .sort((left, right) =>
-      left.comment.createdAt.localeCompare(right.comment.createdAt),
+    .sort(
+      (left, right) =>
+        Date.parse(left.comment.createdAt) -
+        Date.parse(right.comment.createdAt),
     )
     .at(-1);
 
   if (!latestSignal || latestSignal.signal !== "plan-ready") {
     return null;
   }
+
+  // Author validation is intentionally deferred to #48 so #42 only fixes the
+  // runtime handoff semantics; today the issue comment first-line markers are
+  // treated as an open-trust protocol.
 
   return {
     kind: "awaiting-plan-review",

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -149,6 +149,7 @@ describe("GitHubBootstrapTracker", () => {
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
     expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
   it("reports awaiting-review while checks are pending", async () => {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -152,6 +152,23 @@ describe("GitHubBootstrapTracker", () => {
     expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
+  it("reuses cached plan-review observations while the issue is unchanged", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+    });
+
+    const first = await tracker.inspectIssueHandoff("symphony/7");
+    const second = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(first.kind).toBe("awaiting-plan-review");
+    expect(second.kind).toBe("awaiting-plan-review");
+    expect(server.countRequests("GET issues/7")).toBe(2);
+    expect(server.countRequests("GET issues/7/comments")).toBe(1);
+  });
+
   it("reports awaiting-review while checks are pending", async () => {
     const tracker = createTracker(server);
 

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -130,6 +130,27 @@ describe("GitHubBootstrapTracker", () => {
     expect(lifecycle.summary).toMatch(/no open pull request/i);
   });
 
+  it("reads plan-review signals beyond the first page of issue comments", async () => {
+    const tracker = createTracker(server);
+
+    for (let index = 0; index < 120; index += 1) {
+      server.addIssueComment({
+        issueNumber: 7,
+        body: `noise ${index.toString()}`,
+        createdAt: new Date(Date.UTC(2026, 2, 7, 10, 0, index)).toISOString(),
+      });
+    }
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+      createdAt: "2026-03-07T10:05:00.000Z",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("awaiting-plan-review");
+  });
+
   it("reports awaiting-review while checks are pending", async () => {
     const tracker = createTracker(server);
 

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -95,6 +95,41 @@ describe("GitHubBootstrapTracker", () => {
     expect(lifecycle.summary).toMatch(/no open pull request/i);
   });
 
+  it("reports awaiting-plan-review when the latest issue handoff is plan-ready", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
+  });
+
+  it("resumes from missing once a plan review is approved", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+      createdAt: "2026-03-07T10:00:00.000Z",
+    });
+    server.addIssueComment({
+      issueNumber: 7,
+      authorLogin: "jessmartin",
+      body: "Plan review: approved\n\nSummary\n- Approved.",
+      createdAt: "2026-03-07T10:05:00.000Z",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("missing");
+    expect(lifecycle.summary).toMatch(/no open pull request/i);
+  });
+
   it("reports awaiting-review while checks are pending", async () => {
     const tracker = createTracker(server);
 

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -169,6 +169,30 @@ describe("GitHubBootstrapTracker", () => {
     expect(server.countRequests("GET issues/7/comments")).toBe(1);
   });
 
+  it("reuses cached null plan-review observations while the issue is unchanged", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+      createdAt: "2026-03-07T10:00:00.000Z",
+    });
+    server.addIssueComment({
+      issueNumber: 7,
+      authorLogin: "jessmartin",
+      body: "Plan review: changes-requested\n\nRequired changes\n- Split the issue.",
+      createdAt: "2026-03-07T10:05:00.000Z",
+    });
+
+    const first = await tracker.inspectIssueHandoff("symphony/7");
+    const second = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(first.kind).toBe("missing");
+    expect(second.kind).toBe("missing");
+    expect(server.countRequests("GET issues/7")).toBe(2);
+    expect(server.countRequests("GET issues/7/comments")).toBe(1);
+  });
+
   it("reports awaiting-review while checks are pending", async () => {
     const tracker = createTracker(server);
 

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -550,7 +550,10 @@ export class MockGitHubServer {
         json(response, 404, { message: "issue not found" });
         return;
       }
-      json(response, 200, issue.comments);
+      const perPage = Number(url.searchParams.get("per_page") ?? "30");
+      const page = Number(url.searchParams.get("page") ?? "1");
+      const offset = Math.max(page - 1, 0) * perPage;
+      json(response, 200, issue.comments.slice(offset, offset + perPage));
       return;
     }
     if (commentMatch && method === "POST") {

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -65,7 +65,17 @@ interface MockIssue {
   created_at: string;
   updated_at: string;
   labels: Array<{ name: string }>;
-  comments: string[];
+  comments: MockIssueComment[];
+}
+
+interface MockIssueComment {
+  readonly id: number;
+  readonly body: string;
+  readonly created_at: string;
+  readonly html_url: string;
+  readonly user: {
+    readonly login: string;
+  } | null;
 }
 
 interface MockLabel {
@@ -145,12 +155,17 @@ export class MockGitHubServer {
     });
   }
 
-  getIssue(number: number): MockIssue {
+  getIssue(
+    number: number,
+  ): Omit<MockIssue, "comments"> & { comments: string[] } {
     const issue = this.#issues.get(number);
     if (!issue) {
       throw new Error(`Issue ${number} not found`);
     }
-    return structuredClone(issue);
+    return {
+      ...structuredClone(issue),
+      comments: issue.comments.map((comment) => comment.body),
+    };
   }
 
   setIssueLabels(number: number, labels: readonly string[]): void {
@@ -160,6 +175,30 @@ export class MockGitHubServer {
     }
     issue.labels = labels.map((name) => ({ name }));
     issue.updated_at = new Date().toISOString();
+  }
+
+  addIssueComment(input: {
+    issueNumber: number;
+    authorLogin?: string;
+    body: string;
+    createdAt?: string;
+  }): number {
+    const issue = this.#issues.get(input.issueNumber);
+    if (!issue) {
+      throw new Error(`Issue ${input.issueNumber} not found`);
+    }
+    const id = issue.comments.length + 1;
+    issue.comments.push({
+      id,
+      body: input.body,
+      created_at: input.createdAt ?? new Date().toISOString(),
+      html_url: `${issue.html_url}#issuecomment-${id.toString()}`,
+      user: {
+        login: input.authorLogin ?? "symphony[bot]",
+      },
+    });
+    issue.updated_at = new Date().toISOString();
+    return id;
   }
 
   getPullRequests(): ReadonlyArray<{
@@ -504,6 +543,16 @@ export class MockGitHubServer {
     }
 
     const commentMatch = suffix.match(/^issues\/(\d+)\/comments$/);
+    if (commentMatch && method === "GET") {
+      const issueNumber = Number(commentMatch[1]);
+      const issue = this.#issues.get(issueNumber);
+      if (!issue) {
+        json(response, 404, { message: "issue not found" });
+        return;
+      }
+      json(response, 200, issue.comments);
+      return;
+    }
     if (commentMatch && method === "POST") {
       const issueNumber = Number(commentMatch[1]);
       const issue = this.#issues.get(issueNumber);
@@ -512,9 +561,21 @@ export class MockGitHubServer {
         return;
       }
       const body = (await readJson(request)) as { body: string };
-      issue.comments.push(body.body);
+      const id = issue.comments.length + 1;
+      issue.comments.push({
+        id,
+        body: body.body,
+        created_at: new Date().toISOString(),
+        html_url: `${issue.html_url}#issuecomment-${id.toString()}`,
+        user: {
+          login: "symphony[bot]",
+        },
+      });
       issue.updated_at = new Date().toISOString();
-      json(response, 201, { id: randomUUID(), body: body.body });
+      json(response, 201, {
+        id,
+        body: body.body,
+      });
       return;
     }
 

--- a/tests/support/pull-request.ts
+++ b/tests/support/pull-request.ts
@@ -37,7 +37,7 @@ export function createLifecycle(
     kind,
     branchName,
     pullRequest:
-      kind === "missing"
+      kind === "missing" || kind === "awaiting-plan-review"
         ? null
         : {
             number: 1,

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -489,6 +489,47 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.retried).toEqual([]);
   });
 
+  it("waits at a valid plan-review handoff without retrying or failing", async () => {
+    const tempRoot = await createTempDir("symphony-plan-review-wait-test-");
+    try {
+      const tracker = new SequencedTracker({
+        ready: [createIssue(32)],
+      });
+      tracker.setLifecycleSequence(32, [
+        lifecycle("missing", "symphony/32"),
+        lifecycle("awaiting-plan-review", "symphony/32"),
+      ]);
+      const runner = new RecordingRunner();
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        runner,
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      expect(runner.attempts).toEqual([1]);
+      expect(tracker.failed).toEqual([]);
+      expect(tracker.retried).toEqual([]);
+
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-plan-review");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("preserves the running source when a running issue has no PR yet", async () => {
     const tempRoot = await createTempDir("symphony-running-source-test-");
     try {

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -57,6 +57,48 @@ describe("plan-review-policy", () => {
     expect(lifecycle).toBeNull();
   });
 
+  it("does not wait when the latest signal is waived", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+        comment(
+          "Plan review: waived\n\nSummary\n- Proceed without waiting.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+      ],
+    );
+
+    expect(lifecycle).toBeNull();
+  });
+
+  it("does not wait when the latest signal is changes-requested", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+        comment(
+          "Plan review: changes-requested\n\nRequired changes\n- Split the issue.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+      ],
+    );
+
+    expect(lifecycle).toBeNull();
+  });
+
   it("returns to waiting when a revised plan-ready comment is newer than prior feedback", () => {
     const lifecycle = evaluatePlanReviewLifecycle(
       "symphony/32",

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluatePlanReviewLifecycle,
+  type IssueCommentSnapshot,
+} from "../../src/tracker/plan-review-policy.js";
+
+function comment(
+  body: string,
+  createdAt: string,
+  id: number,
+): IssueCommentSnapshot {
+  return {
+    id,
+    body,
+    createdAt,
+    url: `https://example.test/issues/32#issuecomment-${id.toString()}`,
+    authorLogin: "user",
+  };
+}
+
+describe("plan-review-policy", () => {
+  it("waits when the latest relevant signal is plan-ready", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment("some other comment", "2026-03-07T10:00:00.000Z", 1),
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+      ],
+    );
+
+    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+  });
+
+  it("does not wait when a later approval exists", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+        comment(
+          "Plan review: approved\n\nSummary\n- Proceed.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+      ],
+    );
+
+    expect(lifecycle).toBeNull();
+  });
+
+  it("returns to waiting when a revised plan-ready comment is newer than prior feedback", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+        comment(
+          "Plan review: changes-requested\n\nRequired changes\n- Split the issue.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+        comment(
+          "Plan status: plan-ready\n\nRevised for another pass.",
+          "2026-03-07T10:07:00.000Z",
+          4,
+        ),
+      ],
+    );
+
+    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `awaiting-plan-review` lifecycle and status state
- detect `Plan status: plan-ready` issue comments as a valid pre-PR handoff in the GitHub tracker
- stop retrying/failing issues just because no PR exists while they are waiting for human plan review

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `codex review --base origin/main`

Closes #42.
