### PR TITLE
Add Claude Code configuration symlinks

### DIFF
--- a/.claude/commands/symphony-operator.md
+++ b/.claude/commands/symphony-operator.md
@@ -1,0 +1,1 @@
+../../skills/symphony-operator/SKILL.md

--- a/.claude/commands/symphony-plan.md
+++ b/.claude/commands/symphony-plan.md
@@ -1,0 +1,1 @@
+../../skills/symphony-plan/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Enable Claude Code to use project instructions and skills alongside Codex setup by creating symlinks:
- `CLAUDE.md` → `AGENTS.md` (project instructions)
- `.claude/commands/` → symlinked skills (symphony-operator, symphony-plan)

Both tools now share the same source files, eliminating duplication and keeping guidance synchronized.

## Test plan

- [ ] Verify `/symphony-operator` and `/symphony-plan` slash commands are available
- [ ] Confirm CLAUDE.md loads project instructions in Claude Code

🤖 Generated with Claude Code