### PR TITLE
Rewrite README for external audiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,36 @@
 # symphony-ts
 
-TypeScript implementation of the [Symphony spec](https://github.com/openai/symphony).
+A local-first factory orchestrator that turns GitHub issues into pull requests — and lets you see the whole assembly line.
 
-## Status
+Symphony polls your issue tracker, claims work, spins up AI coding agents, supervises their runs, and follows through on CI failures and review feedback until the PR is merge-ready. Your entire factory configuration lives in a single `WORKFLOW.md` file. No hosted infrastructure, no centralized state, no complexity.
 
-Phase 1.2 is implemented.
+## Why Symphony?
 
-Today, `symphony-ts` can:
+Running one AI coding agent in a terminal is manageable. Running a dozen across different issues, branches, and PRs is a coordination problem. There's no single pane of glass — you end up babysitting tickets, checking what's running, what's stuck, what succeeded, which issues opened PRs.
 
-- poll real GitHub issues labeled `symphony:ready`
-- claim one of those issues locally
-- create or reuse a deterministic per-issue git workspace
-- run Codex against that workspace using the rendered `WORKFLOW.md` prompt
-- supervise active local agent subprocesses and persist run ownership metadata
-- observe the pull request associated with the issue branch
-- wait for PR checks and automated review feedback after PR creation
-- re-enter the same workspace branch when CI or review feedback needs follow-up
-- recover orphaned `symphony:running` issues after local worker or agent loss
-- close the issue only after the PR is merge-ready
-- retry failed runs locally
-- emit a local factory status snapshot and render it in the terminal
+OpenAI released [the Symphony spec](https://github.com/openai/symphony) to address this ([background](https://openai.com/index/harness-engineering/)). It nails the right abstraction layers: policy, coordination, execution. But the reference implementation isn't accepting contributions. So we rebuilt it in TypeScript.
 
-This is already being used to build `symphony-ts` itself.
+**What makes symphony-ts different:**
 
-## How It Works
-
-The current runtime is a narrow vertical slice:
-
-1. `bin/symphony.ts` starts the CLI.
-2. `src/config/workflow.ts` loads and validates `WORKFLOW.md`.
-3. `src/tracker/github-bootstrap.ts` polls GitHub and manages labels/comments/state.
-4. `src/workspace/local.ts` clones and resets per-issue workspaces.
-5. `src/runner/local.ts` launches Codex as a subprocess.
-6. `src/orchestrator/service.ts` ties the loop together and supervises active local runs.
-
-The default issue lifecycle is:
-
-1. an issue gets the `symphony:ready` label
-2. Symphony changes it to `symphony:running`
-3. Symphony prepares branch `symphony/<issue-number>`
-4. Codex implements the issue and opens a PR
-5. Symphony keeps the issue in `symphony:running` while PR checks or review feedback are still in flight
-6. Symphony re-enters the same branch if CI fails or actionable review feedback appears
-7. Symphony comments on the issue and closes it only after the PR is green and review feedback is resolved
-
-If a run fails, Symphony either:
-
-- schedules a retry while keeping the issue in the in-flight factory loop, or
-- marks it `symphony:failed` after retries are exhausted
-
-Active run ownership is also persisted locally under the workspace root. On the
-next startup or poll, Symphony reconciles `symphony:running` issues against
-that local state, terminates orphaned local agent processes when needed, and
-resumes or fails the issue from the runtime itself.
-
-Per-issue reporting artifacts are also written locally under
-`.var/factory/issues/<issue-number>/...`. That contract stores durable raw facts
-for one issue (`issue.json`, `events.jsonl`, per-attempt snapshots,
-per-session snapshots, and log pointers) so later report generation can read
-local state without coupling itself to orchestrator control flow.
-Generated per-issue reports are written separately under
-`.var/reports/issues/<issue-number>/report.json` and `report.md`.
-
-## Technical Plan Review Station
-
-Before substantial implementation begins, the repo-owned workflow contract requires a human review station for technical plans:
-
-1. the worker writes `docs/plans/<issue-number>-<task-name>/plan.md`
-2. the worker posts a `plan-ready` issue comment and hands off for review
-3. if human feedback requests changes, the worker revises the plan and posts another `plan-ready` summary
-4. coding begins only after the plan is explicitly approved or explicitly waived with instructions not to wait
-
-This first slice uses issue comments and checked-in repo guidance. It does not require a dashboard or tracker-specific approval subsystem.
-
-## Repository Map
-
-```text
-bin/
-  symphony.ts                CLI entry point
-src/
-  cli/                       CLI wiring
-  config/                    WORKFLOW.md parsing and prompt rendering
-  domain/                    Shared runtime types and errors
-  observability/             Structured logging
-  orchestrator/              Polling, retries, dispatch
-  runner/                    Codex subprocess execution
-  tracker/                   GitHub bootstrap tracker
-  workspace/                 Local git workspace management
-tests/
-  unit/                      Small contract tests
-  integration/               Adapter and fixture tests
-  e2e/                       Full mock-GitHub runtime tests
-docs/
-  architecture.md            Layer boundaries
-  golden-principles.md       Implementation rules
-  plans/                     Issue-specific implementation plans
-  adrs/                      Architecture decision records
-```
-
-## Prerequisites
-
-- Node.js 20+
-- `pnpm`
-- `git`
-- `gh` authenticated against GitHub
-- `codex` installed locally
-
-You also need these labels in the target repository:
-
-- `symphony:ready`
-- `symphony:running`
-- `symphony:failed`
+- **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
+- **Adapter pattern for everything.** Pluggable trackers (GitHub today, Linear planned) and pluggable workers (local Codex today, remote workers planned). Swap any layer without touching the others.
+- **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in GitHub Issues itself. Run multiple factory instances with no centralized coordination.
+- **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
+- **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.
 
 ## Quick Start
 
-Install dependencies:
-
 ```bash
+git clone https://github.com/sociotechnica-org/symphony-ts.git
+cd symphony-ts
 pnpm install
 ```
+
+**Prerequisites:** Node.js 20+, `pnpm`, `git`, [`gh`](https://cli.github.com/) (authenticated), and [`codex`](https://github.com/openai/codex) installed locally.
+
+Your target repo needs three labels: `symphony:ready`, `symphony:running`, `symphony:failed`.
+
+Edit `WORKFLOW.md` to point `tracker.repo` and `workspace.repo_url` at your own repository (the checked-in default targets `sociotechnica-org/symphony-ts`). See [Configuration](#configuration) for all available fields.
 
 Run one poll cycle:
 
@@ -132,16 +44,11 @@ Run continuously:
 pnpm tsx bin/symphony.ts run
 ```
 
-Inspect the latest local factory status:
+Check factory status:
 
 ```bash
-pnpm tsx bin/symphony.ts status
-```
-
-Print the machine-readable snapshot:
-
-```bash
-pnpm tsx bin/symphony.ts status --json
+pnpm tsx bin/symphony.ts status          # terminal view
+pnpm tsx bin/symphony.ts status --json   # machine-readable
 ```
 
 Generate a per-issue report from local artifacts:
@@ -150,13 +57,62 @@ Generate a per-issue report from local artifacts:
 pnpm tsx bin/symphony-report.ts issue --issue 44
 ```
 
-By default, the checked-in `WORKFLOW.md` targets:
+## How It Works
 
-- repo: `sociotechnica-org/symphony-ts`
-- tracker: GitHub bootstrap adapter
-- runner: local Codex CLI
+1. An issue gets the `symphony:ready` label
+2. Symphony claims it, swaps the label to `symphony:running`
+3. Symphony prepares branch `symphony/<issue-number>` in an isolated local workspace
+4. The agent drafts a technical plan and stops at a **human review station** (unless waived)
+5. After plan approval, the agent implements the issue and opens a PR
+6. Symphony monitors CI and automated review feedback on the PR
+7. If CI fails or reviewers request changes, the agent pushes follow-up commits on the same branch
+8. When the PR is green and all feedback is resolved, Symphony comments on the issue and closes it
 
-## Linear Workflow Config Example
+If a run fails, Symphony retries. After retries are exhausted, it marks the issue `symphony:failed`.
+
+Active run ownership is persisted locally. On restart, Symphony reconciles `symphony:running` issues against local state, recovers orphaned runs, and resumes or fails them cleanly. Per-issue reporting artifacts are written to `.var/factory/issues/` so they survive workspace cleanup. Generated per-issue reports are written under `.var/reports/issues/<issue-number>/` when the report command is run.
+
+## Configuration
+
+Everything is configured in `WORKFLOW.md` — YAML front matter for the runtime, a [Liquid](https://liquidjs.com/) template for the agent prompt:
+
+```yaml
+tracker:
+  kind: github-bootstrap
+  repo: your-org/your-repo
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+
+polling:
+  interval_ms: 30000
+  max_concurrent_runs: 1
+
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: git@github.com:your-org/your-repo.git
+  branch_prefix: symphony/
+
+agent:
+  command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
+  timeout_ms: 1800000
+```
+
+| Field                          | Purpose                                                        |
+| ------------------------------ | -------------------------------------------------------------- |
+| `tracker.repo`                 | GitHub repository to poll for labeled issues                   |
+| `tracker.review_bot_logins`    | PR comment authors treated as actionable bot review            |
+| `polling.interval_ms`          | How often to check for new work                                |
+| `polling.max_concurrent_runs`  | Local concurrency cap                                          |
+| `workspace.root`               | Where isolated workspaces are created                          |
+| `workspace.branch_prefix`      | Issue branch naming prefix                                     |
+| `agent.command`                | Subprocess command to launch the coding agent                  |
+| `agent.timeout_ms`             | Max wall-clock time per agent run                              |
+| `workspace.cleanup_on_success` | Remove local workspace after a successful run (default `true`) |
+
+The prompt template below the YAML front matter uses Liquid syntax with access to `issue`, `config`, and `pull_request` variables. See the checked-in [`WORKFLOW.md`](WORKFLOW.md) for the full template.
+
+### Linear Workflow Config Example
 
 Workflow loading also supports a Linear tracker config shape for upcoming adapter work:
 
@@ -180,208 +136,104 @@ tracker:
 
 In this slice, `loadWorkflow` validates and normalizes that config, but `symphony run` still requires the GitHub bootstrap tracker until the Linear adapter lands.
 
-## How to Use Symphony to Build Symphony
+## Architecture
 
-This is the recursive local setup: Symphony runs against the `symphony-ts` GitHub repo and works `symphony-ts` issues by opening PRs back to that same repo.
+Symphony follows the [Symphony spec](https://github.com/openai/symphony/blob/main/SPEC.md) abstraction levels:
 
-### 1. Prepare the local machine
+| Spec Layer    | Implementation                                            | Swappable?                            |
+| ------------- | --------------------------------------------------------- | ------------------------------------- |
+| Policy        | `WORKFLOW.md`, issue plans, repo guidance                 | Yes — edit the workflow file          |
+| Configuration | `src/config/` — YAML + Liquid parsing                     | —                                     |
+| Coordination  | `src/orchestrator/` — polling, retries, reconciliation    | —                                     |
+| Execution     | `src/runner/` + `src/workspace/` — agent subprocess + git | Yes — change `agent.command`          |
+| Integration   | `src/tracker/` — GitHub bootstrap adapter                 | Yes — implement a new tracker adapter |
+| Observability | `src/observability/` — structured logs + status           | —                                     |
 
-Make sure these are installed and configured:
+### Repository Map
 
-- `pnpm`
-- `git`
-- `gh auth login`
-- `codex`
-
-Then install repo dependencies:
-
-```bash
-pnpm install
+```text
+bin/
+  symphony.ts                CLI entry point
+src/
+  cli/                       CLI wiring
+  config/                    WORKFLOW.md parsing and prompt rendering
+  domain/                    Shared runtime types and errors
+  observability/             Structured logging
+  orchestrator/              Polling, retries, dispatch
+  runner/                    Codex subprocess execution
+  tracker/                   GitHub bootstrap tracker
+  workspace/                 Local git workspace management
+tests/
+  unit/                      Small contract tests
+  integration/               Adapter and fixture tests
+  e2e/                       Full mock-GitHub runtime tests
+docs/
+  architecture.md            Layer boundaries
+  golden-principles.md       Implementation rules
+  guides/                    How-to guides for operators
+  plans/                     Issue-specific implementation plans
+  adrs/                      Architecture decision records
 ```
 
-### 2. Confirm the workflow targets this repo
+### Technical Plan Review Station
 
-The checked-in `WORKFLOW.md` should point at:
+Before substantial implementation begins, the workflow requires a human review station for technical plans:
 
-- `tracker.repo: sociotechnica-org/symphony-ts`
-- `workspace.repo_url: git@github.com:sociotechnica-org/symphony-ts.git`
-- `agent.command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`
+1. The agent writes `docs/plans/<issue-number>-<task-name>/plan.md`
+2. The agent posts a `plan-ready` issue comment and hands off for review
+3. If human feedback requests changes, the agent revises the plan and posts another `plan-ready` summary
+4. Coding begins only after the plan is approved or explicitly waived with instructions not to wait
 
-That means the local orchestrator will poll the real `symphony-ts` GitHub repo and create issue branches inside local workspaces cloned from that same repository.
-
-### 3. Create a real GitHub issue in `symphony-ts`
-
-Open an issue in:
-
-- <https://github.com/sociotechnica-org/symphony-ts/issues>
-
-Describe the task normally. Then add the label:
-
-- `symphony:ready`
-
-That label is the dispatch signal.
-
-### 4. Start Symphony locally
-
-Run one poll cycle:
-
-```bash
-pnpm tsx bin/symphony.ts run --once
-```
-
-Or run the worker continuously:
-
-```bash
-pnpm tsx bin/symphony.ts run
-```
-
-In continuous mode, Symphony will keep polling for additional ready issues.
-
-During or after a run, Symphony writes the latest derived status snapshot to `.tmp/status.json`.
-The `status` CLI reads that file and renders either a simple terminal view or the raw JSON contract
-for future tooling.
-Issue-level reporting artifacts are written separately under `.var/factory/issues/`
-so they survive workspace cleanup.
-Generated per-issue reports are written under `.var/reports/issues/<issue-number>/`
-when `pnpm tsx bin/symphony-report.ts issue --issue <issue-number>` is run.
-
-### 5. Watch the issue lifecycle
-
-When Symphony picks up the issue, it should:
-
-1. replace `symphony:ready` with `symphony:running`
-2. create or reuse a local workspace under `./.tmp/workspaces/`
-3. create branch `symphony/<issue-number>`
-4. have the worker draft the technical plan and stop at the human review station unless plan approval is waived
-5. run Codex implementation work from the approved or waived plan
-6. push the branch
-7. open a PR against `main`
-8. keep polling that PR for CI and automated review state
-9. push follow-up commits on the same branch until the PR is actually clean
-
-If the PR reaches a clean merge-ready state, Symphony will comment on the issue and close it.
-
-If the run fails, Symphony will either:
-
-- retry it in the running loop, or
-- mark it `symphony:failed`
-
-### 6. Review and merge the PR
-
-Symphony now owns the local PR follow-through loop:
-
-- wait for CI and automated review checks
-- detect actionable review feedback
-- push follow-up commits when the PR needs more work
-- stop only when the PR is actually clean
-
-Human merge remains a separate repository action once the PR is ready.
-
-That merged PR becomes the new version of Symphony that will work the next issue.
-
-### 7. Repeat
-
-Create the next `symphony-ts` issue, label it `symphony:ready`, and run Symphony again.
-
-That is the self-hosting loop:
-
-1. Symphony works a `symphony-ts` issue
-2. Symphony opens a PR into `symphony-ts`
-3. the PR merges
-4. the improved Symphony is used on the next `symphony-ts` issue
-
-### Practical notes
-
-- Run only one local Symphony instance against this repo at a time in Phase 0.
-- If you want to inspect a failed run, set `workspace.cleanup_on_success: false` temporarily or inspect the workspace before the next retry.
-- Use `--once` when you want tight control over one issue at a time.
-
-## WORKFLOW.md
-
-`WORKFLOW.md` is the runtime contract for a repository.
-
-It contains:
-
-- YAML front matter for tracker, polling, workspace, hooks, and agent config
-- a Liquid template used to render the issue prompt
-
-Key fields in the current workflow:
-
-- `tracker.repo`: GitHub repository to poll
-- `tracker.review_bot_logins`: PR comment authors whose feedback should be treated as actionable bot review
-- `polling.interval_ms`: poll interval
-- `polling.max_concurrent_runs`: local concurrency cap
-- `workspace.root`: local workspace root
-- `workspace.branch_prefix`: issue branch prefix
-- `agent.command`: subprocess command used to run Codex
-
-The checked-in default runner command is:
-
-```bash
-codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
-```
+This uses issue comments and checked-in repo guidance. It does not require a dashboard or tracker-specific approval subsystem. If plan approval is waived, the agent proceeds directly to implementation.
 
 ## Development
 
-Install dependencies:
-
 ```bash
-pnpm install
+pnpm install              # install dependencies
+pnpm format:check         # check formatting
+pnpm lint                 # lint
+pnpm typecheck            # type-check
+pnpm test                 # run tests
 ```
 
-Run the full local gate:
-
 ```bash
-pnpm format:check
-pnpm lint
-pnpm typecheck
-pnpm test
+pnpm dev                  # watch mode
+pnpm build                # compile
 ```
 
-Useful commands:
+Tests run in three layers: unit tests for pure logic, integration tests for adapters and fixtures, and end-to-end tests against an in-process mock GitHub server with a real temporary git remote.
 
-```bash
-pnpm dev
-pnpm build
-```
+## Status & Roadmap
 
-## Testing Strategy
+**Current phase: 1.2** — single local instance, GitHub Issues tracker, local Codex runner.
 
-The repo uses three layers of verification:
+What works today:
 
-- unit tests for pure config, logger, runner, and orchestrator behavior
-- integration tests for GitHub adapter and CLI fixtures
-- end-to-end tests that exercise the full runtime against an in-process mock GitHub server and a real temporary git remote
+- Full issue lifecycle from `symphony:ready` through merge-ready PR
+- Plan review station with human approval gate
+- CI and automated review follow-up loop
+- Orphaned run recovery on restart
+- Local factory status surface
+- Self-hosting: Symphony builds itself
 
-Phase 0 also includes real smoke testing against the live `sociotechnica-org/symphony-ts` repository.
+What's planned:
 
-## Current Constraints
-
-- The Phase 0 GitHub bootstrap tracker is intended for a single local Symphony instance.
-- Issue claiming is label-based and not atomic across multiple independent orchestrators.
-- Remote execution backends are not implemented yet.
-- Beads is not integrated yet.
+- Linear tracker adapter
+- Remote worker backends (Devin, NiteShift, remote dev boxes)
+- Multi-instance coordination
+- Operator agent for factory-level oversight
+- Dashboard UI beyond terminal status
 
 ## Documentation
 
-Start here:
-
-- [docs/architecture.md](docs/architecture.md)
-- [docs/golden-principles.md](docs/golden-principles.md)
-- [AGENTS.md](AGENTS.md)
-
-Plans and ADRs live in:
-
-- [`docs/plans/`](docs/plans/)
-- [`docs/adrs/`](docs/adrs/)
+- [Architecture](docs/architecture.md) — layer boundaries and spec mapping
+- [Golden Principles](docs/golden-principles.md) — implementation rules
+- [AGENTS.md](AGENTS.md) — guidance for AI agents working in this repo
+- [Self-Hosting Loop](docs/guides/self-hosting-loop.md) — how Symphony builds itself
+- [Plans](docs/plans/) — issue-specific implementation plans
+- [ADRs](docs/adrs/) — architecture decision records
 
 ## References
 
-- Symphony spec: <https://github.com/openai/symphony>
-- Symphony spec document: <https://github.com/openai/symphony/blob/main/SPEC.md>
-- Harness Engineering post: <https://openai.com/index/harness-engineering/>
-- Main project issue: <https://github.com/sociotechnica-org/company/issues/34>
-- Phase 0 issue: <https://github.com/sociotechnica-org/company/issues/35>
-- Beads: <https://github.com/steveyegge/beads>
-- Context Library: <https://github.com/sociotechnica-org/context-library>
-- Previous implementation attempt: <https://github.com/sociotechnica-org/symphony-ts-opus>
+- [Symphony spec](https://github.com/openai/symphony) ([SPEC.md](https://github.com/openai/symphony/blob/main/SPEC.md))
+- [Harness Engineering](https://openai.com/index/harness-engineering/) — OpenAI's post on the approach

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 
 - **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
 - **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) and pluggable workers (local Codex today, remote workers planned). Swap any layer without touching the others.
-- **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear). Run multiple factory instances with no centralized coordination.
+- **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear) instead of a separate control plane. Today's bootstrap runtime is designed for one local factory instance; broader multi-instance coordination is planned.
 - **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
 - **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.
 
 ## Quick Start
+
+**Prerequisites:** Node.js 20+, `pnpm`, `git`, [`gh`](https://cli.github.com/) (authenticated), and [`codex`](https://github.com/openai/codex) installed locally.
 
 ```bash
 git clone https://github.com/sociotechnica-org/symphony-ts.git
 cd symphony-ts
 pnpm install
 ```
-
-**Prerequisites:** Node.js 20+, `pnpm`, `git`, [`gh`](https://cli.github.com/) (authenticated), and [`codex`](https://github.com/openai/codex) installed locally.
 
 Your target repo needs three labels: `symphony:ready`, `symphony:running`, `symphony:failed`.
 
@@ -105,6 +105,7 @@ agent:
 | `polling.interval_ms`          | How often to check for new work                                |
 | `polling.max_concurrent_runs`  | Local concurrency cap                                          |
 | `workspace.root`               | Where isolated workspaces are created                          |
+| `workspace.repo_url`           | SSH or HTTPS URL of the repository cloned for each workspace   |
 | `workspace.branch_prefix`      | Issue branch naming prefix                                     |
 | `agent.command`                | Subprocess command to launch the coding agent                  |
 | `agent.timeout_ms`             | Max wall-clock time per agent run                              |

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 **What makes symphony-ts different:**
 
 - **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
-- **Adapter pattern for everything.** Pluggable trackers (GitHub today, Linear planned) and pluggable workers (local Codex today, remote workers planned). Swap any layer without touching the others.
-- **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in GitHub Issues itself. Run multiple factory instances with no centralized coordination.
+- **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) and pluggable workers (local Codex today, remote workers planned). Swap any layer without touching the others.
+- **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear). Run multiple factory instances with no centralized coordination.
 - **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
 - **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.
 
@@ -112,9 +112,9 @@ agent:
 
 The prompt template below the YAML front matter uses Liquid syntax with access to `issue`, `config`, and `pull_request` variables. See the checked-in [`WORKFLOW.md`](WORKFLOW.md) for the full template.
 
-### Linear Workflow Config Example
+### Linear Tracker
 
-Workflow loading also supports a Linear tracker config shape for upcoming adapter work:
+Symphony also supports Linear as a tracker. Set `tracker.kind: linear` in your `WORKFLOW.md`:
 
 ```yaml
 tracker:
@@ -134,7 +134,7 @@ tracker:
     - Done
 ```
 
-In this slice, `loadWorkflow` validates and normalizes that config, but `symphony run` still requires the GitHub bootstrap tracker until the Linear adapter lands.
+The Linear adapter supports project-scoped GraphQL polling, paginated issue reads, issue comment writes, a Symphony-owned workpad section in the issue description, and state transitions through the tracker edge. Integration tests use a mock Linear GraphQL server, so no real Linear workspace is required to run the test suite.
 
 ## Architecture
 
@@ -146,7 +146,7 @@ Symphony follows the [Symphony spec](https://github.com/openai/symphony/blob/mai
 | Configuration | `src/config/` — YAML + Liquid parsing                     | —                                     |
 | Coordination  | `src/orchestrator/` — polling, retries, reconciliation    | —                                     |
 | Execution     | `src/runner/` + `src/workspace/` — agent subprocess + git | Yes — change `agent.command`          |
-| Integration   | `src/tracker/` — GitHub bootstrap adapter                 | Yes — implement a new tracker adapter |
+| Integration   | `src/tracker/` — GitHub and Linear adapters               | Yes — implement a new tracker adapter |
 | Observability | `src/observability/` — structured logs + status           | —                                     |
 
 ### Repository Map
@@ -161,7 +161,7 @@ src/
   observability/             Structured logging
   orchestrator/              Polling, retries, dispatch
   runner/                    Codex subprocess execution
-  tracker/                   GitHub bootstrap tracker
+  tracker/                   GitHub and Linear tracker adapters
   workspace/                 Local git workspace management
 tests/
   unit/                      Small contract tests
@@ -205,20 +205,20 @@ Tests run in three layers: unit tests for pure logic, integration tests for adap
 
 ## Status & Roadmap
 
-**Current phase: 1.2** — single local instance, GitHub Issues tracker, local Codex runner.
+**Current phase: 1.2** — single local instance, GitHub Issues and Linear trackers, local Codex runner.
 
 What works today:
 
-- Full issue lifecycle from `symphony:ready` through merge-ready PR
+- Full issue lifecycle from ready through merge-ready PR
+- GitHub Issues and Linear tracker adapters
 - Plan review station with human approval gate
 - CI and automated review follow-up loop
 - Orphaned run recovery on restart
-- Local factory status surface
+- Local factory status surface and per-issue reporting
 - Self-hosting: Symphony builds itself
 
 What's planned:
 
-- Linear tracker adapter
 - Remote worker backends (Devin, NiteShift, remote dev boxes)
 - Multi-instance coordination
 - Operator agent for factory-level oversight

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -1,0 +1,102 @@
+# The Self-Hosting Loop: Using Symphony to Build Symphony
+
+Symphony runs against the `symphony-ts` GitHub repo and works `symphony-ts` issues by opening PRs back to that same repo. This is how we develop it.
+
+## Setup
+
+### 1. Prepare the local machine
+
+Make sure these are installed and configured:
+
+- `pnpm`
+- `git`
+- `gh auth login`
+- `codex`
+
+Then install repo dependencies:
+
+```bash
+pnpm install
+```
+
+### 2. Confirm the workflow targets this repo
+
+The checked-in `WORKFLOW.md` should point at:
+
+- `tracker.repo: sociotechnica-org/symphony-ts`
+- `workspace.repo_url: git@github.com:sociotechnica-org/symphony-ts.git`
+- `agent.command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`
+
+That means the local orchestrator will poll the real `symphony-ts` GitHub repo and create issue branches inside local workspaces cloned from that same repository.
+
+### 3. Create a real GitHub issue
+
+Open an issue at <https://github.com/sociotechnica-org/symphony-ts/issues>.
+
+Describe the task normally. Then add the label `symphony:ready` — that's the dispatch signal.
+
+### 4. Start Symphony locally
+
+Run one poll cycle:
+
+```bash
+pnpm tsx bin/symphony.ts run --once
+```
+
+Or run the worker continuously:
+
+```bash
+pnpm tsx bin/symphony.ts run
+```
+
+In continuous mode, Symphony will keep polling for additional ready issues.
+
+During or after a run, Symphony writes the latest derived status snapshot to `.tmp/status.json`. The `status` CLI reads that file and renders either a simple terminal view or the raw JSON contract for future tooling.
+
+### 5. Watch the issue lifecycle
+
+When Symphony picks up the issue, it should:
+
+1. Replace `symphony:ready` with `symphony:running`
+2. Create or reuse a local workspace under `./.tmp/workspaces/`
+3. Create branch `symphony/<issue-number>`
+4. Have the worker draft the technical plan and stop at the human review station unless plan approval is waived
+5. Run Codex implementation work from the approved or waived plan
+6. Push the branch
+7. Open a PR against `main`
+8. Keep polling that PR for CI and automated review state
+9. Push follow-up commits on the same branch until the PR is actually clean
+
+If the PR reaches a clean merge-ready state, Symphony will comment on the issue and close it.
+
+If the run fails, Symphony will either retry it in the running loop or mark it `symphony:failed`.
+
+### 6. Review and merge the PR
+
+Symphony owns the local PR follow-through loop:
+
+- Wait for CI and automated review checks
+- Detect actionable review feedback
+- Push follow-up commits when the PR needs more work
+- Stop only when the PR is actually clean
+
+Human merge remains a separate repository action once the PR is ready.
+
+That merged PR becomes the new version of Symphony that will work the next issue.
+
+### 7. Repeat
+
+Create the next `symphony-ts` issue, label it `symphony:ready`, and run Symphony again.
+
+That is the self-hosting loop:
+
+1. Symphony works a `symphony-ts` issue
+2. Symphony opens a PR into `symphony-ts`
+3. The PR merges
+4. The improved Symphony is used on the next `symphony-ts` issue
+
+## Practical Notes
+
+- Run only one local Symphony instance against this repo at a time (Phase 1.2 constraint).
+- If you want to inspect a failed run, set `workspace.cleanup_on_success: false` temporarily or inspect the workspace before the next retry.
+- Use `--once` when you want tight control over one issue at a time.

--- a/docs/plans/update-readme/plan.md
+++ b/docs/plans/update-readme/plan.md
@@ -42,15 +42,15 @@ Six comparable OSS projects were evaluated. Key takeaways:
 
 ### Patterns That Work Across the Best READMEs
 
-| Pattern | Where it works |
-|---------|---------------|
-| One-line value prop at the very top | agent-orchestrator, agentsview |
-| "Why" / problem statement section | agent-orchestrator, CAR |
-| Copy-pasteable quickstart with < 5 commands | agent-orchestrator, agentsview, otter-camp |
-| Plugin/adapter table showing extensibility | agent-orchestrator |
-| Concrete config example | agent-orchestrator |
-| Project structure / repo map for contributors | agentsview, Attractor |
-| Separate detailed docs linked from README | background-agents, Attractor |
+| Pattern                                       | Where it works                             |
+| --------------------------------------------- | ------------------------------------------ |
+| One-line value prop at the very top           | agent-orchestrator, agentsview             |
+| "Why" / problem statement section             | agent-orchestrator, CAR                    |
+| Copy-pasteable quickstart with < 5 commands   | agent-orchestrator, agentsview, otter-camp |
+| Plugin/adapter table showing extensibility    | agent-orchestrator                         |
+| Concrete config example                       | agent-orchestrator                         |
+| Project structure / repo map for contributors | agentsview, Attractor                      |
+| Separate detailed docs linked from README     | background-agents, Attractor               |
 
 ### Anti-Patterns to Avoid
 
@@ -126,18 +126,18 @@ Six comparable OSS projects were evaluated. Key takeaways:
 
 ### Justification for Each Section
 
-| Section | Why it exists |
-|---------|--------------|
-| **Tagline + expansion** | The #1 failure mode is people bouncing because they can't figure out what the project does in 10 seconds. Every good README opens with this. |
-| **Why Symphony?** | This is where the passion and vision live. Your "visible factory" framing is compelling and differentiating. Without this, symphony-ts looks like "yet another agent orchestrator." This section is what makes people star the repo. |
-| **Quick Start** | If someone is intrigued by the pitch, the next question is "can I try it?" Every top-ranked README has this within the first scroll. Must be self-contained, concrete, and < 5 commands. |
-| **How It Works** | After trying it, people want a mental model. The current README's lifecycle description is good but buried. Pull it up, tighten it, add a simple flow diagram if possible. |
-| **Configuration** | Shows the project is configurable without being complex. The WORKFLOW.md concept is a differentiator — "your entire factory config is one markdown file." |
-| **Architecture** | The adapter/plugin table is the single most effective element from agent-orchestrator's README. It signals extensibility and invites contribution. The repo map helps contributors orient. |
-| **Development** | Standard for any OSS project. People need to know how to run the local gate before contributing. |
-| **Status & Roadmap** | Honest about what works and what doesn't. Prevents wasted time from people expecting features that don't exist yet. Also signals active development. |
-| **Documentation** | Consolidates links. Prevents the README from trying to be all docs at once. |
-| **License** | Standard. Currently missing from the README. |
+| Section                 | Why it exists                                                                                                                                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Tagline + expansion** | The #1 failure mode is people bouncing because they can't figure out what the project does in 10 seconds. Every good README opens with this.                                                                                         |
+| **Why Symphony?**       | This is where the passion and vision live. Your "visible factory" framing is compelling and differentiating. Without this, symphony-ts looks like "yet another agent orchestrator." This section is what makes people star the repo. |
+| **Quick Start**         | If someone is intrigued by the pitch, the next question is "can I try it?" Every top-ranked README has this within the first scroll. Must be self-contained, concrete, and < 5 commands.                                             |
+| **How It Works**        | After trying it, people want a mental model. The current README's lifecycle description is good but buried. Pull it up, tighten it, add a simple flow diagram if possible.                                                           |
+| **Configuration**       | Shows the project is configurable without being complex. The WORKFLOW.md concept is a differentiator — "your entire factory config is one markdown file."                                                                            |
+| **Architecture**        | The adapter/plugin table is the single most effective element from agent-orchestrator's README. It signals extensibility and invites contribution. The repo map helps contributors orient.                                           |
+| **Development**         | Standard for any OSS project. People need to know how to run the local gate before contributing.                                                                                                                                     |
+| **Status & Roadmap**    | Honest about what works and what doesn't. Prevents wasted time from people expecting features that don't exist yet. Also signals active development.                                                                                 |
+| **Documentation**       | Consolidates links. Prevents the README from trying to be all docs at once.                                                                                                                                                          |
+| **License**             | Standard. Currently missing from the README.                                                                                                                                                                                         |
 
 ## Sections to Remove or Relocate
 

--- a/docs/plans/update-readme/plan.md
+++ b/docs/plans/update-readme/plan.md
@@ -1,0 +1,187 @@
+# Plan: Rewrite README for External Audiences
+
+## Goal
+
+Rewrite `README.md` so that someone encountering symphony-ts for the first time can understand what it is, why it exists, how to run it, and how to extend it — in that order. The current README is accurate but written for an insider who already knows the project. The new README should sell the vision, then teach.
+
+## Competitive README Analysis
+
+Six comparable OSS projects were evaluated. Key takeaways:
+
+### Ranking (best to worst)
+
+1. **agent-orchestrator** (ComposioHQ) — Best overall README
+   - **Pros:** Opens with a one-line value prop + concrete tagline. "Why" section that names the pain. Clean CLI reference. Plugin table shows extensibility at a glance. YAML config example is immediately copy-pasteable. Progressive disclosure: quick start → how it works → config → CLI → why → dev.
+   - **Cons:** Slightly long. The "Why" section could be higher.
+   - **Lesson:** Lead with the pitch, show the plugin surface, make config concrete.
+
+2. **agentsview** (wesm) — Excellent install-to-value README
+   - **Pros:** One-liner that says exactly what it does. Curl-install one-liner. Keyboard shortcuts table signals polish. Feature list is tight and scannable. Project structure section helps contributors orient fast.
+   - **Cons:** No "why" / motivation section. No architecture diagram. Narrow scope (viewer, not orchestrator) so less comparable.
+   - **Lesson:** Ruthless brevity works. Keyboard shortcut tables and feature lists signal maturity.
+
+3. **codex-autorunner (CAR)** — Strong philosophy, weaker onboarding
+   - **Pros:** "Tickets as code" concept is memorable and well-explained. Philosophy section ("bitter-lesson-pilled") gives personality. Multiple interaction patterns (Web, CLI, Chat, PMA) are clearly laid out.
+   - **Cons:** Quickstart is vague ("pass the setup guide to any AI agent"). No concrete install commands. Architecture section defers to external docs without a summary.
+   - **Lesson:** A strong conceptual hook matters, but you still need concrete install steps.
+
+4. **connect-the-bots (Attractor)** — Technically impressive, hard to grok
+   - **Pros:** Verification architecture section is thorough. Feature list is comprehensive. Dual-license clearly stated. Cargo install is simple.
+   - **Cons:** Opens with "DOT-based pipeline runner" — too implementation-focused for a first line. The six verification layers are detailed but overwhelming upfront. No "why" section. Hard to understand what you'd use it for without reading deeply.
+   - **Lesson:** Technical depth is great, but bury it below the pitch and quickstart.
+
+5. **background-agents** (ColeMurray) — Good architecture docs, poor entry point
+   - **Pros:** Security architecture section is honest and thorough. Package table is clean. Links to separate detailed docs (SETUP_GUIDE, HOW_IT_WORKS, AUTOMATIONS).
+   - **Cons:** Opens with a feature bullet list instead of a value prop. Security warnings dominate the top of the README. No quickstart in the README itself — defers to separate files. Hard to tell if this is for you without clicking through.
+   - **Lesson:** Don't lead with caveats. Separate docs are fine but the README needs a self-contained quickstart.
+
+6. **otter-camp** (samhotchkiss) — Functional but flat
+   - **Pros:** Docker quickstart is concrete and copy-pasteable. Environment variable table is comprehensive.
+   - **Cons:** No explanation of what it actually does beyond "self-hosted AI team coordination platform." No architecture overview, no "why," no feature list. Jumps straight into `docker compose` without motivation. Reads like internal ops docs.
+   - **Lesson:** Even a great quickstart fails if people don't know why they should care.
+
+### Patterns That Work Across the Best READMEs
+
+| Pattern | Where it works |
+|---------|---------------|
+| One-line value prop at the very top | agent-orchestrator, agentsview |
+| "Why" / problem statement section | agent-orchestrator, CAR |
+| Copy-pasteable quickstart with < 5 commands | agent-orchestrator, agentsview, otter-camp |
+| Plugin/adapter table showing extensibility | agent-orchestrator |
+| Concrete config example | agent-orchestrator |
+| Project structure / repo map for contributors | agentsview, Attractor |
+| Separate detailed docs linked from README | background-agents, Attractor |
+
+### Anti-Patterns to Avoid
+
+- Opening with implementation details instead of value prop (Attractor)
+- Leading with security warnings or caveats (background-agents)
+- Deferring quickstart to separate files (background-agents)
+- No "why" section at all (otter-camp, agentsview)
+- Vague quickstart that doesn't show actual commands (CAR)
+
+## Proposed README Structure
+
+```
+# symphony-ts
+
+{one-line tagline: what it is + what it does}
+
+{2-3 sentence expansion: the vision, the pain it solves}
+
+## Why Symphony?
+
+{The problem: babysitting tickets across multiple agents is unmanageable.
+ The insight: OpenAI's Symphony spec nailed the right abstraction layers.
+ The solution: a local-first, pluggable orchestrator that makes the factory visible.}
+
+{Bullet list of what makes it different:}
+- Runs locally — no hosted infrastructure
+- Adapter pattern — pluggable trackers and workers
+- State lives in the tracker — no centralized state, multiple instances stay in sync
+- Visibility — see what every worker is doing
+- Self-hosting — Symphony builds itself
+
+## Quick Start
+
+{4-5 concrete, copy-pasteable commands from clone to first run}
+
+## How It Works
+
+{Concise lifecycle description: issue → claim → branch → plan review → implement → PR → follow-up → done}
+{Keep this to ~10-15 lines max, link to architecture.md for depth}
+
+## Configuration
+
+{Show WORKFLOW.md structure briefly}
+{Key fields table}
+{Link to full WORKFLOW.md reference}
+
+## Architecture
+
+{Plugin/adapter table showing what's swappable:}
+| Layer | Current Default | Alternatives |
+|-------|----------------|--------------|
+| Tracker | GitHub Issues | (Linear planned) |
+| Runner | Local Codex CLI | (Remote workers planned) |
+| Workspace | Local git clone | — |
+
+{Repo map (keep existing one, it's good)}
+
+## Development
+
+{Install, lint, typecheck, test — the local gate}
+
+## Current Status & Roadmap
+
+{What phase we're in, what works today, what's next}
+{Link to relevant issues/milestones}
+
+## Documentation
+
+{Links to architecture.md, golden-principles.md, AGENTS.md, plans/, adrs/}
+
+## License
+```
+
+### Justification for Each Section
+
+| Section | Why it exists |
+|---------|--------------|
+| **Tagline + expansion** | The #1 failure mode is people bouncing because they can't figure out what the project does in 10 seconds. Every good README opens with this. |
+| **Why Symphony?** | This is where the passion and vision live. Your "visible factory" framing is compelling and differentiating. Without this, symphony-ts looks like "yet another agent orchestrator." This section is what makes people star the repo. |
+| **Quick Start** | If someone is intrigued by the pitch, the next question is "can I try it?" Every top-ranked README has this within the first scroll. Must be self-contained, concrete, and < 5 commands. |
+| **How It Works** | After trying it, people want a mental model. The current README's lifecycle description is good but buried. Pull it up, tighten it, add a simple flow diagram if possible. |
+| **Configuration** | Shows the project is configurable without being complex. The WORKFLOW.md concept is a differentiator — "your entire factory config is one markdown file." |
+| **Architecture** | The adapter/plugin table is the single most effective element from agent-orchestrator's README. It signals extensibility and invites contribution. The repo map helps contributors orient. |
+| **Development** | Standard for any OSS project. People need to know how to run the local gate before contributing. |
+| **Status & Roadmap** | Honest about what works and what doesn't. Prevents wasted time from people expecting features that don't exist yet. Also signals active development. |
+| **Documentation** | Consolidates links. Prevents the README from trying to be all docs at once. |
+| **License** | Standard. Currently missing from the README. |
+
+## Sections to Remove or Relocate
+
+From the current README:
+
+- **"How to Use Symphony to Build Symphony"** — Move to a separate doc (e.g., `docs/self-hosting.md` or `docs/guides/building-symphony-with-symphony.md`). It's fascinating for contributors but too long for a README. Link to it from the README instead.
+- **"References"** — Keep but move to bottom, trim to essential links only.
+- **"Prerequisites"** — Fold into Quick Start.
+- **"Current Constraints"** — Fold into "Status & Roadmap."
+- **Duplicate Quick Start sections** — The current README has quickstart info in three places. Consolidate.
+
+## Tone Guidance
+
+The current README is accurate and thorough but reads like internal documentation. The new README should:
+
+- Lead with energy and conviction (borrow from your "visible factory" framing)
+- Use "you" language ("Point it at your repo and it starts working issues")
+- Be concrete over abstract ("runs Codex against your codebase" not "executes agent subprocesses")
+- Show, don't tell (config examples, CLI output, lifecycle diagrams)
+- Stay honest about constraints (single-instance, local-only for now)
+
+## Content to Pull From Your "Visible Factory" Notes
+
+These phrases from your notes should be adapted into the README:
+
+- "a way to actually see what's happening" → drives the "Visibility" bullet
+- "no single pane of glass" → drives the "Why" problem statement
+- "software-based orchestrator that sits on top of a bunch of workers" → drives the tagline
+- "runs locally, no hosted infrastructure, no complexity" → drives the "Runs locally" bullet
+- "the entire factory state lives in Linear itself" → drives the "State lives in the tracker" bullet
+- "it builds itself" → becomes a memorable proof point
+- "configure the workflow stages with a single workflow.md document" → drives the Configuration section
+
+## Implementation Steps
+
+1. Draft the new README following the proposed structure above
+2. Extract "How to Use Symphony to Build Symphony" into `docs/guides/self-hosting-loop.md`
+3. Update cross-references (any docs that link to specific README sections)
+4. Add a LICENSE file if one doesn't exist (check current state)
+5. Review the result against the top-ranked competitor READMEs for parity
+
+## Non-Goals
+
+- Rewriting architecture.md or other docs (separate effort)
+- Adding badges, CI status indicators, or contributor graphics (premature for current phase)
+- Creating a project website or landing page
+- Changing any code or configuration


### PR DESCRIPTION
## Summary

Completely redesigned the README to lead with vision and make the project immediately understandable to newcomers. Analyzed six comparable OSS orchestrator projects (agent-orchestrator, agentsview, codex-autorunner, Attractor, background-agents, otter-camp) and applied their best practices to symphony-ts.

## Changes

- **New structure:** Tagline → why Symphony exists → quickstart → how it works → configuration → architecture → development → status & roadmap → documentation
- **Extracted long guide:** "How to Use Symphony to Build Symphony" moved to `docs/guides/self-hosting-loop.md` (preserve content, improve README focus)
- **Added "Why Symphony?" section:** Frames the problem (no visibility into multi-agent work), the insight (Symphony spec's abstraction layers), and differentiators (local-first, adapter pattern, tracker-based state, visibility, self-hosting)
- **Simplified quickstart:** 3 copy-pasteable commands from clone to first run
- **Added architecture layer table:** Shows what's swappable (tracker adapter, runner command, policy layer) and what's fixed
- **Plan document:** Detailed competitive analysis and justification for each section in `docs/plans/update-readme/plan.md`

The new README speaks to external audiences first (why they should care, what problems it solves) while keeping all necessary technical depth.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>