### PR TITLE
Add local issue reporting artifact contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 dist/
 coverage/
 .tmp/
+.var/
 .ralph/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ next startup or poll, Symphony reconciles `symphony:running` issues against
 that local state, terminates orphaned local agent processes when needed, and
 resumes or fails the issue from the runtime itself.
 
+Per-issue reporting artifacts are also written locally under
+`.var/factory/issues/<issue-number>/...`. That contract stores durable raw facts
+for one issue (`issue.json`, `events.jsonl`, per-attempt snapshots,
+per-session snapshots, and log pointers) so later report generation can read
+local state without coupling itself to orchestrator control flow.
+
 ## Technical Plan Review Station
 
 Before substantial implementation begins, the repo-owned workflow contract requires a human review station for technical plans:
@@ -202,6 +208,8 @@ In continuous mode, Symphony will keep polling for additional ready issues.
 During or after a run, Symphony writes the latest derived status snapshot to `.tmp/status.json`.
 The `status` CLI reads that file and renders either a simple terminal view or the raw JSON contract
 for future tooling.
+Issue-level reporting artifacts are written separately under `.var/factory/issues/`
+so they survive workspace cleanup.
 
 ### 5. Watch the issue lifecycle
 

--- a/docs/plans/043-local-issue-reporting-artifact-contract/plan.md
+++ b/docs/plans/043-local-issue-reporting-artifact-contract/plan.md
@@ -1,0 +1,345 @@
+# Issue 43 Plan: Local Issue Reporting Artifact Contract
+
+## Objective
+
+Define the first durable, local-only issue reporting artifact contract under `.var/factory/issues/<issue-number>/...` so the runtime can emit raw issue facts now and a later CLI can render reports from those facts without changing orchestrator control flow.
+
+## Scope
+
+This slice covers:
+
+1. a stable local directory layout for one issue under gitignored repo state
+2. canonical raw file contracts for `issue.json`, `events.jsonl`, per-attempt files, per-session files, and log-pointer metadata
+3. a provider-neutral observability writer that persists those files atomically and durably enough for later read-side tooling
+4. orchestrator integration that emits raw lifecycle facts the current runtime already knows without adding report-rendering logic
+5. tests and docs for the local contract and path rules
+
+## Non-goals
+
+This slice does not include:
+
+1. rendering a final `report.md`
+2. publishing artifacts to `factory-runs` or any remote store
+3. storing raw provider logs inside the core contract
+4. deep Codex-specific parsing or model/provider enrichment beyond normalized session metadata
+5. redesigning orchestrator retry, review-loop, or tracker policy
+6. a general analytics or dashboard surface over the artifacts
+
+## Current Gaps
+
+Today `symphony-ts` has one local observability artifact: the derived factory status snapshot under `.tmp/status.json`. It does not yet have per-issue durable reporting state:
+
+1. issue-level lifecycle facts are scattered across tracker state, local runner output, and in-memory orchestrator transitions
+2. there is no append-only event history per issue
+3. there is no canonical per-attempt or per-session artifact contract for later report generation
+4. raw provider logs are only implicit in runner stdout/stderr handling and are not represented as normalized pointers
+5. the repo does not yet reserve `.var/factory/issues/...` as stable local state
+
+## Spec / Layer Mapping
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_43/docs/architecture.md).
+
+- Policy Layer: repo-owned guidance already says reporting artifacts are local observability state and raw facts only. This issue does not add new tracker or orchestration policy.
+- Configuration Layer: no workflow schema change in this slice; the artifact root is derived from the long-lived repo-local factory root that sits alongside `.tmp/`, not from any cleanup-managed issue workspace path.
+- Coordination Layer: the orchestrator remains the source of runtime transitions, but it only emits facts to the artifact writer; it must not gain report-rendering or tracker-specific policy branches here.
+- Execution Layer: runner and workspace layers may contribute normalized session/workspace facts, but they do not own issue-report persistence or reporting policy.
+- Integration Layer: tracker-derived lifecycle facts may be reused only in normalized form already exposed to the runtime; provider-specific parsing stays at the edge and deeper enrichment is deferred.
+- Observability Layer: owns the artifact schema, file layout, write/read helpers, atomic persistence, and the durable contract consumed later by report generation.
+
+## Architecture Boundaries
+
+### Observability
+
+Belongs here:
+
+1. contract types for issue, event, attempt, session, and log-pointer artifacts
+2. path helpers for `.var/factory/issues/<issue-number>/...` rooted outside `.tmp/workspaces/`
+3. atomic writers and readers for JSON and JSONL files
+4. idempotent append/update behavior for durable local facts
+
+Does not belong here:
+
+1. dispatch or retry decisions
+2. tracker-specific parsing rules beyond normalized inputs handed to it
+3. markdown or polished report rendering
+
+### Orchestrator
+
+Belongs here:
+
+1. calling the artifact writer on meaningful runtime transitions already owned by the orchestrator
+2. passing normalized issue, attempt, lifecycle, and runner-session facts into observability helpers
+
+Does not belong here:
+
+1. filesystem layout rules inline inside control-flow branches
+2. report formatting
+3. provider-specific log parsing
+
+### Runner
+
+Belongs here:
+
+1. exposing normalized spawn/session facts already known at launch time
+2. exposing raw log pointer inputs when available without making raw logs part of the contract
+
+Does not belong here:
+
+1. deciding artifact paths
+2. parsing provider-specific logs into report-friendly summaries
+
+### Tracker
+
+Belongs here:
+
+1. continuing to normalize plan-review and PR lifecycle state at the tracker edge
+2. exposing only the normalized facts the orchestrator already consumes
+
+Does not belong here:
+
+1. writing issue artifacts directly
+2. coupling GitHub comment or PR transport details into the artifact schema
+
+### Workflow / Config
+
+Belongs here:
+
+1. no schema change in this slice
+2. documentation updates describing the local artifact root
+
+Does not belong here:
+
+1. a new reporting configuration surface before the contract exists
+
+## Slice Strategy
+
+This issue should land as one reviewable PR because it stays on one narrow seam: durable local observability state rooted in the factory runtime area rather than workspace lifecycle state.
+
+The PR should include:
+
+1. the artifact schema and storage helpers in `src/observability/`
+2. the minimal runtime wiring needed to emit those artifacts from existing transitions
+3. tests for the storage contract and runtime emission behavior
+4. repo-local docs and `.gitignore` updates for `.var/`
+
+The PR should explicitly defer:
+
+1. report rendering
+2. remote publication
+3. provider-specific parsing and enrichment for later issue `#46`
+4. any broader status-surface redesign
+
+## Runtime Write Model
+
+This slice does not change the orchestrator state machine, but it does need an explicit write model so artifacts are stable across retries and repeated polls.
+
+### Durable issue artifact states
+
+1. `absent`: no artifact directory exists yet for the issue
+2. `active`: base issue directory exists and contains the current issue summary plus zero or more events, attempts, and sessions
+3. `waiting`: the latest current state in `issue.json` reflects a non-terminal waiting or handoff state such as plan review or PR review
+4. `terminal`: `issue.json` records a terminal outcome while historical events, attempts, and sessions remain preserved
+
+### Allowed write transitions
+
+1. `absent -> active`: first observed issue fact creates the directory tree and `issue.json`
+2. `active -> active`: append a new lifecycle event, update `issue.json`, and upsert the current attempt/session snapshots
+3. `active -> waiting`: update `issue.json` current state and append a waiting-state event only when the normalized lifecycle meaning changes
+4. `active|waiting -> active`: append a new attempt or runner/session event when the issue resumes
+5. `active|waiting -> terminal`: append a terminal event, finalize the current attempt snapshot, and update `issue.json`
+
+### Idempotency rules
+
+To avoid poll-loop duplication:
+
+1. `issue.json`, `attempts/<n>.json`, `sessions/<id>.json`, and `logs/pointers.json` are upserted atomically
+2. `events.jsonl` is append-only, but only for newly observed lifecycle transitions or one-shot facts
+3. repeated observation of the same waiting/review state on later polls must not append duplicate events forever
+4. PR-opened and review-feedback events should be keyed from normalized facts already available to the runtime, not raw transport payloads
+
+## Failure-Class Matrix
+
+| Observed condition                                                | Local facts available                                               | Expected behavior                                                                                                                  |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| First artifact write for an issue                                 | no issue directory yet                                              | create the directory tree and write the base snapshots atomically                                                                  |
+| Runtime revisits the same issue/attempt                           | existing `issue.json` and attempt/session files present             | upsert snapshots in place and avoid duplicating append-only events for unchanged lifecycle state                                   |
+| New attempt starts after retry                                    | prior attempts already persisted                                    | create `attempts/<new-attempt>.json`, preserve prior attempt files, append one retry-scheduled event                               |
+| Session metadata becomes available before any raw log path exists | runner session id and spawn facts available, no raw-log pointer yet | write the session file with null/empty log pointers; later update `logs/pointers.json` or the session file when pointers are known |
+| Raw artifact write fails                                          | runtime still has in-memory facts                                   | surface a typed observability failure and structured log context; do not invent new orchestration policy in this slice             |
+| Poll observes the same waiting lifecycle repeatedly               | existing artifact files show the same lifecycle meaning             | update current timestamps only where needed, but do not append a new duplicate lifecycle event on every poll                       |
+
+## Storage Contract
+
+Introduce a versioned issue-artifact contract rooted at:
+
+```text
+.var/factory/
+  issues/
+    <issue-number>/
+      issue.json
+      events.jsonl
+      attempts/
+        <attempt-number>.json
+      sessions/
+        <session-id>.json
+      logs/
+        pointers.json
+```
+
+### Contract rules
+
+1. `.var/` is gitignored local state rooted at the repo/factory runtime boundary, not inside any issue workspace directory
+2. all JSON documents should carry a schema version for later read-side compatibility
+3. `issue.json` is the latest summary for one issue, not a historical log
+4. `events.jsonl` is the append-only historical ledger for the issue
+5. attempt and session files are stable per-key snapshots, not log streams
+6. `logs/pointers.json` stores references to raw logs or later archive locations, not the raw logs themselves
+
+### `issue.json`
+
+Minimum fields:
+
+1. schema version
+2. issue number / identifier / repo / title / branch
+3. current outcome or current waiting state
+4. first observed timestamp
+5. last updated timestamp
+6. latest attempt number
+7. latest session id when present
+
+### `events.jsonl`
+
+Each line should record:
+
+1. schema version
+2. event kind
+3. issue number
+4. observed timestamp
+5. attempt number when applicable
+6. session id when applicable
+7. normalized event details object
+
+The contract should reserve stable event kinds including:
+
+- `claimed`
+- `plan-ready`
+- `approved`
+- `waived`
+- `runner-spawned`
+- `pr-opened`
+- `review-feedback`
+- `retry-scheduled`
+- `succeeded`
+- `failed`
+
+The initial implementation may emit only the subset the current runtime can observe cleanly without new provider-specific parsing, but the schema must reserve the broader vocabulary now.
+
+### `attempts/<attempt-number>.json`
+
+Minimum fields:
+
+1. schema version
+2. attempt number
+3. started / finished timestamps
+4. attempt outcome
+5. runner/session references
+6. last known PR and review snapshot when relevant
+
+### `sessions/<session-id>.json`
+
+Minimum fields:
+
+1. schema version
+2. session id
+3. provider and model when known
+4. start / end timestamps when known
+5. workspace and issue references
+6. pointers to raw logs when known
+
+### `logs/pointers.json`
+
+Minimum fields:
+
+1. schema version
+2. issue number
+3. known raw log pointer entries keyed by session id or logical log name
+4. archive pointers when later publication exists
+
+## Observability Requirements
+
+1. artifact writes should be atomic enough that later readers do not observe truncated JSON files
+2. the contract must be durable across process restarts, retries, and workspace cleanup
+3. the write path must remain provider-neutral and runner-neutral at the core boundary
+4. structured logs should report artifact write failures with issue, attempt, and session context
+5. later report generation should be able to read only `.var/factory/issues/<issue-number>/...` without replaying orchestrator control flow
+
+## Implementation Steps
+
+1. Add issue-artifact domain types and path helpers in `src/observability/`.
+2. Add a focused local artifact store/writer with:
+   - directory creation
+   - atomic JSON writes
+   - append-only JSONL writes
+   - idempotent event appends based on existing persisted state
+3. Derive the artifact root from the long-lived repo-local factory root so the final path is `<repo>/.var/factory/issues/<issue-number>/...`; infer that root from the configured workspace root without placing artifacts anywhere under `.tmp/workspaces/`.
+4. Extend orchestrator transitions to emit:
+   - issue summary updates
+   - attempt lifecycle snapshots
+   - runner/session metadata
+   - lifecycle events the runtime already observes cleanly
+5. Keep raw log handling pointer-only in this slice.
+6. Update `.gitignore` and `README.md` to document the local artifact root and its purpose.
+7. Add tests for path derivation, contract serialization, idempotent event writing, and orchestrator-driven artifact emission.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. artifact path helpers derive `<repo>/.var/factory/issues/<issue-number>` from the repo/factory root inferred from config and never place artifacts under `.tmp/workspaces/<issue>/...`
+2. atomic JSON writers create the required directory tree and preserve valid JSON on rewrite
+3. event writer appends new events and suppresses duplicates for unchanged waiting/review state
+4. attempt/session/log-pointer writers upsert the expected contract shape
+
+### Integration
+
+1. a successful issue run produces `issue.json`, `events.jsonl`, `attempts/1.json`, and `sessions/<id>.json` with normalized fields
+2. a retrying issue preserves attempt `1`, creates attempt `2`, and appends `retry-scheduled` once
+3. a waiting-for-review lifecycle writes `issue.json` current state plus one waiting/review event without duplicate appends on repeated polls
+4. after workspace cleanup removes `.tmp/workspaces/<issue>`, the `.var/factory/issues/<issue-number>/...` artifacts remain readable and unchanged
+
+### End-to-end / Repo gate
+
+1. `.var/` is gitignored local state and not introduced as tracked source
+2. later tooling could consume the per-issue directory without reading `.tmp/status.json`
+3. `pnpm format`
+4. `pnpm lint`
+5. `pnpm typecheck`
+6. `pnpm test`
+7. `codex review --base origin/main`
+
+## Exit Criteria
+
+1. one canonical local issue-artifact contract exists under `.var/factory/issues/<issue-number>/...`
+2. the runtime writes durable raw facts for issues, attempts, sessions, and event history without coupling report rendering into orchestrator control flow or tying artifact lifetime to workspace cleanup
+3. the artifact schema is provider-neutral and keeps raw provider logs out of the core contract
+4. the contract is documented and gitignored
+5. tests cover both the storage helpers and the runtime emission behavior
+
+## Deferred Work
+
+1. `report.md` or any other polished report rendering
+2. remote publication or archive syncing
+3. provider-specific session/log parsing and enrichment in issue `#46`
+4. expanding the read side into a dedicated reporting CLI
+5. any configuration surface for alternate artifact roots if the default local contract proves insufficient
+
+## Decision Notes
+
+1. Derive the artifact root from the repo-local factory runtime boundary, not from issue workspaces, so cleanup-managed `.tmp/workspaces/...` paths can be deleted without losing reporting artifacts.
+2. Keep event vocabulary broader than the first emitted subset so later tracker- or provider-specific enrichment can extend data coverage without changing the on-disk layout.
+3. Treat these files as observability artifacts, not coordination state; the runtime may read them for idempotent writes, but orchestration decisions should continue to use normalized runtime and tracker facts.
+
+## Revision Log
+
+- 2026-03-09: Initial plan drafted for the local issue reporting artifact contract.
+- 2026-03-09: Revised after review to move artifacts to the long-lived repo-level factory root and require a workspace-cleanup survival scenario.

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -10,6 +10,7 @@ export interface RunSession {
   readonly issue: RuntimeIssue;
   readonly workspace: PreparedWorkspace;
   readonly prompt: string;
+  readonly startedAt: string;
   readonly attempt: RunAttempt;
 }
 

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -1,0 +1,556 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
+
+export const ISSUE_ARTIFACT_SCHEMA_VERSION = 1 as const;
+
+export type IssueArtifactEventKind =
+  | "claimed"
+  | "plan-ready"
+  | "approved"
+  | "waived"
+  | "runner-spawned"
+  | "pr-opened"
+  | "review-feedback"
+  | "retry-scheduled"
+  | "succeeded"
+  | "failed";
+
+export type IssueArtifactOutcome =
+  | "claimed"
+  | "running"
+  | "awaiting-plan-review"
+  | "awaiting-review"
+  | "retry-scheduled"
+  | "succeeded"
+  | "failed";
+
+export interface IssueArtifactPaths {
+  readonly issueRoot: string;
+  readonly issueFile: string;
+  readonly eventsFile: string;
+  readonly attemptsDir: string;
+  readonly sessionsDir: string;
+  readonly logsDir: string;
+  readonly logPointersFile: string;
+}
+
+export interface IssueArtifactSummary {
+  readonly version: typeof ISSUE_ARTIFACT_SCHEMA_VERSION;
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly repo: string;
+  readonly title: string;
+  readonly issueUrl: string;
+  readonly branch: string | null;
+  readonly currentOutcome: IssueArtifactOutcome;
+  readonly currentSummary: string;
+  readonly firstObservedAt: string;
+  readonly lastUpdatedAt: string;
+  readonly latestAttemptNumber: number | null;
+  readonly latestSessionId: string | null;
+}
+
+export interface IssueArtifactEvent {
+  readonly version: typeof ISSUE_ARTIFACT_SCHEMA_VERSION;
+  readonly kind: IssueArtifactEventKind;
+  readonly issueNumber: number;
+  readonly observedAt: string;
+  readonly attemptNumber: number | null;
+  readonly sessionId: string | null;
+  readonly details: Readonly<Record<string, unknown>>;
+}
+
+export interface IssueArtifactPullRequestSnapshot {
+  readonly number: number;
+  readonly url: string;
+  readonly latestCommitAt: string | null;
+}
+
+export interface IssueArtifactReviewSnapshot {
+  readonly actionableCount: number;
+  readonly unresolvedThreadCount: number;
+}
+
+export interface IssueArtifactCheckSnapshot {
+  readonly pendingNames: readonly string[];
+  readonly failingNames: readonly string[];
+}
+
+export interface IssueArtifactAttemptSnapshot {
+  readonly version: typeof ISSUE_ARTIFACT_SCHEMA_VERSION;
+  readonly issueNumber: number;
+  readonly attemptNumber: number;
+  readonly branch: string | null;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly outcome: IssueArtifactOutcome;
+  readonly summary: string;
+  readonly sessionId: string | null;
+  readonly runnerPid: number | null;
+  readonly pullRequest: IssueArtifactPullRequestSnapshot | null;
+  readonly review: IssueArtifactReviewSnapshot | null;
+  readonly checks: IssueArtifactCheckSnapshot | null;
+}
+
+export interface IssueArtifactLogPointer {
+  readonly name: string;
+  readonly location: string | null;
+  readonly archiveLocation: string | null;
+}
+
+export interface IssueArtifactSessionSnapshot {
+  readonly version: typeof ISSUE_ARTIFACT_SCHEMA_VERSION;
+  readonly issueNumber: number;
+  readonly attemptNumber: number;
+  readonly sessionId: string;
+  readonly provider: string;
+  readonly model: string | null;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly workspacePath: string | null;
+  readonly branch: string | null;
+  readonly logPointers: readonly IssueArtifactLogPointer[];
+}
+
+export interface IssueArtifactLogPointerSessionEntry {
+  readonly sessionId: string;
+  readonly pointers: readonly IssueArtifactLogPointer[];
+  readonly archiveLocation: string | null;
+}
+
+export interface IssueArtifactLogPointersDocument {
+  readonly version: typeof ISSUE_ARTIFACT_SCHEMA_VERSION;
+  readonly issueNumber: number;
+  readonly sessions: Readonly<
+    Record<string, IssueArtifactLogPointerSessionEntry | undefined>
+  >;
+}
+
+export interface IssueArtifactIssueUpdate {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly repo: string;
+  readonly title: string;
+  readonly issueUrl: string;
+  readonly branch?: string | null | undefined;
+  readonly currentOutcome: IssueArtifactOutcome;
+  readonly currentSummary: string;
+  readonly observedAt: string;
+  readonly latestAttemptNumber?: number | null | undefined;
+  readonly latestSessionId?: string | null | undefined;
+}
+
+export interface IssueArtifactObservation {
+  readonly issue: IssueArtifactIssueUpdate;
+  readonly events?: readonly IssueArtifactEvent[] | undefined;
+  readonly attempt?: IssueArtifactAttemptSnapshot | undefined;
+  readonly session?: IssueArtifactSessionSnapshot | undefined;
+  readonly logPointers?: IssueArtifactLogPointerSessionEntry | undefined;
+}
+
+export interface IssueArtifactStore {
+  recordObservation(observation: IssueArtifactObservation): Promise<void>;
+}
+
+let issueArtifactWriteSequence = 0;
+
+export class LocalIssueArtifactStore implements IssueArtifactStore {
+  readonly #workspaceRoot: string;
+
+  constructor(workspaceRoot: string) {
+    this.#workspaceRoot = workspaceRoot;
+  }
+
+  async recordObservation(
+    observation: IssueArtifactObservation,
+  ): Promise<void> {
+    const paths = deriveIssueArtifactPaths(
+      this.#workspaceRoot,
+      observation.issue.issueNumber,
+    );
+
+    await this.#ensureLayout(paths, observation.issue.issueNumber);
+
+    const summary = await this.#writeIssueSummary(
+      paths.issueFile,
+      observation.issue,
+    );
+
+    if (observation.attempt !== undefined) {
+      const attemptFile = path.join(
+        paths.attemptsDir,
+        `${observation.attempt.attemptNumber.toString()}.json`,
+      );
+      await writeJsonFile(attemptFile, observation.attempt);
+    } else if (
+      (summary.currentOutcome === "succeeded" ||
+        summary.currentOutcome === "failed") &&
+      summary.latestAttemptNumber !== null
+    ) {
+      await this.#finalizeLatestAttempt(paths, summary);
+    }
+
+    if (observation.session !== undefined) {
+      const sessionFile = path.join(
+        paths.sessionsDir,
+        `${encodeSessionFileName(observation.session.sessionId)}.json`,
+      );
+      await writeJsonFile(sessionFile, observation.session);
+    }
+
+    if (observation.logPointers !== undefined) {
+      await this.#writeLogPointers(
+        paths.logPointersFile,
+        observation.issue.issueNumber,
+        observation.logPointers,
+      );
+    }
+
+    for (const event of observation.events ?? []) {
+      await appendJsonLineIfChanged(paths.eventsFile, event);
+    }
+  }
+
+  async #ensureLayout(
+    paths: IssueArtifactPaths,
+    issueNumber: number,
+  ): Promise<void> {
+    await Promise.all([
+      fs.mkdir(paths.attemptsDir, { recursive: true }),
+      fs.mkdir(paths.sessionsDir, { recursive: true }),
+      fs.mkdir(paths.logsDir, { recursive: true }),
+    ]);
+
+    await fs.writeFile(paths.eventsFile, "", { flag: "a" });
+
+    const logPointers = await readJsonFile<IssueArtifactLogPointersDocument>(
+      paths.logPointersFile,
+    ).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    });
+
+    if (logPointers === null) {
+      await writeJsonFile(paths.logPointersFile, {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        issueNumber,
+        sessions: {},
+      } satisfies IssueArtifactLogPointersDocument);
+    }
+  }
+
+  async #writeIssueSummary(
+    issueFile: string,
+    update: IssueArtifactIssueUpdate,
+  ): Promise<IssueArtifactSummary> {
+    const existing = await readJsonFile<IssueArtifactSummary>(issueFile).catch(
+      (error) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return null;
+        }
+        throw error;
+      },
+    );
+
+    const next: IssueArtifactSummary = {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber: update.issueNumber,
+      issueIdentifier: update.issueIdentifier,
+      repo: update.repo,
+      title: update.title,
+      issueUrl: update.issueUrl,
+      branch: update.branch ?? existing?.branch ?? null,
+      currentOutcome: update.currentOutcome,
+      currentSummary: update.currentSummary,
+      firstObservedAt: existing?.firstObservedAt ?? update.observedAt,
+      lastUpdatedAt: update.observedAt,
+      latestAttemptNumber:
+        update.latestAttemptNumber === undefined
+          ? (existing?.latestAttemptNumber ?? null)
+          : update.latestAttemptNumber,
+      latestSessionId:
+        update.latestSessionId === undefined
+          ? (existing?.latestSessionId ?? null)
+          : update.latestSessionId,
+    };
+
+    await writeJsonFile(issueFile, next);
+    return next;
+  }
+
+  async #writeLogPointers(
+    filePath: string,
+    issueNumber: number,
+    entry: IssueArtifactLogPointerSessionEntry,
+  ): Promise<void> {
+    const existing =
+      (await readJsonFile<IssueArtifactLogPointersDocument>(filePath).catch(
+        (error) => {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return null;
+          }
+          throw error;
+        },
+      )) ??
+      ({
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        issueNumber,
+        sessions: {},
+      } satisfies IssueArtifactLogPointersDocument);
+
+    await writeJsonFile(filePath, {
+      ...existing,
+      issueNumber,
+      sessions: {
+        ...existing.sessions,
+        [entry.sessionId]: entry,
+      },
+    } satisfies IssueArtifactLogPointersDocument);
+  }
+
+  async #finalizeLatestAttempt(
+    paths: IssueArtifactPaths,
+    summary: IssueArtifactSummary,
+  ): Promise<void> {
+    const attemptNumber = summary.latestAttemptNumber;
+    if (attemptNumber === null) {
+      return;
+    }
+
+    const attemptFile = path.join(
+      paths.attemptsDir,
+      `${attemptNumber.toString()}.json`,
+    );
+    const existing = await readJsonFile<IssueArtifactAttemptSnapshot>(
+      attemptFile,
+    ).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    });
+
+    await writeJsonFile(attemptFile, {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber: summary.issueNumber,
+      attemptNumber,
+      branch: existing?.branch ?? summary.branch,
+      startedAt: existing?.startedAt ?? null,
+      finishedAt: summary.lastUpdatedAt,
+      outcome: summary.currentOutcome,
+      summary: summary.currentSummary,
+      sessionId: existing?.sessionId ?? summary.latestSessionId,
+      runnerPid: existing?.runnerPid ?? null,
+      pullRequest: existing?.pullRequest ?? null,
+      review: existing?.review ?? null,
+      checks: existing?.checks ?? null,
+    } satisfies IssueArtifactAttemptSnapshot);
+  }
+}
+
+export class NoopIssueArtifactStore implements IssueArtifactStore {
+  async recordObservation(): Promise<void> {}
+}
+
+export function deriveFactoryRuntimeRoot(workspaceRoot: string): string {
+  const resolved = path.resolve(workspaceRoot);
+  const parent = path.dirname(resolved);
+  const repoRoot =
+    path.basename(parent) === ".tmp" ? path.dirname(parent) : parent;
+  return path.join(repoRoot, ".var", "factory");
+}
+
+export function deriveIssueArtifactsRoot(workspaceRoot: string): string {
+  return path.join(deriveFactoryRuntimeRoot(workspaceRoot), "issues");
+}
+
+export function deriveIssueArtifactPaths(
+  workspaceRoot: string,
+  issueNumber: number,
+): IssueArtifactPaths {
+  const issueRoot = path.join(
+    deriveIssueArtifactsRoot(workspaceRoot),
+    issueNumber.toString(),
+  );
+  return {
+    issueRoot,
+    issueFile: path.join(issueRoot, "issue.json"),
+    eventsFile: path.join(issueRoot, "events.jsonl"),
+    attemptsDir: path.join(issueRoot, "attempts"),
+    sessionsDir: path.join(issueRoot, "sessions"),
+    logsDir: path.join(issueRoot, "logs"),
+    logPointersFile: path.join(issueRoot, "logs", "pointers.json"),
+  };
+}
+
+export async function readIssueArtifactSummary(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<IssueArtifactSummary> {
+  return await readJsonFile<IssueArtifactSummary>(
+    deriveIssueArtifactPaths(workspaceRoot, issueNumber).issueFile,
+  );
+}
+
+export async function readIssueArtifactEvents(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<readonly IssueArtifactEvent[]> {
+  const filePath = deriveIssueArtifactPaths(
+    workspaceRoot,
+    issueNumber,
+  ).eventsFile;
+  const raw = await fs.readFile(filePath, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as IssueArtifactEvent);
+}
+
+export async function readIssueArtifactAttempt(
+  workspaceRoot: string,
+  issueNumber: number,
+  attemptNumber: number,
+): Promise<IssueArtifactAttemptSnapshot> {
+  return await readJsonFile<IssueArtifactAttemptSnapshot>(
+    path.join(
+      deriveIssueArtifactPaths(workspaceRoot, issueNumber).attemptsDir,
+      `${attemptNumber.toString()}.json`,
+    ),
+  );
+}
+
+export async function readIssueArtifactSession(
+  workspaceRoot: string,
+  issueNumber: number,
+  sessionId: string,
+): Promise<IssueArtifactSessionSnapshot> {
+  return await readJsonFile<IssueArtifactSessionSnapshot>(
+    path.join(
+      deriveIssueArtifactPaths(workspaceRoot, issueNumber).sessionsDir,
+      `${encodeSessionFileName(sessionId)}.json`,
+    ),
+  );
+}
+
+export async function readIssueArtifactLogPointers(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<IssueArtifactLogPointersDocument> {
+  return await readJsonFile<IssueArtifactLogPointersDocument>(
+    deriveIssueArtifactPaths(workspaceRoot, issueNumber).logPointersFile,
+  );
+}
+
+function encodeSessionFileName(sessionId: string): string {
+  return encodeURIComponent(sessionId);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, "utf8");
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    throw new ObservabilityError(
+      `Failed to parse JSON artifact at ${filePath}`,
+      {
+        cause: error as Error,
+      },
+    );
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  const directory = path.dirname(filePath);
+  const tempPath = path.join(
+    directory,
+    `.issue-artifact.${process.pid.toString()}.${issueArtifactWriteSequence.toString()}.tmp`,
+  );
+  issueArtifactWriteSequence += 1;
+
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  try {
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function appendJsonLineIfChanged(
+  filePath: string,
+  value: IssueArtifactEvent,
+): Promise<void> {
+  const previous = await readLastJsonLine(filePath);
+  if (
+    previous !== null &&
+    eventFingerprint(previous) === eventFingerprint(value)
+  ) {
+    return;
+  }
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+async function readLastJsonLine(
+  filePath: string,
+): Promise<IssueArtifactEvent | null> {
+  const raw = await fs.readFile(filePath, "utf8").catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+
+  if (raw === null) {
+    return null;
+  }
+
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(lines.at(-1)!) as IssueArtifactEvent;
+  } catch (error) {
+    throw new ObservabilityError(
+      `Failed to parse JSONL artifact at ${filePath}`,
+      { cause: error as Error },
+    );
+  }
+}
+
+function eventFingerprint(event: IssueArtifactEvent): string {
+  return JSON.stringify({
+    kind: event.kind,
+    issueNumber: event.issueNumber,
+    attemptNumber: event.attemptNumber,
+    sessionId: event.sessionId,
+    details: sortJsonValue(event.details),
+  });
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortJsonValue(entry));
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(objectValue)
+      .sort()
+      .map((key) => [key, sortJsonValue(objectValue[key])]),
+  );
+}

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -20,6 +20,7 @@ export type IssueArtifactEventKind =
 export type IssueArtifactOutcome =
   | "claimed"
   | "running"
+  | "attempt-failed"
   | "awaiting-plan-review"
   | "awaiting-review"
   | "needs-follow-up"

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -21,6 +21,7 @@ export type IssueArtifactOutcome =
   | "running"
   | "awaiting-plan-review"
   | "awaiting-review"
+  | "needs-follow-up"
   | "retry-scheduled"
   | "succeeded"
   | "failed";
@@ -349,10 +350,6 @@ export class LocalIssueArtifactStore implements IssueArtifactStore {
       checks: existing?.checks ?? null,
     } satisfies IssueArtifactAttemptSnapshot);
   }
