### PR TITLE
feat: generate per-issue reports from local artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Per-issue reporting artifacts are also written locally under
 for one issue (`issue.json`, `events.jsonl`, per-attempt snapshots,
 per-session snapshots, and log pointers) so later report generation can read
 local state without coupling itself to orchestrator control flow.
+Generated per-issue reports are written separately under
+`.var/reports/issues/<issue-number>/report.json` and `report.md`.
 
 ## Technical Plan Review Station
 
@@ -142,6 +144,12 @@ Print the machine-readable snapshot:
 pnpm tsx bin/symphony.ts status --json
 ```
 
+Generate a per-issue report from local artifacts:
+
+```bash
+pnpm tsx bin/symphony-report.ts issue --issue 44
+```
+
 By default, the checked-in `WORKFLOW.md` targets:
 
 - repo: `sociotechnica-org/symphony-ts`
@@ -210,6 +218,8 @@ The `status` CLI reads that file and renders either a simple terminal view or th
 for future tooling.
 Issue-level reporting artifacts are written separately under `.var/factory/issues/`
 so they survive workspace cleanup.
+Generated per-issue reports are written under `.var/reports/issues/<issue-number>/`
+when `pnpm tsx bin/symphony-report.ts issue --issue <issue-number>` is run.
 
 ### 5. Watch the issue lifecycle
 

--- a/bin/symphony-report.ts
+++ b/bin/symphony-report.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { runReportCli } from "../src/cli/report.js";
+
+runReportCli(process.argv).catch((error: Error) => {
+  process.stderr.write(`${error.name}: ${error.message}\n`);
+  if (error.stack) {
+    process.stderr.write(`${error.stack}\n`);
+  }
+  process.exit(1);
+});

--- a/bin/symphony-report.ts
+++ b/bin/symphony-report.ts
@@ -2,9 +2,8 @@
 import { runReportCli } from "../src/cli/report.js";
 
 runReportCli(process.argv).catch((error: Error) => {
-  process.stderr.write(`${error.name}: ${error.message}\n`);
-  if (error.stack) {
-    process.stderr.write(`${error.stack}\n`);
-  }
+  process.stderr.write(
+    error.stack ? `${error.stack}\n` : `${error.name}: ${error.message}\n`,
+  );
   process.exit(1);
 });

--- a/docs/plans/044-generate-per-issue-reports-from-local-artifacts/plan.md
+++ b/docs/plans/044-generate-per-issue-reports-from-local-artifacts/plan.md
@@ -1,0 +1,307 @@
+# Issue 44 Plan: Generate Per-Issue Reports From Local Artifacts
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Add a read-only CLI at `bin/symphony-report.ts` that reads the canonical local issue artifacts from `#43`, derives one canonical generated report document (`report.json`), renders a human-readable markdown companion (`report.md`), and writes both under `.var/reports/issues/<issue-number>/` without embedding report composition into the orchestrator runtime.
+
+## Scope
+
+This slice covers:
+
+1. a canonical generated report schema for `report.json`
+2. a markdown rendering contract for `report.md` with the required stable section names
+3. read-side observability services that load issue artifacts, derive report facts, and write generated outputs
+4. a standalone CLI/script with command shape `pnpm tsx bin/symphony-report.ts issue --issue <issue-number>`
+5. tests that prove reports generate for completed and failed issues even when some data is unavailable
+6. docs updates for command usage and output locations
+
+## Non-goals
+
+This slice does not include:
+
+1. changing the raw artifact contract introduced in `#43`
+2. publishing reports or raw artifacts to `factory-runs` or any remote destination
+3. making report generation an inline or required orchestrator step
+4. provider-specific token enrichment, pricing tables, or log parsing beyond what canonical local artifacts already expose
+5. defining multi-issue, campaign, or run-digest report formats
+6. refactoring tracker, runner, workspace, or orchestrator control flow unless a narrow read-side seam requires a small helper extraction
+
+## Current Gaps
+
+After `#43`, the runtime writes durable raw issue artifacts under `.var/factory/issues/<issue-number>/...`, but there is no detached report surface yet:
+
+1. operators cannot generate a single per-issue summary from local artifacts
+2. there is no canonical generated report schema for downstream tooling to consume
+3. there is no markdown rendering that keeps the useful `lifebuild` sections stable across issues
+4. token usage must currently remain explicit about availability gaps because the raw artifact contract does not guarantee provider totals
+5. generated outputs do not yet have a stable repo-local path separate from raw artifacts
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_44/docs/architecture.md).
+
+- Policy Layer: the stable report section names, fallback behavior for unavailable data, and operator-facing conclusions belong here. This issue does not introduce new tracker or orchestration policy.
+- Configuration Layer: if the command needs path resolution helpers, they should stay as typed config/path resolution at the boundary. This issue should not add workflow-frontmatter or runtime config knobs.
+- Coordination Layer: untouched. The orchestrator must remain the producer of raw artifacts, not the composer of reports.
+- Execution Layer: untouched except for existing artifact inputs. Workspace and runner behavior must not change to satisfy report formatting.
+- Integration Layer: read-side loading of normalized local artifacts is allowed; provider-specific enrichment and remote lookups are deferred to `#46`.
+- Observability Layer: owns the generated report schema, artifact readers, derivation pipeline, markdown rendering, output-path helpers, and the standalone CLI/service surface.
+
+## Architecture Boundaries
+
+### Observability
+
+Belongs here:
+
+1. typed `report.json` contract and report derivation result types
+2. readers for canonical local issue artifacts produced by `#43`
+3. deterministic output paths under `.var/reports/issues/<issue-number>/`
+4. markdown rendering from canonical report facts
+5. explicit availability states for token usage and other incomplete sections
+
+Does not belong here:
+
+1. tracker mutations
+2. retry or review-loop decisions
+3. provider-specific network enrichment
+4. any second source of truth that diverges from the raw artifacts
+
+### CLI
+
+Belongs here:
+
+1. argument parsing for the standalone report command
+2. wiring the report generator to the local repository paths
+3. rendering simple success or failure output for operators
+
+Does not belong here:
+
+1. report composition logic inline in argument parsing
+2. orchestrator startup or run-loop side effects
+
+### Orchestrator
+
+Belongs here:
+
+1. nothing new in this issue beyond continuing to emit raw artifacts through existing observability hooks
+
+Does not belong here:
+
+1. calling the report generator inline
+2. emitting markdown or generated report documents
+
+### Tracker / Runner / Workspace
+
+Belongs here:
+
+1. no new responsibilities in this slice
+
+Does not belong here:
+
+1. ad hoc data shims created only to satisfy report rendering
+2. provider-specific token/cost estimation logic at the core layer
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR because it stays on a narrow read-side seam:
+
+1. add report schema, derivation, and rendering under `src/observability/`
+2. add a separate CLI entry point and any small path helpers needed to invoke it
+3. add focused unit/integration/e2e coverage for the report command and generated outputs
+4. update docs for command usage
+
+This PR deliberately defers:
+
+1. provider-specific enrichment and token parsing from external logs to `#46`
+2. remote publication or archival upload
+3. multi-issue digest composition
+4. any raw artifact schema expansion unless an omission blocks basic report generation and is approved separately
+
+The seam is reviewable because it adds a pure read-side observability consumer over the existing `#43` contract without reopening orchestrator coordination logic.
+
+## Report Data Model
+
+Add a generated report contract rooted at:
+
+```text
+.var/reports/
+  issues/
+    <issue-number>/
+      report.json
+      report.md
+```
+
+### `report.json`
+
+`report.json` is canonical and versioned. It should include these top-level sections:
+
+1. `summary`
+2. `timeline`
+3. `githubActivity`
+4. `tokenUsage`
+5. `learnings`
+6. `artifacts`
+7. `operatorInterventions`
+
+### Summary contract
+
+The summary section should capture:
+
+1. issue identifier, number, title, repo, and URL
+2. derived final or current outcome
+3. start and end timestamps when derivable
+4. attempt count
+5. PR count
+6. overall conclusion text that stays explicit when data is partial
+
+### Timeline contract
+
+The timeline should be an ordered sequence of major derived events built from `events.jsonl`, attempt snapshots, and issue summary state. It should preserve stable event kinds and include explicit fallback notes when expected transitions are missing from raw artifacts.
+
+### GitHub activity contract
+
+The GitHub activity section should summarize facts derivable from canonical raw artifacts only, such as:
+
+1. PR count and known PR identifiers
+2. latest review and checks snapshots
+3. whether the issue ended awaiting review, succeeded, failed, or needs follow-up
+4. explicit unavailable notes for issue state/label transitions or merged/closed timing when raw artifacts do not capture them yet
+
+### Token usage contract
+
+The token usage section should always include a machine-readable status:
+
+1. `unavailable`
+2. `partial`
+3. `estimated`
+4. `complete`
+
+For this slice, the default expectation is `unavailable` or `partial` unless canonical local artifacts already provide enough facts. The section must also include:
+
+1. an explanation of why totals are unavailable or partial
+2. references to session artifacts and raw log pointers that could support later enrichment
+3. totals only when they can be derived from canonical local artifacts without provider-specific guessing
+
+### Learnings contract
+
+The learnings section should distinguish:
+
+1. evidence-backed observations directly grounded in the raw artifacts
+2. explicit gaps where the report cannot conclude more without richer observability
+
+Initial learnings may be conservative. The goal is an explicit section, not artificial certainty.
+
+### Artifacts contract
+
+The artifacts section should point to:
+
+1. the raw issue artifact directory
+2. `issue.json`, `events.jsonl`, attempts, sessions, and log pointer documents
+3. the generated `report.json` and `report.md` paths
+
+### Operator interventions contract
+
+This section should enumerate manual actions only when they can be derived from canonical local artifacts or recorded as absent/unavailable. It must not infer human actions from provider-specific transport details that are not in the local contract.
+
+## Rendering Rules For `report.md`
+
+`report.md` should be a deterministic rendering of `report.json`, not a separate derivation path. It must always render these sections in this order:
+
+1. `Summary`
+2. `Timeline`
+3. `GitHub Activity`
+4. `Token Usage`
+5. `Learnings`
+6. `Artifacts`
+7. `Operator Interventions`
+
+Markdown should remain readable even when data is missing:
+
+1. explicitly print `Unavailable`, `Partial`, or equivalent explanatory text
+2. keep empty sections from collapsing away
+3. prefer short factual bullets/tables over narrative prose
+
+## State Model / Failure Matrix
+
+This issue does not change long-running orchestration, retries, leases, or reconciliation behavior, so a runtime state machine for orchestrator control flow is not required.
+
+The report generator itself should still handle a small read-side failure matrix:
+
+| Observed condition                                                                                                      | Local facts available                                                                                                                                  | Expected behavior                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Completed or failed issue with a full raw artifact directory                                                            | `issue.json`, `events.jsonl`, attempts, sessions                                                                                                       | Generate both reports successfully                                                                                                                                                                                                                 |
+| Issue artifact directory exists but some optional files are missing                                                     | `issue.json` plus partial attempt/session data                                                                                                         | Generate a partial report with explicit unavailable notes                                                                                                                                                                                          |
+| Canonical orchestrator artifacts are missing or incomplete but canonical issue/session artifacts still anchor the issue | enough canonical local facts to identify the issue, plus session snapshots and/or log pointers, but missing `issue.json` and/or `events.jsonl` details | Generate a partial report with explicit `Unavailable` / `Partial` notes for missing orchestration facts, anchor the report to the issue from remaining canonical artifacts, and do not reconstruct missing facts by parsing provider-specific logs |
+| Token totals are not present in canonical artifacts                                                                     | session files and maybe log pointers only                                                                                                              | Mark token usage `unavailable` or `partial` and reference raw artifacts                                                                                                                                                                            |
+| Generated output directory does not exist yet                                                                           | readable raw artifacts only                                                                                                                            | Create `.var/reports/issues/<issue-number>/` and write outputs                                                                                                                                                                                     |
+| Raw artifact files are malformed                                                                                        | unreadable or invalid JSON/JSONL                                                                                                                       | Fail loudly with an observability/read error and do not mutate runtime state                                                                                                                                                                       |
+| Issue number has no local artifact directory                                                                            | none                                                                                                                                                   | Exit with a clear error that the requested issue report cannot be generated from local artifacts                                                                                                                                                   |
+
+## Implementation Steps
+
+1. Add typed report contracts and output path helpers under `src/observability/`.
+2. Implement a read-only issue artifact loader/aggregator that converts `#43` raw artifacts into a canonical in-memory report model, including fallback anchoring when `issue.json` or `events.jsonl` are incomplete but session or log-pointer artifacts still provide canonical issue identity.
+3. Implement deterministic markdown rendering from that canonical report model.
+4. Implement a report writer that writes `report.json` and `report.md` atomically under `.var/reports/issues/<issue-number>/`.
+5. Add `bin/symphony-report.ts` and the supporting CLI module for `issue --issue <issue-number>`.
+6. Add unit tests for report derivation and markdown rendering.
+7. Add integration-style CLI tests that generate outputs from fixture artifact directories, including the missing-orchestrator-artifact / still-has-session-artifacts case.
+8. Add an end-to-end style test that uses realistic raw artifact fixtures from a completed or failed issue flow and verifies both outputs.
+9. Update `README.md` with the standalone report command and generated output location.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. derives summary, timeline ordering, artifact pointers, and conclusion text from canonical raw artifacts
+2. renders markdown with all required section headings even when data is unavailable
+3. reports token usage status as `unavailable` or `partial` when totals cannot be derived
+4. keeps `report.md` aligned with `report.json` facts rather than recomputing a separate story
+
+### Integration
+
+1. CLI generates `.var/reports/issues/<issue-number>/report.json` and `report.md` for a completed issue fixture
+2. CLI generates readable outputs for a failed issue fixture with partial data
+3. CLI generates a partial report when `issue.json` or `events.jsonl` is missing/incomplete but session artifacts and/or log pointers still canonically anchor the issue
+4. CLI fails clearly when the requested issue has no local artifacts
+
+### End-to-end
+
+1. a realistic local issue artifact tree produced by the current runtime can be fed into `pnpm tsx bin/symphony-report.ts issue --issue <issue-number>` and yields both outputs without mutating raw artifacts
+
+## Acceptance Scenarios
+
+1. Given a completed issue artifact tree, when the operator runs `pnpm tsx bin/symphony-report.ts issue --issue 44`, then `.var/reports/issues/44/report.json` and `.var/reports/issues/44/report.md` are written and the markdown includes `Summary`, `Timeline`, `GitHub Activity`, `Token Usage`, and `Learnings`.
+2. Given a failed issue artifact tree with incomplete token data, when the operator runs the same command, then both outputs are still generated and token status is explicitly `unavailable` or `partial`.
+3. Given canonical session artifacts and/or log pointers for issue `44` but incomplete `issue.json` or `events.jsonl`, when the operator runs the command, then both outputs are still generated, missing orchestration facts are marked `Unavailable` or `Partial`, and the command does not parse provider-specific logs to fill those gaps.
+4. Given a missing local artifact tree, when the operator runs the command, then the command exits with a clear error and does not create misleading report contents.
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. the checked-in plan is approved or explicitly waived
+2. the standalone report command exists and runs independently from `symphony run`
+3. `report.json` is the canonical generated report format with the required top-level sections
+4. `report.md` is rendered from the same underlying report facts and always includes the required stable sections
+5. local tests cover completed, failed, and partial-data report generation
+6. repo docs explain the command and generated output path
+
+## Deferred To Later Issues Or PRs
+
+1. provider-specific token/cost enrichment and log parsing in `#46`
+2. archive publication or `factory-runs` upload
+3. report generation as an optional orchestrator follow-up step, if ever needed
+4. multi-issue or campaign digest reports
+5. richer GitHub state/label transition reporting if the raw local artifact contract grows to include it
+
+## Decision Notes
+
+1. `report.json` is the only canonical generated report. `report.md` is a pure rendering so downstream tooling has one machine-readable source of truth.
+2. The report command stays detached from `symphony run` so observability does not leak back into coordination.
+3. Missing enrichment should be surfaced explicitly instead of guessed from provider-specific logs. That keeps the core command provider-neutral and preserves the raw artifact contract as the source of truth.
+4. Partial generation is preferable to failure when canonical local artifacts still anchor the report to the issue, but missing orchestrator facts must remain visibly missing rather than being reconstructed from provider-specific logs.

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -22,10 +22,10 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   if (issueValue === null) {
     throw new Error("Missing required --issue <number> option");
   }
