### PR TITLE
Standardize plan review comment protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,23 @@ For any GitHub issue assigned for implementation:
 Plans are part of the system of record. Do not implement substantial work without first creating or updating the plan.
 Plan approval is a required workflow handoff and is the repo-owned human review station; it is not terminal success, and it must happen before implementation unless waived.
 
+## Plan Review Comment Protocol
+
+When a worker posts the `plan-ready` handoff comment, it should include:
+
+1. the plan path,
+2. a short summary,
+3. a short note that replies must begin with an accepted review marker,
+4. and copy-pasteable fenced markdown templates for the review reply.
+
+Accepted first-line review markers are:
+
+- `Plan review: approved`
+- `Plan review: changes-requested`
+- `Plan review: waived`
+
+The factory should acknowledge one of those explicit review decisions after it reads it and summarize the next action in the issue thread.
+
 ## Planning Standard
 
 Every substantial implementation plan must:

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -80,3 +80,64 @@ Rules:
 18. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.
 19. Monitor CI and automated review feedback, address follow-up comments, and do not treat the CI/review stage as complete until all checks pass and all actionable comments are resolved. If a CI or automated review check remains in a non-terminal state for more than 30 minutes without progress, comment on the issue describing the blocked check and wait for human guidance before proceeding.
 20. Leave the workspace in a git state that can be inspected if the run fails.
+
+When posting the `plan-ready` handoff comment, include:
+
+- the plan path
+- a short summary
+- a brief note that replies must start with one of the accepted review markers
+- copy-pasteable fenced markdown templates
+
+Accepted first-line review markers are:
+
+- `Plan review: approved`
+- `Plan review: changes-requested`
+- `Plan review: waived`
+
+Use this exact reply-template block in the `plan-ready` comment:
+
+````md
+```md
+Plan review: approved
+
+Summary
+
+- Approved to implement.
+```
+
+```md
+Plan review: changes-requested
+
+Summary
+
+- One-sentence decision.
+
+What is good
+
+- ...
+
+Required changes
+
+- ...
+
+Architecture / spec concerns
+
+- ...
+
+Slice / PR size concerns
+
+- ...
+
+Approval condition
+
+- Approve after ...
+```
+
+```md
+Plan review: waived
+
+Summary
+
+- Plan review is waived; proceed to implementation.
+```
+````