-}
-
-export class NoopIssueArtifactStore implements IssueArtifactStore {
-  async recordObservation(): Promise<void> {}
 }
 
 export function deriveFactoryRuntimeRoot(workspaceRoot: string): string {

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
@@ -153,8 +154,6 @@ export interface IssueArtifactObservation {
 export interface IssueArtifactStore {
   recordObservation(observation: IssueArtifactObservation): Promise<void>;
 }
-
-let issueArtifactWriteSequence = 0;
 
 export class LocalIssueArtifactStore implements IssueArtifactStore {
   readonly #workspaceRoot: string;
@@ -354,9 +353,20 @@ export class LocalIssueArtifactStore implements IssueArtifactStore {
 
 export function deriveFactoryRuntimeRoot(workspaceRoot: string): string {
   const resolved = path.resolve(workspaceRoot);
-  const parent = path.dirname(resolved);
-  const repoRoot =
-    path.basename(parent) === ".tmp" ? path.dirname(parent) : parent;
+  let current = resolved;
+
+  for (;;) {
+    const parent = path.dirname(current);
+    if (path.basename(parent) === ".tmp") {
+      return path.join(path.dirname(parent), ".var", "factory");
+    }
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  const repoRoot = path.dirname(resolved);
   return path.join(repoRoot, ".var", "factory");
 }
 
@@ -475,9 +485,8 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   const directory = path.dirname(filePath);
   const tempPath = path.join(
     directory,
-    `.issue-artifact.${process.pid.toString()}.${issueArtifactWriteSequence.toString()}.tmp`,
+    `.issue-artifact.${process.pid.toString()}.${randomUUID()}.tmp`,
   );
-  issueArtifactWriteSequence += 1;
 
   await fs.mkdir(directory, { recursive: true });
   await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -407,7 +407,18 @@ export async function readIssueArtifactEvents(
   return raw
     .split("\n")
     .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as IssueArtifactEvent);
+    .map((line) => {
+      try {
+        return JSON.parse(line) as IssueArtifactEvent;
+      } catch (error) {
+        throw new ObservabilityError(
+          `Failed to parse JSONL artifact at ${filePath}`,
+          {
+            cause: error as Error,
+          },
+        );
+      }
+    });
 }
 
 export async function readIssueArtifactAttempt(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1239,10 +1239,7 @@ export class BootstrapOrchestrator implements Orchestrator {
               startedAt: options.session?.startedAt ?? null,
               finishedAt: options.observedAt,
               lifecycle: options.lifecycle ?? null,
-              runnerPid:
-                options.session === undefined
-                  ? null
-                  : (options.runnerPid ?? null),
+              runnerPid: options.runnerPid ?? null,
             }),
       session: sessionArtifacts?.session,
       logPointers: sessionArtifacts?.logPointers,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -18,7 +18,10 @@ import type {
   IssueArtifactSessionSnapshot,
   IssueArtifactStore,
 } from "../observability/issue-artifacts.js";
-import { LocalIssueArtifactStore } from "../observability/issue-artifacts.js";
+import {
+  ISSUE_ARTIFACT_SCHEMA_VERSION,
+  LocalIssueArtifactStore,
+} from "../observability/issue-artifacts.js";
 import type { Logger } from "../observability/logger.js";
 import {
   deriveStatusFilePath,
@@ -993,7 +996,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     },
   ): IssueArtifactEvent {
     return {
-      version: 1,
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
       kind,
       issueNumber: issue.number,
       observedAt: options.observedAt,
@@ -1320,7 +1323,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     },
   ): IssueArtifactAttemptSnapshot {
     return {
-      version: 1,
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
       issueNumber: issue.number,
       attemptNumber: attempt,
       branch: options.branchName,
@@ -1344,7 +1347,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   ): IssueArtifactSessionSnapshot {
     const description = describeRunnerSession(this.#runner, session);
     return {
-      version: 1,
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
       issueNumber: session.issue.number,
       attemptNumber: session.attempt.sequence,
       sessionId: session.id,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -5,12 +5,27 @@ import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
 import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
+import type {
+  IssueArtifactAttemptSnapshot,
+  IssueArtifactCheckSnapshot,
+  IssueArtifactEvent,
+  IssueArtifactLogPointer,
+  IssueArtifactLogPointerSessionEntry,
+  IssueArtifactObservation,
+  IssueArtifactOutcome,
+  IssueArtifactPullRequestSnapshot,
+  IssueArtifactReviewSnapshot,
+  IssueArtifactSessionSnapshot,
+  IssueArtifactStore,
+} from "../observability/issue-artifacts.js";
+import { LocalIssueArtifactStore } from "../observability/issue-artifacts.js";
 import type { Logger } from "../observability/logger.js";
 import {
   deriveStatusFilePath,
   writeFactoryStatusSnapshot,
 } from "../observability/status.js";
 import type { Runner } from "../runner/service.js";
+import { describeRunnerSession } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
 import {
@@ -53,6 +68,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #state = createOrchestratorState();
   readonly #instanceId = randomUUID();
   readonly #leaseManager: LocalIssueLeaseManager;
+  readonly #issueArtifactStore: IssueArtifactStore;
   readonly #statusFilePath: string;
   #shutdownSignal: AbortSignal | undefined;
 
@@ -63,6 +79,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     workspaceManager: WorkspaceManager,
     runner: Runner,
     logger: Logger,
+    issueArtifactStore?: IssueArtifactStore,
   ) {
     this.#config = config;
     this.#promptBuilder = promptBuilder;
@@ -74,6 +91,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       config.workspace.root,
       logger,
     );
+    this.#issueArtifactStore =
+      issueArtifactStore ?? new LocalIssueArtifactStore(config.workspace.root);
     this.#statusFilePath = deriveStatusFilePath(config.workspace.root);
   }
 
@@ -273,6 +292,24 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: claimed.number,
       });
       await this.#persistStatusSnapshot();
+      await this.#recordIssueArtifact({
+        issue: this.#createIssueArtifactUpdate(claimed, {
+          observedAt: new Date().toISOString(),
+          outcome: "claimed",
+          summary: `Claimed ${claimed.identifier}`,
+          branchName: this.#branchName(claimed.number),
+          latestAttemptNumber: attempt,
+        }),
+        events: [
+          this.#createIssueEvent("claimed", claimed, {
+            observedAt: new Date().toISOString(),
+            attemptNumber: attempt,
+            details: {
+              branch: this.#branchName(claimed.number),
+            },
+          }),
+        ],
+      });
       await this.#processClaimedIssue(
         claimed,
         attempt,