-  const issueNumber = Number.parseInt(issueValue, 10);
-  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+  if (!/^[1-9]\d*$/u.test(issueValue)) {
     throw new Error(`Invalid issue number: ${issueValue}`);
   }
+  const issueNumber = Number.parseInt(issueValue, 10);
 
   const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
   return {

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+import { loadWorkflow } from "../config/workflow.js";
+import { writeIssueReport } from "../observability/issue-report.js";
+
+export interface ReportCliArgs {
+  readonly command: "issue";
+  readonly issueNumber: number;
+  readonly workflowPath: string;
+}
+
+export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
+  const args = argv.slice(2);
+  const command = args[0];
+
+  if (command !== "issue") {
+    throw new Error(
+      "Usage: symphony-report issue --issue <number> [--workflow <path>]",
+    );
+  }
+
+  const issueValue = readOptionValue(args, "--issue");
+  if (issueValue === null) {
+    throw new Error("Missing value for --issue");
+  }
+  const issueNumber = Number.parseInt(issueValue, 10);
+  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+    throw new Error(`Invalid issue number: ${issueValue}`);
+  }
+
+  const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
+  return {
+    command: "issue",
+    issueNumber,
+    workflowPath: path.resolve(process.cwd(), workflowPath),
+  };
+}
+
+export async function runReportCli(argv: readonly string[]): Promise<void> {
+  const args = parseReportArgs(argv);
+  const workflow = await loadWorkflow(args.workflowPath);
+  const generated = await writeIssueReport(
+    workflow.config.workspace.root,
+    args.issueNumber,
+  );
+  process.stdout.write(
+    `Generated issue report for #${args.issueNumber.toString()}\nreport.json: ${generated.outputPaths.reportJsonFile}\nreport.md: ${generated.outputPaths.reportMarkdownFile}\n`,
+  );
+}
+
+function readOptionValue(args: readonly string[], flag: string): string | null {
+  const index = args.findIndex((arg) => arg === flag);
+  if (index < 0) {
+    return null;
+  }
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -20,7 +20,7 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
 
   const issueValue = readOptionValue(args, "--issue");
   if (issueValue === null) {
-    throw new Error("Missing value for --issue");
+    throw new Error("Missing required --issue <number> option");
   }
   const issueNumber = Number.parseInt(issueValue, 10);
   if (!Number.isInteger(issueNumber) || issueNumber < 1) {

--- a/src/observability/atomic-file.ts
+++ b/src/observability/atomic-file.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+interface AtomicWriteOptions {
+  readonly tempPrefix?: string | undefined;
+}
+
+export async function writeJsonFileAtomic(
+  filePath: string,
+  value: unknown,
+  options?: AtomicWriteOptions,
+): Promise<void> {
+  await writeTextFileAtomic(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    tempPrefix: options?.tempPrefix,
+  });
+}
+
+export async function writeTextFileAtomic(
+  filePath: string,
+  content: string,
+  options?: AtomicWriteOptions,
+): Promise<void> {
+  const directory = path.dirname(filePath);
+  const tempPrefix = options?.tempPrefix ?? ".atomic-write";
+  const tempPath = path.join(
+    directory,
+    `${tempPrefix}.${process.pid.toString()}.${randomUUID()}.tmp`,
+  );
+
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(tempPath, content, "utf8");
+  try {
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -1,7 +1,7 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
 
 export const ISSUE_ARTIFACT_SCHEMA_VERSION = 1 as const;
 
@@ -483,20 +483,9 @@ async function readJsonFile<T>(filePath: string): Promise<T> {
 }
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-  const directory = path.dirname(filePath);
-  const tempPath = path.join(
-    directory,
-    `.issue-artifact.${process.pid.toString()}.${randomUUID()}.tmp`,
-  );
-
-  await fs.mkdir(directory, { recursive: true });
-  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-  try {
-    await fs.rename(tempPath, filePath);
-  } catch (error) {
-    await fs.rm(tempPath, { force: true }).catch(() => undefined);
-    throw error;
-  }
+  await writeJsonFileAtomic(filePath, value, {
+    tempPrefix: ".issue-artifact",
+  });
 }
 
 async function appendJsonLineIfChanged(

--- a/src/observability/issue-report-markdown.ts
+++ b/src/observability/issue-report-markdown.ts
@@ -180,7 +180,7 @@ function renderCurrency(value: number | null): string {
 }
 
 function renderList(values: readonly string[]): string {
-  return values.length === 0 ? "Unavailable" : values.join(", ");
+  return values.length === 0 ? "None" : values.join(", ");
 }
 
 function renderNumberList(values: readonly number[]): string {

--- a/src/observability/issue-report-markdown.ts
+++ b/src/observability/issue-report-markdown.ts
@@ -1,0 +1,190 @@
+import type {
+  IssueReportDocument,
+  IssueReportPullRequestActivity,
+  IssueReportTimelineEntry,
+} from "./issue-report.js";
+
+export function renderIssueReportMarkdown(report: IssueReportDocument): string {
+  const lines: string[] = [];
+
+  lines.push(`# Issue Report: #${report.summary.issueNumber.toString()}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push(
+    `- Issue: ${renderValue(report.summary.issueIdentifier, `#${report.summary.issueNumber.toString()}`)}`,
+  );
+  lines.push(`- Title: ${renderValue(report.summary.title)}`);
+  lines.push(`- Repo: ${renderValue(report.summary.repo)}`);
+  lines.push(`- URL: ${renderValue(report.summary.issueUrl)}`);
+  lines.push(`- Branch: ${renderValue(report.summary.branch)}`);
+  lines.push(`- Outcome: ${renderValue(report.summary.outcome)}`);
+  lines.push(`- Started: ${renderValue(report.summary.startedAt)}`);
+  lines.push(`- Ended: ${renderValue(report.summary.endedAt)}`);
+  lines.push(`- Attempts: ${report.summary.attemptCount.toString()}`);
+  lines.push(`- Pull requests: ${report.summary.pullRequestCount.toString()}`);
+  lines.push(`- Conclusion: ${report.summary.overallConclusion}`);
+  if (report.summary.notes.length > 0) {
+    lines.push("- Notes:");
+    for (const note of report.summary.notes) {
+      lines.push(`  - ${note}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Timeline");
+  if (report.timeline.length === 0) {
+    lines.push("- Unavailable: No major lifecycle events were available.");
+  } else {
+    for (const entry of report.timeline) {
+      lines.push(renderTimelineEntry(entry));
+      for (const detail of entry.details) {
+        lines.push(`  - ${detail}`);
+      }
+    }
+  }
+  lines.push("");
+
+  lines.push("## GitHub Activity");
+  lines.push(
+    `- Issue state transitions: ${report.githubActivity.issueStateTransitionsStatus}`,
+  );
+  lines.push(
+    `- Issue transition note: ${report.githubActivity.issueStateTransitionsNote}`,
+  );
+  lines.push(
+    `- Pull request count: ${report.githubActivity.pullRequests.length.toString()}`,
+  );
+  if (report.githubActivity.pullRequests.length === 0) {
+    lines.push("- Pull requests: Unavailable");
+  } else {
+    for (const pullRequest of report.githubActivity.pullRequests) {
+      lines.push(renderPullRequestActivity(pullRequest));
+    }
+  }
+  lines.push(
+    `- Review rounds: ${report.githubActivity.reviewFeedbackRounds.toString()}`,
+  );
+  lines.push(
+    `- Review-loop summary: ${report.githubActivity.reviewLoopSummary}`,
+  );
+  lines.push(`- Merged at: ${renderValue(report.githubActivity.mergedAt)}`);
+  lines.push(`- Merge note: ${report.githubActivity.mergeNote}`);
+  lines.push(`- Closed at: ${renderValue(report.githubActivity.closedAt)}`);
+  lines.push(`- Close note: ${report.githubActivity.closeNote}`);
+  for (const note of report.githubActivity.notes) {
+    lines.push(`- Note: ${note}`);
+  }
+  lines.push("");
+
+  lines.push("## Token Usage");
+  lines.push(`- Status: ${report.tokenUsage.status}`);
+  lines.push(`- Explanation: ${report.tokenUsage.explanation}`);
+  lines.push(`- Total tokens: ${renderNumber(report.tokenUsage.totalTokens)}`);
+  lines.push(
+    `- Estimated cost (USD): ${renderCurrency(report.tokenUsage.costUsd)}`,
+  );
+  if (report.tokenUsage.sessions.length === 0) {
+    lines.push("- Sessions: Unavailable");
+  } else {
+    for (const session of report.tokenUsage.sessions) {
+      lines.push(
+        `- Session ${session.sessionId}: attempt ${session.attemptNumber.toString()}, agent ${session.provider}${session.model === null ? "" : ` (${session.model})`}, tokens ${renderNumber(session.totalTokens)}, cost ${renderCurrency(session.costUsd)}`,
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push("## Learnings");
+  if (report.learnings.observations.length === 0) {
+    lines.push("- Unavailable: No evidence-backed learnings could be derived.");
+  } else {
+    for (const observation of report.learnings.observations) {
+      lines.push(`- ${observation.title}: ${observation.summary}`);
+      for (const evidence of observation.evidence) {
+        lines.push(`  - ${evidence}`);
+      }
+    }
+  }
+  if (report.learnings.gaps.length === 0) {
+    lines.push("- Gaps: None recorded.");
+  } else {
+    for (const gap of report.learnings.gaps) {
+      lines.push(`- Gap: ${gap}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Artifacts");
+  lines.push(`- Raw issue root: ${report.artifacts.rawIssueRoot}`);
+  lines.push(`- issue.json: ${renderValue(report.artifacts.issueFile)}`);
+  lines.push(`- events.jsonl: ${renderValue(report.artifacts.eventsFile)}`);
+  lines.push(
+    `- attempts/: ${report.artifacts.attemptFiles.length === 0 ? "Unavailable" : report.artifacts.attemptFiles.join(", ")}`,
+  );
+  lines.push(
+    `- sessions/: ${report.artifacts.sessionFiles.length === 0 ? "Unavailable" : report.artifacts.sessionFiles.join(", ")}`,
+  );
+  lines.push(
+    `- log pointers: ${renderValue(report.artifacts.logPointersFile)}`,
+  );
+  lines.push(`- report.json: ${report.artifacts.generatedReportJson}`);
+  lines.push(`- report.md: ${report.artifacts.generatedReportMarkdown}`);
+  if (report.artifacts.missingArtifacts.length > 0) {
+    lines.push(
+      `- Missing artifacts: ${report.artifacts.missingArtifacts.join(", ")}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Operator Interventions");
+  lines.push(`- Status: ${report.operatorInterventions.status}`);
+  lines.push(`- Summary: ${report.operatorInterventions.summary}`);
+  lines.push(`- Note: ${report.operatorInterventions.note}`);
+  if (report.operatorInterventions.entries.length === 0) {
+    lines.push("- Entries: None recorded");
+  } else {
+    for (const entry of report.operatorInterventions.entries) {
+      lines.push(
+        `- ${entry.summary}: ${renderValue(entry.at)} (${entry.kind})`,
+      );
+      for (const detail of entry.details) {
+        lines.push(`  - ${detail}`);
+      }
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function renderTimelineEntry(entry: IssueReportTimelineEntry): string {
+  return `- ${renderValue(entry.at)} | ${entry.title} | ${entry.summary}`;
+}
+
+function renderPullRequestActivity(
+  pullRequest: IssueReportPullRequestActivity,
+): string {
+  return `- PR #${pullRequest.number.toString()}: ${pullRequest.url}; attempts ${renderNumberList(pullRequest.attemptNumbers)}; first observed ${renderValue(pullRequest.firstObservedAt)}; latest commit ${renderValue(pullRequest.latestCommitAt)}; review rounds ${pullRequest.reviewFeedbackRounds.toString()}; actionable ${renderNumber(pullRequest.actionableReviewCount)}; unresolved threads ${renderNumber(pullRequest.unresolvedThreadCount)}; pending checks ${renderList(pullRequest.pendingChecks)}; failing checks ${renderList(pullRequest.failingChecks)}`;
+}
+
+function renderValue(value: string | null, fallback = "Unavailable"): string {
+  return value === null ? fallback : value;
+}
+
+function renderNumber(value: number | null): string {
+  return value === null ? "Unavailable" : value.toString();
+}
+
+function renderCurrency(value: number | null): string {
+  return value === null ? "Unavailable" : value.toFixed(2);
+}
+
+function renderList(values: readonly string[]): string {
+  return values.length === 0 ? "Unavailable" : values.join(", ");
+}
+
+function renderNumberList(values: readonly number[]): string {
+  return values.length === 0
+    ? "Unavailable"
+    : values.map((value) => value.toString()).join(", ");
+}

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -1,0 +1,1388 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
+import type {
+  IssueArtifactAttemptSnapshot,
+  IssueArtifactCheckSnapshot,
+  IssueArtifactEvent,
+  IssueArtifactLogPointersDocument,
+  IssueArtifactOutcome,
+  IssueArtifactPullRequestSnapshot,
+  IssueArtifactReviewSnapshot,
+  IssueArtifactSessionSnapshot,
+  IssueArtifactSummary,
+} from "./issue-artifacts.js";
+import {
+  deriveFactoryRuntimeRoot,
+  deriveIssueArtifactPaths,
+} from "./issue-artifacts.js";
+import { renderIssueReportMarkdown } from "./issue-report-markdown.js";
+
+export const ISSUE_REPORT_SCHEMA_VERSION = 1 as const;
+
+export type IssueReportAvailability = "complete" | "partial" | "unavailable";
+export type IssueReportTokenUsageStatus =
+  | "unavailable"
+  | "partial"
+  | "estimated"
+  | "complete";
+
+export interface IssueReportPaths {
+  readonly issueRoot: string;
+  readonly reportJsonFile: string;
+  readonly reportMarkdownFile: string;
+}
+
+export interface IssueReportSummary {
+  readonly status: IssueReportAvailability;
+  readonly issueNumber: number;
+  readonly issueIdentifier: string | null;
+  readonly repo: string | null;
+  readonly title: string | null;
+  readonly issueUrl: string | null;
+  readonly branch: string | null;
+  readonly outcome: IssueArtifactOutcome | "unknown";
+  readonly startedAt: string | null;
+  readonly endedAt: string | null;
+  readonly attemptCount: number;
+  readonly pullRequestCount: number;
+  readonly overallConclusion: string;
+  readonly notes: readonly string[];
+}
+
+export interface IssueReportTimelineEntry {
+  readonly kind: string;
+  readonly at: string | null;
+  readonly title: string;
+  readonly summary: string;
+  readonly attemptNumber: number | null;
+  readonly sessionId: string | null;
+  readonly details: readonly string[];
+}
+
+export interface IssueReportPullRequestActivity {
+  readonly number: number;
+  readonly url: string;
+  readonly attemptNumbers: readonly number[];
+  readonly firstObservedAt: string | null;
+  readonly latestCommitAt: string | null;
+  readonly reviewFeedbackRounds: number;
+  readonly actionableReviewCount: number | null;
+  readonly unresolvedThreadCount: number | null;
+  readonly pendingChecks: readonly string[];
+  readonly failingChecks: readonly string[];
+}
+
+export interface IssueReportGitHubActivity {
+  readonly status: IssueReportAvailability;
+  readonly issueStateTransitionsStatus: "unavailable";
+  readonly issueStateTransitionsNote: string;
+  readonly pullRequests: readonly IssueReportPullRequestActivity[];
+  readonly reviewFeedbackRounds: number;
+  readonly reviewLoopSummary: string;
+  readonly mergedAt: string | null;
+  readonly mergeNote: string;
+  readonly closedAt: string | null;
+  readonly closeNote: string;
+  readonly notes: readonly string[];
+}
+
+export interface IssueReportTokenUsageSession {
+  readonly sessionId: string;
+  readonly attemptNumber: number;
+  readonly provider: string;
+  readonly model: string | null;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+  readonly sourceArtifacts: readonly string[];
+}
+
+export interface IssueReportTokenUsageAttempt {
+  readonly attemptNumber: number;
+  readonly sessionIds: readonly string[];
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+}
+
+export interface IssueReportTokenUsageAgent {
+  readonly agent: string;
+  readonly sessionCount: number;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+}
+
+export interface IssueReportTokenUsage {
+  readonly status: IssueReportTokenUsageStatus;
+  readonly explanation: string;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+  readonly sessions: readonly IssueReportTokenUsageSession[];
+  readonly attempts: readonly IssueReportTokenUsageAttempt[];
+  readonly agents: readonly IssueReportTokenUsageAgent[];
+  readonly rawArtifacts: readonly string[];
+}
+
+export interface IssueReportLearningItem {
+  readonly title: string;
+  readonly summary: string;
+  readonly evidence: readonly string[];
+}
+
+export interface IssueReportLearnings {
+  readonly status: IssueReportAvailability;
+  readonly observations: readonly IssueReportLearningItem[];
+  readonly gaps: readonly string[];
+}
+
+export interface IssueReportArtifacts {
+  readonly rawIssueRoot: string;
+  readonly issueFile: string | null;
+  readonly eventsFile: string | null;
+  readonly attemptFiles: readonly string[];
+  readonly sessionFiles: readonly string[];
+  readonly logPointersFile: string | null;
+  readonly missingArtifacts: readonly string[];
+  readonly generatedReportJson: string;
+  readonly generatedReportMarkdown: string;
+}
+
+export interface IssueReportOperatorInterventionEntry {
+  readonly kind: "approved" | "waived";
+  readonly at: string | null;
+  readonly summary: string;
+  readonly details: readonly string[];
+}
+
+export interface IssueReportOperatorInterventions {
+  readonly status: IssueReportAvailability;
+  readonly summary: string;
+  readonly entries: readonly IssueReportOperatorInterventionEntry[];
+  readonly note: string;
+}
+
+export interface IssueReportDocument {
+  readonly version: typeof ISSUE_REPORT_SCHEMA_VERSION;
+  readonly generatedAt: string;
+  readonly summary: IssueReportSummary;
+  readonly timeline: readonly IssueReportTimelineEntry[];
+  readonly githubActivity: IssueReportGitHubActivity;
+  readonly tokenUsage: IssueReportTokenUsage;
+  readonly learnings: IssueReportLearnings;
+  readonly artifacts: IssueReportArtifacts;
+  readonly operatorInterventions: IssueReportOperatorInterventions;
+}
+
+interface LoadedIssueArtifacts {
+  readonly issueNumber: number;
+  readonly paths: ReturnType<typeof deriveIssueArtifactPaths>;
+  readonly issue: IssueArtifactSummary | null;
+  readonly events: readonly IssueArtifactEvent[];
+  readonly attempts: readonly IssueArtifactAttemptSnapshot[];
+  readonly sessions: readonly IssueArtifactSessionSnapshot[];
+  readonly logPointers: IssueArtifactLogPointersDocument | null;
+}
+
+export interface GeneratedIssueReport {
+  readonly report: IssueReportDocument;
+  readonly markdown: string;
+  readonly outputPaths: IssueReportPaths;
+}
+
+export function deriveIssueReportsRoot(workspaceRoot: string): string {
+  return path.join(
+    path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
+    "reports",
+    "issues",
+  );
+}
+
+export function deriveIssueReportPaths(
+  workspaceRoot: string,
+  issueNumber: number,
+): IssueReportPaths {
+  const issueRoot = path.join(
+    deriveIssueReportsRoot(workspaceRoot),
+    issueNumber.toString(),
+  );
+  return {
+    issueRoot,
+    reportJsonFile: path.join(issueRoot, "report.json"),
+    reportMarkdownFile: path.join(issueRoot, "report.md"),
+  };
+}
+
+export async function generateIssueReport(
+  workspaceRoot: string,
+  issueNumber: number,
+  options?: {
+    readonly generatedAt?: string | undefined;
+  },
+): Promise<GeneratedIssueReport> {
+  const loaded = await loadIssueArtifacts(workspaceRoot, issueNumber);
+  const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
+  const generatedAt = options?.generatedAt ?? new Date().toISOString();
+  const report = buildIssueReport(loaded, outputPaths, generatedAt);
+  const markdown = renderIssueReportMarkdown(report);
+  return {
+    report,
+    markdown,
+    outputPaths,
+  };
+}
+
+export async function writeIssueReport(
+  workspaceRoot: string,
+  issueNumber: number,
+  options?: {
+    readonly generatedAt?: string | undefined;
+  },
+): Promise<GeneratedIssueReport> {
+  const generated = await generateIssueReport(workspaceRoot, issueNumber, {
+    generatedAt: options?.generatedAt,
+  });
+  await fs.mkdir(generated.outputPaths.issueRoot, { recursive: true });
+  await writeJsonFileAtomic(
+    generated.outputPaths.reportJsonFile,
+    generated.report,
+    ".issue-report",
+  );
+  await writeTextFileAtomic(
+    generated.outputPaths.reportMarkdownFile,
+    generated.markdown,
+    ".issue-report",
+  );
+  return generated;
+}
+
+async function loadIssueArtifacts(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<LoadedIssueArtifacts> {
+  const paths = deriveIssueArtifactPaths(workspaceRoot, issueNumber);
+
+  const issueRootStat = await fs.stat(paths.issueRoot).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  if (issueRootStat === null || !issueRootStat.isDirectory()) {
+    throw new ObservabilityError(
+      `No local issue artifacts found for issue #${issueNumber.toString()} at ${paths.issueRoot}`,
+    );
+  }
+
+  const [issue, events, attempts, sessions, logPointers] = await Promise.all([
+    readOptionalJson<IssueArtifactSummary>(paths.issueFile),
+    readOptionalJsonLines(paths.eventsFile),
+    readJsonArrayFromDir<IssueArtifactAttemptSnapshot>(
+      paths.attemptsDir,
+      compareNumberNamedFiles,
+    ),
+    readJsonArrayFromDir<IssueArtifactSessionSnapshot>(
+      paths.sessionsDir,
+      compareTextNamedFiles,
+    ),
+    readOptionalJson<IssueArtifactLogPointersDocument>(paths.logPointersFile),
+  ]);
+
+  if (
+    issue === null &&
+    events.length === 0 &&
+    attempts.length === 0 &&
+    sessions.length === 0 &&
+    logPointers === null
+  ) {
+    throw new ObservabilityError(
+      `Issue artifact directory ${paths.issueRoot} does not contain readable canonical artifacts for issue #${issueNumber.toString()}`,
+    );
+  }
+
+  return {
+    issueNumber,
+    paths,
+    issue,
+    events,
+    attempts,
+    sessions,
+    logPointers,
+  };
+}
+
+function buildIssueReport(
+  loaded: LoadedIssueArtifacts,
+  outputPaths: IssueReportPaths,
+  generatedAt: string,
+): IssueReportDocument {
+  const pullRequests = collectPullRequests(loaded);
+  const attemptNumbers = collectAttemptNumbers(loaded);
+  const summary = buildSummary(loaded, attemptNumbers, pullRequests);
+  const timeline = buildTimeline(loaded, summary);
+  const githubActivity = buildGitHubActivity(loaded, pullRequests);
+  const tokenUsage = buildTokenUsage(loaded);
+  const learnings = buildLearnings(
+    loaded,
+    summary,
+    githubActivity,
+    tokenUsage,
+    timeline,
+  );
+  const artifacts = buildArtifacts(loaded, outputPaths);
+  const operatorInterventions = buildOperatorInterventions(loaded);
+
+  return {
+    version: ISSUE_REPORT_SCHEMA_VERSION,
+    generatedAt,
+    summary,
+    timeline,
+    githubActivity,
+    tokenUsage,
+    learnings,
+    artifacts,
+    operatorInterventions,
+  };
+}
+
+function buildSummary(
+  loaded: LoadedIssueArtifacts,
+  attemptNumbers: readonly number[],
+  pullRequests: readonly IssueReportPullRequestActivity[],
+): IssueReportSummary {
+  const summary = loaded.issue;
+  const startedAt = earliestTimestamp([
+    summary?.firstObservedAt ?? null,
+    ...loaded.events.map((event) => event.observedAt),
+    ...loaded.attempts.map((attempt) => attempt.startedAt),
+    ...loaded.sessions.map((session) => session.startedAt),
+  ]);
+  const endedAt = latestTimestamp([
+    isTerminalOutcome(summary?.currentOutcome)
+      ? (summary?.lastUpdatedAt ?? null)
+      : null,
+    ...loaded.attempts.map((attempt) =>
+      isTerminalOutcome(attempt.outcome) ? attempt.finishedAt : null,
+    ),
+    ...loaded.events
+      .filter((event) => event.kind === "succeeded" || event.kind === "failed")
+      .map((event) => event.observedAt),
+  ]);
+  const notes: string[] = [];
+
+  if (summary === null) {
+    notes.push(
+      "Canonical issue summary metadata is unavailable; this report is anchored from remaining local artifacts.",
+    );
+  }
+  if (loaded.events.length === 0) {
+    notes.push(
+      "No canonical lifecycle event ledger was available; the timeline is reconstructed from attempt and session snapshots where possible.",
+    );
+  }
+  if (loaded.sessions.length > 0 && loaded.issue === null) {
+    notes.push(
+      "Session metadata preserved the issue anchor, but title, repo, and issue URL could not be recovered from the canonical summary artifact.",
+    );
+  }
+
+  const eventOutcome = inferOutcomeFromEvents(loaded.events);
+  const summaryOutcome = summary?.currentOutcome ?? null;
+  const outcome =
+    (summaryOutcome !== null &&
+    !(
+      eventOutcome !== null &&
+      isTerminalOutcome(eventOutcome) &&
+      !isTerminalOutcome(summaryOutcome)
+    )
+      ? summaryOutcome
+      : null) ??
+    eventOutcome ??
+    loaded.attempts.at(-1)?.outcome ??
+    "unknown";
+  const status =
+    summary !== null && loaded.events.length > 0 ? "complete" : "partial";
+
+  return {
+    status,
+    issueNumber: loaded.issueNumber,
+    issueIdentifier: summary?.issueIdentifier ?? null,
+    repo: summary?.repo ?? null,
+    title: summary?.title ?? null,
+    issueUrl: summary?.issueUrl ?? null,
+    branch:
+      summary?.branch ??
+      loaded.attempts.at(-1)?.branch ??
+      loaded.sessions.at(-1)?.branch ??
+      null,
+    outcome,
+    startedAt,
+    endedAt,
+    attemptCount: attemptNumbers.length,
+    pullRequestCount: pullRequests.length,
+    overallConclusion: buildOverallConclusion({
+      issueNumber: loaded.issueNumber,
+      outcome,
+      attemptCount: attemptNumbers.length,
+      pullRequestCount: pullRequests.length,
+      isPartial: status !== "complete",
+    }),
+    notes,
+  };
+}
+
+function buildTimeline(
+  loaded: LoadedIssueArtifacts,
+  summary: IssueReportSummary,
+): readonly IssueReportTimelineEntry[] {
+  const eventEntries = loaded.events.map((event) => buildTimelineEntry(event));
+  const derivedEntries: IssueReportTimelineEntry[] = [];
+  const runnerSpawnedAttempts = new Set(
+    loaded.events
+      .filter((event) => event.kind === "runner-spawned")
+      .map((event) => event.attemptNumber)
+      .filter(
+        (attemptNumber): attemptNumber is number => attemptNumber !== null,
+      ),
+  );
+
+  for (const attempt of loaded.attempts) {
+    if (
+      !runnerSpawnedAttempts.has(attempt.attemptNumber) &&
+      attempt.startedAt
+    ) {
+      derivedEntries.push({
+        kind: "attempt-started",
+        at: attempt.startedAt,
+        title: `Attempt ${attempt.attemptNumber.toString()} observed`,
+        summary: attempt.summary,
+        attemptNumber: attempt.attemptNumber,
+        sessionId: attempt.sessionId,
+        details: [
+          `Outcome: ${attempt.outcome}`,
+          ...(attempt.branch ? [`Branch: ${attempt.branch}`] : []),
+        ],
+      });
+    }
+  }
+
+  if (
+    isTerminalOutcome(summary.outcome) &&
+    !loaded.events.some((event) =>
+      summary.outcome === "succeeded"
+        ? event.kind === "succeeded"
+        : event.kind === "failed",
+    )
+  ) {
+    derivedEntries.push({
+      kind: "terminal-outcome",
+      at: summary.endedAt,
+      title:
+        summary.outcome === "succeeded" ? "Issue completed" : "Issue failed",
+      summary: summary.overallConclusion,
+      attemptNumber: loaded.attempts.at(-1)?.attemptNumber ?? null,
+      sessionId: loaded.attempts.at(-1)?.sessionId ?? null,
+      details: summary.notes,
+    });
+  }
+
+  if (eventEntries.length === 0 && derivedEntries.length === 0) {
+    const lastSession = loaded.sessions.at(-1);
+    derivedEntries.push({
+      kind: "artifacts-observed",
+      at: summary.startedAt ?? lastSession?.startedAt ?? null,
+      title: "Local artifacts observed",
+      summary:
+        "The canonical event ledger was unavailable; this report is based on the remaining local snapshots.",
+      attemptNumber: lastSession?.attemptNumber ?? null,
+      sessionId: lastSession?.sessionId ?? null,
+      details: summary.notes,
+    });
+  }
+
+  return [...eventEntries, ...derivedEntries].sort(compareTimelineEntries);
+}
+
+function buildGitHubActivity(
+  loaded: LoadedIssueArtifacts,
+  pullRequests: readonly IssueReportPullRequestActivity[],
+): IssueReportGitHubActivity {
+  const reviewFeedbackRounds = loaded.events.filter(
+    (event) => event.kind === "review-feedback",
+  ).length;
+  const notes = [
+    "Issue state and label transitions are not part of the canonical local artifact contract yet.",
+    "Merge timing and exact issue-close timing remain unavailable until richer raw GitHub lifecycle facts are stored locally.",
+  ];
+
+  return {
+    status: "partial",
+    issueStateTransitionsStatus: "unavailable",
+    issueStateTransitionsNote:
+      "Canonical local artifacts do not record issue state or label transition history.",
+    pullRequests,
+    reviewFeedbackRounds,
+    reviewLoopSummary: buildReviewLoopSummary(
+      pullRequests,
+      reviewFeedbackRounds,
+    ),
+    mergedAt: null,
+    mergeNote:
+      "Canonical local artifacts do not yet record merge timestamps or merge commits.",
+    closedAt: null,
+    closeNote:
+      "Canonical local artifacts do not yet record exact issue close timing.",
+    notes,
+  };
+}
+
+function buildTokenUsage(loaded: LoadedIssueArtifacts): IssueReportTokenUsage {
+  const sessions = loaded.sessions.map((session) => ({
+    sessionId: session.sessionId,
+    attemptNumber: session.attemptNumber,
+    provider: session.provider,
+    model: session.model,
+    totalTokens: null,
+    costUsd: null,
+    sourceArtifacts: [
+      path.join(
+        loaded.paths.sessionsDir,
+        `${encodeURIComponent(session.sessionId)}.json`,
+      ),
+    ],
+  }));
+  const attempts = collectAttemptNumbers(loaded).map((attemptNumber) => ({
+    attemptNumber,
+    sessionIds: loaded.sessions
+      .filter((session) => session.attemptNumber === attemptNumber)
+      .map((session) => session.sessionId),
+    totalTokens: null,
+    costUsd: null,
+  }));
+  const agents = aggregateAgents(loaded.sessions);
+
+  return {
+    status: "unavailable",
+    explanation:
+      "Canonical local artifacts include session metadata and raw log pointers, but they do not yet store provider token totals or cost data. Later enrichment is deferred to issue #46.",
+    totalTokens: null,
+    costUsd: null,
+    sessions,
+    attempts,
+    agents,
+    rawArtifacts: [
+      ...sessions.flatMap((session) => session.sourceArtifacts),
+      ...(loaded.logPointers === null ? [] : [loaded.paths.logPointersFile]),
+    ],
+  };
+}
+
+function buildLearnings(
+  loaded: LoadedIssueArtifacts,
+  summary: IssueReportSummary,
+  githubActivity: IssueReportGitHubActivity,
+  tokenUsage: IssueReportTokenUsage,
+  timeline: readonly IssueReportTimelineEntry[],
+): IssueReportLearnings {
+  const observations: IssueReportLearningItem[] = [];
+  const retryCount = loaded.events.filter(
+    (event) => event.kind === "retry-scheduled",
+  ).length;
+  const planReadyCount = loaded.events.filter(
+    (event) => event.kind === "plan-ready",
+  ).length;
+
+  observations.push({
+    title: "Outcome",
+    summary: summary.overallConclusion,
+    evidence: [
+      `Derived outcome: ${summary.outcome}`,
+      `Attempt count: ${summary.attemptCount.toString()}`,
+      `Timeline entries: ${timeline.length.toString()}`,
+    ],
+  });
+
+  if (planReadyCount > 0) {
+    observations.push({
+      title: "Plan review station",
+      summary:
+        "The issue passed through the explicit plan review handoff before implementation continued.",
+      evidence: [`Plan-ready events observed: ${planReadyCount.toString()}`],
+    });
+  }
+
+  if (githubActivity.pullRequests.length > 0) {
+    observations.push({
+      title: "Pull request loop",
+      summary: githubActivity.reviewLoopSummary,
+      evidence: [
+        `Pull requests observed: ${githubActivity.pullRequests.length.toString()}`,
+        `Review feedback rounds: ${githubActivity.reviewFeedbackRounds.toString()}`,
+      ],
+    });
+  }
+
+  if (retryCount > 0) {
+    observations.push({
+      title: "Retries",
+      summary:
+        "The issue required at least one retry or follow-up attempt before reaching its latest recorded state.",
+      evidence: [`Retry events observed: ${retryCount.toString()}`],
+    });
+  }
+
+  const gaps = [
+    tokenUsage.explanation,
+    githubActivity.issueStateTransitionsNote,
+    ...(loaded.issue === null
+      ? [
+          "Issue summary metadata was missing, so this report could not recover the canonical title, repo, or issue URL from local artifacts alone.",
+        ]
+      : []),
+    ...(loaded.events.length === 0
+      ? [
+          "The canonical lifecycle event ledger was unavailable, so timeline reconstruction is necessarily incomplete.",
+        ]
+      : []),
+  ];
+
+  return {
+    status: gaps.length > 0 ? "partial" : "complete",
+    observations,
+    gaps,
+  };
+}
+
+function buildArtifacts(
+  loaded: LoadedIssueArtifacts,
+  outputPaths: IssueReportPaths,
+): IssueReportArtifacts {
+  const missingArtifacts = [
+    ...(loaded.issue === null ? [loaded.paths.issueFile] : []),
+    ...(loaded.events.length === 0 ? [loaded.paths.eventsFile] : []),
+    ...(loaded.logPointers === null ? [loaded.paths.logPointersFile] : []),
+  ];
+
+  return {
+    rawIssueRoot: loaded.paths.issueRoot,
+    issueFile: loaded.issue === null ? null : loaded.paths.issueFile,
+    eventsFile: loaded.events.length === 0 ? null : loaded.paths.eventsFile,
+    attemptFiles: loaded.attempts.map((attempt) =>
+      path.join(
+        loaded.paths.attemptsDir,
+        `${attempt.attemptNumber.toString()}.json`,
+      ),
+    ),
+    sessionFiles: loaded.sessions.map((session) =>
+      path.join(
+        loaded.paths.sessionsDir,
+        `${encodeURIComponent(session.sessionId)}.json`,
+      ),
+    ),
+    logPointersFile:
+      loaded.logPointers === null ? null : loaded.paths.logPointersFile,
+    missingArtifacts,
+    generatedReportJson: outputPaths.reportJsonFile,
+    generatedReportMarkdown: outputPaths.reportMarkdownFile,
+  };
+}
+
+function buildOperatorInterventions(
+  loaded: LoadedIssueArtifacts,
+): IssueReportOperatorInterventions {
+  if (loaded.events.length === 0) {
+    return {
+      status: "unavailable",
+      summary:
+        "Operator interventions could not be assessed because the canonical event ledger was unavailable.",
+      entries: [],
+      note: "Only explicit approved or waived handoff events would appear here.",
+    };
+  }
+
+  const entries = loaded.events
+    .filter(
+      (
+        event,
+      ): event is IssueArtifactEvent & {
+        readonly kind: "approved" | "waived";
+      } => event.kind === "approved" || event.kind === "waived",
+    )
+    .map((event) => ({
+      kind: event.kind,
+      at: event.observedAt,
+      summary:
+        event.kind === "approved" ? "Plan approved" : "Plan review waived",
+      details: formatEventDetails(event.details),
+    }));
+
+  return {
+    status: "partial",
+    summary:
+      entries.length > 0
+        ? `Observed ${entries.length.toString()} explicit operator handoff event(s) in canonical local artifacts.`
+        : "No explicit operator handoff events were recorded in canonical local artifacts.",
+    entries,
+    note: "This section only reflects explicit approved or waived handoff events preserved in local artifacts; it does not prove that no manual action occurred elsewhere.",
+  };
+}
+
+function buildTimelineEntry(
+  event: IssueArtifactEvent,
+): IssueReportTimelineEntry {
+  switch (event.kind) {
+    case "claimed":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Issue claimed",
+        summary:
+          "Symphony claimed the issue and prepared it for local execution.",
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "plan-ready":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Plan ready for review",
+        summary: readEventSummary(event.details, "Plan review handoff posted."),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "approved":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Plan approved",
+        summary: readEventSummary(
+          event.details,
+          "Human review approved implementation.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "waived":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Plan review waived",
+        summary: readEventSummary(
+          event.details,
+          "Plan review was explicitly waived.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "runner-spawned":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: `Attempt ${renderAttemptNumber(event.attemptNumber)} started`,
+        summary: "A local coding-agent session started for this issue.",
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "pr-opened":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Pull request opened",
+        summary: readEventSummary(
+          event.details,
+          "A pull request was observed for the issue branch.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "review-feedback":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Review feedback observed",
+        summary: readEventSummary(
+          event.details,
+          "Actionable review feedback or unresolved review threads were observed.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "retry-scheduled":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Retry scheduled",
+        summary: readEventSummary(
+          event.details,
+          "The runtime scheduled another attempt for the issue.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "succeeded":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Issue completed",
+        summary: readEventSummary(
+          event.details,
+          "The issue reached a successful terminal outcome.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+    case "failed":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Issue failed",
+        summary: readEventSummary(
+          event.details,
+          "The issue reached a failed terminal outcome.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
+  }
+}
+
+function collectAttemptNumbers(
+  loaded: LoadedIssueArtifacts,
+): readonly number[] {
+  return [
+    ...new Set([
+      ...loaded.attempts.map((attempt) => attempt.attemptNumber),
+      ...loaded.sessions.map((session) => session.attemptNumber),
+      ...loaded.events
+        .map((event) => event.attemptNumber)
+        .filter(
+          (attemptNumber): attemptNumber is number => attemptNumber !== null,
+        ),
+      ...(loaded.issue?.latestAttemptNumber === null || loaded.issue === null
+        ? []
+        : [loaded.issue.latestAttemptNumber]),
+    ]),
+  ].sort((left, right) => left - right);
+}
+
+function collectPullRequests(
+  loaded: LoadedIssueArtifacts,
+): readonly IssueReportPullRequestActivity[] {
+  const collected = new Map<
+    number,
+    {
+      url: string;
+      attemptNumbers: Set<number>;
+      firstObservedAt: string | null;
+      latestCommitAt: string | null;
+      reviewFeedbackRounds: number;
+      actionableReviewCount: number | null;
+      unresolvedThreadCount: number | null;
+      pendingChecks: readonly string[];
+      failingChecks: readonly string[];
+    }
+  >();
+
+  for (const attempt of loaded.attempts) {
+    if (attempt.pullRequest === null) {
+      continue;
+    }
+    const existing = collected.get(attempt.pullRequest.number);
+    collected.set(attempt.pullRequest.number, {
+      url: attempt.pullRequest.url,
+      attemptNumbers: new Set([
+        ...(existing?.attemptNumbers ?? []),
+        attempt.attemptNumber,
+      ]),
+      firstObservedAt:
+        earliestTimestamp([
+          existing?.firstObservedAt ?? null,
+          attempt.finishedAt,
+        ]) ?? attempt.finishedAt,
+      latestCommitAt:
+        latestTimestamp([
+          existing?.latestCommitAt ?? null,
+          attempt.pullRequest.latestCommitAt,
+        ]) ?? attempt.pullRequest.latestCommitAt,
+      reviewFeedbackRounds: existing?.reviewFeedbackRounds ?? 0,
+      actionableReviewCount:
+        attempt.review?.actionableCount ??
+        existing?.actionableReviewCount ??
+        null,
+      unresolvedThreadCount:
+        attempt.review?.unresolvedThreadCount ??
+        existing?.unresolvedThreadCount ??
+        null,
+      pendingChecks:
+        attempt.checks?.pendingNames ?? existing?.pendingChecks ?? [],
+      failingChecks:
+        attempt.checks?.failingNames ?? existing?.failingChecks ?? [],
+    });
+  }
+
+  for (const event of loaded.events) {
+    const pullRequest = readPullRequestFromDetails(event.details);
+    if (pullRequest === null) {
+      continue;
+    }
+    const existing = collected.get(pullRequest.number);
+    collected.set(pullRequest.number, {
+      url: pullRequest.url,
+      attemptNumbers: new Set([
+        ...(existing?.attemptNumbers ?? []),
+        ...(event.attemptNumber === null ? [] : [event.attemptNumber]),
+      ]),
+      firstObservedAt:
+        earliestTimestamp([
+          existing?.firstObservedAt ?? null,
+          event.observedAt,
+        ]) ?? event.observedAt,
+      latestCommitAt:
+        latestTimestamp([
+          existing?.latestCommitAt ?? null,
+          pullRequest.latestCommitAt,
+        ]) ?? pullRequest.latestCommitAt,
+      reviewFeedbackRounds:
+        (existing?.reviewFeedbackRounds ?? 0) +
+        (event.kind === "review-feedback" ? 1 : 0),
+      actionableReviewCount:
+        readReviewFromDetails(event.details)?.actionableCount ??
+        existing?.actionableReviewCount ??
+        null,
+      unresolvedThreadCount:
+        readReviewFromDetails(event.details)?.unresolvedThreadCount ??
+        existing?.unresolvedThreadCount ??
+        null,
+      pendingChecks:
+        readChecksFromDetails(event.details)?.pendingNames ??
+        existing?.pendingChecks ??
+        [],
+      failingChecks:
+        readChecksFromDetails(event.details)?.failingNames ??
+        existing?.failingChecks ??
+        [],
+    });
+  }
+
+  return [...collected.entries()]
+    .map(([number, value]) => ({
+      number,
+      url: value.url,
+      attemptNumbers: [...value.attemptNumbers].sort(
+        (left, right) => left - right,
+      ),
+      firstObservedAt: value.firstObservedAt,
+      latestCommitAt: value.latestCommitAt,
+      reviewFeedbackRounds: value.reviewFeedbackRounds,
+      actionableReviewCount: value.actionableReviewCount,
+      unresolvedThreadCount: value.unresolvedThreadCount,
+      pendingChecks: value.pendingChecks,
+      failingChecks: value.failingChecks,
+    }))
+    .sort((left, right) => left.number - right.number);
+}
+
+function buildOverallConclusion(input: {
+  readonly issueNumber: number;
+  readonly outcome: IssueArtifactOutcome | "unknown";
+  readonly attemptCount: number;
+  readonly pullRequestCount: number;
+  readonly isPartial: boolean;
+}): string {
+  const attempts = `${input.attemptCount.toString()} attempt(s)`;
+  const pullRequests = `${input.pullRequestCount.toString()} pull request(s)`;
+  const prefix =
+    input.outcome === "succeeded"
+      ? `Issue #${input.issueNumber.toString()} succeeded after ${attempts} and ${pullRequests}.`
+      : input.outcome === "failed"
+        ? `Issue #${input.issueNumber.toString()} failed after ${attempts} and ${pullRequests}.`
+        : input.outcome === "unknown"
+          ? `Issue #${input.issueNumber.toString()} has only partial local artifacts; the latest outcome could not be determined conclusively.`
+          : `Issue #${input.issueNumber.toString()} is currently recorded as ${input.outcome} after ${attempts} and ${pullRequests}.`;
+  return input.isPartial ? `${prefix} The report is partial.` : prefix;
+}
+
+function buildReviewLoopSummary(
+  pullRequests: readonly IssueReportPullRequestActivity[],
+  reviewFeedbackRounds: number,
+): string {
+  if (pullRequests.length === 0) {
+    return "No pull request was observed in canonical local artifacts.";
+  }
+  if (reviewFeedbackRounds === 0) {
+    return "A pull request was observed with no recorded actionable review-feedback rounds in canonical local artifacts.";
+  }
+  return `Observed ${reviewFeedbackRounds.toString()} recorded review-feedback round(s) across ${pullRequests.length.toString()} pull request(s).`;
+}
+
+function aggregateAgents(
+  sessions: readonly IssueArtifactSessionSnapshot[],
+): readonly IssueReportTokenUsageAgent[] {
+  const grouped = new Map<string, number>();
+  for (const session of sessions) {
+    const label =
+      session.model === null
+        ? session.provider
+        : `${session.provider} (${session.model})`;
+    grouped.set(label, (grouped.get(label) ?? 0) + 1);
+  }
+  return [...grouped.entries()]
+    .map(([agent, sessionCount]) => ({
+      agent,
+      sessionCount,
+      totalTokens: null,
+      costUsd: null,
+    }))
+    .sort((left, right) => left.agent.localeCompare(right.agent));
+}
+
+function readPullRequestFromDetails(
+  details: Readonly<Record<string, unknown>>,
+): IssueArtifactPullRequestSnapshot | null {
+  const pullRequest = details["pullRequest"];
+  if (pullRequest === null || typeof pullRequest !== "object") {
+    return null;
+  }
+  const value = pullRequest as Record<string, unknown>;
+  if (typeof value["number"] !== "number" || typeof value["url"] !== "string") {
+    return null;
+  }
+  return {
+    number: value["number"],
+    url: value["url"],
+    latestCommitAt:
+      typeof value["latestCommitAt"] === "string"
+        ? value["latestCommitAt"]
+        : null,
+  };
+}
+
+function readReviewFromDetails(
+  details: Readonly<Record<string, unknown>>,
+): IssueArtifactReviewSnapshot | null {
+  const review = details["review"];
+  if (review === null || typeof review !== "object") {
+    return null;
+  }
+  const value = review as Record<string, unknown>;
+  if (
+    typeof value["actionableCount"] !== "number" ||
+    typeof value["unresolvedThreadCount"] !== "number"
+  ) {
+    return null;
+  }
+  return {
+    actionableCount: value["actionableCount"],
+    unresolvedThreadCount: value["unresolvedThreadCount"],
+  };
+}
+
+function readChecksFromDetails(
+  details: Readonly<Record<string, unknown>>,
+): IssueArtifactCheckSnapshot | null {
+  const checks = details["checks"];
+  if (checks === null || typeof checks !== "object") {
+    return null;
+  }
+  const value = checks as Record<string, unknown>;
+  const pendingNames = asStringArray(value["pendingNames"]);
+  const failingNames = asStringArray(value["failingNames"]);
+  if (pendingNames === null || failingNames === null) {
+    return null;
+  }
+  return {
+    pendingNames,
+    failingNames,
+  };
+}
+
+function readEventSummary(
+  details: Readonly<Record<string, unknown>>,
+  fallback: string,
+): string {
+  const summary = details["summary"];
+  return typeof summary === "string" && summary.length > 0 ? summary : fallback;
+}
+
+function formatEventDetails(
+  details: Readonly<Record<string, unknown>>,
+): readonly string[] {
+  const rendered: string[] = [];
+  const branch = details["branch"];
+  if (typeof branch === "string" && branch.length > 0) {
+    rendered.push(`Branch: ${branch}`);
+  }
+
+  const pullRequest = readPullRequestFromDetails(details);
+  if (pullRequest !== null) {
+    rendered.push(`PR #${pullRequest.number.toString()}: ${pullRequest.url}`);
+  }
+
+  const review = readReviewFromDetails(details);
+  if (review !== null) {
+    rendered.push(
+      `Review: ${review.actionableCount.toString()} actionable, ${review.unresolvedThreadCount.toString()} unresolved thread(s)`,
+    );
+  }
+
+  const checks = readChecksFromDetails(details);
+  if (checks !== null) {
+    if (checks.pendingNames.length > 0) {
+      rendered.push(`Pending checks: ${checks.pendingNames.join(", ")}`);
+    }
+    if (checks.failingNames.length > 0) {
+      rendered.push(`Failing checks: ${checks.failingNames.join(", ")}`);
+    }
+  }
+
+  const pid = details["pid"];
+  if (typeof pid === "number") {
+    rendered.push(`Runner PID: ${pid.toString()}`);
+  }
+
+  const summary = details["summary"];
+  if (typeof summary === "string" && summary.length > 0) {
+    rendered.push(`Summary: ${summary}`);
+  }
+
+  return rendered;
+}
+
+function compareTimelineEntries(
+  left: IssueReportTimelineEntry,
+  right: IssueReportTimelineEntry,
+): number {
+  const leftTimestamp = left.at ?? "";
+  const rightTimestamp = right.at ?? "";
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp.localeCompare(rightTimestamp);
+  }
+  return timelineKindOrder(left.kind) - timelineKindOrder(right.kind);
+}
+
+function timelineKindOrder(kind: string): number {
+  switch (kind) {
+    case "claimed":
+      return 1;
+    case "plan-ready":
+      return 2;
+    case "approved":
+    case "waived":
+      return 3;
+    case "runner-spawned":
+    case "attempt-started":
+      return 4;
+    case "pr-opened":
+      return 5;
+    case "review-feedback":
+      return 6;
+    case "retry-scheduled":
+      return 7;
+    case "succeeded":
+    case "failed":
+    case "terminal-outcome":
+      return 8;
+    default:
+      return 99;
+  }
+}
+
+function renderAttemptNumber(attemptNumber: number | null): string {
+  return attemptNumber === null ? "unknown" : attemptNumber.toString();
+}
+
+function inferOutcomeFromEvents(
+  events: readonly IssueArtifactEvent[],
+): IssueArtifactOutcome | null {
+  for (const event of [...events].reverse()) {
+    if (event.kind === "succeeded") {
+      return "succeeded";
+    }
+    if (event.kind === "failed") {
+      return "failed";
+    }
+    if (event.kind === "retry-scheduled") {
+      return "retry-scheduled";
+    }
+    if (event.kind === "review-feedback") {
+      return "needs-follow-up";
+    }
+    if (event.kind === "pr-opened") {
+      return "awaiting-review";
+    }
+    if (event.kind === "runner-spawned") {
+      return "running";
+    }
+    if (event.kind === "plan-ready") {
+      return "awaiting-plan-review";
+    }
+    if (event.kind === "claimed") {
+      return "claimed";
+    }
+  }
+  return null;
+}
+
+function isTerminalOutcome(
+  outcome: IssueArtifactOutcome | "unknown" | null | undefined,
+): outcome is "succeeded" | "failed" {
+  return outcome === "succeeded" || outcome === "failed";
+}
+
+async function readOptionalJson<T>(filePath: string): Promise<T | null> {
+  return await readJsonFile<T>(filePath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+}
+
+async function readOptionalJsonLines(
+  filePath: string,
+): Promise<readonly IssueArtifactEvent[]> {
+  const raw = await fs.readFile(filePath, "utf8").catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  if (raw === null) {
+    return [];
+  }
+
+  return raw
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as IssueArtifactEvent;
+      } catch (error) {
+        throw new ObservabilityError(
+          `Failed to parse JSONL artifact at ${filePath}`,
+          { cause: error as Error },
+        );
+      }
+    });
+}
+
+async function readJsonArrayFromDir<T>(
+  dirPath: string,
+  compareNames: (left: string, right: string) => number,
+): Promise<readonly T[]> {
+  const entries = await fs.readdir(dirPath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  if (entries === null) {
+    return [];
+  }
+
+  const jsonFiles = entries
+    .filter((entry) => entry.endsWith(".json"))
+    .sort(compareNames);
+  return await Promise.all(
+    jsonFiles.map((entry) => readJsonFile<T>(path.join(dirPath, entry))),
+  );
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, "utf8");
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    throw new ObservabilityError(
+      `Failed to parse JSON artifact at ${filePath}`,
+      {
+        cause: error as Error,
+      },
+    );
+  }
+}
+
+async function writeJsonFileAtomic(
+  filePath: string,
+  value: unknown,
+  tempPrefix: string,
+): Promise<void> {
+  const directory = path.dirname(filePath);
+  const tempPath = path.join(
+    directory,
+    `${tempPrefix}.${process.pid.toString()}.${randomUUID()}.tmp`,
+  );
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  try {
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function writeTextFileAtomic(
+  filePath: string,
+  content: string,
+  tempPrefix: string,
+): Promise<void> {
+  const directory = path.dirname(filePath);
+  const tempPath = path.join(
+    directory,
+    `${tempPrefix}.${process.pid.toString()}.${randomUUID()}.tmp`,
+  );
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(tempPath, content, "utf8");
+  try {
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function earliestTimestamp(
+  timestamps: readonly (string | null | undefined)[],
+): string | null {
+  const values = timestamps.filter(
+    (timestamp): timestamp is string => typeof timestamp === "string",
+  );
+  return values.length === 0 ? null : ([...values].sort()[0] ?? null);
+}
+
+function latestTimestamp(
+  timestamps: readonly (string | null | undefined)[],
+): string | null {
+  const values = timestamps.filter(
+    (timestamp): timestamp is string => typeof timestamp === "string",
+  );
+  return values.length === 0 ? null : ([...values].sort().at(-1) ?? null);
+}
+
+function compareNumberNamedFiles(left: string, right: string): number {
+  return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+}
+
+function compareTextNamedFiles(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function asStringArray(value: unknown): readonly string[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    return null;
+  }
+  return value;
+}

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -241,7 +241,6 @@ export async function writeIssueReport(
   const generated = await generateIssueReport(workspaceRoot, issueNumber, {
     generatedAt: options?.generatedAt,
   });
-  await fs.mkdir(generated.outputPaths.issueRoot, { recursive: true });
   await writeJsonFileAtomic(
     generated.outputPaths.reportJsonFile,
     generated.report,

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -178,6 +178,7 @@ interface LoadedIssueArtifacts {
   readonly paths: ReturnType<typeof deriveIssueArtifactPaths>;
   readonly issue: IssueArtifactSummary | null;
   readonly events: readonly IssueArtifactEvent[];
+  readonly hasEventsFile: boolean;
   readonly attempts: readonly IssueArtifactAttemptSnapshot[];
   readonly sessions: readonly IssueArtifactSessionSnapshot[];
   readonly logPointers: IssueArtifactLogPointersDocument | null;
@@ -272,19 +273,22 @@ async function loadIssueArtifacts(
     );
   }
 
-  const [issue, events, attempts, sessions, logPointers] = await Promise.all([
-    readOptionalJson<IssueArtifactSummary>(paths.issueFile),
-    readOptionalJsonLines(paths.eventsFile),
-    readJsonArrayFromDir<IssueArtifactAttemptSnapshot>(
-      paths.attemptsDir,
-      compareNumberNamedFiles,
-    ),
-    readJsonArrayFromDir<IssueArtifactSessionSnapshot>(
-      paths.sessionsDir,
-      compareTextNamedFiles,
-    ),
-    readOptionalJson<IssueArtifactLogPointersDocument>(paths.logPointersFile),
-  ]);
+  const [issue, eventLedger, attempts, sessions, logPointers] =
+    await Promise.all([
+      readOptionalJson<IssueArtifactSummary>(paths.issueFile),
+      readOptionalJsonLines(paths.eventsFile),
+      readJsonArrayFromDir<IssueArtifactAttemptSnapshot>(
+        paths.attemptsDir,
+        compareNumberNamedFiles,
+        isNumberNamedJsonFile,
+      ),
+      readJsonArrayFromDir<IssueArtifactSessionSnapshot>(
+        paths.sessionsDir,
+        compareTextNamedFiles,
+      ),
+      readOptionalJson<IssueArtifactLogPointersDocument>(paths.logPointersFile),
+    ]);
+  const events = eventLedger ?? [];
 
   if (
     issue === null &&
@@ -303,6 +307,7 @@ async function loadIssueArtifacts(
     paths,
     issue,
     events,
+    hasEventsFile: eventLedger !== null,
     attempts,
     sessions,
     logPointers,
@@ -367,9 +372,13 @@ function buildSummary(
       "Canonical issue summary metadata is unavailable; this report is anchored from remaining local artifacts.",
     );
   }
-  if (loaded.events.length === 0) {
+  if (!loaded.hasEventsFile) {
     notes.push(
       "No canonical lifecycle event ledger was available; the timeline is reconstructed from attempt and session snapshots where possible.",
+    );
+  } else if (loaded.events.length === 0) {
+    notes.push(
+      "The canonical lifecycle event ledger was present but contained no recorded lifecycle events.",
     );
   }
   if (loaded.sessions.length > 0 && loaded.issue === null) {
@@ -484,8 +493,9 @@ function buildTimeline(
       kind: "artifacts-observed",
       at: summary.startedAt ?? lastSession?.startedAt ?? null,
       title: "Local artifacts observed",
-      summary:
-        "The canonical event ledger was unavailable; this report is based on the remaining local snapshots.",
+      summary: !loaded.hasEventsFile
+        ? "The canonical event ledger was unavailable; this report is based on the remaining local snapshots."
+        : "No lifecycle events were recorded in the canonical event ledger; this report is based on the remaining local snapshots.",
       attemptNumber: lastSession?.attemptNumber ?? null,
       sessionId: lastSession?.sessionId ?? null,
       details: summary.notes,
@@ -631,11 +641,15 @@ function buildLearnings(
           "Issue summary metadata was missing, so this report could not recover the canonical title, repo, or issue URL from local artifacts alone.",
         ]
       : []),
-    ...(loaded.events.length === 0
+    ...(!loaded.hasEventsFile
       ? [
           "The canonical lifecycle event ledger was unavailable, so lifecycle learnings are necessarily incomplete.",
         ]
-      : []),
+      : loaded.events.length === 0
+        ? [
+            "The canonical lifecycle event ledger was present but empty, so lifecycle learnings are necessarily incomplete.",
+          ]
+        : []),
   ];
 
   return {
@@ -651,14 +665,14 @@ function buildArtifacts(
 ): IssueReportArtifacts {
   const missingArtifacts = [
     ...(loaded.issue === null ? [loaded.paths.issueFile] : []),
-    ...(loaded.events.length === 0 ? [loaded.paths.eventsFile] : []),
+    ...(!loaded.hasEventsFile ? [loaded.paths.eventsFile] : []),
     ...(loaded.logPointers === null ? [loaded.paths.logPointersFile] : []),
   ];
 
   return {
     rawIssueRoot: loaded.paths.issueRoot,
     issueFile: loaded.issue === null ? null : loaded.paths.issueFile,
-    eventsFile: loaded.events.length === 0 ? null : loaded.paths.eventsFile,
+    eventsFile: loaded.hasEventsFile ? loaded.paths.eventsFile : null,
     attemptFiles: loaded.attempts.map((attempt) =>
       path.join(
         loaded.paths.attemptsDir,
@@ -682,7 +696,7 @@ function buildArtifacts(
 function buildOperatorInterventions(
   loaded: LoadedIssueArtifacts,
 ): IssueReportOperatorInterventions {
-  if (loaded.events.length === 0) {
+  if (!loaded.hasEventsFile) {
     return {
       status: "unavailable",
       summary:
@@ -1242,7 +1256,7 @@ async function readOptionalJson<T>(filePath: string): Promise<T | null> {
 
 async function readOptionalJsonLines(
   filePath: string,
-): Promise<readonly IssueArtifactEvent[]> {
+): Promise<readonly IssueArtifactEvent[] | null> {
   const raw = await fs.readFile(filePath, "utf8").catch((error) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
@@ -1250,7 +1264,7 @@ async function readOptionalJsonLines(
     throw error;
   });
   if (raw === null) {
-    return [];
+    return null;
   }
 
   return raw
@@ -1271,6 +1285,7 @@ async function readOptionalJsonLines(
 async function readJsonArrayFromDir<T>(
   dirPath: string,
   compareNames: (left: string, right: string) => number,
+  includeName?: (fileName: string) => boolean,
 ): Promise<readonly T[]> {
   const entries = await fs
     .readdir(dirPath, { withFileTypes: true })
@@ -1286,6 +1301,7 @@ async function readJsonArrayFromDir<T>(
 
   const jsonFiles = entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .filter((entry) => includeName?.(entry.name) ?? true)
     .map((entry) => entry.name)
     .sort(compareNames);
   return await Promise.all(
@@ -1326,11 +1342,20 @@ function latestTimestamp(
 }
 
 function compareNumberNamedFiles(left: string, right: string): number {
-  return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+  const leftNumber = Number.parseInt(path.parse(left).name, 10);
+  const rightNumber = Number.parseInt(path.parse(right).name, 10);
+  if (Number.isNaN(leftNumber) || Number.isNaN(rightNumber)) {
+    return left.localeCompare(right);
+  }
+  return leftNumber - rightNumber;
 }
 
 function compareTextNamedFiles(left: string, right: string): number {
   return left.localeCompare(right);
+}
+
+function isNumberNamedJsonFile(fileName: string): boolean {
+  return /^\d+\.json$/u.test(fileName);
 }
 
 function asStringArray(value: unknown): readonly string[] | null {

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -321,13 +321,7 @@ function buildIssueReport(
   const timeline = buildTimeline(loaded, summary);
   const githubActivity = buildGitHubActivity(loaded, pullRequests);
   const tokenUsage = buildTokenUsage(loaded);
-  const learnings = buildLearnings(
-    loaded,
-    summary,
-    githubActivity,
-    tokenUsage,
-    timeline,
-  );
+  const learnings = buildLearnings(loaded, summary, timeline);
   const artifacts = buildArtifacts(loaded, outputPaths);
   const operatorInterventions = buildOperatorInterventions(loaded);
 
@@ -579,8 +573,6 @@ function buildTokenUsage(loaded: LoadedIssueArtifacts): IssueReportTokenUsage {
 function buildLearnings(
   loaded: LoadedIssueArtifacts,
   summary: IssueReportSummary,
-  githubActivity: IssueReportGitHubActivity,
-  tokenUsage: IssueReportTokenUsage,
   timeline: readonly IssueReportTimelineEntry[],
 ): IssueReportLearnings {
   const observations: IssueReportLearningItem[] = [];
@@ -589,6 +581,10 @@ function buildLearnings(
   ).length;
   const planReadyCount = loaded.events.filter(
     (event) => event.kind === "plan-ready",
+  ).length;
+  const pullRequests = collectPullRequests(loaded);
+  const reviewFeedbackRounds = loaded.events.filter(
+    (event) => event.kind === "review-feedback",
   ).length;
 
   observations.push({
@@ -610,13 +606,13 @@ function buildLearnings(
     });
   }
 
-  if (githubActivity.pullRequests.length > 0) {
+  if (pullRequests.length > 0) {
     observations.push({
       title: "Pull request loop",
-      summary: githubActivity.reviewLoopSummary,
+      summary: buildReviewLoopSummary(pullRequests, reviewFeedbackRounds),
       evidence: [
-        `Pull requests observed: ${githubActivity.pullRequests.length.toString()}`,
-        `Review feedback rounds: ${githubActivity.reviewFeedbackRounds.toString()}`,
+        `Pull requests observed: ${pullRequests.length.toString()}`,
+        `Review feedback rounds: ${reviewFeedbackRounds.toString()}`,
       ],
     });
   }
@@ -631,8 +627,6 @@ function buildLearnings(
   }
 
   const gaps = [
-    tokenUsage.explanation,
-    githubActivity.issueStateTransitionsNote,
     ...(loaded.issue === null
       ? [
           "Issue summary metadata was missing, so this report could not recover the canonical title, repo, or issue URL from local artifacts alone.",
@@ -640,7 +634,17 @@ function buildLearnings(
       : []),
     ...(loaded.events.length === 0
       ? [
-          "The canonical lifecycle event ledger was unavailable, so timeline reconstruction is necessarily incomplete.",
+          "The canonical lifecycle event ledger was unavailable, so lifecycle learnings are necessarily incomplete.",
+        ]
+      : []),
+    ...(timeline.length === 0
+      ? [
+          "No canonical or derived timeline entries were available, so the report could not derive lifecycle learnings beyond the final summary.",
+        ]
+      : []),
+    ...(observations.length === 0
+      ? [
+          "No evidence-backed learnings could be derived from the available local artifacts.",
         ]
       : []),
   ];

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -324,7 +324,7 @@ function buildIssueReport(
   const summary = buildSummary(loaded, attemptNumbers, pullRequests);
   const timeline = buildTimeline(loaded, summary);
   const githubActivity = buildGitHubActivity(loaded, pullRequests);
-  const tokenUsage = buildTokenUsage(loaded);
+  const tokenUsage = buildTokenUsage(loaded, attemptNumbers);
   const learnings = buildLearnings(loaded, summary, timeline, pullRequests);
   const artifacts = buildArtifacts(loaded, outputPaths);
   const operatorInterventions = buildOperatorInterventions(loaded);
@@ -538,7 +538,10 @@ function buildGitHubActivity(
   };
 }
 
-function buildTokenUsage(loaded: LoadedIssueArtifacts): IssueReportTokenUsage {
+function buildTokenUsage(
+  loaded: LoadedIssueArtifacts,
+  attemptNumbers: readonly number[],
+): IssueReportTokenUsage {
   const sessions = loaded.sessions.map((session) => ({
     sessionId: session.sessionId,
     attemptNumber: session.attemptNumber,
@@ -553,7 +556,7 @@ function buildTokenUsage(loaded: LoadedIssueArtifacts): IssueReportTokenUsage {
       ),
     ],
   }));
-  const attempts = collectAttemptNumbers(loaded).map((attemptNumber) => ({
+  const attempts = attemptNumbers.map((attemptNumber) => ({
     attemptNumber,
     sessionIds: loaded.sessions
       .filter((session) => session.attemptNumber === attemptNumber)

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -1232,6 +1232,9 @@ function inferOutcomeFromEvents(
     if (event.kind === "runner-spawned") {
       return "running";
     }
+    if (event.kind === "approved" || event.kind === "waived") {
+      return "claimed";
+    }
     if (event.kind === "plan-ready") {
       return "awaiting-plan-review";
     }

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -320,7 +320,7 @@ function buildIssueReport(
   const timeline = buildTimeline(loaded, summary);
   const githubActivity = buildGitHubActivity(loaded, pullRequests);
   const tokenUsage = buildTokenUsage(loaded);
-  const learnings = buildLearnings(loaded, summary, timeline);
+  const learnings = buildLearnings(loaded, summary, timeline, pullRequests);
   const artifacts = buildArtifacts(loaded, outputPaths);
   const operatorInterventions = buildOperatorInterventions(loaded);
 
@@ -573,6 +573,7 @@ function buildLearnings(
   loaded: LoadedIssueArtifacts,
   summary: IssueReportSummary,
   timeline: readonly IssueReportTimelineEntry[],
+  pullRequests: readonly IssueReportPullRequestActivity[],
 ): IssueReportLearnings {
   const observations: IssueReportLearningItem[] = [];
   const retryCount = loaded.events.filter(
@@ -581,7 +582,6 @@ function buildLearnings(
   const planReadyCount = loaded.events.filter(
     (event) => event.kind === "plan-ready",
   ).length;
-  const pullRequests = collectPullRequests(loaded);
   const reviewFeedbackRounds = loaded.events.filter(
     (event) => event.kind === "review-feedback",
   ).length;
@@ -634,16 +634,6 @@ function buildLearnings(
     ...(loaded.events.length === 0
       ? [
           "The canonical lifecycle event ledger was unavailable, so lifecycle learnings are necessarily incomplete.",
-        ]
-      : []),
-    ...(timeline.length === 0
-      ? [
-          "No canonical or derived timeline entries were available, so the report could not derive lifecycle learnings beyond the final summary.",
-        ]
-      : []),
-    ...(observations.length === 0
-      ? [
-          "No evidence-backed learnings could be derived from the available local artifacts.",
         ]
       : []),
   ];
@@ -1282,18 +1272,21 @@ async function readJsonArrayFromDir<T>(
   dirPath: string,
   compareNames: (left: string, right: string) => number,
 ): Promise<readonly T[]> {
-  const entries = await fs.readdir(dirPath).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw error;
-  });
+  const entries = await fs
+    .readdir(dirPath, { withFileTypes: true })
+    .catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    });
   if (entries === null) {
     return [];
   }
 
   const jsonFiles = entries
-    .filter((entry) => entry.endsWith(".json"))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
     .sort(compareNames);
   return await Promise.all(
     jsonFiles.map((entry) => readJsonFile<T>(path.join(dirPath, entry))),

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -1,7 +1,7 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
+import { writeJsonFileAtomic, writeTextFileAtomic } from "./atomic-file.js";
 import type {
   IssueArtifactAttemptSnapshot,
   IssueArtifactCheckSnapshot,
@@ -189,7 +189,7 @@ export interface GeneratedIssueReport {
   readonly outputPaths: IssueReportPaths;
 }
 
-export function deriveIssueReportsRoot(workspaceRoot: string): string {
+function deriveIssueReportsRoot(workspaceRoot: string): string {
   return path.join(
     path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
     "reports",
@@ -197,7 +197,7 @@ export function deriveIssueReportsRoot(workspaceRoot: string): string {
   );
 }
 
-export function deriveIssueReportPaths(
+function deriveIssueReportPaths(
   workspaceRoot: string,
   issueNumber: number,
 ): IssueReportPaths {
@@ -244,12 +244,12 @@ export async function writeIssueReport(
   await writeJsonFileAtomic(
     generated.outputPaths.reportJsonFile,
     generated.report,
-    ".issue-report",
+    { tempPrefix: ".issue-report" },
   );
   await writeTextFileAtomic(
     generated.outputPaths.reportMarkdownFile,
     generated.markdown,
-    ".issue-report",
+    { tempPrefix: ".issue-report" },
   );
   return generated;
 }
@@ -1304,46 +1304,6 @@ async function readJsonFile<T>(filePath: string): Promise<T> {
         cause: error as Error,
       },
     );
-  }
-}
-
-async function writeJsonFileAtomic(
-  filePath: string,
-  value: unknown,
-  tempPrefix: string,
-): Promise<void> {
-  const directory = path.dirname(filePath);
-  const tempPath = path.join(
-    directory,
-    `${tempPrefix}.${process.pid.toString()}.${randomUUID()}.tmp`,
-  );
-  await fs.mkdir(directory, { recursive: true });
-  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-  try {
-    await fs.rename(tempPath, filePath);
-  } catch (error) {
-    await fs.rm(tempPath, { force: true }).catch(() => undefined);
-    throw error;
-  }
-}
-
-async function writeTextFileAtomic(
-  filePath: string,
-  content: string,
-  tempPrefix: string,
-): Promise<void> {
-  const directory = path.dirname(filePath);
-  const tempPath = path.join(
-    directory,
-    `${tempPrefix}.${process.pid.toString()}.${randomUUID()}.tmp`,
-  );
-  await fs.mkdir(directory, { recursive: true });
-  await fs.writeFile(tempPath, content, "utf8");
-  try {
-    await fs.rename(tempPath, filePath);
-  } catch (error) {
-    await fs.rm(tempPath, { force: true }).catch(() => undefined);
-    throw error;
   }
 }
 

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -13,6 +13,7 @@ import {
   readIssueArtifactSession,
   readIssueArtifactSummary,
 } from "../../src/observability/issue-artifacts.js";
+import { runReportCli } from "../../src/cli/report.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
@@ -250,6 +251,66 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       "IMPLEMENTED.txt",
     );
     expect(implemented).toContain("sociotechnica-org/symphony-ts#1");
+  });
+
+  it("generates a detached per-issue report from runtime artifacts without mutating raw artifacts", async () => {
+    server.seedIssue({
+      number: 11,
+      title: "Render issue report",
+      body: "Generate report artifacts from local state",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success.sh"),
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/11", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    await orchestrator.runOnce();
+
+    const artifactPaths = deriveIssueArtifactPaths(
+      path.join(tempDir, ".tmp", "workspaces"),
+      11,
+    );
+    const summaryBefore = await fs.readFile(artifactPaths.issueFile, "utf8");
+    const eventsBefore = await fs.readFile(artifactPaths.eventsFile, "utf8");
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "issue",
+      "--issue",
+      "11",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "11");
+    const reportJson = await fs.readFile(
+      path.join(reportDir, "report.json"),
+      "utf8",
+    );
+    const reportMd = await fs.readFile(
+      path.join(reportDir, "report.md"),
+      "utf8",
+    );
+    const summaryAfter = await fs.readFile(artifactPaths.issueFile, "utf8");
+    const eventsAfter = await fs.readFile(artifactPaths.eventsFile, "utf8");
+
+    expect(reportJson).toContain('"summary"');
+    expect(reportJson).toContain('"githubActivity"');
+    expect(reportMd).toContain("## Summary");
+    expect(reportMd).toContain("## Timeline");
+    expect(reportMd).toContain("## Token Usage");
+    expect(summaryAfter).toBe(summaryBefore);
+    expect(eventsAfter).toBe(eventsBefore);
   });
 
   it("reruns the same PR branch after CI failure and closes only after the rerun goes green", async () => {

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runReportCli } from "../../src/cli/report.js";
+import { createTempDir } from "../support/git.js";
+import {
+  deriveWorkspaceRoot,
+  seedFailedIssueArtifacts,
+  seedSessionAnchoredPartialArtifacts,
+  seedSuccessfulIssueArtifacts,
+  writeReportWorkflow,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("report CLI", () => {
+  it("writes report.json and report.md for a completed issue", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-complete-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "issue",
+      "--issue",
+      "44",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
+    await expect(
+      fs.readFile(path.join(reportDir, "report.json"), "utf8"),
+    ).resolves.toContain('"githubActivity"');
+    await expect(
+      fs.readFile(path.join(reportDir, "report.md"), "utf8"),
+    ).resolves.toContain("## Learnings");
+    expect(stdout.join("")).toContain("Generated issue report for #44");
+  });
+
+  it("renders a failed issue report with explicit token unavailability", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-failed-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedFailedIssueArtifacts(workspaceRoot, 44);
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "issue",
+      "--issue",
+      "44",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
+    const reportJson = await fs.readFile(
+      path.join(reportDir, "report.json"),
+      "utf8",
+    );
+    const reportMd = await fs.readFile(
+      path.join(reportDir, "report.md"),
+      "utf8",
+    );
+    expect(reportJson).toContain('"status": "unavailable"');
+    expect(reportJson).toContain('"outcome": "failed"');
+    expect(reportMd).toContain("## Token Usage");
+    expect(reportMd).toContain("Status: unavailable");
+  });
+
+  it("generates a partial report when session artifacts still anchor the issue", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-partial-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSessionAnchoredPartialArtifacts(workspaceRoot, 44);
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "issue",
+      "--issue",
+      "44",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
+    const reportMd = await fs.readFile(
+      path.join(reportDir, "report.md"),
+      "utf8",
+    );
+    expect(reportMd).toContain("## Summary");
+    expect(reportMd).toContain("## Timeline");
+    expect(reportMd).toContain("## GitHub Activity");
+    expect(reportMd).toContain("## Token Usage");
+    expect(reportMd).toContain("## Learnings");
+    expect(reportMd).toContain("Unavailable");
+  });
+
+  it("fails clearly when the requested issue has no local artifacts", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-missing-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+
+    await expect(
+      runReportCli([
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ]),
+    ).rejects.toThrowError(
+      `No local issue artifacts found for issue #44 at ${path.join(tempDir, ".var", "factory", "issues", "44")}`,
+    );
+  });
+});

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -1,0 +1,423 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  ISSUE_ARTIFACT_SCHEMA_VERSION,
+  LocalIssueArtifactStore,
+  deriveIssueArtifactPaths,
+} from "../../src/observability/issue-artifacts.js";
+
+export async function writeReportWorkflow(rootDir: string): Promise<string> {
+  const workflowPath = path.join(rootDir, "WORKFLOW.md");
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://example.test
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  review_bot_logins: []
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: /tmp/repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
+export function deriveWorkspaceRoot(rootDir: string): string {
+  return path.join(rootDir, ".tmp", "workspaces");
+}
+
+export async function seedSuccessfulIssueArtifacts(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<void> {
+  const store = new LocalIssueArtifactStore(workspaceRoot);
+  const issueIdentifier = `sociotechnica-org/symphony-ts#${issueNumber.toString()}`;
+  const issueUrl = `https://github.com/sociotechnica-org/symphony-ts/issues/${issueNumber.toString()}`;
+  const branch = `symphony/${issueNumber.toString()}`;
+  const sessionId = `${issueIdentifier}/attempt-1/session-1`;
+
+  await store.recordObservation({
+    issue: {
+      issueNumber,
+      issueIdentifier,
+      repo: "sociotechnica-org/symphony-ts",
+      title: "Generate per-issue reports from local artifacts",
+      issueUrl,
+      branch,
+      currentOutcome: "claimed",
+      currentSummary: `Claimed ${issueIdentifier}`,
+      observedAt: "2026-03-09T10:00:00.000Z",
+      latestAttemptNumber: 1,
+    },
+    events: [
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "claimed",
+        issueNumber,
+        observedAt: "2026-03-09T10:00:00.000Z",
+        attemptNumber: 1,
+        sessionId: null,
+        details: {
+          branch,
+        },
+      },
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "plan-ready",
+        issueNumber,
+        observedAt: "2026-03-09T10:02:00.000Z",
+        attemptNumber: 1,
+        sessionId: null,
+        details: {
+          branch,
+          summary: "Waiting for plan review",
+        },
+      },
+    ],
+  });
+
+  await store.recordObservation({
+    issue: {
+      issueNumber,
+      issueIdentifier,
+      repo: "sociotechnica-org/symphony-ts",
+      title: "Generate per-issue reports from local artifacts",
+      issueUrl,
+      branch,
+      currentOutcome: "awaiting-review",
+      currentSummary: "PR opened and awaiting checks",
+      observedAt: "2026-03-09T10:10:00.000Z",
+      latestAttemptNumber: 1,
+      latestSessionId: sessionId,
+    },
+    attempt: {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 1,
+      branch,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      finishedAt: "2026-03-09T10:10:00.000Z",
+      outcome: "awaiting-review",
+      summary: "PR opened and awaiting checks",
+      sessionId,
+      runnerPid: 4242,
+      pullRequest: {
+        number: 144,
+        url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
+        latestCommitAt: "2026-03-09T10:09:30.000Z",
+      },
+      review: {
+        actionableCount: 0,
+        unresolvedThreadCount: 0,
+      },
+      checks: {
+        pendingNames: ["CI"],
+        failingNames: [],
+      },
+    },
+    session: {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 1,
+      sessionId,
+      provider: "codex",
+      model: "gpt-5.4",
+      startedAt: "2026-03-09T10:05:00.000Z",
+      finishedAt: "2026-03-09T10:10:00.000Z",
+      workspacePath: path.join(
+        workspaceRoot,
+        `issue-${issueNumber.toString()}`,
+      ),
+      branch,
+      logPointers: [
+        {
+          name: "runner.log",
+          location: path.join(workspaceRoot, "logs", "runner.log"),
+          archiveLocation: null,
+        },
+      ],
+    },
+    logPointers: {
+      sessionId,
+      pointers: [
+        {
+          name: "runner.log",
+          location: path.join(workspaceRoot, "logs", "runner.log"),
+          archiveLocation: null,
+        },
+      ],
+      archiveLocation: null,
+    },
+    events: [
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "runner-spawned",
+        issueNumber,
+        observedAt: "2026-03-09T10:05:00.000Z",
+        attemptNumber: 1,
+        sessionId,
+        details: {
+          pid: 4242,
+        },
+      },
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "pr-opened",
+        issueNumber,
+        observedAt: "2026-03-09T10:10:00.000Z",
+        attemptNumber: 1,
+        sessionId,
+        details: {
+          branch,
+          summary: "PR opened and awaiting checks",
+          pullRequest: {
+            number: 144,
+            url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
+            latestCommitAt: "2026-03-09T10:09:30.000Z",
+          },
+          review: {
+            actionableCount: 0,
+            unresolvedThreadCount: 0,
+          },
+          checks: {
+            pendingNames: ["CI"],
+            failingNames: [],
+          },
+        },
+      },
+    ],
+  });
+
+  await store.recordObservation({
+    issue: {
+      issueNumber,
+      issueIdentifier,
+      repo: "sociotechnica-org/symphony-ts",
+      title: "Generate per-issue reports from local artifacts",
+      issueUrl,
+      branch,
+      currentOutcome: "succeeded",
+      currentSummary: "Issue completed successfully",
+      observedAt: "2026-03-09T10:20:00.000Z",
+      latestAttemptNumber: 1,
+      latestSessionId: sessionId,
+    },
+    events: [
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "succeeded",
+        issueNumber,
+        observedAt: "2026-03-09T10:20:00.000Z",
+        attemptNumber: 1,
+        sessionId,
+        details: {
+          summary: "Issue completed successfully",
+          pullRequest: {
+            number: 144,
+            url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
+            latestCommitAt: "2026-03-09T10:19:00.000Z",
+          },
+          review: {
+            actionableCount: 0,
+            unresolvedThreadCount: 0,
+          },
+          checks: {
+            pendingNames: [],
+            failingNames: [],
+          },
+        },
+      },
+    ],
+  });
+}
+
+export async function seedFailedIssueArtifacts(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<void> {
+  const store = new LocalIssueArtifactStore(workspaceRoot);
+  const issueIdentifier = `sociotechnica-org/symphony-ts#${issueNumber.toString()}`;
+  const issueUrl = `https://github.com/sociotechnica-org/symphony-ts/issues/${issueNumber.toString()}`;
+  const branch = `symphony/${issueNumber.toString()}`;
+  const sessionId = `${issueIdentifier}/attempt-2/session-1`;
+
+  await store.recordObservation({
+    issue: {
+      issueNumber,
+      issueIdentifier,
+      repo: "sociotechnica-org/symphony-ts",
+      title: "Generate per-issue reports from local artifacts",
+      issueUrl,
+      branch,
+      currentOutcome: "retry-scheduled",
+      currentSummary: "Retry scheduled after missing PR",
+      observedAt: "2026-03-09T11:00:00.000Z",
+      latestAttemptNumber: 2,
+      latestSessionId: sessionId,
+    },
+    attempt: {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 2,
+      branch,
+      startedAt: "2026-03-09T10:55:00.000Z",
+      finishedAt: "2026-03-09T11:00:00.000Z",
+      outcome: "attempt-failed",
+      summary: "No open pull request found",
+      sessionId,
+      runnerPid: 5252,
+      pullRequest: null,
+      review: null,
+      checks: null,
+    },
+    session: {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 2,
+      sessionId,
+      provider: "codex",
+      model: "gpt-5.4",
+      startedAt: "2026-03-09T10:55:00.000Z",
+      finishedAt: "2026-03-09T11:00:00.000Z",
+      workspacePath: path.join(
+        workspaceRoot,
+        `issue-${issueNumber.toString()}`,
+      ),
+      branch,
+      logPointers: [],
+    },
+    logPointers: {
+      sessionId,
+      pointers: [],
+      archiveLocation: null,
+    },
+    events: [
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "retry-scheduled",
+        issueNumber,
+        observedAt: "2026-03-09T11:00:00.000Z",
+        attemptNumber: 2,
+        sessionId,
+        details: {
+          summary: "Retry scheduled after missing PR",
+          branch,
+        },
+      },
+      {
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        kind: "failed",
+        issueNumber,
+        observedAt: "2026-03-09T11:10:00.000Z",
+        attemptNumber: 2,
+        sessionId,
+        details: {
+          summary: "Issue failed after retries were exhausted",
+          branch,
+        },
+      },
+    ],
+  });
+}
+
+export async function seedSessionAnchoredPartialArtifacts(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<void> {
+  const paths = deriveIssueArtifactPaths(workspaceRoot, issueNumber);
+  const sessionId = `issue-${issueNumber.toString()}-session-1`;
+
+  await fs.mkdir(paths.attemptsDir, { recursive: true });
+  await fs.mkdir(paths.sessionsDir, { recursive: true });
+  await fs.mkdir(paths.logsDir, { recursive: true });
+
+  await writeJsonFile(path.join(paths.attemptsDir, "1.json"), {
+    version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+    issueNumber,
+    attemptNumber: 1,
+    branch: `symphony/${issueNumber.toString()}`,
+    startedAt: "2026-03-09T12:00:00.000Z",
+    finishedAt: "2026-03-09T12:05:00.000Z",
+    outcome: "attempt-failed",
+    summary: "Observed from attempt snapshot only",
+    sessionId,
+    runnerPid: 6363,
+    pullRequest: null,
+    review: null,
+    checks: null,
+  });
+
+  await writeJsonFile(
+    path.join(paths.sessionsDir, `${encodeURIComponent(sessionId)}.json`),
+    {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 1,
+      sessionId,
+      provider: "codex",
+      model: "gpt-5.4",
+      startedAt: "2026-03-09T12:00:00.000Z",
+      finishedAt: "2026-03-09T12:05:00.000Z",
+      workspacePath: path.join(
+        workspaceRoot,
+        `issue-${issueNumber.toString()}`,
+      ),
+      branch: `symphony/${issueNumber.toString()}`,
+      logPointers: [
+        {
+          name: "runner.log",
+          location: path.join(paths.logsDir, "runner.log"),
+          archiveLocation: null,
+        },
+      ],
+    },
+  );
+
+  await writeJsonFile(paths.logPointersFile, {
+    version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+    issueNumber,
+    sessions: {
+      [sessionId]: {
+        sessionId,
+        pointers: [
+          {
+            name: "runner.log",
+            location: path.join(paths.logsDir, "runner.log"),
+            archiveLocation: null,
+          },
+        ],
+        archiveLocation: null,
+      },
+    },
+  });
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -251,9 +251,7 @@ describe("issue report generation", () => {
       });
 
       expect(generated.report.summary.outcome).toBe("claimed");
-      expect(generated.report.summary.outcome).not.toBe(
-        "awaiting-plan-review",
-      );
+      expect(generated.report.summary.outcome).not.toBe("awaiting-plan-review");
     },
   );
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -88,4 +88,44 @@ describe("issue report generation", () => {
       fs.readFile(generated.outputPaths.reportMarkdownFile, "utf8"),
     ).resolves.toContain("## Artifacts");
   });
+
+  it("ignores nested .json directories when reading attempt and session artifacts", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-nested-json-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await fs.mkdir(
+      path.join(
+        tempDir,
+        ".var",
+        "factory",
+        "issues",
+        "44",
+        "attempts",
+        "nested.json",
+      ),
+      { recursive: true },
+    );
+    await fs.mkdir(
+      path.join(
+        tempDir,
+        ".var",
+        "factory",
+        "issues",
+        "44",
+        "sessions",
+        "nested.json",
+      ),
+      { recursive: true },
+    );
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:20:00.000Z",
+    });
+
+    expect(generated.report.summary.outcome).toBe("succeeded");
+    expect(generated.report.artifacts.attemptFiles).toHaveLength(1);
+    expect(generated.report.artifacts.sessionFiles).toHaveLength(1);
+  });
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -39,6 +39,7 @@ describe("issue report generation", () => {
     expect(generated.report.summary.outcome).toBe("succeeded");
     expect(generated.report.summary.attemptCount).toBe(1);
     expect(generated.report.summary.pullRequestCount).toBe(1);
+    expect(generated.report.learnings.status).toBe("complete");
     expect(generated.report.timeline.map((entry) => entry.kind)).toEqual(
       expect.arrayContaining([
         "claimed",
@@ -54,6 +55,8 @@ describe("issue report generation", () => {
     expect(generated.markdown).toContain("## GitHub Activity");
     expect(generated.markdown).toContain("## Token Usage");
     expect(generated.markdown).toContain("## Learnings");
+    expect(generated.markdown).toContain("pending checks None");
+    expect(generated.markdown).toContain("failing checks None");
   });
 
   it("generates a partial report when issue and event artifacts are missing but session artifacts remain", async () => {

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -5,6 +5,10 @@ import {
   generateIssueReport,
   writeIssueReport,
 } from "../../src/observability/issue-report.js";
+import {
+  ISSUE_ARTIFACT_SCHEMA_VERSION,
+  deriveIssueArtifactPaths,
+} from "../../src/observability/issue-artifacts.js";
 import { createTempDir } from "../support/git.js";
 import {
   deriveWorkspaceRoot,
@@ -195,4 +199,61 @@ describe("issue report generation", () => {
       ),
     ]);
   });
+
+  it.each(["approved", "waived"] as const)(
+    "does not keep awaiting plan review after a %s handoff event",
+    async (decisionKind) => {
+      const tempDir = await createTempDir(
+        `symphony-issue-report-${decisionKind}-`,
+      );
+      tempRoots.push(tempDir);
+      const workspaceRoot = deriveWorkspaceRoot(tempDir);
+      const artifactPaths = deriveIssueArtifactPaths(workspaceRoot, 44);
+      await fs.mkdir(artifactPaths.issueRoot, { recursive: true });
+      await fs.writeFile(
+        artifactPaths.eventsFile,
+        [
+          {
+            version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+            kind: "claimed",
+            issueNumber: 44,
+            observedAt: "2026-03-09T10:00:00.000Z",
+            attemptNumber: null,
+            sessionId: null,
+            details: {},
+          },
+          {
+            version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+            kind: "plan-ready",
+            issueNumber: 44,
+            observedAt: "2026-03-09T10:02:00.000Z",
+            attemptNumber: null,
+            sessionId: null,
+            details: {},
+          },
+          {
+            version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+            kind: decisionKind,
+            issueNumber: 44,
+            observedAt: "2026-03-09T10:03:00.000Z",
+            attemptNumber: null,
+            sessionId: null,
+            details: {},
+          },
+        ]
+          .map((event) => JSON.stringify(event))
+          .join("\n"),
+        "utf8",
+      );
+
+      const generated = await generateIssueReport(workspaceRoot, 44, {
+        generatedAt: "2026-03-09T13:50:00.000Z",
+      });
+
+      expect(generated.report.summary.outcome).toBe("claimed");
+      expect(generated.report.summary.outcome).not.toBe(
+        "awaiting-plan-review",
+      );
+    },
+  );
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -128,4 +128,71 @@ describe("issue report generation", () => {
     expect(generated.report.artifacts.attemptFiles).toHaveLength(1);
     expect(generated.report.artifacts.sessionFiles).toHaveLength(1);
   });
+
+  it("keeps events.jsonl in artifact pointers when the file exists but is empty", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-empty-events-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const eventsFile = path.join(
+      tempDir,
+      ".var",
+      "factory",
+      "issues",
+      "44",
+      "events.jsonl",
+    );
+    await fs.writeFile(eventsFile, "", "utf8");
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:30:00.000Z",
+    });
+
+    expect(generated.report.artifacts.eventsFile).toBe(eventsFile);
+    expect(generated.report.artifacts.missingArtifacts).not.toContain(
+      eventsFile,
+    );
+    expect(generated.report.summary.notes).toContain(
+      "The canonical lifecycle event ledger was present but contained no recorded lifecycle events.",
+    );
+  });
+
+  it("ignores non-numeric attempt json files when loading attempt artifacts", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-attempt-json-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await fs.writeFile(
+      path.join(
+        tempDir,
+        ".var",
+        "factory",
+        "issues",
+        "44",
+        "attempts",
+        "metadata.json",
+      ),
+      `${JSON.stringify({ note: "ignore me" }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:40:00.000Z",
+    });
+
+    expect(generated.report.summary.outcome).toBe("succeeded");
+    expect(generated.report.artifacts.attemptFiles).toEqual([
+      path.join(
+        tempDir,
+        ".var",
+        "factory",
+        "issues",
+        "44",
+        "attempts",
+        "1.json",
+      ),
+    ]);
+  });
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  generateIssueReport,
+  writeIssueReport,
+} from "../../src/observability/issue-report.js";
+import { createTempDir } from "../support/git.js";
+import {
+  deriveWorkspaceRoot,
+  seedSessionAnchoredPartialArtifacts,
+  seedSuccessfulIssueArtifacts,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("issue report generation", () => {
+  it("derives canonical report facts and markdown from complete issue artifacts", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-unit-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:00:00.000Z",
+    });
+
+    expect(generated.report.summary.issueIdentifier).toBe(
+      "sociotechnica-org/symphony-ts#44",
+    );
+    expect(generated.report.summary.outcome).toBe("succeeded");
+    expect(generated.report.summary.attemptCount).toBe(1);
+    expect(generated.report.summary.pullRequestCount).toBe(1);
+    expect(generated.report.timeline.map((entry) => entry.kind)).toEqual(
+      expect.arrayContaining([
+        "claimed",
+        "plan-ready",
+        "runner-spawned",
+        "pr-opened",
+        "succeeded",
+      ]),
+    );
+    expect(generated.report.tokenUsage.status).toBe("unavailable");
+    expect(generated.markdown).toContain("## Summary");
+    expect(generated.markdown).toContain("## Timeline");
+    expect(generated.markdown).toContain("## GitHub Activity");
+    expect(generated.markdown).toContain("## Token Usage");
+    expect(generated.markdown).toContain("## Learnings");
+  });
+
+  it("generates a partial report when issue and event artifacts are missing but session artifacts remain", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-partial-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSessionAnchoredPartialArtifacts(workspaceRoot, 44);
+
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:10:00.000Z",
+    });
+
+    expect(generated.report.summary.status).toBe("partial");
+    expect(generated.report.summary.title).toBeNull();
+    expect(generated.report.summary.issueIdentifier).toBeNull();
+    expect(generated.report.summary.outcome).toBe("attempt-failed");
+    expect(generated.report.artifacts.missingArtifacts).toEqual(
+      expect.arrayContaining([
+        path.join(tempDir, ".var", "factory", "issues", "44", "issue.json"),
+        path.join(tempDir, ".var", "factory", "issues", "44", "events.jsonl"),
+      ]),
+    );
+    expect(generated.markdown).toContain("Unavailable");
+    expect(generated.markdown).toContain("## Operator Interventions");
+    await expect(
+      fs.readFile(generated.outputPaths.reportJsonFile, "utf8"),
+    ).resolves.toContain('"summary"');
+    await expect(
+      fs.readFile(generated.outputPaths.reportMarkdownFile, "utf8"),
+    ).resolves.toContain("## Artifacts");
+  });
+});

--- a/tests/unit/report-cli.test.ts
+++ b/tests/unit/report-cli.test.ts
@@ -16,6 +16,9 @@ describe("parseReportArgs", () => {
       parseReportArgs(["node", "symphony-report", "issue", "--issue", "abc"]),
     ).toThrowError("Invalid issue number: abc");
     expect(() =>
+      parseReportArgs(["node", "symphony-report", "issue", "--issue", "44x"]),
+    ).toThrowError("Invalid issue number: 44x");
+    expect(() =>
       parseReportArgs(["node", "symphony-report", "issue", "--issue", "0"]),
     ).toThrowError("Invalid issue number: 0");
   });

--- a/tests/unit/report-cli.test.ts
+++ b/tests/unit/report-cli.test.ts
@@ -20,6 +20,12 @@ describe("parseReportArgs", () => {
     ).toThrowError("Invalid issue number: 0");
   });
 
+  it("requires the issue flag", () => {
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "issue"]),
+    ).toThrowError("Missing required --issue <number> option");
+  });
+
   it("shows usage for unknown commands", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "status"]),

--- a/tests/unit/report-cli.test.ts
+++ b/tests/unit/report-cli.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseReportArgs } from "../../src/cli/report.js";
+
+describe("parseReportArgs", () => {
+  it("parses the issue report command", () => {
+    expect(
+      parseReportArgs(["node", "symphony-report", "issue", "--issue", "44"]),
+    ).toMatchObject({
+      command: "issue",
+      issueNumber: 44,
+    });
+  });
+
+  it("requires a valid issue number", () => {
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "issue", "--issue", "abc"]),
+    ).toThrowError("Invalid issue number: abc");
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "issue", "--issue", "0"]),
+    ).toThrowError("Invalid issue number: 0");
+  });
+
+  it("shows usage for unknown commands", () => {
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "status"]),
+    ).toThrowError(
+      "Usage: symphony-report issue --issue <number> [--workflow <path>]",
+    );
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary
- add a detached `symphony-report` CLI that reads canonical local issue artifacts and writes `report.json` plus `report.md` under `.var/reports/issues/<issue-number>/`
- define the canonical report schema, deterministic markdown rendering, and partial-data fallback behavior for missing `issue.json` / `events.jsonl` cases
- cover the flow with unit, integration, and end-to-end tests against runtime-produced artifacts

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `codex review --base origin/main`