--- a/docs/plans/048-plan-review-comment-protocol/plan.md
+++ b/docs/plans/048-plan-review-comment-protocol/plan.md
@@ -1,0 +1,118 @@
+# Issue 48 Plan: Plan Review Comment Protocol And Acknowledgement Loop
+
+## Objective
+
+Make the GitHub-based human plan review station explicit and machine-readable by standardizing the `plan-ready` comment format, the accepted human review reply markers, and the acknowledgement comment the tracker posts after it reads a review decision.
+
+## Scope
+
+- standardize the `plan-ready` issue comment format in checked-in workflow/policy docs
+- include copy-pasteable fenced markdown reply templates for `approved`, `changes-requested`, and `waived`
+- add tracker-edge acknowledgement comments after the latest explicit review decision is read
+- ensure acknowledgement comments are posted once per review comment, not once per poll
+- add tests for the accepted review markers, acknowledgement emission, and repo-policy wording
+
+## Non-goals
+
+- changing the runtime waiting-state semantics from `#42`
+- redesigning PR review handling
+- Beads-native plan review UX
+- generalizing lifecycle semantics beyond the GitHub bootstrap tracker
+- cross-repo publication or reporting work
+
+## Current Gap
+
+The repo policy and prompts now describe a human plan review station, but the protocol is underspecified and only partially visible to humans:
+
+- `plan-ready` comments do not provide a rigid reply template for humans
+- the tracker reads explicit plan review markers, but the issue thread does not acknowledge what decision was read or what action will happen next
+- this makes the issue thread harder to interpret and leaves the protocol too implicit for future Beads migration
+
+## Spec / Layer Mapping
+
+- Policy: accepted plan review states and comment protocol
+- Configuration: none beyond existing tracker/workflow configuration
+- Coordination: unchanged; runtime semantics already fixed in `#42`
+- Execution: none
+- Integration: GitHub issue comment read/write behavior in the bootstrap tracker
+- Observability: acknowledgement comments provide human-visible handoff traceability
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- tracker-edge parsing/formatting for plan review comments
+- repo-owned workflow/policy text that instructs workers how to emit the `plan-ready` handoff comment
+- tests for protocol acceptance and single-emission acknowledgement behavior
+
+### Does not belong in this issue
+
+- orchestrator lifecycle redesign
+- tracker-neutral handoff generalization (`#50`)
+- Beads workflow migration
+- dashboards or richer worker visibility
+- report generation and publication
+
+## Slice Strategy
+
+This should fit in one reviewable PR because it is one narrow seam:
+
+1. tighten the repo-owned prompt/policy text for `plan-ready`
+2. add a small tracker-edge acknowledgement mechanism
+3. add focused tests around those behaviors
+
+The slice stays reviewable by keeping all changes in workflow docs, the plan review parser, the GitHub tracker adapter, and related tests.
+
+## Runtime State / Failure Notes
+
+`#42` already established `awaiting-plan-review` as a valid handoff state. This issue should not change the state machine. The only runtime-sensitive behavior is preventing repeated acknowledgement comments during polling by keying acknowledgements to the latest parsed human review comment.
+
+## Implementation Steps
+
+1. Add a small plan-review protocol helper that:
+   - parses the latest explicit plan review signal from issue comments
+   - parses prior acknowledgement comments
+   - formats the acknowledgement body for each accepted review decision
+2. Update the GitHub bootstrap tracker so that when it reads `changes-requested`, `approved`, or `waived` as the latest explicit review decision with no PR yet, it posts one acknowledgement comment if that exact review comment has not already been acknowledged.
+3. Keep the acknowledgement behavior at the tracker edge rather than the orchestrator.
+4. Update `WORKFLOW.md`, `AGENTS.md`, and `skills/symphony-plan/SKILL.md` so the `plan-ready` comment includes:
+   - plan path
+   - summary
+   - brief instructions
+   - fenced markdown reply templates
+5. Extend tests:
+   - unit tests for plan review parsing / acknowledgement recognition
+   - integration tests that the tracker posts acknowledgement comments once per review comment
+   - planning contract tests for the template wording in workflow/policy docs
+
+## Tests And Acceptance Scenarios
+
+- unit: parse `Plan review: approved`, `changes-requested`, `waived`
+- unit: detect an acknowledgement comment for a specific source review comment id
+- integration: latest `changes-requested` produces one acknowledgement comment and does not duplicate on unchanged polls
+- integration: latest `approved` produces one acknowledgement comment and does not duplicate on unchanged polls
+- integration: latest `waived` produces one acknowledgement comment and does not duplicate on unchanged polls
+- contract: workflow/policy docs include copy-pasteable reply templates and explicit accepted markers
+- repo gate: `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, `codex review --base origin/main`
+
+## Observability
+
+The issue thread itself is the human-visible observability surface for this slice. Each parsed human review decision should have an acknowledgement comment that states the next action.
+
+## Exit Criteria
+
+- `plan-ready` workflow text is standardized across repo-owned docs
+- explicit human reply templates are present in the runtime contract
+- the GitHub tracker posts one acknowledgement comment per explicit review decision
+- acknowledgement comments are not duplicated on repeated unchanged polls
+- tests cover both the protocol parsing and acknowledgement emission
+
+## Deferred Work
+
+- tracker-neutral handoff lifecycle generalization (`#50`)
+- Beads-native review state and conversation UX
+- stronger author validation for review comments if the token/identity model changes
+
+## Revision Log
+
+- 2026-03-07: Initial plan written. Human plan review explicitly waived by operator instruction in chat so implementation may proceed directly from this plan.

--- a/skills/symphony-plan/SKILL.md
+++ b/skills/symphony-plan/SKILL.md
@@ -227,6 +227,19 @@ Required behavior:
 5. begin substantial implementation only after the plan is explicitly `approved` or explicitly `waived`
 6. if approval is waived, record that fact in the issue or PR notes so the handoff remains inspectable
 