@@ -301,6 +338,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
       });
       await this.#persistStatusSnapshot();
+      await this.#recordIssueArtifact({
+        issue: this.#createIssueArtifactUpdate(issue, {
+          observedAt: new Date().toISOString(),
+          outcome: "running",
+          summary: `Inspecting ${issue.identifier}`,
+          branchName: this.#branchName(issue.number),
+        }),
+      });
       await this.#processClaimedIssue(issue, attempt, lockDir);
     });
   }
@@ -338,7 +383,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       initialLifecycle ?? (await this.#refreshLifecycle(branchName));
 
     if (lifecycle.kind === "ready") {
-      await this.#completeIssue(issue.number);
+      await this.#completeIssue(issue);
       await this.#cleanupIssueWorkspaceIfNeeded(issue);
       return;
     }
@@ -365,6 +410,9 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
       });
       await this.#persistStatusSnapshot();
+      await this.#recordIssueArtifact(
+        this.#createLifecycleObservation(issue, attempt, branchName, lifecycle),
+      );
       return;
     }
 
@@ -443,6 +491,9 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
+    await this.#recordIssueArtifact(
+      this.#createRunStartedObservation(issue, attempt, session, pullRequest),
+    );
     await this.#leaseManager.recordRun(lockDir, session);
     const abortController = new AbortController();
     const shutdownSignal = this.#shutdownSignal;
@@ -461,7 +512,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       result = await this.#runner.run(session, {
         signal: abortController.signal,
         onSpawn: (event) => {
-          this.#recordRunnerSpawn(issue.number, lockDir, event);
+          this.#recordRunnerSpawn(session, lockDir, event);
         },
       });
     } finally {
@@ -485,13 +536,23 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
 
       if (nextLifecycle.kind === "ready") {
-        await this.#completeIssue(issue.number);
+        await this.#completeIssue(issue, {
+          attemptNumber: attempt,
+          branchName: workspace.branchName,
+          session,
+          finishedAt: result.finishedAt,
+        });
         await this.#cleanupWorkspaceIfNeeded(workspace, issue.number);
         return;
       }
 
       if (nextLifecycle.kind === "missing") {
-        await this.#handleFailure(session, attempt, nextLifecycle.summary);
+        await this.#handleFailure(
+          session,
+          attempt,
+          nextLifecycle.summary,
+          result.finishedAt,
+        );
         return;
       }
 
@@ -516,6 +577,18 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
       });
       await this.#persistStatusSnapshot();
+      await this.#recordIssueArtifact(
+        this.#createLifecycleObservation(
+          issue,
+          attempt,
+          workspace.branchName,
+          nextLifecycle,
+          {
+            session,
+            finishedAt: result.finishedAt,
+          },
+        ),
+      );
 
       const decision = noteLifecycleObservation(
         this.#state.followUp,
@@ -526,8 +599,15 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
       if (decision.kind === "exhausted") {
         await this.#failIssue(
-          issue.number,
+          issue,
           this.#followUpFailureMessage(nextLifecycle),
+          {
+            attemptNumber: attempt,
+            branchName: workspace.branchName,
+            session,
+            finishedAt: result.finishedAt,
+            lifecycle: nextLifecycle,
+          },
         );
       }
     } catch (error) {
@@ -535,25 +615,43 @@ export class BootstrapOrchestrator implements Orchestrator {
         session,
         attempt,
         this.#normalizeFailure(error as Error),
+        new Date().toISOString(),
       );
     }
   }
 
-  async #completeIssue(issueNumber: number): Promise<void> {
-    await this.#tracker.completeIssue(issueNumber);
-    this.#state.retries.delete(issueNumber);
-    clearFollowUpRuntimeState(this.#state.followUp, issueNumber);
-    clearActiveIssue(this.#state.status, issueNumber);
+  async #completeIssue(
+    issue: RuntimeIssue,
+    options?: {
+      readonly attemptNumber?: number;
+      readonly branchName?: string | null;
+      readonly session?: RunSession;
+      readonly finishedAt?: string;
+    },
+  ): Promise<void> {
+    await this.#tracker.completeIssue(issue.number);
+    this.#state.retries.delete(issue.number);
+    clearFollowUpRuntimeState(this.#state.followUp, issue.number);
+    clearActiveIssue(this.#state.status, issue.number);
     adjustTrackerIssueCounts(this.#state.status, {
       running: -1,
     });
-    this.#logger.info("Issue completed", { issueNumber });
+    this.#logger.info("Issue completed", { issueNumber: issue.number });
     noteStatusAction(this.#state.status, {
       kind: "issue-completed",
-      summary: `Completed issue #${issueNumber.toString()}`,
-      issueNumber,
+      summary: `Completed issue #${issue.number.toString()}`,
+      issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
+    await this.#recordIssueArtifact(
+      this.#createTerminalObservation(issue, "succeeded", {
+        observedAt: options?.finishedAt ?? new Date().toISOString(),
+        summary: `Completed ${issue.identifier}`,
+        attemptNumber: options?.attemptNumber,
+        branchName: options?.branchName ?? this.#branchName(issue.number),
+        session: options?.session,
+      }),
+    );
   }
 
   async #cleanupIssueWorkspaceIfNeeded(issue: RuntimeIssue): Promise<void> {
