### PR TITLE
config: support SYMPHONY_REPO for parallel factory development

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -21,7 +21,6 @@ polling:
     backoff_ms: 5000
 workspace:
   root: ./.tmp/workspaces
-  repo_url: git@github.com:sociotechnica-org/symphony-ts.git
   branch_prefix: symphony/
   cleanup_on_success: true
 hooks:
@@ -30,8 +29,7 @@ agent:
   command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
   prompt_transport: stdin
   timeout_ms: 5400000
-  env:
-    GITHUB_REPO: sociotechnica-org/symphony-ts
+  env: {}
 ---
 
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "pnpm install && pnpm build",
+    "run": "SYMPHONY_REPO=sociotechnica-org/symphony-ts-test pnpm exec tsx bin/symphony.ts run"
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "dev": "tsx watch bin/symphony.ts"
+    "dev": "tsx watch bin/symphony.ts run"
   },
   "dependencies": {
     "liquidjs": "^10.24.0",

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -56,7 +56,21 @@ function requireString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim() === "") {
     throw new ConfigError(`Expected non-empty string for ${field}`);
   }
-  return value;
+  return value.trim();
+}
+
+function requireGitHubRepo(value: unknown): string {
+  if (value !== undefined && typeof value !== "string") {
+    throw new ConfigError(
+      `tracker.repo must be a non-empty string, got ${JSON.stringify(value)}`,
+    );
+  }
+  if (value === undefined || value.trim() === "") {
+    throw new ConfigError(
+      "tracker.repo is not set; provide it in WORKFLOW.md or set the SYMPHONY_REPO environment variable",
+    );
+  }
+  return value.trim();
 }
 
 function requireUrlString(value: unknown, field: string): string {
@@ -241,6 +255,37 @@ async function readParsedWorkflow(
   return parseFrontMatter(await readWorkflowSource(workflowPath));
 }
 
+function resolveRepoUrl(
+  explicitRepoUrl: unknown,
+  derivedRepoUrl: string | undefined,
+  envOverrideActive: boolean,
+): string {
+  // When SYMPHONY_REPO is set, the derived URL always wins so the factory
+  // polls, clones, and pushes to the same repo.
+  if (derivedRepoUrl !== undefined && envOverrideActive) {
+    if (explicitRepoUrl !== undefined) {
+      console.warn(
+        `[symphony] SYMPHONY_REPO overrides workspace.repo_url; using ${derivedRepoUrl}`,
+      );
+    }
+    return derivedRepoUrl;
+  }
+
+  if (explicitRepoUrl === undefined) {
+    if (derivedRepoUrl !== undefined) {
+      return derivedRepoUrl;
+    }
+    const hint = envOverrideActive
+      ? " (SYMPHONY_REPO is set but has no effect for this tracker kind)"
+      : "";
+    throw new ConfigError(
+      `workspace.repo_url is required when not using github-bootstrap tracker${hint}`,
+    );
+  }
+
+  return requireString(explicitRepoUrl, "workspace.repo_url");
+}
+
 function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   const tracker = coerceOptionalObject(raw.tracker, "tracker");
   const polling = coerceOptionalObject(raw.polling, "polling");
@@ -248,9 +293,58 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   const hooks = coerceOptionalObject(raw.hooks, "hooks");
   const agent = coerceOptionalObject(raw.agent, "agent");
 
+  // Apply SYMPHONY_REPO env override (github-bootstrap only; ignored by other tracker kinds)
+  const rawRepoEnv = process.env["SYMPHONY_REPO"];
+  const repoOverride =
+    rawRepoEnv !== undefined
+      ? requireString(rawRepoEnv, "SYMPHONY_REPO env var")
+      : undefined;
+  const rawTrackerRepo = tracker["repo"];
+  const effectiveTracker =
+    repoOverride !== undefined ? { ...tracker, repo: repoOverride } : tracker;
+
+  if (
+    repoOverride !== undefined &&
+    typeof rawTrackerRepo === "string" &&
+    rawTrackerRepo.trim() !== repoOverride
+  ) {
+    console.warn(
+      `[symphony] SYMPHONY_REPO="${repoOverride}" overrides tracker.repo="${rawTrackerRepo.trim()}" from WORKFLOW.md`,
+    );
+  }
+
+  const resolvedTracker = resolveTrackerConfig(effectiveTracker);
+
+  if (
+    repoOverride !== undefined &&
+    resolvedTracker.kind !== "github-bootstrap"
+  ) {
+    console.warn(
+      `[symphony] SYMPHONY_REPO is set but ignored for tracker.kind="${resolvedTracker.kind}"`,
+    );
+  }
+
+  // For github-bootstrap trackers, derive repoUrl and inject GITHUB_REPO
+  let derivedRepoUrl: string | undefined;
+  let repo: string | undefined;
+  if (resolvedTracker.kind === "github-bootstrap") {
+    repo = resolvedTracker.repo;
+    try {
+      const gitHost = new URL(resolvedTracker.apiUrl).hostname.replace(
+        /^api\./,
+        "",
+      );
+      derivedRepoUrl = `git@${gitHost}:${repo}.git`;
+    } catch {
+      throw new ConfigError(
+        `tracker.api_url is not a valid URL: ${resolvedTracker.apiUrl}`,
+      );
+    }
+  }
+
   const resolved: ResolvedConfig = {
     workflowPath,
-    tracker: resolveTrackerConfig(tracker),
+    tracker: resolvedTracker,
     polling: {
       intervalMs: requireNumber(polling["interval_ms"], "polling.interval_ms"),
       maxConcurrentRuns: requireNumber(
@@ -264,7 +358,11 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         path.dirname(workflowPath),
         requireString(workspace["root"], "workspace.root"),
       ),
-      repoUrl: requireString(workspace["repo_url"], "workspace.repo_url"),
+      repoUrl: resolveRepoUrl(
+        workspace["repo_url"],
+        derivedRepoUrl,
+        repoOverride !== undefined,
+      ),
       branchPrefix: requireString(
         workspace["branch_prefix"],
         "workspace.branch_prefix",
@@ -284,11 +382,14 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         "agent.prompt_transport",
       ) as "stdin" | "file",
       timeoutMs: requireNumber(agent["timeout_ms"], "agent.timeout_ms"),
-      env: Object.fromEntries(
-        Object.entries((agent["env"] ?? {}) as Record<string, unknown>).map(
-          ([key, value]) => [key, String(value)],
+      env: {
+        ...Object.fromEntries(
+          Object.entries((agent["env"] ?? {}) as Record<string, unknown>).map(
+            ([key, value]) => [key, String(value)],
+          ),
         ),
-      ),
+        ...(repo !== undefined ? { GITHUB_REPO: repo } : {}),
+      },
     },
   };
 
@@ -351,7 +452,7 @@ function resolveGitHubBootstrapTrackerConfig(
 ): GitHubBootstrapTrackerConfig {
   return {
     kind: "github-bootstrap",
-    repo: requireString(tracker["repo"], "tracker.repo"),
+    repo: requireGitHubRepo(tracker["repo"]),
     apiUrl: requireString(tracker["api_url"], "tracker.api_url"),
     readyLabel: requireString(tracker["ready_label"], "tracker.ready_label"),
     runningLabel: requireString(

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -73,8 +73,7 @@ agent:
   command: ${options.agentCommand}
   prompt_transport: stdin
   timeout_ms: 30000
-  env:
-    GITHUB_REPO: sociotechnica-org/symphony-ts
+  env: {}
 ---
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 Description: {{ issue.description }}
@@ -136,9 +135,11 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       MOCK_GITHUB_API_URL: server.baseUrl,
       PATH: `${fixturePath}:${originalEnv.PATH ?? ""}`,
     };
+    delete process.env["SYMPHONY_REPO"];
   });
 
   afterEach(async () => {
+    // Restores full original env including SYMPHONY_REPO if it was set
     process.env = { ...originalEnv };
     await server.stop();
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPromptBuilder,
   loadWorkflow,
@@ -43,6 +43,18 @@ agent:
 }
 
 describe("workflow config", () => {
+  const savedSymphonyRepo = process.env["SYMPHONY_REPO"];
+  beforeEach(() => {
+    delete process.env["SYMPHONY_REPO"];
+  });
+  afterEach(() => {
+    if (savedSymphonyRepo !== undefined) {
+      process.env["SYMPHONY_REPO"] = savedSymphonyRepo;
+    } else {
+      delete process.env["SYMPHONY_REPO"];
+    }
+  });
+
   it("loads workflow config and renders prompt strictly", async () => {
     const dir = await createTempDir("workflow-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
@@ -71,6 +83,9 @@ ${buildSharedWorkflowSections()}`,
     expect(workflow.config.tracker.kind).toBe("github-bootstrap");
     expect(workflow.config.polling.retry.maxAttempts).toBe(2);
     expect(workflow.config.polling.retry.maxFollowUpAttempts).toBe(3);
+    expect(workflow.config.agent.env["GITHUB_REPO"]).toBe(
+      "sociotechnica-org/symphony-ts",
+    );
     const promptBuilder = createPromptBuilder(workflow);
     const rendered = await promptBuilder.build({
       issue: {
@@ -90,6 +105,211 @@ ${buildSharedWorkflowSections()}`,
     });
     expect(rendered).toContain("repo#1");
     expect(rendered).toContain("sociotechnica-org/symphony-ts");
+  });
+
+  it("derives workspace.repoUrl from tracker.repo and api_url when repo_url is omitted", async () => {
+    const dir = await createTempDir("workflow-derived-url-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: my-org/my-repo
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  command: echo test
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.workspace.repoUrl).toBe(
+      "git@github.com:my-org/my-repo.git",
+    );
+    expect(workflow.config.agent.env["GITHUB_REPO"]).toBe("my-org/my-repo");
+  });
+
+  it("SYMPHONY_REPO overrides tracker.repo and derives repoUrl and GITHUB_REPO", async () => {
+    process.env["SYMPHONY_REPO"] = "my-org/my-test-repo";
+
+    const dir = await createTempDir("workflow-override-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  command: echo test
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+        "Repo: {{ config.tracker.repo }}",
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.tracker.kind).toBe("github-bootstrap");
+    if (workflow.config.tracker.kind === "github-bootstrap") {
+      expect(workflow.config.tracker.repo).toBe("my-org/my-test-repo");
+    }
+    expect(workflow.config.workspace.repoUrl).toBe(
+      "git@github.com:my-org/my-test-repo.git",
+    );
+    expect(workflow.config.agent.env["GITHUB_REPO"]).toBe(
+      "my-org/my-test-repo",
+    );
+  });
+
+  it("SYMPHONY_REPO overrides explicit workspace.repo_url", async () => {
+    process.env["SYMPHONY_REPO"] = "my-org/override-repo";
+
+    const dir = await createTempDir("workflow-repo-url-override-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: my-org/original-repo
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const workflow = await loadWorkflow(workflowPath);
+      expect(workflow.config.workspace.repoUrl).toBe(
+        "git@github.com:my-org/override-repo.git",
+      );
+      expect(workflow.config.agent.env["GITHUB_REPO"]).toBe(
+        "my-org/override-repo",
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("SYMPHONY_REPO overrides workspace.repo_url"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'SYMPHONY_REPO="my-org/override-repo" overrides tracker.repo="my-org/original-repo"',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("throws when SYMPHONY_REPO is empty string", async () => {
+    process.env["SYMPHONY_REPO"] = "";
+    const dir = await createTempDir("workflow-empty-env-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: r
+  running_label: r
+  failed_label: f
+  success_comment: done
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+    await expect(loadWorkflow(workflowPath)).rejects.toThrow(
+      "SYMPHONY_REPO env var",
+    );
+  });
+
+  it("throws with helpful message when neither SYMPHONY_REPO nor tracker.repo is set", async () => {
+    const dir = await createTempDir("workflow-no-repo-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  api_url: https://api.github.com
+  ready_label: r
+  running_label: r
+  failed_label: f
+  success_comment: done
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+    await expect(loadWorkflow(workflowPath)).rejects.toThrow("SYMPHONY_REPO");
+  });
+
+  it("warns when SYMPHONY_REPO is set with a linear tracker", async () => {
+    process.env["SYMPHONY_REPO"] = "my-org/ignored-repo";
+    const dir = await createTempDir("workflow-linear-warn-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const workflow = await loadWorkflow(workflowPath);
+      expect(workflow.config.tracker.kind).toBe("linear");
+      expect(workflow.config.agent.env["GITHUB_REPO"]).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'SYMPHONY_REPO is set but ignored for tracker.kind="linear"',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("loads a valid linear workflow with upstream defaults", async () => {


### PR DESCRIPTION
## Summary

Enable parallel factory development on Conductor by supporting a `SYMPHONY_REPO` environment variable that overrides the tracker repo and derives the workspace repo URL. This allows multiple isolated factory instances to poll different GitHub repos without competing for issues.

**Changes:**
- Add `conductor.json` for Conductor workspace setup (builds deps, runs factory on test repo)
- Support `SYMPHONY_REPO` env var in config loader to override tracker.repo and derive repo_url
- Remove hardcoded production repo references from WORKFLOW.md
- Fix dev script to pass the required 'run' subcommand
- Preserve workspace.repo_url as fallback for e2e tests with local git repos

When Conductor creates a worktree, the factory will poll `sociotechnica-org/symphony-ts-test` by default, isolating it from the production factory.

## Test plan

- [x] All 108 unit/integration tests pass
- [x] SYMPHONY_REPO env var correctly overrides config
- [x] Missing SYMPHONY_REPO errors cleanly
- [x] E2E tests with local repo_url still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)