### PR TITLE
Generalize the internal handoff lifecycle model

### DIFF
--- a/docs/plans/050-generalize-handoff-lifecycle-model/plan.md
+++ b/docs/plans/050-generalize-handoff-lifecycle-model/plan.md
@@ -1,0 +1,252 @@
+# Issue 50 Plan: Generalize Handoff Lifecycle Model Beyond GitHub PR Semantics
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Introduce a tracker-neutral internal handoff lifecycle model so the orchestrator and live status surface reason about generalized handoff states rather than GitHub pull-request lifecycle names, while keeping GitHub-specific mapping policy at the tracker edge.
+
+## Scope
+
+- add a tracker-neutral shared handoff lifecycle contract for orchestrator-facing logic
+- map GitHub bootstrap plan-review and PR-review facts into that shared contract at the tracker edge
+- update orchestrator branching and follow-up handling to depend on generalized handoff states rather than GitHub-shaped lifecycle names
+- update the live status/observability surface to render generalized handoff states
+- preserve the current GitHub bootstrap behavior covered by `#42` and `#48`
+- keep tracker mapping tests separate from orchestrator behavior tests
+
+## Non-goals
+
+- replacing the GitHub bootstrap tracker
+- implementing the Beads or Linear adapter in this issue
+- redesigning the external human review workflow or PR review workflow itself
+- changing `WORKFLOW.md` prompt variables or the prompt-builder template contract unless implementation fallout makes a minimal compatibility shim necessary
+- redesigning the durable issue-report artifact schema beyond any compatibility mapping required by the refactor
+
+## Current Gaps
+
+- the shared domain lifecycle type is still `PullRequestLifecycle` with GitHub-shaped states: `missing`, `awaiting-plan-review`, `awaiting-review`, `needs-follow-up`, `ready`
+- the orchestrator branches directly on those GitHub/PR-shaped state names even though the tracker already performs the external-state inspection
+- the status snapshot exposes those same state names to operators, which reinforces the GitHub bootstrap vocabulary in the control plane
+- plan-review policy and PR policy both normalize correctly at the tracker edge, but they normalize into a contract whose names are still shaped around the current adapter
+- tests exercise behavior correctly, but many of them still encode GitHub-shaped lifecycle names as the orchestrator-facing contract
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: naming the generalized handoff states and their meanings in repo-owned docs for future tracker work
+  - does not belong: tracker-specific PR policy or GitHub comment parsing rules
+- Configuration Layer
+  - belongs: nothing new in this slice unless a compatibility shim is needed to keep prompt rendering stable
+  - does not belong: lifecycle classification logic or tracker policy branches
+- Coordination Layer
+  - belongs: orchestrator decisions about wait, rerun, fail, or complete based on generalized handoff states
+  - does not belong: parsing GitHub review comments, PR checks, or adapter-specific lifecycle rules
+- Execution Layer
+  - belongs: unchanged workspace and runner behavior that consumes the orchestrator decision
+  - does not belong: lifecycle naming or tracker-state interpretation
+- Integration Layer
+  - belongs: mapping GitHub issue comments, PR checks, and review feedback into the generalized handoff contract
+  - does not belong: orchestrator retry policy or status-surface branching
+- Observability Layer
+  - belongs: live factory status names and summaries derived from the generalized handoff contract
+  - does not belong: reimplementing tracker mapping policy inside status rendering
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- a new or renamed shared domain contract for tracker-neutral handoff lifecycle state
+- focused GitHub tracker mapping from:
+  - no handoff target yet
+  - plan-ready waiting
+  - PR checks/review waiting
+  - actionable follow-up
+  - clean handoff ready
+- orchestrator updates that consume only the generalized contract
+- status-state and status rendering updates that consume only the generalized contract
+- test helpers/builders updated so tracker mapping and orchestrator policy stay distinct
+- lightweight docs updates where the runtime contract description still uses the old internal lifecycle names
+
+### Does not belong in this issue
+
+- changing tracker transport APIs or mixing transport, normalization, and policy into one module
+- broad prompt-template redesign
+- issue-report product work unrelated to the live handoff model
+- a larger tracker abstraction overhaul beyond the normalized handoff lifecycle seam
+- bundling the first Beads or Linear adapter slices into the same PR
+
+## Slice Strategy And PR Seam
+
+This should remain one reviewable PR if the slice stays limited to the shared handoff contract plus the direct consumers of that contract:
+
+1. introduce the generalized handoff state model
+2. adapt GitHub plan-review and PR policy modules to map into it
+3. update orchestrator and live status handling to consume it
+4. update tests and minimal docs to match
+
+This seam is reviewable because it deliberately avoids changing:
+
+- tracker transport
+- workspace/runner behavior
+- prompt-template shape
+- durable report-generation semantics unless a narrow compatibility adapter is unavoidable
+
+If the implementation shows that artifact/report vocabulary must change to keep the system coherent, keep that work limited to compatibility mapping inside this PR and defer any schema redesign to a follow-up issue.
+
+## Runtime State Model
+
+The orchestrator-facing handoff states for this issue are:
+
+- `missing-target`
+  - no handoff artifact or target exists yet for the current issue branch
+- `awaiting-human-handoff`
+  - the tracker has recorded a valid human handoff wait state, such as `Plan status: plan-ready`
+- `awaiting-system-checks`
+  - a handoff target exists, but automated checks or human review completion are still in flight
+- `actionable-follow-up`
+  - the tracker has enough evidence that another worker run is needed
+- `handoff-ready`
+  - the current handoff target is clean and ready for completion
+
+### Allowed transitions
+
+- initial claimed issue -> `missing-target`
+- `missing-target` -> `awaiting-human-handoff`
+  - latest relevant tracker fact is a valid plan-ready handoff with no PR yet
+- `missing-target` -> `awaiting-system-checks`
+  - a PR exists and checks/review are still settling
+- `awaiting-human-handoff` -> `missing-target`
+  - review decision is `approved`, `waived`, or `changes-requested`, so the next action is a rerun rather than continued waiting
+- `awaiting-system-checks` -> `actionable-follow-up`
+  - tracker shows actionable bot feedback or failing checks with no remaining pending checks
+- `awaiting-system-checks` -> `handoff-ready`
+  - tracker shows no actionable feedback and no blocking checks
+- `actionable-follow-up` -> `awaiting-system-checks`
+  - a follow-up run pushes new work and the tracker returns to waiting on checks/review
+- `actionable-follow-up` -> `handoff-ready`
+  - a follow-up run resolves the remaining blockers
+- `handoff-ready` -> terminal completion
+  - orchestrator completes the issue and cleans up local state
+
+### Runtime decision rules
+
+- wait on `awaiting-human-handoff`
+- wait on `awaiting-system-checks`
+- rerun on `actionable-follow-up`
+- fail on `missing-target` only after a successful run still leaves no valid handoff target
+- complete on `handoff-ready`
+
+## Failure-Class Matrix
+
+| Observed condition                                        | Local facts available                  | Normalized tracker facts available                     | Expected decision                                                       |
+| --------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Claimed issue has no PR and no valid plan-review handoff  | successful run finished, branch exists | `missing-target`                                       | treat as missing handoff target and keep current failure/retry behavior |
+| Claimed issue stops after plan-ready comment              | successful run finished, no PR yet     | `awaiting-human-handoff`                               | wait without retry/fail                                                 |
+| Human review comment says approved or waived, still no PR | next poll on running issue             | `missing-target` after tracker acknowledgement/mapping | rerun issue from the same branch                                        |
+| Human review comment says changes-requested, still no PR  | next poll on running issue             | `missing-target` after tracker acknowledgement/mapping | rerun issue to revise the plan                                          |
+| PR exists with pending checks                             | no local runner active                 | `awaiting-system-checks`                               | wait                                                                    |
+| PR has failing checks but some checks are still pending   | no local runner active                 | `awaiting-system-checks`                               | wait and do not rerun yet                                               |
+| PR has failing checks and no pending checks remain        | no local runner active                 | `actionable-follow-up`                                 | rerun with follow-up budget                                             |
+| PR has unresolved actionable bot feedback                 | no local runner active                 | `actionable-follow-up`                                 | rerun with follow-up budget                                             |
+| PR is clean and merge-ready                               | no local runner active                 | `handoff-ready`                                        | complete issue                                                          |
+
+## Storage / Persistence Contract
+
+- the live factory status snapshot should store the generalized handoff status names
+- orchestrator in-memory follow-up and retry state should continue to key off the normalized lifecycle contract, not raw tracker payloads
+- if issue-artifact persistence still needs the old outcome names for schema compatibility, keep that translation explicit and localized rather than letting the old names leak back into orchestrator branching
+
+## Observability Requirements
+
+- `src/observability/status.ts` should expose generalized handoff status names in the machine-readable snapshot and rendered terminal output
+- `src/orchestrator/status-state.ts` should translate normalized handoff states into status entries without GitHub-specific branches
+- log messages and status actions should describe generalized handoff state while preserving specific summaries from the tracker edge
+- if compatibility mapping is needed for issue artifacts, document that mapping in code comments or the plan revision log so the remaining PR-specific vocabulary is explicit rather than accidental
+
+## Implementation Steps
+
+1. Introduce a tracker-neutral handoff lifecycle domain contract and migrate the tracker service interface to use it.
+2. Update `src/tracker/plan-review-policy.ts` to emit generalized handoff states for plan-review waiting or rerun-required conditions.
+3. Update `src/tracker/pull-request-policy.ts` and related snapshot helpers to emit generalized handoff states while preserving the existing GitHub behavior.
+4. Update `src/tracker/github-bootstrap.ts` so plan-review and PR policy remain at the tracker edge and cache normalized handoff observations against the new contract.
+5. Update `src/orchestrator/service.ts` and `src/orchestrator/follow-up-state.ts` to branch on generalized handoff states only.
+6. Update `src/orchestrator/status-state.ts` and `src/observability/status.ts` to surface the generalized statuses.
+7. Apply minimal compatibility updates where prompt building, issue artifacts, or tests currently depend on the old lifecycle type name.
+8. Update README or architecture notes where the runtime still documents the old internal lifecycle vocabulary.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- plan-review policy maps `Plan status: plan-ready` to `awaiting-human-handoff`
+- plan-review policy keeps `approved`, `waived`, and `changes-requested` as rerun-required rather than a waiting state
+- PR policy maps:
+  - pending checks -> `awaiting-system-checks`
+  - failing checks with no pending -> `actionable-follow-up`
+  - actionable review feedback -> `actionable-follow-up`
+  - clean PR -> `handoff-ready`
+- follow-up/orchestrator helper tests use the generalized lifecycle states rather than GitHub names
+- status snapshot parsing/rendering accepts the generalized status names
+
+### Integration
+
+- GitHub bootstrap tracker reports:
+  - `missing-target` when no PR or plan-ready handoff exists
+  - `awaiting-human-handoff` when latest issue handoff is plan-ready
+  - `awaiting-system-checks` while checks are pending or review is still in flight
+  - `actionable-follow-up` when bot feedback or settled failures require another run
+  - `handoff-ready` when the PR is clean
+- tracker acknowledgement behavior from `#48` still works with the generalized contract
+
+### End-to-end
+
+- the bootstrap factory waits at plan review without failing the run
+- the bootstrap factory waits on pending checks without rerunning the agent
+- the bootstrap factory reruns when actionable feedback appears
+- the bootstrap factory completes only when the handoff becomes ready
+
+### Repo gate
+
+- `pnpm format`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. A worker posts `Plan status: plan-ready`, no PR exists yet, and the orchestrator reports the issue as `awaiting-human-handoff` without retrying or failing.
+2. A PR exists with pending CI and no actionable bot feedback, and the orchestrator reports `awaiting-system-checks` while leaving the runner idle.
+3. A PR has actionable bot feedback or settled failing checks, and the orchestrator treats it as `actionable-follow-up` and schedules a rerun within the existing follow-up budget.
+4. A PR is clean, and the orchestrator treats it as `handoff-ready` and completes the issue.
+5. Tracker-mapping tests prove that the GitHub adapter is responsible for translating GitHub-specific facts into the generalized states, while orchestrator tests assert behavior only against the generalized states.
+
+## Exit Criteria
+
+- the orchestrator no longer branches on `missing`, `awaiting-plan-review`, `awaiting-review`, `needs-follow-up`, or `ready`
+- the shared internal handoff contract uses generalized state names
+- the GitHub tracker remains responsible for mapping plan-review and PR-review facts into the generalized handoff model
+- the live status snapshot and rendered status output use the generalized handoff model
+- existing plan-review and PR lifecycle behavior from `#42` and `#48` still passes through tests
+- the work remains one reviewable PR without mixing new tracker adapters or prompt-contract redesign
+
+## Deferred To Later Issues Or PRs
+
+- renaming prompt-template variables such as `pull_request` to a broader handoff-target vocabulary
+- redesigning issue-artifact/report schemas around the generalized handoff model if that proves worthwhile after this refactor lands
+- adding new tracker adapters on top of the new seam
+- broad tracker-neutral modeling of non-PR handoff target metadata beyond the lifecycle states needed in this issue
+
+## Decision Notes
+
+- This slice intentionally prioritizes generalized lifecycle states over a full rename of every `pullRequest`-shaped payload field. The control-plane state names are the architectural blocker for future trackers; broader payload renaming can follow in a smaller dedicated slice once the behavior seam is stable.
+- Tracker transport, normalization, and policy stay separate. This issue should not move GitHub API parsing into orchestrator code or collapse plan-review and PR policy into the transport client.
+- If a compatibility bridge is required for issue artifacts or prompt rendering, keep it explicit and local so the old GitHub vocabulary does not silently remain the orchestrator contract.
+
+## Revision Log
+
+- 2026-03-10: Initial draft plan created for issue #50.
+- 2026-03-10: Promoted to `plan-ready` and prepared for issue-thread review handoff.

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import * as yaml from "yaml";
 import { ConfigError, WorkflowError } from "../domain/errors.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -28,7 +28,7 @@ interface PromptRenderInput {
     readonly identifier: string;
   };
   readonly attempt: number | null;