@@ -666,6 +764,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issue,
       workspace,
       prompt,
+      startedAt: new Date().toISOString(),
       attempt: {
         sequence: attempt,
       },
@@ -695,6 +794,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     session: RunSession,
     attempt: number,
     message: string,
+    finishedAt = new Date().toISOString(),
   ): Promise<void> {
     this.#logger.error("Issue run failed", {
       issueNumber: session.issue.number,
@@ -709,6 +809,14 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber: session.issue.number,
     });
     await this.#persistStatusSnapshot();
+    await this.#recordIssueArtifact(
+      this.#createAttemptFailureObservation(
+        session,
+        attempt,
+        message,
+        finishedAt,
+      ),
+    );
     await this.#scheduleRetryOrFailSafely(session.issue, attempt, message);
   }
 
@@ -780,16 +888,37 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
       });
       await this.#persistStatusSnapshot();
+      await this.#recordIssueArtifact(
+        this.#createRetryScheduledObservation(
+          issue,
+          runSequence,
+          message,
+          this.#state.retries.get(issue.number)!.nextAttempt,
+        ),
+      );
       return;
     }
-    await this.#failIssue(issue.number, message);
+    await this.#failIssue(issue, message, {
+      attemptNumber: runSequence,
+      branchName: this.#branchName(issue.number),
+    });
   }
 
-  async #failIssue(issueNumber: number, message: string): Promise<void> {
-    await this.#tracker.markIssueFailed(issueNumber, message);
-    this.#state.retries.delete(issueNumber);
-    clearFollowUpRuntimeState(this.#state.followUp, issueNumber);
-    clearActiveIssue(this.#state.status, issueNumber);
+  async #failIssue(
+    issue: RuntimeIssue,
+    message: string,
+    options?: {
+      readonly attemptNumber?: number;
+      readonly branchName?: string | null;
+      readonly session?: RunSession;
+      readonly finishedAt?: string;
+      readonly lifecycle?: PullRequestLifecycle | null;
+    },
+  ): Promise<void> {
+    await this.#tracker.markIssueFailed(issue.number, message);
+    this.#state.retries.delete(issue.number);
+    clearFollowUpRuntimeState(this.#state.followUp, issue.number);
+    clearActiveIssue(this.#state.status, issue.number);
     adjustTrackerIssueCounts(this.#state.status, {
       running: -1,
       failed: 1,
@@ -797,9 +926,504 @@ export class BootstrapOrchestrator implements Orchestrator {
     noteStatusAction(this.#state.status, {
       kind: "issue-failed",
       summary: message,
-      issueNumber,
+      issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
+    await this.#recordIssueArtifact(
+      this.#createTerminalObservation(issue, "failed", {
+        observedAt: options?.finishedAt ?? new Date().toISOString(),
+        summary: message,
+        attemptNumber: options?.attemptNumber,
+        branchName: options?.branchName ?? this.#branchName(issue.number),
+        session: options?.session,
+        lifecycle: options?.lifecycle ?? null,
+      }),
+    );
+  }
+
+  async #recordIssueArtifact(
+    observation: IssueArtifactObservation,
+  ): Promise<void> {
+    try {
+      await this.#issueArtifactStore.recordObservation(observation);
+    } catch (error) {
+      this.#logger.warn("Failed to write issue artifact", {
+        issueNumber: observation.issue.issueNumber,
+        attemptNumber: observation.issue.latestAttemptNumber ?? null,
+        sessionId: observation.issue.latestSessionId ?? null,
+        error: this.#normalizeFailure(error as Error),
+      });
+    }
+  }
+
+  #createIssueArtifactUpdate(
+    issue: RuntimeIssue,
+    options: {
+      readonly observedAt: string;
+      readonly outcome: IssueArtifactOutcome;
+      readonly summary: string;
+      readonly branchName?: string | null | undefined;
+      readonly latestAttemptNumber?: number | null | undefined;
+      readonly latestSessionId?: string | null | undefined;
+    },
+  ) {
+    return {
+      issueNumber: issue.number,
+      issueIdentifier: issue.identifier,
+      repo: this.#config.tracker.repo,
+      title: issue.title,
+      issueUrl: issue.url,
+      branch: options.branchName,
+      currentOutcome: options.outcome,
+      currentSummary: options.summary,
+      observedAt: options.observedAt,
+      latestAttemptNumber: options.latestAttemptNumber,
+      latestSessionId: options.latestSessionId,
+    } as const;
+  }
+
+  #createIssueEvent(
+    kind: IssueArtifactEvent["kind"],
+    issue: RuntimeIssue,
+    options: {
+      readonly observedAt: string;
+      readonly attemptNumber?: number | null | undefined;
+      readonly sessionId?: string | null | undefined;
+      readonly details?: Readonly<Record<string, unknown>>;
+    },
+  ): IssueArtifactEvent {
+    return {
+      version: 1,
+      kind,
+      issueNumber: issue.number,
+      observedAt: options.observedAt,
+      attemptNumber: options.attemptNumber ?? null,
+      sessionId: options.sessionId ?? null,
+      details: options.details ?? {},
+    };
+  }
+
+  #createRunStartedObservation(
+    issue: RuntimeIssue,
+    attempt: number,
+    session: RunSession,
+    lifecycle: PullRequestLifecycle | null,
+  ): IssueArtifactObservation {
+    return {
+      issue: this.#createIssueArtifactUpdate(issue, {
+        observedAt: session.startedAt,
+        outcome: "running",
+        summary: `Running ${issue.identifier}`,
+        branchName: session.workspace.branchName,
+        latestAttemptNumber: attempt,
+        latestSessionId: session.id,
+      }),
+      attempt: this.#createAttemptArtifact(issue, attempt, {
+        outcome: "running",
+        summary: `Running ${issue.identifier}`,
+        branchName: session.workspace.branchName,
+        sessionId: session.id,
+        startedAt: session.startedAt,
+        lifecycle,
+      }),
+      session: this.#createSessionArtifact(session),
+      logPointers: this.#createSessionLogPointers(session),
+    };
+  }
+
+  #createLifecycleObservation(
+    issue: RuntimeIssue,
+    attempt: number,
+    branchName: string,
+    lifecycle: PullRequestLifecycle,
+    options?: {
+      readonly session?: RunSession;
+      readonly finishedAt?: string | undefined;
+    },
+  ): IssueArtifactObservation {
+    const observedAt = options?.finishedAt ?? new Date().toISOString();
+    const currentOutcome =
+      lifecycle.kind === "awaiting-plan-review"
+        ? "awaiting-plan-review"
+        : "awaiting-review";
+    const event = this.#createLifecycleEvent(
+      issue,
+      attempt,
+      options?.session?.id ?? null,
+      lifecycle,
+      observedAt,
+    );
+
+    return {
+      issue: this.#createIssueArtifactUpdate(issue, {
+        observedAt,
+        outcome: currentOutcome,
+        summary: lifecycle.summary,
+        branchName,
+        latestAttemptNumber:
+          options?.session === undefined ? undefined : attempt,
+        latestSessionId: options?.session?.id,
+      }),
+      events: event === null ? [] : [event],
+      attempt:
+        options?.session === undefined
+          ? undefined
+          : this.#createAttemptArtifact(issue, attempt, {
+              outcome: currentOutcome,
+              summary: lifecycle.summary,
+              branchName,
+              sessionId: options.session.id,
+              startedAt: options.session.startedAt,
+              finishedAt: observedAt,
+              lifecycle,
+              runnerPid: this.#currentRunnerPid(issue.number),
+            }),
+      session:
+        options?.session === undefined
+          ? undefined
+          : this.#createSessionArtifact(options.session, observedAt),
+      logPointers:
+        options?.session === undefined
+          ? undefined
+          : this.#createSessionLogPointers(options.session),
+    };
+  }
+
+  #createAttemptFailureObservation(
+    session: RunSession,
+    attempt: number,
+    message: string,
+    finishedAt: string,
+  ): IssueArtifactObservation {
+    return {
+      issue: this.#createIssueArtifactUpdate(session.issue, {
+        observedAt: finishedAt,
+        outcome: "running",
+        summary: `Run failed for ${session.issue.identifier}; evaluating retry state`,
+        branchName: session.workspace.branchName,
+        latestAttemptNumber: attempt,
+        latestSessionId: session.id,
+      }),
+      attempt: this.#createAttemptArtifact(session.issue, attempt, {
+        outcome: "failed",
+        summary: message,
+        branchName: session.workspace.branchName,
+        sessionId: session.id,
+        startedAt: session.startedAt,
+        finishedAt,
+        runnerPid: this.#currentRunnerPid(session.issue.number),
+      }),
+      session: this.#createSessionArtifact(session, finishedAt),
+      logPointers: this.#createSessionLogPointers(session),
+    };
+  }
+
+  #createRetryScheduledObservation(
+    issue: RuntimeIssue,
+    attempt: number,
+    message: string,
+    nextAttempt: number,
+  ): IssueArtifactObservation {
+    const observedAt = new Date().toISOString();
+    return {
+      issue: this.#createIssueArtifactUpdate(issue, {
+        observedAt,
+        outcome: "retry-scheduled",
+        summary: `Retry ${nextAttempt.toString()} scheduled for ${issue.identifier}`,
+        branchName: this.#branchName(issue.number),
+        latestAttemptNumber: attempt,
+      }),
+      events: [
+        this.#createIssueEvent("retry-scheduled", issue, {
+          observedAt,
+          attemptNumber: attempt,
+          details: {
+            nextAttempt,
+            reason: message,
+          },
+        }),
+      ],
+    };
+  }
+
+  #createTerminalObservation(
+    issue: RuntimeIssue,
+    outcome: "succeeded" | "failed",
+    options: {
+      readonly observedAt: string;
+      readonly summary: string;
+      readonly attemptNumber?: number | undefined;
+      readonly branchName?: string | null | undefined;
+      readonly session?: RunSession | undefined;
+      readonly lifecycle?: PullRequestLifecycle | null | undefined;
+    },
+  ): IssueArtifactObservation {
+    return {
+      issue: this.#createIssueArtifactUpdate(issue, {
+        observedAt: options.observedAt,
+        outcome,
+        summary: options.summary,
+        branchName: options.branchName,
+        latestAttemptNumber:
+          options.session === undefined ? undefined : options.attemptNumber,
+        latestSessionId: options.session?.id,
+      }),
+      events: [
+        this.#createIssueEvent(outcome, issue, {
+          observedAt: options.observedAt,
+          attemptNumber: options.attemptNumber,
+          sessionId: options.session?.id,
+          details: {
+            branch: options.branchName ?? null,
+            summary: options.summary,
+          },
+        }),
+      ],
+      attempt:
+        options.attemptNumber === undefined
+          ? undefined
+          : this.#createAttemptArtifact(issue, options.attemptNumber, {
+              outcome,
+              summary: options.summary,
+              branchName: options.branchName ?? null,
+              sessionId: options.session?.id ?? null,
+              startedAt: options.session?.startedAt ?? null,
+              finishedAt: options.observedAt,
+              lifecycle: options.lifecycle ?? null,
+              runnerPid:
+                options.session === undefined
+                  ? null
+                  : this.#currentRunnerPid(issue.number),
+            }),
+      session:
+        options.session === undefined
+          ? undefined
+          : this.#createSessionArtifact(options.session, options.observedAt),
+      logPointers:
+        options.session === undefined
+          ? undefined
+          : this.#createSessionLogPointers(options.session),
+    };
+  }
+
+  #createRunnerSpawnObservation(
+    session: RunSession,
+    event: RunSpawnEvent,
+  ): IssueArtifactObservation {
+    return {
+      issue: this.#createIssueArtifactUpdate(session.issue, {
+        observedAt: event.spawnedAt,
+        outcome: "running",
+        summary: `Running ${session.issue.identifier}`,
+        branchName: session.workspace.branchName,
+        latestAttemptNumber: session.attempt.sequence,
+        latestSessionId: session.id,
+      }),
+      events: [
+        this.#createIssueEvent("runner-spawned", session.issue, {
+          observedAt: event.spawnedAt,
+          attemptNumber: session.attempt.sequence,
+          sessionId: session.id,
+          details: {
+            pid: event.pid,
+          },
+        }),
+      ],
+      attempt: this.#createAttemptArtifact(
+        session.issue,
+        session.attempt.sequence,
+        {
+          outcome: "running",
+          summary: `Running ${session.issue.identifier}`,
+          branchName: session.workspace.branchName,
+          sessionId: session.id,
+          startedAt: session.startedAt,
+          runnerPid: event.pid,
+        },
+      ),
+      session: this.#createSessionArtifact(session),
+      logPointers: this.#createSessionLogPointers(session),
+    };
+  }
+
+  #createLifecycleEvent(
+    issue: RuntimeIssue,
+    attempt: number,
+    sessionId: string | null,
+    lifecycle: PullRequestLifecycle,
+    observedAt: string,
+  ): IssueArtifactEvent | null {
+    if (lifecycle.kind === "awaiting-plan-review") {
+      return this.#createIssueEvent("plan-ready", issue, {
+        observedAt,
+        attemptNumber: attempt,
+        sessionId,
+        details: this.#createLifecycleEventDetails(lifecycle),
+      });
+    }
+
+    if (lifecycle.kind !== "awaiting-review") {
+      return null;
+    }
+
+    const kind =
+      lifecycle.actionableReviewFeedback.length > 0 ||
+      lifecycle.unresolvedThreadIds.length > 0
+        ? "review-feedback"
+        : "pr-opened";
+
+    return this.#createIssueEvent(kind, issue, {
+      observedAt,
+      attemptNumber: attempt,
+      sessionId,
+      details: this.#createLifecycleEventDetails(lifecycle),
+    });
+  }
+
+  #createLifecycleEventDetails(
+    lifecycle: PullRequestLifecycle,
+  ): Readonly<Record<string, unknown>> {
+    return {
+      branch: lifecycle.branchName,
+      summary: lifecycle.summary,
+      pullRequest:
+        lifecycle.pullRequest === null
+          ? null
+          : {
+              number: lifecycle.pullRequest.number,
+              url: lifecycle.pullRequest.url,
+              latestCommitAt: lifecycle.pullRequest.latestCommitAt,
+            },
+      checks: {
+        pendingNames: [...lifecycle.pendingCheckNames],
+        failingNames: [...lifecycle.failingCheckNames],
+      },
+      review: {
+        actionableCount: lifecycle.actionableReviewFeedback.length,
+        unresolvedThreadCount: lifecycle.unresolvedThreadIds.length,
+      },
+    };
+  }
+
+  #createAttemptArtifact(
+    issue: RuntimeIssue,
+    attempt: number,
+    options: {
+      readonly outcome: IssueArtifactOutcome;
+      readonly summary: string;
+      readonly branchName: string | null;
+      readonly sessionId: string | null;
+      readonly startedAt: string | null;
+      readonly finishedAt?: string | null;
+      readonly lifecycle?: PullRequestLifecycle | null;
+      readonly runnerPid?: number | null;
+    },
+  ): IssueArtifactAttemptSnapshot {
+    return {
+      version: 1,
+      issueNumber: issue.number,
+      attemptNumber: attempt,
+      branch: options.branchName,
+      startedAt: options.startedAt,
+      finishedAt: options.finishedAt ?? null,
+      outcome: options.outcome,
+      summary: options.summary,
+      sessionId: options.sessionId,
+      runnerPid: options.runnerPid ?? null,
+      pullRequest: this.#createPullRequestArtifactSnapshot(
+        options.lifecycle ?? null,
+      ),
+      review: this.#createReviewArtifactSnapshot(options.lifecycle ?? null),
+      checks: this.#createCheckArtifactSnapshot(options.lifecycle ?? null),
+    };
+  }
+
+  #createSessionArtifact(
+    session: RunSession,
+    finishedAt?: string,
+  ): IssueArtifactSessionSnapshot {
+    const description = describeRunnerSession(this.#runner, session);
+    return {
+      version: 1,
+      issueNumber: session.issue.number,
+      attemptNumber: session.attempt.sequence,
+      sessionId: session.id,
+      provider: description.provider,
+      model: description.model,
+      startedAt: session.startedAt,
+      finishedAt: finishedAt ?? null,
+      workspacePath: session.workspace.path,
+      branch: session.workspace.branchName,
+      logPointers: description.logPointers.map((pointer) =>
+        this.#createLogPointer(pointer),
+      ),
+    };
+  }
+
+  #createSessionLogPointers(
+    session: RunSession,
+  ): IssueArtifactLogPointerSessionEntry {
+    const description = describeRunnerSession(this.#runner, session);
+    return {
+      sessionId: session.id,
+      pointers: description.logPointers.map((pointer) =>
+        this.#createLogPointer(pointer),
+      ),
+      archiveLocation: null,
+    };
+  }
+
+  #createLogPointer(pointer: {
+    readonly name: string;
+    readonly location: string | null;
+    readonly archiveLocation: string | null;
+  }): IssueArtifactLogPointer {
+    return {
+      name: pointer.name,
+      location: pointer.location,
+      archiveLocation: pointer.archiveLocation,
+    };
+  }
+
+  #createPullRequestArtifactSnapshot(
+    lifecycle: PullRequestLifecycle | null,
+  ): IssueArtifactPullRequestSnapshot | null {
+    if (lifecycle?.pullRequest === null || lifecycle === null) {
+      return null;
+    }
+    return {
+      number: lifecycle.pullRequest.number,
+      url: lifecycle.pullRequest.url,
+      latestCommitAt: lifecycle.pullRequest.latestCommitAt,
+    };
+  }
+
+  #createReviewArtifactSnapshot(
+    lifecycle: PullRequestLifecycle | null,
+  ): IssueArtifactReviewSnapshot | null {
+    if (lifecycle === null) {
+      return null;
+    }
+    return {
+      actionableCount: lifecycle.actionableReviewFeedback.length,
+      unresolvedThreadCount: lifecycle.unresolvedThreadIds.length,
+    };
+  }
+
+  #createCheckArtifactSnapshot(
+    lifecycle: PullRequestLifecycle | null,
+  ): IssueArtifactCheckSnapshot | null {
+    if (lifecycle === null) {
+      return null;
+    }
+    return {
+      pendingNames: [...lifecycle.pendingCheckNames],
+      failingNames: [...lifecycle.failingCheckNames],
+    };
+  }
+
+  #currentRunnerPid(issueNumber: number): number | null {
+    return this.#state.status.activeIssues.get(issueNumber)?.runnerPid ?? null;
   }
 
   #followUpFailureMessage(lifecycle: PullRequestLifecycle): string {