+Use these exact first-line markers for the human reply protocol:
+
+- `Plan review: approved`
+- `Plan review: changes-requested`
+- `Plan review: waived`
+
+The `plan-ready` issue comment should include:
+
+- the plan path
+- a short summary
+- a short note that the review reply must begin with one of the accepted markers
+- copy-pasteable fenced markdown templates for `approved`, `changes-requested`, and `waived`
+
 This review station is the first slice for plan-process issues because it preserves the workflow boundary and uses existing issue comments instead of inventing new runtime machinery.
 
 ## Plan Output
@@ -245,5 +258,53 @@ After writing the plan:
 4. follow the Human Review Station above: unless plan approval is explicitly waived, stop at `plan-ready`, treat the plan as `in review`, and wait for human review before substantial implementation
 5. if review feedback arrives, revise the plan, summarize the changes in a fresh issue comment, and return to `plan-ready`
 6. once the plan is explicitly `approved`, or plan approval is explicitly `waived`, begin substantial implementation; if approval is waived, record that waiver in the issue or PR notes so the handoff remains inspectable
+
+Use this exact reply-template block in the `plan-ready` comment:
+
+````md
+```md
+Plan review: approved
+
+Summary
+
+- Approved to implement.
+```
+
+```md
+Plan review: changes-requested
+
+Summary
+
+- One-sentence decision.
+
+What is good
+
+- ...
+
+Required changes
+
+- ...
+
+Architecture / spec concerns
+
+- ...
+
+Slice / PR size concerns
+
+- ...
+
+Approval condition
+
+- Approve after ...
+```
+
+```md
+Plan review: waived
+
+Summary
+
+- Plan review is waived; proceed to implementation.
+```
+````
 
 Current enforcement is guidance and process expectation; orchestrator-level pause support is deferred.

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -157,6 +157,7 @@ export class GitHubBootstrapTracker implements Tracker {
         issueNumber,
         protocol.acknowledgement.body,
       );
+      return protocol.lifecycle;
     }
     const lifecycle = protocol.lifecycle;
     this.#planReviewObservations.set(branchName, {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -3,7 +3,7 @@ import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { TrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { GitHubClient } from "./github-client.js";