-  readonly pullRequest: PullRequestLifecycle | null;
+  readonly pullRequest: HandoffLifecycle | null;
   readonly config: ResolvedConfig;
 }
 

--- a/src/domain/handoff.ts
+++ b/src/domain/handoff.ts
@@ -1,0 +1,48 @@
+export type HandoffLifecycleKind =
+  | "missing-target"
+  | "awaiting-human-handoff"
+  | "awaiting-system-checks"
+  | "actionable-follow-up"
+  | "handoff-ready";
+
+export type PullRequestCheckStatus = "pending" | "success" | "failure";
+
+export interface PullRequestHandle {
+  readonly number: number;
+  readonly url: string;
+  readonly branchName: string;
+  readonly latestCommitAt: string | null;
+}
+
+export interface PullRequestCheck {
+  readonly name: string;
+  readonly status: PullRequestCheckStatus;
+  readonly conclusion: string | null;
+  readonly detailsUrl: string | null;
+}
+
+export type ReviewFeedbackKind = "review-thread" | "issue-comment";
+
+export interface ReviewFeedback {
+  readonly id: string;
+  readonly kind: ReviewFeedbackKind;
+  readonly threadId: string | null;
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+  readonly path: string | null;
+  readonly line: number | null;
+}
+
+export interface HandoffLifecycle {
+  readonly kind: HandoffLifecycleKind;
+  readonly branchName: string;
+  readonly pullRequest: PullRequestHandle | null;
+  readonly checks: readonly PullRequestCheck[];
+  readonly pendingCheckNames: readonly string[];
+  readonly failingCheckNames: readonly string[];
+  readonly actionableReviewFeedback: readonly ReviewFeedback[];
+  readonly unresolvedThreadIds: readonly string[];
+  readonly summary: string;
+}

--- a/src/domain/pull-request.ts
+++ b/src/domain/pull-request.ts
@@ -1,48 +1,9 @@
-export type PullRequestLifecycleKind =
-  | "missing"
-  | "awaiting-plan-review"
-  | "awaiting-review"
-  | "needs-follow-up"
-  | "ready";
-
-export type PullRequestCheckStatus = "pending" | "success" | "failure";
-
-export interface PullRequestHandle {
-  readonly number: number;
-  readonly url: string;
-  readonly branchName: string;
-  readonly latestCommitAt: string | null;
-}
-
-export interface PullRequestCheck {
-  readonly name: string;
-  readonly status: PullRequestCheckStatus;
-  readonly conclusion: string | null;
-  readonly detailsUrl: string | null;
-}
-
-export type ReviewFeedbackKind = "review-thread" | "issue-comment";
-
-export interface ReviewFeedback {
-  readonly id: string;
-  readonly kind: ReviewFeedbackKind;
-  readonly threadId: string | null;
-  readonly authorLogin: string | null;
-  readonly body: string;
-  readonly createdAt: string;
-  readonly url: string;
-  readonly path: string | null;
-  readonly line: number | null;
-}
-
-export interface PullRequestLifecycle {
-  readonly kind: PullRequestLifecycleKind;
-  readonly branchName: string;
-  readonly pullRequest: PullRequestHandle | null;
-  readonly checks: readonly PullRequestCheck[];
-  readonly pendingCheckNames: readonly string[];
-  readonly failingCheckNames: readonly string[];
-  readonly actionableReviewFeedback: readonly ReviewFeedback[];
-  readonly unresolvedThreadIds: readonly string[];
-  readonly summary: string;
-}
+export type {
+  HandoffLifecycle as PullRequestLifecycle,
+  HandoffLifecycleKind as PullRequestLifecycleKind,
+  PullRequestCheck,
+  PullRequestCheckStatus,
+  PullRequestHandle,
+  ReviewFeedback,
+  ReviewFeedbackKind,
+} from "./handoff.js";

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -1,5 +1,5 @@
 import type { RuntimeIssue } from "./issue.js";