@@ -831,10 +1455,11 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #recordRunnerSpawn(
-    issueNumber: number,
+    session: RunSession,
     lockDir: string,
     event: RunSpawnEvent,
   ): void {
+    const issueNumber = session.issue.number;
     this.#leaseManager.recordRunnerSpawn(lockDir, event);
     const entry = this.#state.status.activeIssues.get(issueNumber);
     if (entry) {
@@ -852,6 +1477,9 @@ export class BootstrapOrchestrator implements Orchestrator {
     });
     // The runner onSpawn callback is synchronous; snapshot persistence is optional.
     void this.#persistStatusSnapshot();
+    void this.#recordIssueArtifact(
+      this.#createRunnerSpawnObservation(session, event),
+    );
     this.#logger.info("Runner process attached to active issue", {
       issueNumber,
       runnerPid: event.pid,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -295,9 +295,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: claimed.number,
       });
       await this.#persistStatusSnapshot();
+      const observedAt = new Date().toISOString();
       await this.#recordIssueArtifact({
         issue: this.#createIssueArtifactUpdate(claimed, {
-          observedAt: new Date().toISOString(),
+          observedAt,
           outcome: "claimed",
           summary: `Claimed ${claimed.identifier}`,
           branchName: this.#branchName(claimed.number),
@@ -305,7 +306,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         }),
         events: [
           this.#createIssueEvent("claimed", claimed, {
-            observedAt: new Date().toISOString(),
+            observedAt,
             attemptNumber: attempt,
             details: {
               branch: this.#branchName(claimed.number),
@@ -341,9 +342,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
       });
       await this.#persistStatusSnapshot();
+      const observedAt = new Date().toISOString();
       await this.#recordIssueArtifact({
         issue: this.#createIssueArtifactUpdate(issue, {
-          observedAt: new Date().toISOString(),
+          observedAt,
           outcome: "running",
           summary: `Inspecting ${issue.identifier}`,
           branchName: this.#branchName(issue.number),
@@ -528,6 +530,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         session,
         attempt,
         `Runner exited with ${result.exitCode}\n${result.stderr}`,
+        result.finishedAt,
       );
       return;
     }
@@ -947,15 +950,24 @@ export class BootstrapOrchestrator implements Orchestrator {
   async #recordIssueArtifact(
     observation: IssueArtifactObservation,
   ): Promise<void> {
+    const write = async (): Promise<void> => {
+      try {
+        await this.#issueArtifactStore.recordObservation(observation);
+      } catch (error) {
+        this.#logger.warn("Failed to write issue artifact", {
+          issueNumber: observation.issue.issueNumber,
+          attemptNumber: observation.issue.latestAttemptNumber ?? null,
+          sessionId: observation.issue.latestSessionId ?? null,
+          error: this.#normalizeFailure(error as Error),
+        });
+      }
+    };
+
+    this.#state.artifactWriteQueue = this.#state.artifactWriteQueue.then(write);
     try {
-      await this.#issueArtifactStore.recordObservation(observation);
-    } catch (error) {
-      this.#logger.warn("Failed to write issue artifact", {
-        issueNumber: observation.issue.issueNumber,
-        attemptNumber: observation.issue.latestAttemptNumber ?? null,
-        sessionId: observation.issue.latestSessionId ?? null,
-        error: this.#normalizeFailure(error as Error),
-      });
+      await this.#state.artifactWriteQueue;
+    } catch {
+      // write() logs and absorbs its own failures; this is purely defensive.
     }
   }
 
@@ -1045,10 +1057,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     },
   ): IssueArtifactObservation {
     const observedAt = options?.finishedAt ?? new Date().toISOString();
-    const currentOutcome =
-      lifecycle.kind === "awaiting-plan-review"
-        ? "awaiting-plan-review"
-        : "awaiting-review";
+    const currentOutcome = this.#createLifecycleOutcome(lifecycle);
     const event = this.#createLifecycleEvent(
       issue,
       attempt,
@@ -1265,7 +1274,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       });
     }
 
-    if (lifecycle.kind !== "awaiting-review") {
+    if (
+      lifecycle.kind !== "awaiting-review" &&
+      lifecycle.kind !== "needs-follow-up"
+    ) {
       return null;
     }
 
@@ -1281,6 +1293,21 @@ export class BootstrapOrchestrator implements Orchestrator {
       sessionId,
       details: this.#createLifecycleEventDetails(lifecycle),
     });
+  }
+
+  #createLifecycleOutcome(
+    lifecycle: PullRequestLifecycle,
+  ): Extract<
+    IssueArtifactOutcome,
+    "awaiting-plan-review" | "awaiting-review" | "needs-follow-up"
+  > {
+    if (lifecycle.kind === "awaiting-plan-review") {
+      return "awaiting-plan-review";
+    }
+    if (lifecycle.kind === "needs-follow-up") {
+      return "needs-follow-up";
+    }
+    return "awaiting-review";
   }
 
   #createLifecycleEventDetails(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -949,6 +949,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   async #recordIssueArtifact(
     observation: IssueArtifactObservation,
   ): Promise<void> {
+    const issueNumber = observation.issue.issueNumber;
     const write = async (): Promise<void> => {
       try {
         await this.#issueArtifactStore.recordObservation(observation);
@@ -962,11 +963,18 @@ export class BootstrapOrchestrator implements Orchestrator {
       }
     };
 
-    this.#state.artifactWriteQueue = this.#state.artifactWriteQueue.then(write);
+    const previousQueue =
+      this.#state.artifactWriteQueues.get(issueNumber) ?? Promise.resolve();
+    const nextQueue = previousQueue.then(write, write);
+    this.#state.artifactWriteQueues.set(issueNumber, nextQueue);
     try {
-      await this.#state.artifactWriteQueue;
+      await nextQueue;
     } catch {
       // write() logs and absorbs its own failures; this is purely defensive.
+    } finally {
+      if (this.#state.artifactWriteQueues.get(issueNumber) === nextQueue) {
+        this.#state.artifactWriteQueues.delete(issueNumber);
+      }
     }
   }
 
@@ -1109,7 +1117,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     return {
       issue: this.#createIssueArtifactUpdate(session.issue, {
         observedAt: finishedAt,
-        outcome: "running",
+        outcome: "attempt-failed",
         summary: `Run failed for ${session.issue.identifier}; evaluating retry state`,
         branchName: session.workspace.branchName,
         latestAttemptNumber: attempt,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -28,7 +28,6 @@ import {
   writeFactoryStatusSnapshot,
 } from "../observability/status.js";
 import type { Runner } from "../runner/service.js";
-import { describeRunnerSession } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
 import {
@@ -1176,8 +1175,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         outcome,
         summary: options.summary,
         branchName: options.branchName,
-        latestAttemptNumber:
-          options.session === undefined ? undefined : options.attemptNumber,
+        latestAttemptNumber: options.attemptNumber,
         latestSessionId: options.session?.id,
       }),
       events: [
@@ -1301,13 +1299,20 @@ export class BootstrapOrchestrator implements Orchestrator {
     IssueArtifactOutcome,
     "awaiting-plan-review" | "awaiting-review" | "needs-follow-up"
   > {
-    if (lifecycle.kind === "awaiting-plan-review") {
-      return "awaiting-plan-review";
+    switch (lifecycle.kind) {
+      case "awaiting-plan-review":
+        return "awaiting-plan-review";
+      case "awaiting-review":
+        return "awaiting-review";
+      case "needs-follow-up":
+        return "needs-follow-up";
+      case "missing":
+      case "ready":
+        break;
     }
-    if (lifecycle.kind === "needs-follow-up") {
-      return "needs-follow-up";
-    }
-    return "awaiting-review";
+    throw new OrchestratorError(
+      `Unsupported lifecycle kind for issue artifact outcome: ${lifecycle.kind}`,
+    );
   }
 
   #createLifecycleEventDetails(
@@ -1372,7 +1377,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     session: RunSession,
     finishedAt?: string,
   ): IssueArtifactSessionSnapshot {
-    const description = describeRunnerSession(this.#runner, session);
+    const description = this.#runner.describeSession(session);
     return {
       version: ISSUE_ARTIFACT_SCHEMA_VERSION,
       issueNumber: session.issue.number,
@@ -1393,7 +1398,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   #createSessionLogPointers(
     session: RunSession,
   ): IssueArtifactLogPointerSessionEntry {
-    const description = describeRunnerSession(this.#runner, session);
+    const description = this.#runner.describeSession(session);
     return {
       sessionId: session.id,
       pointers: description.logPointers.map((pointer) =>

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -634,6 +634,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly finishedAt?: string;
     },
   ): Promise<void> {
+    const runnerPid = this.#currentRunnerPid(issue.number);
     await this.#tracker.completeIssue(issue.number);
     this.#state.retries.delete(issue.number);
     clearFollowUpRuntimeState(this.#state.followUp, issue.number);
@@ -655,6 +656,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         attemptNumber: options?.attemptNumber,
         branchName: options?.branchName ?? this.#branchName(issue.number),
         session: options?.session,
+        runnerPid,
       }),
     );
   }
@@ -938,6 +940,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly lifecycle?: PullRequestLifecycle | null;
     },
   ): Promise<void> {
+    const runnerPid = this.#currentRunnerPid(issue.number);
     await this.#tracker.markIssueFailed(issue.number, message);
     this.#state.retries.delete(issue.number);
     clearFollowUpRuntimeState(this.#state.followUp, issue.number);
@@ -959,6 +962,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         attemptNumber: options?.attemptNumber,
         branchName: options?.branchName ?? this.#branchName(issue.number),
         session: options?.session,
+        runnerPid,
         lifecycle: options?.lifecycle ?? null,
       }),
     );
@@ -1193,6 +1197,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly attemptNumber?: number | undefined;
       readonly branchName?: string | null | undefined;
       readonly session?: RunSession | undefined;
+      readonly runnerPid?: number | null | undefined;
       readonly lifecycle?: PullRequestLifecycle | null | undefined;
     },
   ): IssueArtifactObservation {
@@ -1237,7 +1242,7 @@ export class BootstrapOrchestrator implements Orchestrator {
               runnerPid:
                 options.session === undefined
                   ? null
-                  : this.#currentRunnerPid(issue.number),
+                  : (options.runnerPid ?? null),
             }),
       session: sessionArtifacts?.session,
       logPointers: sessionArtifacts?.logPointers,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -27,7 +27,7 @@ import {
   deriveStatusFilePath,
   writeFactoryStatusSnapshot,
 } from "../observability/status.js";