-import { evaluatePlanReviewLifecycle } from "./plan-review-policy.js";
+import { evaluatePlanReviewProtocol } from "./plan-review-policy.js";
 import {
   evaluatePullRequestLifecycle,
   missingPullRequestLifecycle,
@@ -141,7 +141,7 @@ export class GitHubBootstrapTracker implements Tracker {
     }
 
     const comments = await this.#client.getIssueComments(issueNumber);
-    const lifecycle = evaluatePlanReviewLifecycle(
+    const protocol = evaluatePlanReviewProtocol(
       branchName,
       issue.url,
       comments.map((comment) => ({
@@ -152,6 +152,13 @@ export class GitHubBootstrapTracker implements Tracker {
         authorLogin: comment.user?.login ?? null,
       })),
     );
+    if (protocol.acknowledgement !== null) {
+      await this.#client.createComment(
+        issueNumber,
+        protocol.acknowledgement.body,
+      );
+    }
+    const lifecycle = protocol.lifecycle;
     this.#planReviewObservations.set(branchName, {
       issueUpdatedAt: issue.updatedAt,
       lifecycle,

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -14,9 +14,27 @@ type PlanReviewSignal =
   | "approved"
   | "waived";
 
+type PlanReviewDecisionSignal = Exclude<PlanReviewSignal, "plan-ready">;
+
 interface ParsedPlanReviewComment {
   readonly signal: PlanReviewSignal;
   readonly comment: IssueCommentSnapshot;
+}
+
+interface ParsedPlanReviewAcknowledgement {
+  readonly signal: PlanReviewDecisionSignal;
+  readonly reviewCommentId: number;
+  readonly comment: IssueCommentSnapshot;
+}
+
+export interface PlanReviewProtocolEvaluation {
+  readonly latestSignal: ParsedPlanReviewComment | null;
+  readonly lifecycle: PullRequestLifecycle | null;
+  readonly acknowledgement: {
+    readonly signal: PlanReviewDecisionSignal;
+    readonly reviewCommentId: number;
+    readonly body: string;
+  } | null;
 }
 
 function parsePlanReviewComment(
@@ -48,39 +66,156 @@ function parsePlanReviewComment(
   return null;
 }
 
+function parsePlanReviewAcknowledgement(
+  comment: IssueCommentSnapshot,
+): ParsedPlanReviewAcknowledgement | null {
+  const lines = comment.body
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+  const [firstLine, ...rest] = lines;
+  if (!firstLine) {
+    return null;
+  }
+
+  const normalized = firstLine.toLowerCase();
+  let signal: PlanReviewDecisionSignal | null = null;
+  if (normalized === "plan review acknowledged: changes-requested") {
+    signal = "changes-requested";
+  } else if (normalized === "plan review acknowledged: approved") {
+    signal = "approved";
+  } else if (normalized === "plan review acknowledged: waived") {
+    signal = "waived";
+  }
+
+  if (signal === null) {
+    return null;
+  }
+
+  const idLine = rest.find((line) => /^review comment id:\s*\d+$/iu.test(line));
+  if (!idLine) {
+    return null;
+  }
+
+  const match = idLine.match(/^review comment id:\s*(\d+)$/iu);
+  if (!match || !match[1]) {
+    return null;
+  }
+
+  return {
+    signal,
+    reviewCommentId: Number(match[1]),
+    comment,
+  };
+}
+
+function hasAcknowledgedLatestSignal(
+  signal: PlanReviewDecisionSignal,
+  reviewCommentId: number,
+  comments: readonly IssueCommentSnapshot[],
+): boolean {
+  return comments.some((comment) => {
+    const acknowledgement = parsePlanReviewAcknowledgement(comment);
+    return (
+      acknowledgement !== null &&
+      acknowledgement.signal === signal &&
+      acknowledgement.reviewCommentId === reviewCommentId
+    );
+  });
+}
+
+function buildPlanReviewAcknowledgement(
+  signal: PlanReviewDecisionSignal,
+  comment: IssueCommentSnapshot,
+): string {
+  const nextAction =
+    signal === "changes-requested"
+      ? "Revise the plan, post a fresh `Plan status: plan-ready` comment, and wait for review again."
+      : signal === "approved"
+        ? "Begin substantial implementation."
+        : "Begin substantial implementation without waiting for plan approval.";
+
+  return [
+    `Plan review acknowledged: ${signal}`,
+    "",
+    `Review comment id: ${comment.id.toString()}`,
+    `Review comment URL: ${comment.url}`,
+    "",
+    "Next action",
+    `- ${nextAction}`,
+  ].join("\n");
+}
+
+export function evaluatePlanReviewProtocol(
+  branchName: string,
+  issueUrl: string,
+  comments: readonly IssueCommentSnapshot[],
+): PlanReviewProtocolEvaluation {
+  const latestSignal =
+    comments
+      .map(parsePlanReviewComment)
+      .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
+      .sort((left, right) => {
+        const timeDiff =
+          Date.parse(left.comment.createdAt) -
+          Date.parse(right.comment.createdAt);
+        return timeDiff !== 0 ? timeDiff : left.comment.id - right.comment.id;
+      })
+      .at(-1) ?? null;
+
+  if (latestSignal === null) {
+    return {
+      latestSignal: null,
+      lifecycle: null,
+      acknowledgement: null,
+    };
+  }
+
+  if (latestSignal.signal !== "plan-ready") {
+    const acknowledgement = hasAcknowledgedLatestSignal(
+      latestSignal.signal,
+      latestSignal.comment.id,
+      comments,
+    )
+      ? null
+      : {
+          signal: latestSignal.signal,
+          reviewCommentId: latestSignal.comment.id,
+          body: buildPlanReviewAcknowledgement(
+            latestSignal.signal,
+            latestSignal.comment,
+          ),
+        };
+
+    return {
+      latestSignal,
+      lifecycle: null,
+      acknowledgement,
+    };
+  }
+
+  return {
+    latestSignal,
+    lifecycle: {
+      kind: "awaiting-plan-review",
+      branchName,
+      pullRequest: null,
+      checks: [],
+      pendingCheckNames: [],
+      failingCheckNames: [],
+      actionableReviewFeedback: [],
+      unresolvedThreadIds: [],
+      summary: `Waiting for human plan review on ${issueUrl}`,
+    },
+    acknowledgement: null,
+  };
+}
+
 export function evaluatePlanReviewLifecycle(
   branchName: string,
   issueUrl: string,
   comments: readonly IssueCommentSnapshot[],
 ): PullRequestLifecycle | null {
-  const latestSignal = comments
-    .map(parsePlanReviewComment)
-    .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
-    .sort((left, right) => {
-      const timeDiff =
-        Date.parse(left.comment.createdAt) -
-        Date.parse(right.comment.createdAt);
-      return timeDiff !== 0 ? timeDiff : left.comment.id - right.comment.id;
-    })
-    .at(-1);
-
-  if (!latestSignal || latestSignal.signal !== "plan-ready") {
-    return null;
-  }
-
-  // Author validation is intentionally deferred to #48 so #42 only fixes the
-  // runtime handoff semantics; today the issue comment first-line markers are
-  // treated as an open-trust protocol.
-
-  return {
-    kind: "awaiting-plan-review",
-    branchName,
-    pullRequest: null,
-    checks: [],
-    pendingCheckNames: [],
-    failingCheckNames: [],
-    actionableReviewFeedback: [],
-    unresolvedThreadIds: [],
-    summary: `Waiting for human plan review on ${issueUrl}`,
-  };
+  return evaluatePlanReviewProtocol(branchName, issueUrl, comments).lifecycle;
 }

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -24,7 +24,6 @@ interface ParsedPlanReviewComment {
 interface ParsedPlanReviewAcknowledgement {
   readonly signal: PlanReviewDecisionSignal;
   readonly reviewCommentId: number;
-  readonly comment: IssueCommentSnapshot;
 }
 
 export interface PlanReviewProtocolEvaluation {

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -24,6 +24,7 @@ interface ParsedPlanReviewComment {
 interface ParsedPlanReviewAcknowledgement {
   readonly signal: PlanReviewDecisionSignal;
   readonly reviewCommentId: number;
+  readonly comment: IssueCommentSnapshot;
 }
 
 export interface PlanReviewProtocolEvaluation {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -124,10 +124,13 @@ describe("GitHubBootstrapTracker", () => {
       createdAt: "2026-03-07T10:05:00.000Z",
     });
 
-    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+    const first = await tracker.inspectIssueHandoff("symphony/7");
+    const second = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("missing");
-    expect(lifecycle.summary).toMatch(/no open pull request/i);
+    expect(first.kind).toBe("missing");
+    expect(first.summary).toMatch(/no open pull request/i);
+    expect(second.kind).toBe("missing");
+    expect(second.summary).toMatch(/no open pull request/i);
     expect(
       server
         .getIssue(7)
@@ -137,6 +140,13 @@ describe("GitHubBootstrapTracker", () => {
             body.includes("Review comment id: 2"),
         ),
     ).toBe(true);
+    expect(
+      server
+        .getIssue(7)
+        .comments.filter((body) =>
+          body.startsWith("Plan review acknowledged: approved"),
+        ),
+    ).toHaveLength(1);
   });
 
   it("reads plan-review signals beyond the first page of issue comments", async () => {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -128,6 +128,15 @@ describe("GitHubBootstrapTracker", () => {
 
     expect(lifecycle.kind).toBe("missing");
     expect(lifecycle.summary).toMatch(/no open pull request/i);
+    expect(
+      server
+        .getIssue(7)
+        .comments.some(
+          (body) =>
+            body.includes("Plan review acknowledged: approved") &&
+            body.includes("Review comment id: 2"),
+        ),
+    ).toBe(true);
   });
 
   it("reads plan-review signals beyond the first page of issue comments", async () => {
@@ -190,7 +199,43 @@ describe("GitHubBootstrapTracker", () => {
     expect(first.kind).toBe("missing");
     expect(second.kind).toBe("missing");
     expect(server.countRequests("GET issues/7")).toBe(2);
-    expect(server.countRequests("GET issues/7/comments")).toBe(1);
+    expect(server.countRequests("GET issues/7/comments")).toBe(2);
+    expect(
+      server
+        .getIssue(7)
+        .comments.filter((body) =>
+          body.startsWith("Plan review acknowledged: changes-requested"),
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("acknowledges waived plan review decisions once", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan status: plan-ready\n\nWaiting for human review.",
+      createdAt: "2026-03-07T10:00:00.000Z",
+    });
+    server.addIssueComment({
+      issueNumber: 7,
+      authorLogin: "jessmartin",
+      body: "Plan review: waived\n\nSummary\n- Proceed without waiting.",
+      createdAt: "2026-03-07T10:05:00.000Z",
+    });
+
+    const first = await tracker.inspectIssueHandoff("symphony/7");
+    const second = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(first.kind).toBe("missing");
+    expect(second.kind).toBe("missing");
+    expect(
+      server
+        .getIssue(7)
+        .comments.filter((body) =>
+          body.startsWith("Plan review acknowledged: waived"),
+        ),
+    ).toHaveLength(1);
   });
 
   it("reports awaiting-review while checks are pending", async () => {

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  evaluatePlanReviewProtocol,
   evaluatePlanReviewLifecycle,
   type IssueCommentSnapshot,
 } from "../../src/tracker/plan-review-policy.js";
@@ -123,5 +124,62 @@ describe("plan-review-policy", () => {
     );
 
     expect(lifecycle?.kind).toBe("awaiting-plan-review");
+  });
+
+  it("requests an acknowledgement comment for approved reviews", () => {
+    const protocol = evaluatePlanReviewProtocol(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+        comment(
+          "Plan review: approved\n\nSummary\n- Proceed.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+      ],
+    );
+
+    expect(protocol.lifecycle).toBeNull();
+    expect(protocol.acknowledgement?.signal).toBe("approved");
+    expect(protocol.acknowledgement?.reviewCommentId).toBe(3);
+    expect(protocol.acknowledgement?.body).toContain(
+      "Plan review acknowledged: approved",
+    );
+    expect(protocol.acknowledgement?.body).toContain("Review comment id: 3");
+  });
+
+  it("does not request a duplicate acknowledgement when one already exists", () => {
+    const protocol = evaluatePlanReviewProtocol(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan review: changes-requested\n\nRequired changes\n- Split the issue.",
+          "2026-03-07T10:06:00.000Z",
+          3,
+        ),
+        comment(
+          [
+            "Plan review acknowledged: changes-requested",
+            "",
+            "Review comment id: 3",
+            "Review comment URL: https://example.test/issues/32#issuecomment-3",
+            "",
+            "Next action",
+            "- Revise the plan, post a fresh `Plan status: plan-ready` comment, and wait for review again.",
+          ].join("\n"),
+          "2026-03-07T10:07:00.000Z",
+          4,
+        ),
+      ],
+    );
+
+    expect(protocol.lifecycle).toBeNull();
+    expect(protocol.acknowledgement).toBeNull();
   });
 });

--- a/tests/unit/planning-contract.test.ts
+++ b/tests/unit/planning-contract.test.ts
@@ -58,6 +58,10 @@ describe("repo planning contract", () => {
       "waived",
       "human feedback",
       "wait for human review", // SKILL.md §Plan Output step 4 — keep this exact wording
+      "plan review: approved",
+      "plan review: changes-requested",
+      "plan review: waived",
+      "copy-pasteable fenced markdown templates",
     ]);
   });
 
@@ -111,6 +115,10 @@ describe("repo planning contract", () => {
       "approved",
       "waived",
       "human feedback",
+      "plan review: approved",
+      "plan review: changes-requested",
+      "plan review: waived",
+      "copy-pasteable",
     ]);
   });
 
@@ -143,6 +151,11 @@ describe("repo planning contract", () => {
       "approved",
       "waives waiting", // AGENTS.md §Issue Workflow step 5 — keep this exact wording
       "human review station",
+      "plan review comment protocol",
+      "plan review: approved",
+      "plan review: changes-requested",
+      "plan review: waived",
+      "acknowledge",
     ]);
   });
 


### PR DESCRIPTION
Closes #48

## Summary
- standardize the `plan-ready` issue comment protocol in repo-owned workflow docs
- add tracker-edge acknowledgement comments for explicit plan review decisions
- cover the protocol with unit, integration, and contract tests

## Plan
- `docs/plans/048-plan-review-comment-protocol/plan.md`

## Waiver
- Human plan approval for `#48` was explicitly waived by operator instruction in chat on 2026-03-07, and that waiver is also recorded on the issue.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `codex review --base origin/main`