-import type { PullRequestLifecycle } from "./pull-request.js";
+import type { HandoffLifecycle } from "./handoff.js";
 
 export interface RetryPolicy {
   readonly maxAttempts: number;
@@ -60,6 +60,6 @@ export interface PromptBuilder {
   build(input: {
     readonly issue: RuntimeIssue;
     readonly attempt: number | null;
-    readonly pullRequest: PullRequestLifecycle | null;
+    readonly pullRequest: HandoffLifecycle | null;
   }): Promise<string>;
 }

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -10,9 +10,9 @@ export type FactoryIssueStatus =
   | "queued"
   | "preparing"
   | "running"
-  | "awaiting-plan-review"
-  | "awaiting-review"
-  | "needs-follow-up";
+  | "awaiting-human-handoff"
+  | "awaiting-system-checks"
+  | "actionable-follow-up";
 
 export interface FactoryWorkerSnapshot {
   readonly instanceId: string;
@@ -418,9 +418,9 @@ function parseActiveIssue(
         "queued",
         "preparing",
         "running",
-        "awaiting-plan-review",
-        "awaiting-review",
-        "needs-follow-up",
+        "awaiting-human-handoff",
+        "awaiting-system-checks",
+        "actionable-follow-up",
       ],
       filePath,
       `${field}.status`,

--- a/src/orchestrator/follow-up-state.ts
+++ b/src/orchestrator/follow-up-state.ts
@@ -1,5 +1,5 @@
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 
 export interface FollowUpRuntimeState {
@@ -77,13 +77,13 @@ export function noteLifecycleObservation(
   state: FollowUpRuntimeState,
   issueNumber: number,
   attempt: number,
-  lifecycle: PullRequestLifecycle,
+  lifecycle: HandoffLifecycle,
   maxFollowUpAttempts: number,
 ): FollowUpBudgetDecision {
   const nextRunSequence = attempt + 1;
   state.nextRunSequenceByIssueNumber.set(issueNumber, nextRunSequence);
 
-  if (lifecycle.kind !== "needs-follow-up") {
+  if (lifecycle.kind !== "actionable-follow-up") {
     return {
       kind: "continue",
       nextRunSequence,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { OrchestratorError, RunnerAbortedError } from "../domain/errors.js";
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
 import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
@@ -379,22 +379,22 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     lockDir: string,
-    initialLifecycle?: PullRequestLifecycle,
+    initialLifecycle?: HandoffLifecycle,
   ): Promise<void> {
     const branchName = this.#branchName(issue.number);
     const issueSource = initialLifecycle !== undefined ? "ready" : "running";
     const lifecycle =
       initialLifecycle ?? (await this.#refreshLifecycle(branchName));
 
-    if (lifecycle.kind === "ready") {
+    if (lifecycle.kind === "handoff-ready") {
       await this.#completeIssue(issue);
       await this.#cleanupIssueWorkspaceIfNeeded(issue);
       return;
     }
 
     if (
-      lifecycle.kind === "awaiting-review" ||
-      lifecycle.kind === "awaiting-plan-review"
+      lifecycle.kind === "awaiting-system-checks" ||
+      lifecycle.kind === "awaiting-human-handoff"
     ) {
       noteLifecycleForIssue(
         this.#state.status,
@@ -425,7 +425,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       attempt,
       lockDir,
       issueSource,
-      lifecycle.kind === "missing" ? null : lifecycle,
+      lifecycle.kind === "missing-target" ? null : lifecycle,
     );
   }
 
@@ -434,7 +434,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     attempt: number,
     lockDir: string,
     source: "ready" | "running",
-    pullRequest: PullRequestLifecycle | null,
+    pullRequest: HandoffLifecycle | null,
   ): Promise<void> {
     upsertActiveIssue(this.#state.status, issue, {
       source,
@@ -540,7 +540,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         pullRequest,
       );
 
-      if (nextLifecycle.kind === "ready") {
+      if (nextLifecycle.kind === "handoff-ready") {
         await this.#completeIssue(issue, {
           attemptNumber: attempt,
           branchName: workspace.branchName,
@@ -551,7 +551,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         return;
       }
 
-      if (nextLifecycle.kind === "missing") {
+      if (nextLifecycle.kind === "missing-target") {
         await this.#handleFailure(
           session,
           attempt,
@@ -569,7 +569,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         workspace.branchName,
         nextLifecycle,
       );
-      this.#logger.info("Issue remains in PR lifecycle", {
+      this.#logger.info("Issue remains in handoff lifecycle", {
         issueNumber: issue.number,
         branchName: workspace.branchName,
         runSessionId: session.id,
@@ -695,7 +695,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
   }
 
-  async #refreshLifecycle(branchName: string): Promise<PullRequestLifecycle> {
+  async #refreshLifecycle(branchName: string): Promise<HandoffLifecycle> {
     return await this.#tracker.inspectIssueHandoff(branchName);
   }
 
@@ -782,10 +782,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     return `${this.#config.workspace.branchPrefix}${issueNumber.toString()}`;
   }
 
-  #missingLifecycle(issueNumber: number): PullRequestLifecycle {
+  #missingLifecycle(issueNumber: number): HandoffLifecycle {
     const branchName = this.#branchName(issueNumber);
     return {
-      kind: "missing",
+      kind: "missing-target",
       branchName,
       pullRequest: null,
       checks: [],
@@ -937,7 +937,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly branchName?: string | null;
       readonly session?: RunSession;
       readonly finishedAt?: string;
-      readonly lifecycle?: PullRequestLifecycle | null;
+      readonly lifecycle?: HandoffLifecycle | null;
     },
   ): Promise<void> {
     const runnerPid = this.#currentRunnerPid(issue.number);
@@ -1051,7 +1051,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     session: RunSession,
-    lifecycle: PullRequestLifecycle | null,
+    lifecycle: HandoffLifecycle | null,
   ): IssueArtifactObservation {
     const sessionArtifacts = this.#createSessionObservationArtifacts(session);
     return {
@@ -1079,7 +1079,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     branchName: string,
-    lifecycle: PullRequestLifecycle,
+    lifecycle: HandoffLifecycle,
     options?: {
       readonly session?: RunSession;
       readonly finishedAt?: string | undefined;
@@ -1198,7 +1198,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly branchName?: string | null | undefined;
       readonly session?: RunSession | undefined;
       readonly runnerPid?: number | null | undefined;
-      readonly lifecycle?: PullRequestLifecycle | null | undefined;
+      readonly lifecycle?: HandoffLifecycle | null | undefined;
     },
   ): IssueArtifactObservation {
     const sessionArtifacts =
@@ -1290,10 +1290,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     attempt: number,
     sessionId: string | null,
-    lifecycle: PullRequestLifecycle,
+    lifecycle: HandoffLifecycle,
     observedAt: string,
   ): IssueArtifactEvent | null {
-    if (lifecycle.kind === "awaiting-plan-review") {
+    if (lifecycle.kind === "awaiting-human-handoff") {
       return this.#createIssueEvent("plan-ready", issue, {
         observedAt,
         attemptNumber: attempt,
@@ -1303,8 +1303,8 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
 
     if (
-      lifecycle.kind !== "awaiting-review" &&
-      lifecycle.kind !== "needs-follow-up"
+      lifecycle.kind !== "awaiting-system-checks" &&
+      lifecycle.kind !== "actionable-follow-up"
     ) {
       return null;
     }
@@ -1324,20 +1324,20 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #createLifecycleOutcome(
-    lifecycle: PullRequestLifecycle,
+    lifecycle: HandoffLifecycle,
   ): Extract<
     IssueArtifactOutcome,
     "awaiting-plan-review" | "awaiting-review" | "needs-follow-up"
   > {
     switch (lifecycle.kind) {
-      case "awaiting-plan-review":
+      case "awaiting-human-handoff":
         return "awaiting-plan-review";
-      case "awaiting-review":
+      case "awaiting-system-checks":
         return "awaiting-review";
-      case "needs-follow-up":
+      case "actionable-follow-up":
         return "needs-follow-up";
-      case "missing":
-      case "ready":
+      case "missing-target":
+      case "handoff-ready":
         break;
     }
     throw new OrchestratorError(
@@ -1346,7 +1346,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #createLifecycleEventDetails(
-    lifecycle: PullRequestLifecycle,
+    lifecycle: HandoffLifecycle,
   ): Readonly<Record<string, unknown>> {
     return {
       branch: lifecycle.branchName,
@@ -1394,7 +1394,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly sessionId: string | null;
       readonly startedAt: string | null;
       readonly finishedAt?: string | null;
-      readonly lifecycle?: PullRequestLifecycle | null;
+      readonly lifecycle?: HandoffLifecycle | null;
       readonly runnerPid?: number | null;
     },
   ): IssueArtifactAttemptSnapshot {
@@ -1465,7 +1465,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #createPullRequestArtifactSnapshot(
-    lifecycle: PullRequestLifecycle | null,
+    lifecycle: HandoffLifecycle | null,
   ): IssueArtifactPullRequestSnapshot | null {
     if (lifecycle === null || lifecycle.pullRequest === null) {
       return null;
@@ -1478,7 +1478,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #createReviewArtifactSnapshot(
-    lifecycle: PullRequestLifecycle | null,
+    lifecycle: HandoffLifecycle | null,
   ): IssueArtifactReviewSnapshot | null {
     if (lifecycle === null) {
       return null;
@@ -1490,7 +1490,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #createCheckArtifactSnapshot(
-    lifecycle: PullRequestLifecycle | null,
+    lifecycle: HandoffLifecycle | null,
   ): IssueArtifactCheckSnapshot | null {
     if (lifecycle === null) {
       return null;
@@ -1505,14 +1505,14 @@ export class BootstrapOrchestrator implements Orchestrator {
     return this.#state.status.activeIssues.get(issueNumber)?.runnerPid ?? null;
   }
 
-  #followUpFailureMessage(lifecycle: PullRequestLifecycle): string {
+  #followUpFailureMessage(lifecycle: HandoffLifecycle): string {
     if (!this.#hasHumanReviewFeedback(lifecycle)) {
       return lifecycle.summary;
     }
     return `${lifecycle.summary}; human review feedback remains unresolved`;
   }
 
-  #hasHumanReviewFeedback(lifecycle: PullRequestLifecycle): boolean {
+  #hasHumanReviewFeedback(lifecycle: HandoffLifecycle): boolean {
     const reviewBotLogins = new Set(
       this.#config.tracker.reviewBotLogins.map((login) => login.toLowerCase()),
     );

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -1,5 +1,5 @@
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { RetryState } from "../domain/retry.js";
 import type {
   FactoryActiveIssueSnapshot,
@@ -144,19 +144,19 @@ export function noteLifecycleForIssue(
   source: "ready" | "running",
   runSequence: number,
   branchName: string,
-  lifecycle: PullRequestLifecycle,
+  lifecycle: HandoffLifecycle,
 ): void {
   upsertActiveIssue(state, issue, {
     source,
     runSequence,
     branchName,
     status:
-      lifecycle.kind === "needs-follow-up"
-        ? "needs-follow-up"
-        : lifecycle.kind === "awaiting-plan-review"
-          ? "awaiting-plan-review"
-          : lifecycle.kind === "awaiting-review"
-            ? "awaiting-review"
+      lifecycle.kind === "actionable-follow-up"
+        ? "actionable-follow-up"
+        : lifecycle.kind === "awaiting-human-handoff"
+          ? "awaiting-human-handoff"
+          : lifecycle.kind === "awaiting-system-checks"
+            ? "awaiting-system-checks"
             : "queued",
     summary: lifecycle.summary,
     pullRequest:
@@ -176,9 +176,9 @@ export function noteLifecycleForIssue(
       unresolvedThreadCount: lifecycle.unresolvedThreadIds.length,
     },
     blockedReason:
-      lifecycle.kind === "awaiting-plan-review" ||
-      lifecycle.kind === "awaiting-review" ||
-      lifecycle.kind === "needs-follow-up"
+      lifecycle.kind === "awaiting-human-handoff" ||
+      lifecycle.kind === "awaiting-system-checks" ||
+      lifecycle.kind === "actionable-follow-up"
         ? lifecycle.summary
         : null,
   });

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -1,5 +1,5 @@
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
 import type { TrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { GitHubClient } from "./github-client.js";
@@ -22,7 +22,7 @@ export class GitHubBootstrapTracker implements Tracker {
     string,
     {
       readonly issueUpdatedAt: string;
-      readonly lifecycle: PullRequestLifecycle | null;
+      readonly lifecycle: HandoffLifecycle | null;
     }
   >();
 
@@ -79,7 +79,7 @@ export class GitHubBootstrapTracker implements Tracker {
     return updated;
   }
 
-  async inspectIssueHandoff(branchName: string): Promise<PullRequestLifecycle> {
+  async inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle> {
     const pullRequest = await this.#client.findOpenPullRequest(branchName);
     if (pullRequest === null) {
       this.#noCheckObservations.delete(branchName);
@@ -114,8 +114,8 @@ export class GitHubBootstrapTracker implements Tracker {
 
   async reconcileSuccessfulRun(
     branchName: string,
-    lifecycle: PullRequestLifecycle | null,
-  ): Promise<PullRequestLifecycle> {
+    lifecycle: HandoffLifecycle | null,
+  ): Promise<HandoffLifecycle> {
     if (lifecycle !== null && lifecycle.unresolvedThreadIds.length > 0) {
       await this.#client.resolveReviewThreads(lifecycle.unresolvedThreadIds);
     }
@@ -125,7 +125,7 @@ export class GitHubBootstrapTracker implements Tracker {
 
   async #inspectPlanReviewHandoff(
     branchName: string,
-  ): Promise<PullRequestLifecycle | null> {
+  ): Promise<HandoffLifecycle | null> {
     const issueNumber = this.#issueNumberFromBranchName(branchName);
     if (issueNumber === null) {
       return null;

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -1,4 +1,4 @@
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
+import type { HandoffLifecycle } from "../domain/handoff.js";
 
 export interface IssueCommentSnapshot {
   readonly id: number;
@@ -29,7 +29,7 @@ interface ParsedPlanReviewAcknowledgement {
 
 export interface PlanReviewProtocolEvaluation {
   readonly latestSignal: ParsedPlanReviewComment | null;
-  readonly lifecycle: PullRequestLifecycle | null;
+  readonly lifecycle: HandoffLifecycle | null;
   readonly acknowledgement: {
     readonly signal: PlanReviewDecisionSignal;
     readonly reviewCommentId: number;
@@ -201,7 +201,7 @@ export function evaluatePlanReviewProtocol(
   return {
     latestSignal,
     lifecycle: {
-      kind: "awaiting-plan-review",
+      kind: "awaiting-human-handoff",
       branchName,
       pullRequest: null,
       checks: [],
@@ -219,6 +219,6 @@ export function evaluatePlanReviewLifecycle(
   branchName: string,
   issueUrl: string,
   comments: readonly IssueCommentSnapshot[],
-): PullRequestLifecycle | null {
+): HandoffLifecycle | null {
   return evaluatePlanReviewProtocol(branchName, issueUrl, comments).lifecycle;
 }

--- a/src/tracker/pull-request-policy.ts
+++ b/src/tracker/pull-request-policy.ts
@@ -1,7 +1,4 @@
-import type {
-  PullRequestLifecycle,
-  ReviewFeedback,
-} from "../domain/pull-request.js";
+import type { HandoffLifecycle, ReviewFeedback } from "../domain/handoff.js";
 import type { PullRequestSnapshot } from "./pull-request-snapshot.js";
 
 export interface NoCheckObservation {
@@ -10,7 +7,7 @@ export interface NoCheckObservation {
 }
 
 export interface PullRequestPolicyResult {
-  readonly lifecycle: PullRequestLifecycle;
+  readonly lifecycle: HandoffLifecycle;
   readonly nextNoCheckObservation: NoCheckObservation | null;
 }
 
@@ -37,9 +34,9 @@ function summarizeLifecycle(
 
 export function missingPullRequestLifecycle(
   branchName: string,
-): PullRequestLifecycle {
+): HandoffLifecycle {
   return {
-    kind: "missing",
+    kind: "missing-target",
     branchName,
     pullRequest: null,
     checks: [],
@@ -62,7 +59,7 @@ export function evaluatePullRequestLifecycle(
   ) {
     return {
       lifecycle: {
-        kind: "needs-follow-up",
+        kind: "actionable-follow-up",
         branchName: snapshot.branchName,
         pullRequest: snapshot.pullRequest,
         checks: snapshot.checks,
@@ -84,7 +81,7 @@ export function evaluatePullRequestLifecycle(
   if (snapshot.failingCheckNames.length > 0) {
     return {
       lifecycle: {
-        kind: "awaiting-review",
+        kind: "awaiting-system-checks",
         branchName: snapshot.branchName,
         pullRequest: snapshot.pullRequest,
         checks: snapshot.checks,
@@ -106,7 +103,7 @@ export function evaluatePullRequestLifecycle(
   if (snapshot.pendingCheckNames.length > 0) {
     return {
       lifecycle: {
-        kind: "awaiting-review",
+        kind: "awaiting-system-checks",
         branchName: snapshot.branchName,
         pullRequest: snapshot.pullRequest,
         checks: snapshot.checks,
@@ -128,7 +125,7 @@ export function evaluatePullRequestLifecycle(
   if (snapshot.actionableReviewFeedback.length > 0) {
     return {
       lifecycle: {
-        kind: "awaiting-review",
+        kind: "awaiting-system-checks",
         branchName: snapshot.branchName,
         pullRequest: snapshot.pullRequest,
         checks: snapshot.checks,
@@ -154,7 +151,7 @@ export function evaluatePullRequestLifecycle(
     if (!sawSameNoCheckLifecycle) {
       return {
         lifecycle: {
-          kind: "awaiting-review",
+          kind: "awaiting-system-checks",
           branchName: snapshot.branchName,
           pullRequest: snapshot.pullRequest,
           checks: snapshot.checks,
@@ -171,7 +168,7 @@ export function evaluatePullRequestLifecycle(
 
   return {
     lifecycle: {
-      kind: "ready",
+      kind: "handoff-ready",
       branchName: snapshot.branchName,
       pullRequest: snapshot.pullRequest,
       checks: snapshot.checks,

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -1,5 +1,5 @@
+import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { PullRequestLifecycle } from "../domain/pull-request.js";
 
 export interface Tracker {
   ensureLabels(): Promise<void>;
@@ -8,11 +8,11 @@ export interface Tracker {
   fetchFailedIssues(): Promise<readonly RuntimeIssue[]>;
   getIssue(issueNumber: number): Promise<RuntimeIssue>;
   claimIssue(issueNumber: number): Promise<RuntimeIssue | null>;
-  inspectIssueHandoff(branchName: string): Promise<PullRequestLifecycle>;
+  inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle>;
   reconcileSuccessfulRun(
     branchName: string,
-    lifecycle: PullRequestLifecycle | null,
-  ): Promise<PullRequestLifecycle>;
+    lifecycle: HandoffLifecycle | null,
+  ): Promise<HandoffLifecycle>;
   recordRetry(issueNumber: number, reason: string): Promise<void>;
   completeIssue(issueNumber: number): Promise<void>;
   markIssueFailed(issueNumber: number, reason: string): Promise<void>;

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -170,11 +170,11 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     );
     expect(status.factoryState).toBe("blocked");
     expect(status.counts.running).toBe(1);
-    expect(status.lastAction?.kind).toBe("awaiting-review");
+    expect(status.lastAction?.kind).toBe("awaiting-system-checks");
     expect(status.activeIssues).toHaveLength(1);
     expect(status.activeIssues[0]).toMatchObject({
       issueNumber: 1,
-      status: "awaiting-review",
+      status: "awaiting-system-checks",
       branchName: "symphony/1",
     });
     expect(status.activeIssues[0]?.pullRequest?.number).toBe(1);

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -78,7 +78,7 @@ describe("GitHubBootstrapTracker", () => {
     ]);
 
     expect((await tracker.inspectIssueHandoff("symphony/7")).kind).toBe(
-      "ready",
+      "handoff-ready",
     );
 
     await tracker.completeIssue(7);
@@ -91,11 +91,11 @@ describe("GitHubBootstrapTracker", () => {
     const tracker = createTracker(server);
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("missing");
+    expect(lifecycle.kind).toBe("missing-target");
     expect(lifecycle.summary).toMatch(/no open pull request/i);
   });
 
-  it("reports awaiting-plan-review when the latest issue handoff is plan-ready", async () => {
+  it("reports awaiting-human-handoff when the latest issue handoff is plan-ready", async () => {
     const tracker = createTracker(server);
 
     server.addIssueComment({
@@ -105,11 +105,11 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.kind).toBe("awaiting-human-handoff");
     expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
-  it("reports awaiting-plan-review for the legacy plan-ready wording", async () => {
+  it("reports awaiting-human-handoff for the legacy plan-ready wording", async () => {
     const tracker = createTracker(server);
 
     server.addIssueComment({
@@ -119,7 +119,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.kind).toBe("awaiting-human-handoff");
     expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
@@ -141,9 +141,9 @@ describe("GitHubBootstrapTracker", () => {
     const first = await tracker.inspectIssueHandoff("symphony/7");
     const second = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(first.kind).toBe("missing");
+    expect(first.kind).toBe("missing-target");
     expect(first.summary).toMatch(/no open pull request/i);
-    expect(second.kind).toBe("missing");
+    expect(second.kind).toBe("missing-target");
     expect(second.summary).toMatch(/no open pull request/i);
     expect(
       server
@@ -181,7 +181,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-plan-review");
+    expect(lifecycle.kind).toBe("awaiting-human-handoff");
     expect(lifecycle.summary).toMatch(/waiting for human plan review/i);
   });
 
@@ -196,8 +196,8 @@ describe("GitHubBootstrapTracker", () => {
     const first = await tracker.inspectIssueHandoff("symphony/7");
     const second = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(first.kind).toBe("awaiting-plan-review");
-    expect(second.kind).toBe("awaiting-plan-review");
+    expect(first.kind).toBe("awaiting-human-handoff");
+    expect(second.kind).toBe("awaiting-human-handoff");
     expect(server.countRequests("GET issues/7")).toBe(2);
     expect(server.countRequests("GET issues/7/comments")).toBe(1);
   });
@@ -220,8 +220,8 @@ describe("GitHubBootstrapTracker", () => {
     const first = await tracker.inspectIssueHandoff("symphony/7");
     const second = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(first.kind).toBe("missing");
-    expect(second.kind).toBe("missing");
+    expect(first.kind).toBe("missing-target");
+    expect(second.kind).toBe("missing-target");
     expect(server.countRequests("GET issues/7")).toBe(2);
     expect(server.countRequests("GET issues/7/comments")).toBe(2);
     expect(
@@ -251,8 +251,8 @@ describe("GitHubBootstrapTracker", () => {
     const first = await tracker.inspectIssueHandoff("symphony/7");
     const second = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(first.kind).toBe("missing");
-    expect(second.kind).toBe("missing");
+    expect(first.kind).toBe("missing-target");
+    expect(second.kind).toBe("missing-target");
     expect(
       server
         .getIssue(7)
@@ -262,7 +262,7 @@ describe("GitHubBootstrapTracker", () => {
     ).toHaveLength(1);
   });
 
-  it("reports awaiting-review while checks are pending", async () => {
+  it("reports awaiting-system-checks while checks are pending", async () => {
     const tracker = createTracker(server);
 
     await server.recordPullRequest({
@@ -277,7 +277,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
     expect(lifecycle.pendingCheckNames).toEqual(["CI"]);
   });
 
@@ -296,7 +296,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
     expect(lifecycle.pendingCheckNames).toEqual(["Bugbot"]);
   });
 
@@ -315,7 +315,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("ready");
+    expect(lifecycle.kind).toBe("handoff-ready");
     expect(lifecycle.failingCheckNames).toEqual([]);
   });
 
@@ -335,7 +335,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("ready");
+    expect(lifecycle.kind).toBe("handoff-ready");
     expect(lifecycle.failingCheckNames).toEqual([]);
   });
 
@@ -351,11 +351,11 @@ describe("GitHubBootstrapTracker", () => {
 
     const first = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(first.kind).toBe("awaiting-review");
+    expect(first.kind).toBe("awaiting-system-checks");
     expect(first.summary).toMatch(/waiting for pr checks to appear/i);
 
     const second = await tracker.inspectIssueHandoff("symphony/7");
-    expect(second.kind).toBe("ready");
+    expect(second.kind).toBe("handoff-ready");
     expect(second.summary).toMatch(/merge-ready/i);
   });
 
@@ -399,7 +399,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("needs-follow-up");
+    expect(lifecycle.kind).toBe("actionable-follow-up");
     expect(lifecycle.failingCheckNames).toEqual(["CI"]);
     expect(lifecycle.unresolvedThreadIds).toEqual([threadId]);
     expect(lifecycle.actionableReviewFeedback).toHaveLength(2);
@@ -417,7 +417,7 @@ describe("GitHubBootstrapTracker", () => {
       lifecycle,
     );
     expect(server.isReviewThreadResolved(threadId)).toBe(true);
-    expect(refreshed.kind).toBe("ready");
+    expect(refreshed.kind).toBe("handoff-ready");
   });
 
   it("does not auto-resolve human review threads after a follow-up push", async () => {
@@ -449,7 +449,7 @@ describe("GitHubBootstrapTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("needs-follow-up");
+    expect(lifecycle.kind).toBe("actionable-follow-up");
     expect(lifecycle.unresolvedThreadIds).toEqual([botThreadId]);
     expect(lifecycle.actionableReviewFeedback).toHaveLength(2);
 
@@ -460,7 +460,7 @@ describe("GitHubBootstrapTracker", () => {
 
     expect(server.isReviewThreadResolved(botThreadId)).toBe(true);
     expect(server.isReviewThreadResolved(humanThreadId)).toBe(false);
-    expect(refreshed.kind).toBe("awaiting-review");
+    expect(refreshed.kind).toBe("awaiting-system-checks");
     expect(refreshed.actionableReviewFeedback).toHaveLength(1);
     expect(refreshed.actionableReviewFeedback[0]?.authorLogin).toBe(
       "jessmartin",
@@ -492,12 +492,12 @@ describe("GitHubBootstrapTracker", () => {
     });
 
     const first = await tracker.inspectIssueHandoff("symphony/8");
-    expect(first.kind).toBe("awaiting-review");
+    expect(first.kind).toBe("awaiting-system-checks");
 
     await tracker.completeIssue(7);
 
     const second = await tracker.inspectIssueHandoff("symphony/8");
-    expect(second.kind).toBe("ready");
+    expect(second.kind).toBe("handoff-ready");
   });
 
   it("preserves no-check stabilization for other branches when another issue is claimed", async () => {
@@ -524,12 +524,12 @@ describe("GitHubBootstrapTracker", () => {
     });
 
     const first = await tracker.inspectIssueHandoff("symphony/8");
-    expect(first.kind).toBe("awaiting-review");
+    expect(first.kind).toBe("awaiting-system-checks");
 
     await tracker.claimIssue(7);
 
     const second = await tracker.inspectIssueHandoff("symphony/8");
-    expect(second.kind).toBe("ready");
+    expect(second.kind).toBe("handoff-ready");
   });
 
   it("deduplicates two concurrent ensureLabels calls", async () => {

--- a/tests/support/pull-request.ts
+++ b/tests/support/pull-request.ts
@@ -1,8 +1,8 @@
 import type { RuntimeIssue } from "../../src/domain/issue.js";
 import type {
-  PullRequestLifecycle,
+  HandoffLifecycle,
   ReviewFeedback,
-} from "../../src/domain/pull-request.js";
+} from "../../src/domain/handoff.js";
 
 export function createIssue(
   number: number,
@@ -24,7 +24,7 @@ export function createIssue(
 }
 
 export function createLifecycle(
-  kind: PullRequestLifecycle["kind"],
+  kind: HandoffLifecycle["kind"],
   branchName: string,
   options?: {
     failingCheckNames?: readonly string[];
@@ -32,12 +32,12 @@ export function createLifecycle(
     actionableReviewFeedback?: readonly ReviewFeedback[];
     unresolvedThreadIds?: readonly string[];
   },
-): PullRequestLifecycle {
+): HandoffLifecycle {
   return {
     kind,
     branchName,
     pullRequest:
-      kind === "missing" || kind === "awaiting-plan-review"
+      kind === "missing-target" || kind === "awaiting-human-handoff"
         ? null
         : {
             number: 1,

--- a/tests/unit/follow-up-state.test.ts
+++ b/tests/unit/follow-up-state.test.ts
@@ -18,7 +18,7 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       1,
-      createLifecycle("awaiting-review", "symphony/16"),
+      createLifecycle("awaiting-system-checks", "symphony/16"),
       2,
     );
 
@@ -30,7 +30,7 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       2,
-      createLifecycle("needs-follow-up", "symphony/16"),
+      createLifecycle("actionable-follow-up", "symphony/16"),
       2,
     );
 
@@ -47,7 +47,7 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       1,
-      createLifecycle("awaiting-review", "symphony/17"),
+      createLifecycle("awaiting-system-checks", "symphony/17"),
       2,
     );
 
@@ -55,14 +55,14 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       2,
-      createLifecycle("needs-follow-up", "symphony/17"),
+      createLifecycle("actionable-follow-up", "symphony/17"),
       2,
     );
     const secondFollowUp = noteLifecycleObservation(
       state,
       issue.number,
       3,
-      createLifecycle("needs-follow-up", "symphony/17"),
+      createLifecycle("actionable-follow-up", "symphony/17"),
       2,
     );
 
@@ -78,7 +78,7 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       1,
-      createLifecycle("needs-follow-up", "symphony/18"),
+      createLifecycle("actionable-follow-up", "symphony/18"),
       3,
     );
 
@@ -102,7 +102,7 @@ describe("follow-up-state", () => {
       state,
       19,
       2,
-      createLifecycle("needs-follow-up", "symphony/19"),
+      createLifecycle("actionable-follow-up", "symphony/19"),
       1,
     );
 
@@ -118,14 +118,14 @@ describe("follow-up-state", () => {
       state,
       issue.number,
       1,
-      createLifecycle("awaiting-review", "symphony/20"),
+      createLifecycle("awaiting-system-checks", "symphony/20"),
       2,
     );
     noteLifecycleObservation(
       state,
       issue.number,
       2,
-      createLifecycle("needs-follow-up", "symphony/20"),
+      createLifecycle("actionable-follow-up", "symphony/20"),
       2,
     );
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
+import type { HandoffLifecycle } from "../../src/domain/handoff.js";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
-import type { PullRequestLifecycle } from "../../src/domain/pull-request.js";
 import type { RunResult, RunSession } from "../../src/domain/run.js";
 import type { PreparedWorkspace } from "../../src/domain/workspace.js";
 import type {
@@ -121,7 +121,7 @@ class SequencedTracker implements Tracker {
   readonly readyIssues = new Map<number, RuntimeIssue>();
   readonly runningIssues = new Map<number, RuntimeIssue>();
   readonly failedIssues = new Map<number, RuntimeIssue>();
-  readonly lifecycleSequences = new Map<number, PullRequestLifecycle[]>();
+  readonly lifecycleSequences = new Map<number, HandoffLifecycle[]>();
   readonly completed: number[] = [];
   readonly retried: Array<{ issueNumber: number; reason: string }> = [];
   readonly failed: Array<{ issueNumber: number; reason: string }> = [];
@@ -142,7 +142,7 @@ class SequencedTracker implements Tracker {
 
   setLifecycleSequence(
     issueNumber: number,
-    sequence: readonly PullRequestLifecycle[],
+    sequence: readonly HandoffLifecycle[],
   ): void {
     this.lifecycleSequences.set(issueNumber, [...sequence]);
   }
@@ -179,7 +179,7 @@ class SequencedTracker implements Tracker {
     return claimed;
   }
 
-  async inspectIssueHandoff(branchName: string): Promise<PullRequestLifecycle> {
+  async inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle> {
     const issueNumber = Number(branchName.split("/").at(-1));
     if (Number.isNaN(issueNumber)) {
       throw new Error(`Invalid branch name ${branchName}`);
@@ -196,15 +196,15 @@ class SequencedTracker implements Tracker {
 
   async reconcileSuccessfulRun(
     branchName: string,
-    lifecycle: PullRequestLifecycle | null,
-  ): Promise<PullRequestLifecycle> {
+    lifecycle: HandoffLifecycle | null,
+  ): Promise<HandoffLifecycle> {
     if (lifecycle !== null && lifecycle.unresolvedThreadIds.length > 0) {
       this.resolvedThreadBatches.push([...lifecycle.unresolvedThreadIds]);
     }
     if (lifecycle === null) {
       const issueNumber = Number(branchName.split("/").at(-1));
       const sequence = this.lifecycleSequences.get(issueNumber);
-      if (sequence?.[0]?.kind === "missing") {
+      if (sequence?.[0]?.kind === "missing-target") {
         sequence.shift();
       }
     }
@@ -472,16 +472,16 @@ describe("BootstrapOrchestrator", () => {
         ready: [createIssue(1), createIssue(2), createIssue(3)],
       });
       tracker.setLifecycleSequence(1, [
-        lifecycle("missing", "symphony/1"),
-        lifecycle("ready", "symphony/1"),
+        lifecycle("missing-target", "symphony/1"),
+        lifecycle("handoff-ready", "symphony/1"),
       ]);
       tracker.setLifecycleSequence(2, [
-        lifecycle("missing", "symphony/2"),
-        lifecycle("ready", "symphony/2"),
+        lifecycle("missing-target", "symphony/2"),
+        lifecycle("handoff-ready", "symphony/2"),
       ]);
       tracker.setLifecycleSequence(3, [
-        lifecycle("missing", "symphony/3"),
-        lifecycle("ready", "symphony/3"),
+        lifecycle("missing-target", "symphony/3"),
+        lifecycle("handoff-ready", "symphony/3"),
       ]);
       const runner = new ConcurrencyRunner();
       const orchestrator = new BootstrapOrchestrator(
@@ -525,8 +525,8 @@ describe("BootstrapOrchestrator", () => {
         ready: [createIssue(1)],
       });
       tracker.setLifecycleSequence(1, [
-        lifecycle("missing", "symphony/1"),
-        lifecycle("ready", "symphony/1"),
+        lifecycle("missing-target", "symphony/1"),
+        lifecycle("handoff-ready", "symphony/1"),
       ]);
       const logger = new NullLogger();
       const orchestrator = new BootstrapOrchestrator(
@@ -581,7 +581,7 @@ describe("BootstrapOrchestrator", () => {
       running: [createIssue(7, "symphony:running")],
     });
     tracker.setLifecycleSequence(7, [
-      lifecycle("awaiting-review", "symphony/7", {
+      lifecycle("awaiting-system-checks", "symphony/7", {
         pendingCheckNames: ["CI"],
       }),
     ]);
@@ -617,8 +617,8 @@ describe("BootstrapOrchestrator", () => {
         ready: [createIssue(32)],
       });
       tracker.setLifecycleSequence(32, [
-        lifecycle("missing", "symphony/32"),
-        lifecycle("awaiting-plan-review", "symphony/32"),
+        lifecycle("missing-target", "symphony/32"),
+        lifecycle("awaiting-human-handoff", "symphony/32"),
       ]);
       const runner = new RecordingRunner();
       const orchestrator = new BootstrapOrchestrator(
@@ -645,7 +645,7 @@ describe("BootstrapOrchestrator", () => {
       const snapshot = await readFactoryStatusSnapshot(
         deriveStatusFilePath(tempRoot),
       );
-      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-plan-review");
+      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-human-handoff");
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
@@ -658,8 +658,8 @@ describe("BootstrapOrchestrator", () => {
         running: [createIssue(79, "symphony:running")],
       });
       tracker.setLifecycleSequence(79, [
-        lifecycle("missing", "symphony/79"),
-        lifecycle("awaiting-review", "symphony/79", {
+        lifecycle("missing-target", "symphony/79"),
+        lifecycle("awaiting-system-checks", "symphony/79", {
           pendingCheckNames: ["CI"],
         }),
       ]);
@@ -685,7 +685,7 @@ describe("BootstrapOrchestrator", () => {
       );
       expect(snapshot.activeIssues).toHaveLength(1);
       expect(snapshot.activeIssues[0]?.source).toBe("running");
-      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-review");
+      expect(snapshot.activeIssues[0]?.status).toBe("awaiting-system-checks");
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
@@ -698,7 +698,7 @@ describe("BootstrapOrchestrator", () => {
         running: [createIssue(70, "symphony:running")],
       });
       tracker.setLifecycleSequence(70, [
-        lifecycle("needs-follow-up", "symphony/70", {
+        lifecycle("actionable-follow-up", "symphony/70", {
           failingCheckNames: ["CI"],
         }),
       ]);
@@ -745,7 +745,9 @@ describe("BootstrapOrchestrator", () => {
       const tracker = new SequencedTracker({
         running: [createIssue(71, "symphony:running")],
       });
-      tracker.setLifecycleSequence(71, [lifecycle("ready", "symphony/71")]);
+      tracker.setLifecycleSequence(71, [
+        lifecycle("handoff-ready", "symphony/71"),
+      ]);
       const lockDir = path.join(tempRoot, ".symphony-locks", "71");
       await fs.mkdir(lockDir, { recursive: true });
       await fs.writeFile(path.join(lockDir, "pid"), "999999\n", "utf8");
@@ -779,10 +781,12 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(78)],
       running: [createIssue(77, "symphony:running")],
     });
-    tracker.setLifecycleSequence(77, [lifecycle("ready", "symphony/77")]);
+    tracker.setLifecycleSequence(77, [
+      lifecycle("handoff-ready", "symphony/77"),
+    ]);
     tracker.setLifecycleSequence(78, [
-      lifecycle("missing", "symphony/78"),
-      lifecycle("ready", "symphony/78"),
+      lifecycle("missing-target", "symphony/78"),
+      lifecycle("handoff-ready", "symphony/78"),
     ]);
     const logger = new NullLogger();
     const originalReconcile = LocalIssueLeaseManager.prototype.reconcile;
@@ -835,7 +839,7 @@ describe("BootstrapOrchestrator", () => {
         running: [issue],
       });
       tracker.setLifecycleSequence(72, [
-        lifecycle("awaiting-review", "symphony/72"),
+        lifecycle("awaiting-system-checks", "symphony/72"),
       ]);
       const orchestrator = new BootstrapOrchestrator(
         {
@@ -874,7 +878,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       running: [createIssue(72, "symphony:running")],
     });
-    tracker.setLifecycleSequence(72, [lifecycle("ready", "symphony/72")]);
+    tracker.setLifecycleSequence(72, [
+      lifecycle("handoff-ready", "symphony/72"),
+    ]);
     const lockDir = path.join(tempRoot, ".symphony-locks", "72");
     await fs.mkdir(lockDir, { recursive: true });
     await fs.writeFile(path.join(lockDir, "pid"), "4242\n", "utf8");
@@ -916,8 +922,8 @@ describe("BootstrapOrchestrator", () => {
       running: [createIssue(71, "symphony:running")],
     });
     tracker.setLifecycleSequence(71, [
-      lifecycle("awaiting-review", "symphony/71"),
-      lifecycle("ready", "symphony/71"),
+      lifecycle("awaiting-system-checks", "symphony/71"),
+      lifecycle("handoff-ready", "symphony/71"),
     ]);
     const workspace = new CleanupFailingWorkspaceManager();
     const logger = new NullLogger();
@@ -958,7 +964,7 @@ describe("BootstrapOrchestrator", () => {
       running: [createIssue(8, "symphony:running")],
     });
     tracker.setLifecycleSequence(8, [
-      lifecycle("needs-follow-up", "symphony/8", {
+      lifecycle("actionable-follow-up", "symphony/8", {
         failingCheckNames: ["CI"],
         unresolvedThreadIds: ["thread-1"],
         actionableReviewFeedback: [
@@ -975,7 +981,7 @@ describe("BootstrapOrchestrator", () => {
           },
         ],
       }),
-      lifecycle("ready", "symphony/8"),
+      lifecycle("handoff-ready", "symphony/8"),
     ]);
     const runner = new RecordingRunner();
     const workspace = new CleanupFailingWorkspaceManager();
@@ -1008,7 +1014,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       running: [createIssue(81, "symphony:running")],
     });
-    tracker.setLifecycleSequence(81, [lifecycle("ready", "symphony/81")]);
+    tracker.setLifecycleSequence(81, [
+      lifecycle("handoff-ready", "symphony/81"),
+    ]);
     const workspace = new CleanupFailingWorkspaceManager();
     let runnerCalls = 0;
     const orchestrator = new BootstrapOrchestrator(
@@ -1047,17 +1055,17 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(9)],
     });
     tracker.setLifecycleSequence(9, [
-      lifecycle("missing", "symphony/9"),
-      lifecycle("awaiting-review", "symphony/9", {
+      lifecycle("missing-target", "symphony/9"),
+      lifecycle("awaiting-system-checks", "symphony/9", {
         pendingCheckNames: ["CI"],
       }),
-      lifecycle("awaiting-review", "symphony/9", {
+      lifecycle("awaiting-system-checks", "symphony/9", {
         pendingCheckNames: ["CI"],
       }),
-      lifecycle("needs-follow-up", "symphony/9", {
+      lifecycle("actionable-follow-up", "symphony/9", {
         failingCheckNames: ["CI"],
       }),
-      lifecycle("ready", "symphony/9"),
+      lifecycle("handoff-ready", "symphony/9"),
     ]);
     const runner = new RecordingRunner();
     const orchestrator = new BootstrapOrchestrator(
@@ -1082,7 +1090,7 @@ describe("BootstrapOrchestrator", () => {
       running: [createIssue(73, "symphony:running")],
     });
     tracker.setLifecycleSequence(73, [
-      lifecycle("needs-follow-up", "symphony/73", {
+      lifecycle("actionable-follow-up", "symphony/73", {
         actionableReviewFeedback: [
           {
             id: "feedback-1",
@@ -1098,7 +1106,7 @@ describe("BootstrapOrchestrator", () => {
         ],
         unresolvedThreadIds: ["thread-1"],
       }),
-      lifecycle("needs-follow-up", "symphony/73", {
+      lifecycle("actionable-follow-up", "symphony/73", {
         actionableReviewFeedback: [
           {
             id: "feedback-2",
@@ -1130,7 +1138,7 @@ describe("BootstrapOrchestrator", () => {
     expect(tracker.failed).toEqual([
       {
         issueNumber: 73,
-        reason: "needs-follow-up for symphony/73",
+        reason: "actionable-follow-up for symphony/73",
       },
     ]);
   });
@@ -1140,11 +1148,11 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(74)],
     });
     tracker.setLifecycleSequence(74, [
-      lifecycle("missing", "symphony/74"),
-      lifecycle("awaiting-review", "symphony/74", {
+      lifecycle("missing-target", "symphony/74"),
+      lifecycle("awaiting-system-checks", "symphony/74", {
         pendingCheckNames: ["CI"],
       }),
-      lifecycle("needs-follow-up", "symphony/74", {
+      lifecycle("actionable-follow-up", "symphony/74", {
         failingCheckNames: ["CI"],
         actionableReviewFeedback: [
           {
@@ -1161,7 +1169,7 @@ describe("BootstrapOrchestrator", () => {
         ],
         unresolvedThreadIds: ["thread-1"],
       }),
-      lifecycle("needs-follow-up", "symphony/74", {
+      lifecycle("actionable-follow-up", "symphony/74", {
         failingCheckNames: ["CI"],
         actionableReviewFeedback: [
           {
@@ -1178,7 +1186,7 @@ describe("BootstrapOrchestrator", () => {
         ],
         unresolvedThreadIds: ["thread-2"],
       }),
-      lifecycle("ready", "symphony/74"),
+      lifecycle("handoff-ready", "symphony/74"),
     ]);
     const runner = new RecordingRunner();
     const orchestrator = new BootstrapOrchestrator(
@@ -1204,14 +1212,14 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(13)],
     });
     tracker.setLifecycleSequence(13, [
-      lifecycle("missing", "symphony/13"),
-      lifecycle("awaiting-review", "symphony/13", {
+      lifecycle("missing-target", "symphony/13"),
+      lifecycle("awaiting-system-checks", "symphony/13", {
         pendingCheckNames: ["CI"],
       }),
-      lifecycle("needs-follow-up", "symphony/13", {
+      lifecycle("actionable-follow-up", "symphony/13", {
         failingCheckNames: ["CI"],
       }),
-      lifecycle("ready", "symphony/13"),
+      lifecycle("handoff-ready", "symphony/13"),
     ]);
     const runner = new RecordingRunner();
     const orchestrator = new BootstrapOrchestrator(
@@ -1236,7 +1244,7 @@ describe("BootstrapOrchestrator", () => {
       JSON.stringify({
         issue: "sociotechnica-org/symphony-ts#13",
         attempt: 2,
-        pullRequest: "needs-follow-up",
+        pullRequest: "actionable-follow-up",
       }),
     ]);
   });
@@ -1245,7 +1253,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(10)],
     });
-    tracker.setLifecycleSequence(10, [lifecycle("missing", "symphony/10")]);
+    tracker.setLifecycleSequence(10, [
+      lifecycle("missing-target", "symphony/10"),
+    ]);
     const runnerCalls: number[] = [];
     const runner: Runner = {
       describeSession() {
@@ -1294,7 +1304,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(77)],
     });
-    tracker.setLifecycleSequence(77, [lifecycle("missing", "symphony/77")]);
+    tracker.setLifecycleSequence(77, [
+      lifecycle("missing-target", "symphony/77"),
+    ]);
     const runnerPid = 4321;
     const orchestrator = new BootstrapOrchestrator(
       {
@@ -1371,7 +1383,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(82)],
     });
-    tracker.setLifecycleSequence(82, [lifecycle("missing", "symphony/82")]);
+    tracker.setLifecycleSequence(82, [
+      lifecycle("missing-target", "symphony/82"),
+    ]);
     const runnerPid = 8765;
     const orchestrator = new BootstrapOrchestrator(
       {
@@ -1426,7 +1440,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(78)],
     });
-    tracker.setLifecycleSequence(78, [lifecycle("missing", "symphony/78")]);
+    tracker.setLifecycleSequence(78, [
+      lifecycle("missing-target", "symphony/78"),
+    ]);
     const artifactStore = new RecordingIssueArtifactStore();
     const orchestrator = new BootstrapOrchestrator(
       {
@@ -1484,7 +1500,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(81)],
     });
-    tracker.setLifecycleSequence(81, [lifecycle("missing", "symphony/81")]);
+    tracker.setLifecycleSequence(81, [
+      lifecycle("missing-target", "symphony/81"),
+    ]);
     let describeSessionCalls = 0;
     const orchestrator = new BootstrapOrchestrator(
       baseConfig,
@@ -1520,12 +1538,12 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(79), createIssue(80)],
     });
     tracker.setLifecycleSequence(79, [
-      lifecycle("missing", "symphony/79"),
-      lifecycle("ready", "symphony/79"),
+      lifecycle("missing-target", "symphony/79"),
+      lifecycle("handoff-ready", "symphony/79"),
     ]);
     tracker.setLifecycleSequence(80, [
-      lifecycle("missing", "symphony/80"),
-      lifecycle("ready", "symphony/80"),
+      lifecycle("missing-target", "symphony/80"),
+      lifecycle("handoff-ready", "symphony/80"),
     ]);
     const artifactStore = new PerIssueBlockingArtifactStore(79);
     const runner = new BlockingRecordingRunner([79, 80]);
@@ -1555,7 +1573,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new RetryRecordingFailingTracker({
       ready: [createIssue(11)],
     });
-    tracker.setLifecycleSequence(11, [lifecycle("missing", "symphony/11")]);
+    tracker.setLifecycleSequence(11, [
+      lifecycle("missing-target", "symphony/11"),
+    ]);
     const logger = new NullLogger();
     const orchestrator = new BootstrapOrchestrator(
       baseConfig,
@@ -1592,7 +1612,9 @@ describe("BootstrapOrchestrator", () => {
     const tracker = new FailOnceMarkIssueFailedTracker({
       ready: [createIssue(75)],
     });
-    tracker.setLifecycleSequence(75, [lifecycle("missing", "symphony/75")]);
+    tracker.setLifecycleSequence(75, [
+      lifecycle("missing-target", "symphony/75"),
+    ]);
     const runnerCalls: number[] = [];
     const logger = new NullLogger();
     const orchestrator = new BootstrapOrchestrator(
@@ -1651,7 +1673,9 @@ describe("BootstrapOrchestrator", () => {
       const tracker = new SequencedTracker({
         ready: [createIssue(76)],
       });
-      tracker.setLifecycleSequence(76, [lifecycle("missing", "symphony/76")]);
+      tracker.setLifecycleSequence(76, [
+        lifecycle("missing-target", "symphony/76"),
+      ]);
       const started = createDeferred<void>();
       const orchestrator = new BootstrapOrchestrator(
         {
@@ -1713,12 +1737,12 @@ describe("BootstrapOrchestrator", () => {
     const firstTracker = new SequencedTracker({ ready: [issue] });
     const secondTracker = new SequencedTracker({ ready: [issue] });
     firstTracker.setLifecycleSequence(12, [
-      lifecycle("missing", "symphony/12"),
-      lifecycle("ready", "symphony/12"),
+      lifecycle("missing-target", "symphony/12"),
+      lifecycle("handoff-ready", "symphony/12"),
     ]);
     secondTracker.setLifecycleSequence(12, [
-      lifecycle("missing", "symphony/12"),
-      lifecycle("ready", "symphony/12"),
+      lifecycle("missing-target", "symphony/12"),
+      lifecycle("handoff-ready", "symphony/12"),
     ]);
     const runner = new RecordingRunner();
 

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -34,7 +34,7 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+    expect(lifecycle?.kind).toBe("awaiting-human-handoff");
   });
 
   it("waits when the latest relevant signal uses the legacy plan-ready marker", () => {
@@ -51,7 +51,7 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+    expect(lifecycle?.kind).toBe("awaiting-human-handoff");
   });
 
   it("does not wait when a later approval exists", () => {
@@ -140,7 +140,7 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle?.kind).toBe("awaiting-plan-review");
+    expect(lifecycle?.kind).toBe("awaiting-human-handoff");
   });
 
   it("requests an acknowledgement comment for approved reviews", () => {

--- a/tests/unit/pull-request-policy.test.ts
+++ b/tests/unit/pull-request-policy.test.ts
@@ -33,8 +33,8 @@ describe("pull-request-policy", () => {
       first.nextNoCheckObservation ?? undefined,
     );
 
-    expect(first.lifecycle.kind).toBe("awaiting-review");
-    expect(second.lifecycle.kind).toBe("ready");
+    expect(first.lifecycle.kind).toBe("awaiting-system-checks");
+    expect(second.lifecycle.kind).toBe("handoff-ready");
   });
 
   it("waits on human-only review feedback without scheduling follow-up", () => {
@@ -57,7 +57,7 @@ describe("pull-request-policy", () => {
       undefined,
     ).lifecycle;
 
-    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
     expect(lifecycle.actionableReviewFeedback).toHaveLength(1);
   });
 
@@ -96,7 +96,7 @@ describe("pull-request-policy", () => {
       undefined,
     ).lifecycle;
 
-    expect(lifecycle.kind).toBe("needs-follow-up");
+    expect(lifecycle.kind).toBe("actionable-follow-up");
     expect(lifecycle.failingCheckNames).toEqual(["CI"]);
     expect(lifecycle.unresolvedThreadIds).toEqual(["thread-2"]);
   });
@@ -110,7 +110,7 @@ describe("pull-request-policy", () => {
       undefined,
     ).lifecycle;
 
-    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
     expect(lifecycle.pendingCheckNames).toEqual(["integration"]);
     expect(lifecycle.failingCheckNames).toEqual(["lint"]);
   });
@@ -137,7 +137,7 @@ describe("pull-request-policy", () => {
       undefined,
     ).lifecycle;
 
-    expect(lifecycle.kind).toBe("awaiting-review");
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
     expect(lifecycle.pendingCheckNames).toEqual(["integration"]);
     expect(lifecycle.actionableReviewFeedback).toEqual(feedback);
   });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -33,7 +33,7 @@ function createSnapshot(
       retries: 1,
     },
     lastAction: {
-      kind: "awaiting-review",
+      kind: "awaiting-system-checks",
       summary: "Waiting for PR checks to appear on https://example.test/pr/12",
       at: "2026-03-06T12:00:00.000Z",
       issueNumber: 12,
@@ -45,7 +45,7 @@ function createSnapshot(
         title: "Expose factory status",
         source: "running",
         runSequence: 2,
-        status: "awaiting-review",
+        status: "awaiting-system-checks",
         summary:
           "Waiting for PR checks to appear on https://example.test/pr/12",
         workspacePath: "/tmp/workspaces/12",
@@ -273,7 +273,9 @@ describe("factory status helpers", () => {
     expect(output).toContain(
       "Counts: ready=1 tracker_running=2 failed=0 local=0 retries=1",
     );
-    expect(output).toContain("#12 Expose factory status [awaiting-review]");
+    expect(output).toContain(
+      "#12 Expose factory status [awaiting-system-checks]",
+    );
     expect(output).toContain("PR: #12 https://example.test/pr/12");
     expect(output).toContain("Pending checks: CI");
     expect(output).toContain("Retries:");


### PR DESCRIPTION
Closes #50.

## Summary
- introduce a tracker-neutral `HandoffLifecycle` contract and keep the legacy `PullRequestLifecycle` export as a compatibility alias
- map GitHub plan-review and PR facts into the generalized handoff states at the tracker edge, then update orchestrator and status surfaces to consume only those states
- keep issue-artifact outcomes on the existing vocabulary via an explicit compatibility mapper while updating tracker, orchestrator, integration, and e2e tests to the generalized model

## Plan
- `docs/plans/050-generalize-handoff-lifecycle-model/plan.md`

## Verification
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `codex review --base origin/main` (started and inspected the diff, but the CLI session did not return a terminating summary before the local checks completed)
