### PR TITLE
fix: handle plan-ready protocol mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,10 +101,11 @@ Plan approval is a required workflow handoff and is the repo-owned human review 
 
 When a worker posts the `plan-ready` handoff comment, it should include:
 
-1. the plan path,
-2. a short summary,
-3. a short note that replies must begin with an accepted review marker,
-4. and copy-pasteable fenced markdown templates for the review reply.
+1. the exact first line `Plan status: plan-ready`,
+2. the plan path,
+3. a short summary,
+4. a short note that replies must begin with an accepted review marker,
+5. and copy-pasteable fenced markdown templates for the review reply.
 
 Accepted first-line review markers are:
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -83,6 +83,7 @@ Rules:
 
 When posting the `plan-ready` handoff comment, include:
 
+- the exact first line `Plan status: plan-ready`
 - the plan path
 - a short summary
 - a brief note that replies must start with one of the accepted review markers

--- a/docs/plans/061-plan-ready-protocol-mismatch/plan.md
+++ b/docs/plans/061-plan-ready-protocol-mismatch/plan.md
@@ -1,0 +1,61 @@
+# Issue 61 Plan: Fix Plan-Ready Protocol Mismatch
+
+## Status
+
+`approved`
+
+## Goal
+
+Make the plan-review handoff robust by ensuring the worker and tracker parser agree on the canonical `plan-ready` marker and by accepting the currently emitted `Plan ready for review.` wording as a compatible input.
+
+## Scope
+
+1. update the tracker-side parser to recognize the legacy/emitted `Plan ready for review.` first line as `plan-ready`
+2. normalize worker-facing protocol text so the canonical first line is `Plan status: plan-ready`
+3. add unit and integration coverage for both accepted `plan-ready` forms
+4. keep review decision markers unchanged
+
+## Non-goals
+
+1. changing `approved`, `changes-requested`, or `waived` markers
+2. redesigning the full plan-review UX or branch-push flow
+3. changing orchestrator retry/requeue semantics beyond making the handoff detectable
+
+## Spec / Layer Mapping
+
+- Policy: accepted `plan-ready` marker semantics
+- Configuration: none
+- Coordination: no new orchestrator state shape; only restore correct entry into existing `awaiting-plan-review`
+- Execution: none
+- Integration: tracker comment parsing at the edge
+- Observability: tests only
+
+## Architecture Boundaries
+
+- Tracker policy owns normalization of equivalent comment markers into `plan-ready`.
+- Worker-facing prompts/docs must emit the canonical marker consistently.
+- Orchestrator should continue to consume normalized `awaiting-plan-review`, not raw comment strings.
+
+## Implementation Steps
+
+1. extend `parsePlanReviewComment` to accept both canonical and legacy `plan-ready` first lines
+2. tighten prompt/docs text so plan-ready examples use `Plan status: plan-ready`
+3. add unit tests for both recognized forms
+4. add integration coverage that the legacy marker still yields `awaiting-plan-review`
+
+## Tests And Acceptance
+
+1. unit: both `Plan status: plan-ready` and `Plan ready for review.` parse as `plan-ready`
+2. integration: issue comments with either marker yield `awaiting-plan-review`
+3. local gate: format, lint, typecheck, test
+
+## Exit Criteria
+
+1. runtime no longer fails a valid plan-review handoff because of the legacy first line
+2. worker-facing protocol text consistently uses the canonical marker
+3. tests cover both forms
+
+## Deferred
+
+1. richer plan-review comment UX in `#48`
+2. branch-push/direct-link recoverability in `#53`

--- a/skills/symphony-plan/SKILL.md
+++ b/skills/symphony-plan/SKILL.md
@@ -235,6 +235,7 @@ Use these exact first-line markers for the human reply protocol:
 
 The `plan-ready` issue comment should include:
 
+- the exact first line `Plan status: plan-ready`
 - the plan path
 - a short summary
 - a short note that the review reply must begin with one of the accepted markers

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -50,7 +50,10 @@ function parsePlanReviewComment(
   }
 
   const normalized = firstLine.toLowerCase();
-  if (normalized === "plan status: plan-ready") {
+  if (
+    normalized === "plan status: plan-ready" ||
+    normalized === "plan ready for review."
+  ) {
     return { signal: "plan-ready", comment };
   }
   if (normalized === "plan review: changes-requested") {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -109,6 +109,20 @@ describe("GitHubBootstrapTracker", () => {
     expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
+  it("reports awaiting-plan-review for the legacy plan-ready wording", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      body: "Plan ready for review.\n\nWaiting for human review.",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
+  });
+
   it("resumes from missing once a plan review is approved", async () => {
     const tracker = createTracker(server);
 

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -37,6 +37,23 @@ describe("plan-review-policy", () => {
     expect(lifecycle?.kind).toBe("awaiting-plan-review");
   });
 
+  it("waits when the latest relevant signal uses the legacy plan-ready marker", () => {
+    const lifecycle = evaluatePlanReviewLifecycle(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment("some other comment", "2026-03-07T10:00:00.000Z", 1),
+        comment(
+          "Plan ready for review.\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
+      ],
+    );
+
+    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+  });
+
   it("does not wait when a later approval exists", () => {
     const lifecycle = evaluatePlanReviewLifecycle(
       "symphony/32",


### PR DESCRIPTION
Closes #61.

## Summary
- accept both the canonical `Plan status: plan-ready` marker and the currently emitted legacy `Plan ready for review.` marker
- tighten worker-facing docs so the canonical first line is explicit everywhere
- add unit and integration coverage for both accepted `plan-ready` forms

## Validation
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- codex review --base origin/main