-import type { Runner } from "../runner/service.js";
+import type { Runner, RunnerSessionDescription } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
 import {
@@ -822,7 +822,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         finishedAt,
       ),
     );
-    await this.#scheduleRetryOrFailSafely(session.issue, attempt, message);
+    await this.#scheduleRetryOrFailSafely(session.issue, attempt, message, {
+      session,
+      finishedAt,
+    });
   }
 
   async #handleUnexpectedFailure(
@@ -849,9 +852,13 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     message: string,
+    options?: {
+      readonly session?: RunSession;
+      readonly finishedAt?: string;
+    },
   ): Promise<void> {
     try {
-      await this.#scheduleRetryOrFail(issue, attempt, message);
+      await this.#scheduleRetryOrFail(issue, attempt, message, options);
     } catch (error) {
       this.#logger.error("Failure handling failed", {
         issueNumber: issue.number,
@@ -866,6 +873,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     runSequence: number,
     message: string,
+    options?: {
+      readonly session?: RunSession;
+      readonly finishedAt?: string;
+    },
   ): Promise<void> {
     const failureRetryAttempt = resolveFailureRetryAttempt(
       this.#state.followUp,
@@ -903,10 +914,16 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
       return;
     }
-    await this.#failIssue(issue, message, {
+    const failureOptions = {
       attemptNumber: runSequence,
-      branchName: this.#branchName(issue.number),
-    });
+      branchName:
+        options?.session?.workspace.branchName ?? this.#branchName(issue.number),
+      ...(options?.session === undefined ? {} : { session: options.session }),
+      ...(options?.finishedAt === undefined
+        ? {}
+        : { finishedAt: options.finishedAt }),
+    };
+    await this.#failIssue(issue, message, failureOptions);
   }
 
   async #failIssue(
@@ -1031,6 +1048,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     session: RunSession,
     lifecycle: PullRequestLifecycle | null,
   ): IssueArtifactObservation {
+    const sessionArtifacts = this.#createSessionObservationArtifacts(session);
     return {
       issue: this.#createIssueArtifactUpdate(issue, {
         observedAt: session.startedAt,
@@ -1048,8 +1066,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         startedAt: session.startedAt,
         lifecycle,
       }),
-      session: this.#createSessionArtifact(session),
-      logPointers: this.#createSessionLogPointers(session),
+      ...sessionArtifacts,
     };
   }
 
@@ -1072,6 +1089,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       lifecycle,
       observedAt,
     );
+    const sessionArtifacts =
+      options?.session === undefined
+        ? undefined
+        : this.#createSessionObservationArtifacts(options.session, observedAt);
 
     return {
       issue: this.#createIssueArtifactUpdate(issue, {
@@ -1098,13 +1119,9 @@ export class BootstrapOrchestrator implements Orchestrator {
               runnerPid: this.#currentRunnerPid(issue.number),
             }),
       session:
-        options?.session === undefined
-          ? undefined
-          : this.#createSessionArtifact(options.session, observedAt),
+        sessionArtifacts?.session,
       logPointers:
-        options?.session === undefined
-          ? undefined
-          : this.#createSessionLogPointers(options.session),
+        sessionArtifacts?.logPointers,
     };
   }
 
@@ -1114,6 +1131,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     message: string,
     finishedAt: string,
   ): IssueArtifactObservation {
+    const sessionArtifacts = this.#createSessionObservationArtifacts(
+      session,
+      finishedAt,
+    );
     return {
       issue: this.#createIssueArtifactUpdate(session.issue, {
         observedAt: finishedAt,
@@ -1132,8 +1153,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         finishedAt,
         runnerPid: this.#currentRunnerPid(session.issue.number),
       }),
-      session: this.#createSessionArtifact(session, finishedAt),
-      logPointers: this.#createSessionLogPointers(session),
+      ...sessionArtifacts,
     };
   }
 
@@ -1177,6 +1197,13 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly lifecycle?: PullRequestLifecycle | null | undefined;
     },
   ): IssueArtifactObservation {
+    const sessionArtifacts =
+      options.session === undefined
+        ? undefined
+        : this.#createSessionObservationArtifacts(
+            options.session,
+            options.observedAt,
+          );
     return {
       issue: this.#createIssueArtifactUpdate(issue, {
         observedAt: options.observedAt,
@@ -1214,13 +1241,9 @@ export class BootstrapOrchestrator implements Orchestrator {
                   : this.#currentRunnerPid(issue.number),
             }),
       session:
-        options.session === undefined
-          ? undefined
-          : this.#createSessionArtifact(options.session, options.observedAt),
+        sessionArtifacts?.session,
       logPointers:
-        options.session === undefined
-          ? undefined
-          : this.#createSessionLogPointers(options.session),
+        sessionArtifacts?.logPointers,
     };
   }
 
@@ -1228,6 +1251,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     session: RunSession,
     event: RunSpawnEvent,
   ): IssueArtifactObservation {
+    const sessionArtifacts = this.#createSessionObservationArtifacts(session);
     return {
       issue: this.#createIssueArtifactUpdate(session.issue, {
         observedAt: event.spawnedAt,
@@ -1259,8 +1283,7 @@ export class BootstrapOrchestrator implements Orchestrator {
           runnerPid: event.pid,
         },
       ),
-      session: this.#createSessionArtifact(session),
-      logPointers: this.#createSessionLogPointers(session),
+      ...sessionArtifacts,
     };
   }
 
@@ -1348,6 +1371,20 @@ export class BootstrapOrchestrator implements Orchestrator {
     };
   }
 
+  #createSessionObservationArtifacts(
+    session: RunSession,
+    finishedAt?: string,
+  ): {
+    readonly session: IssueArtifactSessionSnapshot;
+    readonly logPointers: IssueArtifactLogPointerSessionEntry;
+  } {
+    const description = this.#runner.describeSession(session);
+    return {
+      session: this.#createSessionArtifact(session, description, finishedAt),
+      logPointers: this.#createSessionLogPointers(session, description),
+    };
+  }
+
   #createAttemptArtifact(
     issue: RuntimeIssue,
     attempt: number,
@@ -1383,9 +1420,9 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   #createSessionArtifact(
     session: RunSession,
+    description: RunnerSessionDescription,
     finishedAt?: string,
   ): IssueArtifactSessionSnapshot {
-    const description = this.#runner.describeSession(session);
     return {
       version: ISSUE_ARTIFACT_SCHEMA_VERSION,
       issueNumber: session.issue.number,
@@ -1405,8 +1442,8 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   #createSessionLogPointers(
     session: RunSession,
+    description: RunnerSessionDescription,
   ): IssueArtifactLogPointerSessionEntry {
-    const description = this.#runner.describeSession(session);
     return {
       sessionId: session.id,
       pointers: description.logPointers.map((pointer) =>

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1470,7 +1470,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   #createPullRequestArtifactSnapshot(
     lifecycle: PullRequestLifecycle | null,
   ): IssueArtifactPullRequestSnapshot | null {
-    if (lifecycle?.pullRequest === null || lifecycle === null) {
+    if (lifecycle === null || lifecycle.pullRequest === null) {
       return null;
     }
     return {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -917,7 +917,8 @@ export class BootstrapOrchestrator implements Orchestrator {
     const failureOptions = {
       attemptNumber: runSequence,
       branchName:
-        options?.session?.workspace.branchName ?? this.#branchName(issue.number),
+        options?.session?.workspace.branchName ??
+        this.#branchName(issue.number),
       ...(options?.session === undefined ? {} : { session: options.session }),
       ...(options?.finishedAt === undefined
         ? {}
@@ -1118,10 +1119,8 @@ export class BootstrapOrchestrator implements Orchestrator {
               lifecycle,
               runnerPid: this.#currentRunnerPid(issue.number),
             }),
-      session:
-        sessionArtifacts?.session,
-      logPointers:
-        sessionArtifacts?.logPointers,
+      session: sessionArtifacts?.session,
+      logPointers: sessionArtifacts?.logPointers,
     };
   }
 
@@ -1240,10 +1239,8 @@ export class BootstrapOrchestrator implements Orchestrator {
                   ? null
                   : this.#currentRunnerPid(issue.number),
             }),
-      session:
-        sessionArtifacts?.session,
-      logPointers:
-        sessionArtifacts?.logPointers,
+      session: sessionArtifacts?.session,
+      logPointers: sessionArtifacts?.logPointers,
     };
   }
 

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -14,6 +14,7 @@ export interface OrchestratorState {
   readonly retries: Map<number, RetryState>;
   readonly followUp: FollowUpRuntimeState;
   readonly status: RuntimeStatusState;
+  artifactWriteQueue: Promise<void>;
 }
 
 export function createOrchestratorState(): OrchestratorState {
@@ -23,5 +24,6 @@ export function createOrchestratorState(): OrchestratorState {
     retries: new Map<number, RetryState>(),
     followUp: createFollowUpRuntimeState(),
     status: createRuntimeStatusState(),
+    artifactWriteQueue: Promise.resolve(),
   };
 }

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -14,7 +14,7 @@ export interface OrchestratorState {
   readonly retries: Map<number, RetryState>;
   readonly followUp: FollowUpRuntimeState;
   readonly status: RuntimeStatusState;
-  artifactWriteQueue: Promise<void>;
+  readonly artifactWriteQueues: Map<number, Promise<void>>;
 }
 
 export function createOrchestratorState(): OrchestratorState {
@@ -24,6 +24,6 @@ export function createOrchestratorState(): OrchestratorState {
     retries: new Map<number, RetryState>(),
     followUp: createFollowUpRuntimeState(),
     status: createRuntimeStatusState(),
-    artifactWriteQueue: Promise.resolve(),
+    artifactWriteQueues: new Map<number, Promise<void>>(),
   };
 }

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -5,7 +5,11 @@ import { RunnerAbortedError, RunnerError } from "../domain/errors.js";
 import type { RunResult, RunSession } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import type { Runner, RunnerRunOptions } from "./service.js";
+import type {
+  Runner,
+  RunnerRunOptions,
+  RunnerSessionDescription,
+} from "./service.js";
 
 export class LocalRunner implements Runner {
   static readonly #terminationGraceMs = 200;
@@ -15,6 +19,14 @@ export class LocalRunner implements Runner {
   constructor(config: AgentConfig, logger: Logger) {
     this.#config = config;
     this.#logger = logger;
+  }
+
+  describeSession(_session: RunSession): RunnerSessionDescription {
+    return {
+      provider: "local-runner",
+      model: null,
+      logPointers: [],
+    };
   }
 
   async run(

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -76,6 +76,7 @@ export class LocalRunner implements Runner {
       let aborted = false;
       let spawnError: RunnerError | null = null;
       let forcedKillTimeout: NodeJS.Timeout | null = null;
+      let spawnNotificationPromise: Promise<void> = Promise.resolve();
 
       const finish = (callback: () => void): void => {
         if (settled) {
@@ -130,13 +131,14 @@ export class LocalRunner implements Runner {
 
       if (child.pid !== undefined) {
         try {
-          const spawnNotification = options?.onSpawn?.({
-            pid: child.pid,
-            spawnedAt: new Date().toISOString(),
+          spawnNotificationPromise = Promise.resolve(
+            options?.onSpawn?.({
+              pid: child.pid,
+              spawnedAt: new Date().toISOString(),
+            }),
+          ).catch((error) => {
+            handleSpawnFailure(error);
           });
-          if (spawnNotification instanceof Promise) {
-            void spawnNotification.catch(handleSpawnFailure);
-          }
         } catch (error) {
           handleSpawnFailure(error);
         }
@@ -190,30 +192,32 @@ export class LocalRunner implements Runner {
         });
       });
       child.on("close", (exitCode) => {
-        finish(() => {
-          const finishedAt = new Date().toISOString();
-          if (timedOut) {
-            reject(
-              new RunnerError(
-                `Runner timed out after ${this.#config.timeoutMs}ms`,
-              ),
-            );
-            return;
-          }
-          if (aborted) {
-            reject(new RunnerAbortedError(`Runner cancelled by shutdown`));
-            return;
-          }
-          if (spawnError !== null) {
-            reject(spawnError);
-            return;
-          }
-          resolve({
-            exitCode: exitCode ?? 1,
-            stdout,
-            stderr,
-            startedAt,
-            finishedAt,
+        void spawnNotificationPromise.finally(() => {
+          finish(() => {
+            const finishedAt = new Date().toISOString();
+            if (timedOut) {
+              reject(
+                new RunnerError(
+                  `Runner timed out after ${this.#config.timeoutMs}ms`,
+                ),
+              );
+              return;
+            }
+            if (aborted) {
+              reject(new RunnerAbortedError(`Runner cancelled by shutdown`));
+              return;
+            }
+            if (spawnError !== null) {
+              reject(spawnError);
+              return;
+            }
+            resolve({
+              exitCode: exitCode ?? 1,
+              stdout,
+              stderr,
+              startedAt,
+              finishedAt,
+            });
           });
         });
       });

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -23,10 +23,3 @@ export interface RunnerRunOptions {
 export interface Runner extends RunnerSessionDescriber {
   run(session: RunSession, options?: RunnerRunOptions): Promise<RunResult>;
 }
-
-export function describeRunnerSession(
-  runner: Runner,
-  session: RunSession,
-): RunnerSessionDescription {
-  return runner.describeSession(session);
-}

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -20,7 +20,7 @@ export interface RunnerRunOptions {
   readonly onSpawn?: (event: RunSpawnEvent) => void | Promise<void>;
 }
 
-export interface Runner {
+export interface Runner extends RunnerSessionDescriber {
   run(session: RunSession, options?: RunnerRunOptions): Promise<RunResult>;
 }
 
@@ -28,16 +28,5 @@ export function describeRunnerSession(
   runner: Runner,
   session: RunSession,
 ): RunnerSessionDescription {
-  if (
-    "describeSession" in runner &&
-    typeof runner.describeSession === "function"
-  ) {
-    return (runner as RunnerSessionDescriber).describeSession(session);
-  }
-
-  return {
-    provider: "unknown",
-    model: null,
-    logPointers: [],
-  };
+  return runner.describeSession(session);
 }

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,4 +1,19 @@
 import type { RunResult, RunSession, RunSpawnEvent } from "../domain/run.js";
+export interface RunnerLogPointer {
+  readonly name: string;
+  readonly location: string | null;
+  readonly archiveLocation: string | null;
+}
+
+export interface RunnerSessionDescription {
+  readonly provider: string;
+  readonly model: string | null;
+  readonly logPointers: readonly RunnerLogPointer[];
+}
+
+export interface RunnerSessionDescriber {
+  describeSession(session: RunSession): RunnerSessionDescription;
+}
 
 export interface RunnerRunOptions {
   readonly signal?: AbortSignal;
@@ -7,4 +22,22 @@ export interface RunnerRunOptions {
 
 export interface Runner {
   run(session: RunSession, options?: RunnerRunOptions): Promise<RunResult>;
+}
+
+export function describeRunnerSession(
+  runner: Runner,
+  session: RunSession,
+): RunnerSessionDescription {
+  if (
+    "describeSession" in runner &&
+    typeof runner.describeSession === "function"
+  ) {
+    return (runner as RunnerSessionDescriber).describeSession(session);
+  }
+
+  return {
+    provider: "unknown",
+    model: null,
+    logPointers: [],
+  };
 }

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -6,6 +6,13 @@ import {
   createPromptBuilder,
   loadWorkflow,
 } from "../../src/config/workflow.js";
+import {
+  deriveIssueArtifactPaths,
+  readIssueArtifactAttempt,
+  readIssueArtifactEvents,
+  readIssueArtifactSession,
+  readIssueArtifactSummary,
+} from "../../src/observability/issue-artifacts.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
@@ -183,6 +190,59 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     expect(issue.comments).toContain(
       "Symphony completed this issue successfully.",
     );
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+    );
+    expect(artifactSummary.currentOutcome).toBe("succeeded");
+    expect(artifactSummary.branch).toBe("symphony/1");
+    expect(artifactSummary.latestAttemptNumber).toBe(1);
+    expect(artifactSummary.latestSessionId).not.toBeNull();
+
+    const artifactEvents = await readIssueArtifactEvents(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+    );
+    expect(artifactEvents.map((event) => event.kind)).toEqual(
+      expect.arrayContaining([
+        "claimed",
+        "runner-spawned",
+        "pr-opened",
+        "succeeded",
+      ]),
+    );
+
+    const attempt = await readIssueArtifactAttempt(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+      1,
+    );
+    expect(attempt.outcome).toBe("succeeded");
+    expect(attempt.pullRequest?.number).toBe(1);
+
+    const session = await readIssueArtifactSession(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+      artifactSummary.latestSessionId!,
+    );
+    expect(session.provider).toBe("local-runner");
+
+    const workspacePath = path.join(
+      tempDir,
+      ".tmp",
+      "workspaces",
+      "sociotechnica-org_symphony-ts_1",
+    );
+    await expect(fs.stat(workspacePath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs.stat(
+        deriveIssueArtifactPaths(path.join(tempDir, ".tmp", "workspaces"), 1)
+          .issueRoot,
+      ),
+    ).resolves.toBeDefined();
 
     const implemented = await readRemoteBranchFile(
       remotePath,

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { ObservabilityError } from "../../src/domain/errors.js";
 import {
+  ISSUE_ARTIFACT_SCHEMA_VERSION,
   LocalIssueArtifactStore,
   deriveFactoryRuntimeRoot,
   deriveIssueArtifactPaths,
@@ -66,7 +68,7 @@ describe("issue artifacts", () => {
       },
       events: [
         {
-          version: 1,
+          version: ISSUE_ARTIFACT_SCHEMA_VERSION,
           kind: "plan-ready",
           issueNumber: 43,
           observedAt: firstObservedAt,
@@ -92,7 +94,7 @@ describe("issue artifacts", () => {
       },
       events: [
         {
-          version: 1,
+          version: ISSUE_ARTIFACT_SCHEMA_VERSION,
           kind: "plan-ready",
           issueNumber: 43,
           observedAt: secondObservedAt,
@@ -145,7 +147,7 @@ describe("issue artifacts", () => {
         latestSessionId: sessionId,
       },
       attempt: {
-        version: 1,
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         issueNumber: 43,
         attemptNumber: 1,
         branch: "symphony/43",
@@ -170,7 +172,7 @@ describe("issue artifacts", () => {
         },
       },
       session: {
-        version: 1,
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         issueNumber: 43,
         attemptNumber: 1,
         sessionId,
@@ -209,5 +211,20 @@ describe("issue artifacts", () => {
       `${encodeURIComponent(sessionId)}.json`,
     );
     await expect(fs.stat(sessionPath)).resolves.toBeDefined();
+  });
+
+  it("wraps malformed event JSONL reads in an observability error", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const paths = deriveIssueArtifactPaths(workspaceRoot, 43);
+
+    await fs.mkdir(paths.issueRoot, { recursive: true });
+    await fs.writeFile(paths.eventsFile, "{not-json}\n", "utf8");
+
+    await expect(readIssueArtifactEvents(workspaceRoot, 43)).rejects.toThrow(
+      ObservabilityError,
+    );
+    await expect(readIssueArtifactEvents(workspaceRoot, 43)).rejects.toThrow(
+      paths.eventsFile,
+    );
   });
 });

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -35,8 +35,21 @@ afterEach(async () => {
 describe("issue artifacts", () => {
   it("derives a repo-level factory root outside the cleanup-managed workspace tree", () => {
     const workspaceRoot = path.join("/repo", ".tmp", "workspaces");
+    const nestedWorkspaceRoot = path.join(
+      "/repo",
+      ".tmp",
+      "factory",
+      "workspaces",
+    );
+    const nonTmpWorkspaceRoot = path.join("/repo", "local-workspaces");
 
     expect(deriveFactoryRuntimeRoot(workspaceRoot)).toBe(
+      path.join("/repo", ".var", "factory"),
+    );
+    expect(deriveFactoryRuntimeRoot(nestedWorkspaceRoot)).toBe(
+      path.join("/repo", ".var", "factory"),
+    );
+    expect(deriveFactoryRuntimeRoot(nonTmpWorkspaceRoot)).toBe(
       path.join("/repo", ".var", "factory"),
     );
     expect(deriveIssueArtifactsRoot(workspaceRoot)).toBe(

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  LocalIssueArtifactStore,
+  deriveFactoryRuntimeRoot,
+  deriveIssueArtifactPaths,
+  deriveIssueArtifactsRoot,
+  readIssueArtifactAttempt,
+  readIssueArtifactEvents,
+  readIssueArtifactLogPointers,
+  readIssueArtifactSession,
+  readIssueArtifactSummary,
+} from "../../src/observability/issue-artifacts.js";
+import { createTempDir } from "../support/git.js";
+
+const tempRoots: string[] = [];
+
+async function createWorkspaceRoot(): Promise<string> {
+  const tempDir = await createTempDir("symphony-issue-artifacts-");
+  tempRoots.push(tempDir);
+  return path.join(tempDir, ".tmp", "workspaces");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("issue artifacts", () => {
+  it("derives a repo-level factory root outside the cleanup-managed workspace tree", () => {
+    const workspaceRoot = path.join("/repo", ".tmp", "workspaces");
+
+    expect(deriveFactoryRuntimeRoot(workspaceRoot)).toBe(
+      path.join("/repo", ".var", "factory"),
+    );
+    expect(deriveIssueArtifactsRoot(workspaceRoot)).toBe(
+      path.join("/repo", ".var", "factory", "issues"),
+    );
+    expect(deriveIssueArtifactPaths(workspaceRoot, 43).issueRoot).toBe(
+      path.join("/repo", ".var", "factory", "issues", "43"),
+    );
+  });
+
+  it("writes the base layout and suppresses duplicate consecutive lifecycle events", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const store = new LocalIssueArtifactStore(workspaceRoot);
+    const firstObservedAt = "2026-03-09T10:00:00.000Z";
+    const secondObservedAt = "2026-03-09T10:05:00.000Z";
+
+    await store.recordObservation({
+      issue: {
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        branch: "symphony/43",
+        currentOutcome: "awaiting-plan-review",
+        currentSummary: "Waiting for human review",
+        observedAt: firstObservedAt,
+        latestAttemptNumber: 1,
+      },
+      events: [
+        {
+          version: 1,
+          kind: "plan-ready",
+          issueNumber: 43,
+          observedAt: firstObservedAt,
+          attemptNumber: 1,
+          sessionId: null,
+          details: {
+            branch: "symphony/43",
+          },
+        },
+      ],
+    });
+
+    await store.recordObservation({
+      issue: {
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        currentOutcome: "awaiting-plan-review",
+        currentSummary: "Waiting for human review",
+        observedAt: secondObservedAt,
+      },
+      events: [
+        {
+          version: 1,
+          kind: "plan-ready",
+          issueNumber: 43,
+          observedAt: secondObservedAt,
+          attemptNumber: 1,
+          sessionId: null,
+          details: {
+            branch: "symphony/43",
+          },
+        },
+      ],
+    });
+
+    const summary = await readIssueArtifactSummary(workspaceRoot, 43);
+    expect(summary.firstObservedAt).toBe(firstObservedAt);
+    expect(summary.lastUpdatedAt).toBe(secondObservedAt);
+    expect(summary.latestAttemptNumber).toBe(1);
+    expect(summary.branch).toBe("symphony/43");
+
+    const events = await readIssueArtifactEvents(workspaceRoot, 43);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("plan-ready");
+
+    const logPointers = await readIssueArtifactLogPointers(workspaceRoot, 43);
+    expect(logPointers.sessions).toEqual({});
+
+    const paths = deriveIssueArtifactPaths(workspaceRoot, 43);
+    await expect(fs.stat(paths.attemptsDir)).resolves.toBeDefined();
+    await expect(fs.stat(paths.sessionsDir)).resolves.toBeDefined();
+    await expect(fs.stat(paths.logsDir)).resolves.toBeDefined();
+  });
+
+  it("writes attempt, session, and pointer snapshots with session-id-safe filenames", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const store = new LocalIssueArtifactStore(workspaceRoot);
+    const observedAt = "2026-03-09T10:10:00.000Z";
+    const sessionId = "sociotechnica-org/symphony-ts#43/attempt-1/abc";
+
+    await store.recordObservation({
+      issue: {
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        branch: "symphony/43",
+        currentOutcome: "awaiting-review",
+        currentSummary: "PR opened",
+        observedAt,
+        latestAttemptNumber: 1,
+        latestSessionId: sessionId,
+      },
+      attempt: {
+        version: 1,
+        issueNumber: 43,
+        attemptNumber: 1,
+        branch: "symphony/43",
+        startedAt: "2026-03-09T10:00:00.000Z",
+        finishedAt: observedAt,
+        outcome: "awaiting-review",
+        summary: "PR opened",
+        sessionId,
+        runnerPid: 1234,
+        pullRequest: {
+          number: 99,
+          url: "https://example.test/pulls/99",
+          latestCommitAt: observedAt,
+        },
+        review: {
+          actionableCount: 0,
+          unresolvedThreadCount: 0,
+        },
+        checks: {
+          pendingNames: [],
+          failingNames: [],
+        },
+      },
+      session: {
+        version: 1,
+        issueNumber: 43,
+        attemptNumber: 1,
+        sessionId,
+        provider: "local-runner",
+        model: null,
+        startedAt: "2026-03-09T10:00:00.000Z",
+        finishedAt: observedAt,
+        workspacePath: "/tmp/workspaces/43",
+        branch: "symphony/43",
+        logPointers: [],
+      },
+      logPointers: {
+        sessionId,
+        pointers: [],
+        archiveLocation: null,
+      },
+    });
+
+    const attempt = await readIssueArtifactAttempt(workspaceRoot, 43, 1);
+    expect(attempt.runnerPid).toBe(1234);
+    expect(attempt.pullRequest?.number).toBe(99);
+
+    const session = await readIssueArtifactSession(
+      workspaceRoot,
+      43,
+      sessionId,
+    );
+    expect(session.provider).toBe("local-runner");
+    expect(session.finishedAt).toBe(observedAt);
+
+    const logPointers = await readIssueArtifactLogPointers(workspaceRoot, 43);
+    expect(logPointers.sessions[sessionId]?.sessionId).toBe(sessionId);
+
+    const sessionPath = path.join(
+      deriveIssueArtifactPaths(workspaceRoot, 43).sessionsDir,
+      `${encodeURIComponent(sessionId)}.json`,
+    );
+    await expect(fs.stat(sessionPath)).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/issue-lease.test.ts
+++ b/tests/unit/issue-lease.test.ts
@@ -32,6 +32,7 @@ function createSession(issueNumber: number, workspacePath: string): RunSession {
       createdNow: false,
     },
     prompt: "test prompt",
+    startedAt: timestamp,
     attempt: {
       sequence: 1,
     },

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -27,6 +27,7 @@ function createSession(): RunSession {
       createdNow: false,
     },
     prompt: "x".repeat(10_000_000),
+    startedAt: new Date().toISOString(),
     attempt: {
       sequence: 1,
     },

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -12,6 +12,8 @@ import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import {
   deriveFactoryRuntimeRoot,
+  readIssueArtifactAttempt,
+  readIssueArtifactSession,
   type IssueArtifactObservation,
   type IssueArtifactStore,
   readIssueArtifactSummary,
@@ -1288,7 +1290,7 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.failed).toEqual([]);
   });
 
-  it("records the terminal attempt number when a run fails without a surviving session", async () => {
+  it("preserves attempt session fields when a failed run becomes terminal", async () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(77)],
     });
@@ -1341,6 +1343,22 @@ describe("BootstrapOrchestrator", () => {
     ]);
     expect(artifactSummary.currentOutcome).toBe("failed");
     expect(artifactSummary.latestAttemptNumber).toBe(1);
+    expect(artifactSummary.latestSessionId).not.toBeNull();
+
+    const attempt = await readIssueArtifactAttempt(
+      baseConfig.workspace.root,
+      77,
+      1,
+    );
+    const session = await readIssueArtifactSession(
+      baseConfig.workspace.root,
+      77,
+      artifactSummary.latestSessionId!,
+    );
+    expect(attempt.outcome).toBe("failed");
+    expect(attempt.sessionId).toBe(artifactSummary.latestSessionId);
+    expect(attempt.startedAt).toBe(session.startedAt);
+    expect(attempt.finishedAt).toBe("2026-03-09T16:30:00.000Z");
   });
 
   it("records an explicit attempt-failed issue state before retry scheduling", async () => {
@@ -1399,6 +1417,41 @@ describe("BootstrapOrchestrator", () => {
           observation.issue.currentOutcome === "retry-scheduled",
       ),
     ).toBeDefined();
+  });
+
+  it("describes a session once per observation when writing session artifacts", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(81)],
+    });
+    tracker.setLifecycleSequence(81, [lifecycle("missing", "symphony/81")]);
+    let describeSessionCalls = 0;
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          describeSessionCalls += 1;
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunResult> {
+          const timestamp = "2026-03-09T17:00:00.000Z";
+          return {
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      },
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(describeSessionCalls).toBe(2);
   });
 
   it("does not block one issue's artifact writes behind another issue's queue", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1295,6 +1295,7 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(77)],
     });
     tracker.setLifecycleSequence(77, [lifecycle("missing", "symphony/77")]);
+    const runnerPid = 4321;
     const orchestrator = new BootstrapOrchestrator(
       {
         ...baseConfig,
@@ -1314,8 +1315,12 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(_session, options): Promise<RunResult> {
           const timestamp = "2026-03-09T16:30:00.000Z";
+          await options?.onSpawn?.({
+            pid: runnerPid,
+            spawnedAt: timestamp,
+          });
           return {
             exitCode: 17,
             stdout: "",
@@ -1359,6 +1364,7 @@ describe("BootstrapOrchestrator", () => {
     expect(attempt.sessionId).toBe(artifactSummary.latestSessionId);
     expect(attempt.startedAt).toBe(session.startedAt);
     expect(attempt.finishedAt).toBe("2026-03-09T16:30:00.000Z");
+    expect(attempt.runnerPid).toBe(runnerPid);
   });
 
   it("records an explicit attempt-failed issue state before retry scheduling", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1367,6 +1367,61 @@ describe("BootstrapOrchestrator", () => {
     expect(attempt.runnerPid).toBe(runnerPid);
   });
 
+  it("preserves a captured runner pid when a spawned run fails without session context", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(82)],
+    });
+    tracker.setLifecycleSequence(82, [lifecycle("missing", "symphony/82")]);
+    const runnerPid = 8765;
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 1,
+            maxFollowUpAttempts: 1,
+            backoffMs: 0,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(_session, options): Promise<RunResult> {
+          await options?.onSpawn?.({
+            pid: runnerPid,
+            spawnedAt: "2026-03-09T16:35:00.000Z",
+          });
+          throw new Error("runner crashed after spawn");
+        },
+      },
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(tracker.failed).toEqual([
+      {
+        issueNumber: 82,
+        reason: "Error: runner crashed after spawn",
+      },
+    ]);
+
+    const attempt = await readIssueArtifactAttempt(
+      baseConfig.workspace.root,
+      82,
+      1,
+    );
+    expect(attempt.outcome).toBe("failed");
+    expect(attempt.sessionId).toBeNull();
+    expect(attempt.runnerPid).toBe(runnerPid);
+  });
+
   it("records an explicit attempt-failed issue state before retry scheduling", async () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(78)],

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
 import type { PullRequestLifecycle } from "../../src/domain/pull-request.js";
@@ -10,6 +10,7 @@ import type {
 } from "../../src/domain/workflow.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
+import { deriveFactoryRuntimeRoot } from "../../src/observability/issue-artifacts.js";
 import {
   deriveStatusFilePath,
   readFactoryStatusSnapshot,
@@ -59,7 +60,11 @@ const baseConfig: ResolvedConfig = {
     },
   },
   workspace: {
-    root: "/tmp/workspaces",
+    root: path.join(
+      "/tmp",
+      `symphony-orchestrator-test-${process.pid}`,
+      "workspaces",
+    ),
     repoUrl: "/tmp/remote.git",
     branchPrefix: "symphony/",
     cleanupOnSuccess: false,
@@ -347,6 +352,20 @@ class RecordingRunner implements Runner {
 }
 
 describe("BootstrapOrchestrator", () => {
+  beforeEach(async () => {
+    await fs.rm(deriveFactoryRuntimeRoot(baseConfig.workspace.root), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(deriveFactoryRuntimeRoot(baseConfig.workspace.root), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   it("starts up to maxConcurrentRuns ready issues in parallel", async () => {
     const tempRoot = await createTempDir("symphony-parallel-test-");
     try {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -27,6 +27,14 @@ import {
   createLifecycle as lifecycle,
 } from "../support/pull-request.js";
 
+function createRunnerSessionDescription() {
+  return {
+    provider: "test-runner",
+    model: null,
+    logPointers: [],
+  } as const;
+}
+
 function createDeferred<T>(): {
   readonly promise: Promise<T>;
   resolve(value: T | PromiseLike<T>): void;
@@ -311,6 +319,10 @@ class ConcurrencyRunner implements Runner {
     this.#finishBarrier.resolve();
   }
 
+  describeSession() {
+    return createRunnerSessionDescription();
+  }
+
   async run(session: RunSession): Promise<RunResult> {
     this.startedIssues.push(session.issue.number);
     this.#active += 1;
@@ -335,6 +347,10 @@ class RecordingRunner implements Runner {
   readonly sessionIds: string[] = [];
   readonly attempts: number[] = [];
   readonly prompts: string[] = [];
+
+  describeSession() {
+    return createRunnerSessionDescription();
+  }
 
   async run(session: RunSession): Promise<RunResult> {
     this.sessionIds.push(session.id);
@@ -493,6 +509,9 @@ describe("BootstrapOrchestrator", () => {
       tracker,
       new StaticWorkspaceManager(),
       {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
         async run(): Promise<RunResult> {
           runnerCalls += 1;
           throw new Error("runner should not be called");
@@ -616,6 +635,9 @@ describe("BootstrapOrchestrator", () => {
         tracker,
         new StaticWorkspaceManager(),
         {
+          describeSession() {
+            return createRunnerSessionDescription();
+          },
           async run(): Promise<RunResult> {
             runnerCalls += 1;
             throw new Error("runner should not be called");
@@ -828,6 +850,9 @@ describe("BootstrapOrchestrator", () => {
       tracker,
       workspace,
       {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
         async run(): Promise<RunResult> {
           throw new Error("runner should not be called");
         },
@@ -915,6 +940,9 @@ describe("BootstrapOrchestrator", () => {
       tracker,
       workspace,
       {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
         async run(): Promise<RunResult> {
           runnerCalls += 1;
           throw new Error("runner should not be called");
@@ -1137,6 +1165,9 @@ describe("BootstrapOrchestrator", () => {
     tracker.setLifecycleSequence(10, [lifecycle("missing", "symphony/10")]);
     const runnerCalls: number[] = [];
     const runner: Runner = {
+      describeSession() {
+        return createRunnerSessionDescription();
+      },
       async run(session): Promise<RunResult> {
         runnerCalls.push(session.attempt.sequence);
         const timestamp = new Date().toISOString();
@@ -1188,6 +1219,9 @@ describe("BootstrapOrchestrator", () => {
       tracker,
       new StaticWorkspaceManager(),
       {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
         async run(): Promise<RunResult> {
           const timestamp = new Date().toISOString();
           return {
@@ -1233,6 +1267,9 @@ describe("BootstrapOrchestrator", () => {
       tracker,
       new StaticWorkspaceManager(),
       {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
         async run(session): Promise<RunResult> {
           runnerCalls.push(session.attempt.sequence);
           const timestamp = new Date().toISOString();
@@ -1288,6 +1325,9 @@ describe("BootstrapOrchestrator", () => {
         tracker,
         new StaticWorkspaceManager(),
         {
+          describeSession() {
+            return createRunnerSessionDescription();
+          },
           async run(_session, options): Promise<RunResult> {
             started.resolve();
             return await new Promise<RunResult>((_resolve, reject) => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -10,7 +10,10 @@ import type {
 } from "../../src/domain/workflow.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
-import { deriveFactoryRuntimeRoot } from "../../src/observability/issue-artifacts.js";
+import {
+  deriveFactoryRuntimeRoot,
+  readIssueArtifactSummary,
+} from "../../src/observability/issue-artifacts.js";
 import {
   deriveStatusFilePath,
   readFactoryStatusSnapshot,
@@ -1205,6 +1208,61 @@ describe("BootstrapOrchestrator", () => {
     expect(runnerCalls).toEqual([1]);
     expect(tracker.retried).toHaveLength(1);
     expect(tracker.failed).toEqual([]);
+  });
+
+  it("records the terminal attempt number when a run fails without a surviving session", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(77)],
+    });
+    tracker.setLifecycleSequence(77, [lifecycle("missing", "symphony/77")]);
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 1,
+            maxFollowUpAttempts: 1,
+            backoffMs: 0,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunResult> {
+          const timestamp = "2026-03-09T16:30:00.000Z";
+          return {
+            exitCode: 17,
+            stdout: "",
+            stderr: "simulated failure",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      },
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+
+    const artifactSummary = await readIssueArtifactSummary(
+      baseConfig.workspace.root,
+      77,
+    );
+
+    expect(tracker.failed).toEqual([
+      {
+        issueNumber: 77,
+        reason: "Runner exited with 17\nsimulated failure",
+      },
+    ]);
+    expect(artifactSummary.currentOutcome).toBe("failed");
+    expect(artifactSummary.latestAttemptNumber).toBe(1);
   });
 
   it("does not invoke the unexpected failure path when retry bookkeeping fails", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -12,6 +12,8 @@ import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import {
   deriveFactoryRuntimeRoot,
+  type IssueArtifactObservation,
+  type IssueArtifactStore,
   readIssueArtifactSummary,
 } from "../../src/observability/issue-artifacts.js";
 import {
@@ -359,6 +361,82 @@ class RecordingRunner implements Runner {
     this.sessionIds.push(session.id);
     this.attempts.push(session.attempt.sequence);
     this.prompts.push(session.prompt);
+    const timestamp = new Date().toISOString();
+    return {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      startedAt: timestamp,
+      finishedAt: timestamp,
+    };
+  }
+}
+
+class RecordingIssueArtifactStore implements IssueArtifactStore {
+  readonly observations: IssueArtifactObservation[] = [];
+
+  async recordObservation(
+    observation: IssueArtifactObservation,
+  ): Promise<void> {
+    this.observations.push(observation);
+  }
+}
+
+class PerIssueBlockingArtifactStore implements IssueArtifactStore {
+  readonly #blockedIssueNumber: number;
+  readonly #release = createDeferred<void>();
+
+  constructor(blockedIssueNumber: number) {
+    this.#blockedIssueNumber = blockedIssueNumber;
+  }
+
+  release(): void {
+    this.#release.resolve();
+  }
+
+  async recordObservation(
+    observation: IssueArtifactObservation,
+  ): Promise<void> {
+    if (
+      observation.issue.issueNumber === this.#blockedIssueNumber &&
+      observation.issue.currentOutcome === "running" &&
+      observation.issue.latestSessionId !== null
+    ) {
+      await this.#release.promise;
+    }
+  }
+}
+
+class BlockingRecordingRunner implements Runner {
+  readonly startedIssues: number[] = [];
+  readonly issueStarted = new Map<
+    number,
+    ReturnType<typeof createDeferred<void>>
+  >();
+  readonly #finish = createDeferred<void>();
+
+  constructor(issueNumbers: readonly number[]) {
+    for (const issueNumber of issueNumbers) {
+      this.issueStarted.set(issueNumber, createDeferred<void>());
+    }
+  }
+
+  describeSession() {
+    return createRunnerSessionDescription();
+  }
+
+  release(): void {
+    this.#finish.resolve();
+  }
+
+  async waitForIssue(issueNumber: number): Promise<void> {
+    await this.issueStarted.get(issueNumber)?.promise;
+  }
+
+  async run(session: RunSession): Promise<RunResult> {
+    this.startedIssues.push(session.issue.number);
+    this.issueStarted.get(session.issue.number)?.resolve();
+    await this.#finish.promise;
     const timestamp = new Date().toISOString();
     return {
       exitCode: 0,
@@ -1263,6 +1341,100 @@ describe("BootstrapOrchestrator", () => {
     ]);
     expect(artifactSummary.currentOutcome).toBe("failed");
     expect(artifactSummary.latestAttemptNumber).toBe(1);
+  });
+
+  it("records an explicit attempt-failed issue state before retry scheduling", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(78)],
+    });
+    tracker.setLifecycleSequence(78, [lifecycle("missing", "symphony/78")]);
+    const artifactStore = new RecordingIssueArtifactStore();
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 2,
+            maxFollowUpAttempts: 2,
+            backoffMs: 0,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunResult> {
+          const timestamp = "2026-03-09T16:45:00.000Z";
+          return {
+            exitCode: 17,
+            stdout: "",
+            stderr: "simulated failure",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      },
+      new NullLogger(),
+      artifactStore,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(
+      artifactStore.observations.find(
+        (observation) =>
+          observation.issue.issueNumber === 78 &&
+          observation.issue.currentOutcome === "attempt-failed",
+      ),
+    ).toBeDefined();
+    expect(
+      artifactStore.observations.find(
+        (observation) =>
+          observation.issue.issueNumber === 78 &&
+          observation.issue.currentOutcome === "retry-scheduled",
+      ),
+    ).toBeDefined();
+  });
+
+  it("does not block one issue's artifact writes behind another issue's queue", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(79), createIssue(80)],
+    });
+    tracker.setLifecycleSequence(79, [
+      lifecycle("missing", "symphony/79"),
+      lifecycle("ready", "symphony/79"),
+    ]);
+    tracker.setLifecycleSequence(80, [
+      lifecycle("missing", "symphony/80"),
+      lifecycle("ready", "symphony/80"),
+    ]);
+    const artifactStore = new PerIssueBlockingArtifactStore(79);
+    const runner = new BlockingRecordingRunner([79, 80]);
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      runner,
+      new NullLogger(),
+      artifactStore,
+    );
+
+    const runOnce = orchestrator.runOnce();
+
+    await runner.waitForIssue(80);
+    expect(runner.startedIssues).toContain(80);
+    expect(runner.startedIssues).not.toContain(79);
+
+    artifactStore.release();
+    await runner.waitForIssue(79);
+    runner.release();
+    await runOnce;
   });
 
   it("does not invoke the unexpected failure path when retry bookkeeping fails", async () => {


### PR DESCRIPTION
Closes #43

## Summary
- add a provider-neutral local issue artifact contract under `.var/factory/issues/<issue-number>/...`
- emit issue, event, attempt, session, and log-pointer artifacts from the orchestrator without coupling in report rendering
- cover the contract with unit and e2e tests, including workspace-cleanup survival

## Validation
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- `codex review --base origin/main` was run twice, but the tool hung after diff inspection in this workspace and never returned findings.