### PR TITLE
Add Linear workflow config and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,30 @@ By default, the checked-in `WORKFLOW.md` targets:
 - tracker: GitHub bootstrap adapter
 - runner: local Codex CLI
 
+## Linear Workflow Config Example
+
+Workflow loading also supports a Linear tracker config shape for upcoming adapter work:
+
+```yaml
+tracker:
+  kind: linear
+  endpoint: https://api.linear.app/graphql
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-0c79b11b75ea
+  assignee: $LINEAR_ASSIGNEE
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+    - Done
+```
+
+In this slice, `loadWorkflow` validates and normalizes that config, but `symphony run` still requires the GitHub bootstrap tracker until the Linear adapter lands.
+
 ## How to Use Symphony to Build Symphony
 
 This is the recursive local setup: Symphony runs against the `symphony-ts` GitHub repo and works `symphony-ts` issues by opening PRs back to that same repo.

--- a/docs/plans/065-linear-workflow-config-validation/plan.md
+++ b/docs/plans/065-linear-workflow-config-validation/plan.md
@@ -1,0 +1,229 @@
+# Issue 65 Plan: Linear Workflow Config And Validation
+
+## Status
+
+- approved
+
+## Goal
+
+Add a typed `tracker.kind: linear` workflow contract so `WORKFLOW.md` can describe a Linear-backed tracker at the configuration boundary, with defaults and validation aligned to the upstream Symphony/Elixir seams, while keeping Linear-specific assumptions out of the orchestrator.
+
+## Scope
+
+- add a discriminated tracker config contract that supports:
+  - `tracker.kind: github-bootstrap`
+  - `tracker.kind: linear`
+- resolve and validate the Linear workflow fields needed in this slice:
+  - `tracker.endpoint`
+  - `tracker.api_key` / token resolution
+  - `tracker.project_slug` or equivalent required project scope
+  - optional `tracker.assignee`
+  - `tracker.active_states`
+  - `tracker.terminal_states`
+- apply Linear defaults that match the upstream Elixir config seam where that seam is already established:
+  - default endpoint
+  - default active states
+  - default terminal states
+- keep validation at `src/config/` so malformed Linear config fails before orchestration
+- add focused tests for successful parsing and clear boundary failures
+- document a Linear `WORKFLOW.md` example snippet for future adapter work
+- add the smallest possible runtime seam needed to keep the existing GitHub execution path type-safe after `tracker` becomes a union
+
+## Non-goals
+
+- implementing a Linear tracker client, GraphQL transport, normalization, or tracker reads/writes
+- making `pnpm tsx bin/symphony.ts run` dispatch real Linear work in this issue
+- encoding Linear state names or eligibility rules in the orchestrator
+- redesigning the broader workflow schema outside the tracker config seam
+- inventing speculative Linear workpad/comment fields that are not yet required by a stable downstream contract
+
+## Current Gaps
+
+- `src/domain/workflow.ts` models `tracker` as a single GitHub-bootstrap-only shape
+- `src/config/workflow.ts` ignores `tracker.kind` and always requires GitHub-specific fields
+- workflow validation currently cannot distinguish:
+  - supported tracker kinds
+  - unsupported tracker kinds
+  - missing Linear credentials
+  - missing Linear project scope
+- tests only cover GitHub bootstrap workflow parsing
+- README and the checked-in workflow example only document GitHub bootstrap usage
+- the CLI/run path currently constructs `GitHubBootstrapTracker` directly, so a tracker-config union needs an explicit boundary to avoid type leakage or unsafe casts
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: documenting the repository-owned workflow contract for choosing `tracker.kind: linear`
+  - does not belong: hard-coded Linear workflow state names inside orchestrator control flow
+- Configuration Layer
+  - belongs: parsing front matter, applying defaults, resolving env-backed credentials, normalizing tracker config into typed unions, and emitting clear validation failures
+  - does not belong: Linear API calls, project lookups, or tracker eligibility behavior
+- Coordination Layer
+  - belongs: no new behavior in this slice
+  - does not belong: interpreting Linear config fields or compensating for missing Linear validation
+- Execution Layer
+  - belongs: at most a narrow runtime guard/factory seam so execution code does not assume every tracker config is GitHub-shaped
+  - does not belong: Linear transport, issue polling, or config parsing
+- Integration Layer
+  - belongs: no transport work yet; only preserving a future seam where a Linear adapter can consume the validated Linear config later
+  - does not belong: mixing future GraphQL concerns into `src/config/`
+- Observability Layer
+  - belongs: surfacing precise config error messages in tests and user-facing failures
+  - does not belong: tracker-specific status rendering or new runtime telemetry
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts`
+  - add discriminated tracker config types for GitHub bootstrap and Linear
+- `src/config/workflow.ts`
+  - branch on `tracker.kind`
+  - parse GitHub config through the existing path
+  - parse Linear config through a dedicated resolver with defaults and validation
+  - keep all malformed-input checks at the boundary
+- minimal CLI/runtime wiring only if needed to avoid unsafe casts after the tracker config union is introduced
+- unit tests that exercise both tracker kinds and validation failures
+- docs/example updates for Linear workflow front matter
+
+### Does not belong in this issue
+
+- adding a `src/tracker/linear-*` client/adapter
+- changing orchestrator dispatch, retry, or handoff logic
+- teaching workspace or runner layers anything about Linear
+- mixing tracker transport, normalization, and policy into the workflow loader
+- broad docs churn unrelated to the workflow contract
+
+## Slice Strategy And PR Seam
+
+This issue should stay one reviewable PR by landing only the config seam required before any Linear adapter can exist:
+
+1. introduce a typed tracker union
+2. parse and validate Linear config in `src/config/`
+3. keep the run path compile-safe with a narrow tracker-construction boundary
+4. add tests and docs for the new contract
+
+This seam is reviewable on its own because it deliberately defers:
+
+- all Linear API transport
+- all Linear payload normalization
+- all orchestrator policy changes
+- all workpad/comment-write behavior
+
+## Runtime State Model
+
+Not applicable for this slice. The issue is limited to configuration loading and validation and does not change orchestration state, retries, reconciliation, leases, or handoff transitions.
+
+## Validation Failure Matrix
+
+| Observed input                                                            | Boundary facts available          | Expected result                                                                                                                         |
+| ------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `tracker.kind` omitted with existing GitHub fields present                | front matter map only             | preserve current GitHub bootstrap behavior for backward compatibility or require explicit defaulting to `github-bootstrap` in one place |
+| `tracker.kind: github-bootstrap` with missing required GitHub field       | front matter map only             | `ConfigError` names the missing GitHub field                                                                                            |
+| `tracker.kind: linear` with no `tracker.api_key` and no env fallback      | front matter map plus process env | `ConfigError` clearly states that a Linear API key/token is required                                                                    |
+| `tracker.kind: linear` with missing `tracker.project_slug`                | front matter map only             | `ConfigError` clearly states that project scope is required                                                                             |
+| `tracker.kind: linear` with malformed `active_states` / `terminal_states` | front matter map only             | `ConfigError` names the invalid field and expected type                                                                                 |
+| `tracker.kind: linear` with omitted endpoint/states                       | front matter map only             | workflow loads successfully using upstream-aligned defaults                                                                             |
+| unknown `tracker.kind` value                                              | front matter map only             | `ConfigError` clearly states the supported tracker kinds                                                                                |
+
+## Storage / Persistence Contract
+
+- no new durable storage is introduced
+- `ResolvedConfig` remains the typed in-memory contract returned from `loadWorkflow`
+- any future Linear tracker adapter should consume the normalized `ResolvedConfig.tracker` union rather than reparsing raw workflow fields
+
+## Observability Requirements
+
+- config failures must remain loud and field-specific at workflow-load time
+- tests should assert the exact field names involved in the error so operator-facing failures stay actionable
+- no new logs or status-surface fields are required in this slice
+
+## Implementation Steps
+
+1. Split tracker config types in `src/domain/workflow.ts` into:
+   - `GitHubBootstrapTrackerConfig`
+   - `LinearTrackerConfig`
+   - `TrackerConfig` as the discriminated union
+2. Refactor `src/config/workflow.ts` so tracker resolution is delegated to focused helpers instead of one inline object literal.
+3. Preserve the GitHub bootstrap resolver behavior, with `tracker.kind` defaulting cleanly to `github-bootstrap` for compatibility if that is required by existing fixtures and checked-in workflow files.
+4. Add a Linear resolver that:
+   - requires `kind: linear`
+   - applies the upstream default endpoint
+   - applies upstream default active/terminal states
+   - resolves the Linear API key/token from workflow config and, if needed, documented env fallback
+   - accepts optional assignee routing / worker identity filter
+   - requires non-empty project scope
+5. Add explicit unsupported-kind validation with a message listing supported kinds.
+6. Add the narrowest runtime construction guard needed so code that instantiates the GitHub tracker narrows on `tracker.kind` explicitly instead of assuming every tracker config is GitHub-shaped.
+7. Add unit coverage for:
+   - GitHub bootstrap backward compatibility
+   - valid Linear workflow parsing
+   - defaulted Linear endpoint/states
+   - missing Linear token
+   - missing Linear project scope
+   - unsupported tracker kind
+8. Add a docs/example workflow snippet for `tracker.kind: linear` in the most relevant checked-in docs surface.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `loadWorkflow` still parses the current GitHub bootstrap workflow
+- `loadWorkflow` parses a valid Linear workflow and returns a `tracker.kind === "linear"` config with:
+  - endpoint defaulted correctly when omitted
+  - active states defaulted correctly when omitted
+  - terminal states defaulted correctly when omitted
+- `loadWorkflow` rejects:
+  - unknown tracker kind
+  - Linear config without token
+  - Linear config without project scope
+  - malformed Linear state arrays
+
+### Integration
+
+- CLI/status-path code paths that only need workflow loading continue to work with a valid Linear workflow definition
+- run-path wiring remains explicit about unsupported execution for `linear` until the adapter issue lands
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. A repository `WORKFLOW.md` with `tracker.kind: linear`, a valid token, and a project slug loads successfully and returns a typed Linear tracker config.
+2. A Linear workflow with omitted endpoint or state lists still loads, using the upstream default endpoint and state defaults.
+3. A Linear workflow missing token material fails early with a clear `ConfigError`.
+4. A Linear workflow missing project scope fails early with a clear `ConfigError`.
+5. An unsupported tracker kind fails early before any orchestrator or tracker execution starts.
+6. Existing GitHub bootstrap workflow fixtures still load unchanged.
+
+## Exit Criteria
+
+- `WORKFLOW.md` parsing supports both GitHub bootstrap and Linear tracker config shapes
+- malformed or incomplete Linear workflow config fails at the config boundary with clear field-specific errors
+- the orchestrator and tracker transport layers remain free of Linear config parsing logic
+- the existing GitHub bootstrap workflow contract remains intact
+- the change lands as one reviewable PR without bundling Linear transport or orchestration work
+
+## Deferred To Later Issues Or PRs
+
+- Linear GraphQL transport and API client
+- Linear issue normalization into the runtime issue model
+- tracker factory support that can dispatch real Linear work
+- Linear workpad/comment lifecycle behavior
+- any repo-owned policy about default Linear state names beyond the upstream config defaults already established in the Elixir reference
+
+## Decision Notes
+
+- This slice should mirror the upstream Elixir config seam where it is already explicit: `endpoint`, `api_key`, `project_slug`, `assignee`, `active_states`, and `terminal_states`.
+- Backward compatibility for existing GitHub bootstrap workflows matters more than forcing every current workflow to add `tracker.kind` immediately. If the current fixtures rely on implicit GitHub bootstrap behavior, keep that compatibility in the config layer rather than pushing churn into unrelated files.
+- The runtime guard after config resolution is intentionally narrow. It exists only to keep TypeScript honest about the new tracker union until the Linear integration issue lands.
+- Do not add speculative workpad/comment fields unless the downstream Linear behavior issue identifies a concrete contract. This issue should establish the config seam first, not pre-commit the next slice’s policy surface.
+
+## Revision Log
+
+- 2026-03-10: Initial plan created and marked `plan-ready` for issue #65.
+- 2026-03-10: Plan approved on the issue thread; implementation started.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import {
 } from "../observability/status.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
 import { LocalRunner } from "../runner/local.js";
-import { GitHubBootstrapTracker } from "../tracker/github-bootstrap.js";
+import { createTracker } from "../tracker/factory.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
 
 export type CliArgs =
@@ -107,7 +107,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   const logger = new JsonLogger();
   const workflow = await loadWorkflow(args.workflowPath);
   const promptBuilder = createPromptBuilder(workflow);
-  const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);
+  const tracker = createTracker(workflow.config.tracker, logger);
   const workspace = new LocalWorkspaceManager(
     workflow.config.workspace,
     workflow.config.hooks.afterCreate,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createPromptBuilder, loadWorkflow } from "../config/workflow.js";
+import {
+  createPromptBuilder,
+  loadWorkflow,
+  loadWorkflowWorkspaceRoot,
+} from "../config/workflow.js";
 import { JsonLogger } from "../observability/logger.js";
 import {
   deriveStatusFilePath,
@@ -135,8 +139,8 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 }
 
 async function resolveStatusFilePath(workflowPath: string): Promise<string> {
-  const workflow = await loadWorkflow(workflowPath);
-  return deriveStatusFilePath(workflow.config.workspace.root);
+  const workspaceRoot = await loadWorkflowWorkspaceRoot(workflowPath);
+  return deriveStatusFilePath(workspaceRoot);
 }
 
 function readOptionValue(args: readonly string[], flag: string): string | null {

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { loadWorkflow } from "../config/workflow.js";
+import { loadWorkflowWorkspaceRoot } from "../config/workflow.js";
 import { writeIssueReport } from "../observability/issue-report.js";
 
 export interface ReportCliArgs {
@@ -37,11 +37,8 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
 
 export async function runReportCli(argv: readonly string[]): Promise<void> {
   const args = parseReportArgs(argv);
-  const workflow = await loadWorkflow(args.workflowPath);
-  const generated = await writeIssueReport(
-    workflow.config.workspace.root,
-    args.issueNumber,
-  );
+  const workspaceRoot = await loadWorkflowWorkspaceRoot(args.workflowPath);
+  const generated = await writeIssueReport(workspaceRoot, args.issueNumber);
   process.stdout.write(
     `Generated issue report for #${args.issueNumber.toString()}\nreport.json: ${generated.outputPaths.reportJsonFile}\nreport.md: ${generated.outputPaths.reportMarkdownFile}\n`,
   );

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -61,10 +61,16 @@ function requireString(value: unknown, field: string): string {
 
 function requireUrlString(value: unknown, field: string): string {
   const resolved = requireString(value, field);
+  let url: URL;
   try {
-    new URL(resolved);
+    url = new URL(resolved);
   } catch {
     throw new ConfigError(`${field} must be a valid URL, got '${resolved}'`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new ConfigError(
+      `${field} must use https:// or http://, got '${resolved}'`,
+    );
   }
   return resolved;
 }

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -317,6 +317,8 @@ function resolveTrackerConfig(
       return resolveGitHubBootstrapTrackerConfig(tracker);
     case "linear":
       return resolveLinearTrackerConfig(tracker);
+    default:
+      return exhaustiveTrackerConfig(kind);
   }
 }
 

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -467,17 +467,30 @@ export async function loadWorkflowWorkspaceRoot(
   );
 }
 
-function redactPromptConfig(config: ResolvedConfig): ResolvedConfig {
-  if (config.tracker.kind !== "linear") {
-    return config;
-  }
+function exhaustiveTrackerConfig(tracker: never): never {
+  throw new ConfigError(
+    `Unsupported tracker config '${JSON.stringify(tracker)}'`,
+  );
+}
 
+function redactTrackerConfig(tracker: TrackerConfig): TrackerConfig {
+  switch (tracker.kind) {
+    case "github-bootstrap":
+      return tracker;
+    case "linear":
+      return {
+        ...tracker,
+        apiKey: "[redacted]",
+      };
+    default:
+      return exhaustiveTrackerConfig(tracker);
+  }
+}
+
+function redactPromptConfig(config: ResolvedConfig): ResolvedConfig {
   return {
     ...config,
-    tracker: {
-      ...config.tracker,
-      apiKey: "[redacted]",
-    },
+    tracker: redactTrackerConfig(config.tracker),
   };
 }
 

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -5,8 +5,11 @@ import * as yaml from "yaml";
 import { ConfigError, WorkflowError } from "../domain/errors.js";
 import type { HandoffLifecycle } from "../domain/handoff.js";
 import type {
+  GitHubBootstrapTrackerConfig,
+  LinearTrackerConfig,
   PromptBuilder,
   ResolvedConfig,
+  TrackerConfig,
   WorkflowDefinition,
 } from "../domain/workflow.js";
 
@@ -22,6 +25,17 @@ const liquid = new Liquid({
   strictFilters: true,
   strictVariables: true,
 });
+
+const DEFAULT_LINEAR_ENDPOINT = "https://api.linear.app/graphql";
+const DEFAULT_LINEAR_ACTIVE_STATES = ["Todo", "In Progress"] as const;
+const DEFAULT_LINEAR_TERMINAL_STATES = [
+  "Closed",
+  "Cancelled",
+  "Canceled",
+  "Duplicate",
+  "Done",
+] as const;
+const SUPPORTED_TRACKER_KINDS = ["github-bootstrap", "linear"] as const;
 
 interface PromptRenderInput {
   readonly issue: {
@@ -46,11 +60,74 @@ function requireNumber(value: unknown, field: string): number {
   return value;
 }
 
+function requireObject(
+  value: unknown,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigError(`Expected object for ${field}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireOptionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new ConfigError(`Expected string for ${field}`);
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
 function requireStringArray(value: unknown, field: string): readonly string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
     throw new ConfigError(`Expected string array for ${field}`);
   }
   return value;
+}
+
+function normalizeSecretValue(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function resolveEnvReferenceName(value: string): string | null {
+  const match = value.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/u);
+  return match?.[1] ?? null;
+}
+
+function resolveEnvBackedSecret(
+  value: unknown,
+  field: string,
+  fallbackEnvName: string,
+): string | null {
+  if (value === undefined || value === null) {
+    return normalizeSecretValue(process.env[fallbackEnvName]);
+  }
+  if (typeof value !== "string") {
+    throw new ConfigError(`Expected string for ${field}`);
+  }
+
+  const trimmed = value.trim();
+  const referencedEnvName = resolveEnvReferenceName(trimmed);
+  if (referencedEnvName === null) {
+    return normalizeSecretValue(trimmed);
+  }
+
+  const referencedValue = process.env[referencedEnvName];
+  if (referencedValue === undefined) {
+    return normalizeSecretValue(process.env[fallbackEnvName]);
+  }
+
+  return normalizeSecretValue(referencedValue);
 }
 
 function parseFrontMatter(raw: string): {
@@ -88,39 +165,15 @@ function parseFrontMatter(raw: string): {
 }
 
 function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
-  const tracker = raw.tracker ?? {};
-  const polling = raw.polling ?? {};
-  const workspace = raw.workspace ?? {};
-  const hooks = raw.hooks ?? {};
-  const agent = raw.agent ?? {};
+  const tracker = requireObject(raw.tracker, "tracker");
+  const polling = requireObject(raw.polling, "polling");
+  const workspace = requireObject(raw.workspace, "workspace");
+  const hooks = requireObject(raw.hooks, "hooks");
+  const agent = requireObject(raw.agent, "agent");
 
   const resolved: ResolvedConfig = {
     workflowPath,
-    tracker: {
-      kind: "github-bootstrap",
-      repo: requireString(tracker["repo"], "tracker.repo"),
-      apiUrl: requireString(tracker["api_url"], "tracker.api_url"),
-      readyLabel: requireString(tracker["ready_label"], "tracker.ready_label"),
-      runningLabel: requireString(
-        tracker["running_label"],
-        "tracker.running_label",
-      ),
-      failedLabel: requireString(
-        tracker["failed_label"],
-        "tracker.failed_label",
-      ),
-      successComment: requireString(
-        tracker["success_comment"],
-        "tracker.success_comment",
-      ),
-      reviewBotLogins:
-        tracker["review_bot_logins"] === undefined
-          ? []
-          : requireStringArray(
-              tracker["review_bot_logins"],
-              "tracker.review_bot_logins",
-            ),
-    },
+    tracker: resolveTrackerConfig(tracker),
     polling: {
       intervalMs: requireNumber(polling["interval_ms"], "polling.interval_ms"),
       maxConcurrentRuns: requireNumber(
@@ -178,6 +231,110 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   }
 
   return resolved;
+}
+
+function resolveTrackerConfig(
+  tracker: Readonly<Record<string, unknown>>,
+): TrackerConfig {
+  const kind = resolveTrackerKind(tracker["kind"]);
+  if (kind === "github-bootstrap") {
+    return resolveGitHubBootstrapTrackerConfig(tracker);
+  }
+  return resolveLinearTrackerConfig(tracker);
+}
+
+function resolveTrackerKind(value: unknown): TrackerConfig["kind"] {
+  if (value === undefined || value === null) {
+    return "github-bootstrap";
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ConfigError("Expected non-empty string for tracker.kind");
+  }
+
+  const normalizedKind = value.trim();
+  if (normalizedKind === "github-bootstrap" || normalizedKind === "linear") {
+    return normalizedKind;
+  }
+
+  throw new ConfigError(
+    `Unsupported tracker.kind '${normalizedKind}'. Supported kinds: ${SUPPORTED_TRACKER_KINDS.join(", ")}`,
+  );
+}
+
+function resolveGitHubBootstrapTrackerConfig(
+  tracker: Readonly<Record<string, unknown>>,
+): GitHubBootstrapTrackerConfig {
+  return {
+    kind: "github-bootstrap",
+    repo: requireString(tracker["repo"], "tracker.repo"),
+    apiUrl: requireString(tracker["api_url"], "tracker.api_url"),
+    readyLabel: requireString(tracker["ready_label"], "tracker.ready_label"),
+    runningLabel: requireString(
+      tracker["running_label"],
+      "tracker.running_label",
+    ),
+    failedLabel: requireString(tracker["failed_label"], "tracker.failed_label"),
+    successComment: requireString(
+      tracker["success_comment"],
+      "tracker.success_comment",
+    ),
+    reviewBotLogins:
+      tracker["review_bot_logins"] === undefined
+        ? []
+        : requireStringArray(
+            tracker["review_bot_logins"],
+            "tracker.review_bot_logins",
+          ),
+  };
+}
+
+function resolveLinearTrackerConfig(
+  tracker: Readonly<Record<string, unknown>>,
+): LinearTrackerConfig {
+  const apiKey = resolveEnvBackedSecret(
+    tracker["api_key"],
+    "tracker.api_key",
+    "LINEAR_API_KEY",
+  );
+  if (apiKey === null) {
+    throw new ConfigError(
+      "Linear tracker requires tracker.api_key or LINEAR_API_KEY",
+    );
+  }
+
+  const projectSlug = requireOptionalString(
+    tracker["project_slug"],
+    "tracker.project_slug",
+  );
+  if (projectSlug === null) {
+    throw new ConfigError("Linear tracker requires tracker.project_slug");
+  }
+
+  return {
+    kind: "linear",
+    endpoint:
+      tracker["endpoint"] === undefined
+        ? DEFAULT_LINEAR_ENDPOINT
+        : requireString(tracker["endpoint"], "tracker.endpoint"),
+    apiKey,
+    projectSlug,
+    assignee: resolveEnvBackedSecret(
+      tracker["assignee"],
+      "tracker.assignee",
+      "LINEAR_ASSIGNEE",
+    ),
+    activeStates:
+      tracker["active_states"] === undefined
+        ? DEFAULT_LINEAR_ACTIVE_STATES
+        : requireStringArray(tracker["active_states"], "tracker.active_states"),
+    terminalStates:
+      tracker["terminal_states"] === undefined
+        ? DEFAULT_LINEAR_TERMINAL_STATES
+        : requireStringArray(
+            tracker["terminal_states"],
+            "tracker.terminal_states",
+          ),
+  };
 }
 
 function resolveRetryConfig(value: unknown): {

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -82,10 +82,12 @@ function requireNumber(value: unknown, field: string): number {
   return value;
 }
 
-function requireObject(
+function coerceOptionalObject(
   value: unknown,
   field: string,
 ): Readonly<Record<string, unknown>> {
+  // Omitted top-level sections keep the legacy "{}" parsing path, but an
+  // explicit YAML null is treated as malformed boundary input and fails early.
   if (value === undefined) {
     return {};
   }
@@ -240,11 +242,11 @@ async function readParsedWorkflow(
 }
 
 function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
-  const tracker = requireObject(raw.tracker, "tracker");
-  const polling = requireObject(raw.polling, "polling");
-  const workspace = requireObject(raw.workspace, "workspace");
-  const hooks = requireObject(raw.hooks, "hooks");
-  const agent = requireObject(raw.agent, "agent");
+  const tracker = coerceOptionalObject(raw.tracker, "tracker");
+  const polling = coerceOptionalObject(raw.polling, "polling");
+  const workspace = coerceOptionalObject(raw.workspace, "workspace");
+  const hooks = coerceOptionalObject(raw.hooks, "hooks");
+  const agent = coerceOptionalObject(raw.agent, "agent");
 
   const resolved: ResolvedConfig = {
     workflowPath,
@@ -462,7 +464,10 @@ export async function loadWorkflowWorkspaceRoot(
   workflowPath: string,
 ): Promise<string> {
   const parsed = await readParsedWorkflow(workflowPath);
-  const workspace = requireObject(parsed.frontMatter.workspace, "workspace");
+  const workspace = coerceOptionalObject(
+    parsed.frontMatter.workspace,
+    "workspace",
+  );
   return path.resolve(
     path.dirname(workflowPath),
     requireString(workspace["root"], "workspace.root"),

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -47,11 +47,26 @@ interface PromptRenderInput {
   readonly config: ResolvedConfig;
 }
 
+interface ParsedWorkflow {
+  readonly frontMatter: RawWorkflow;
+  readonly body: string;
+}
+
 function requireString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim() === "") {
     throw new ConfigError(`Expected non-empty string for ${field}`);
   }
   return value;
+}
+
+function requireUrlString(value: unknown, field: string): string {
+  const resolved = requireString(value, field);
+  try {
+    new URL(resolved);
+  } catch {
+    throw new ConfigError(`${field} must be a valid URL, got '${resolved}'`);
+  }
+  return resolved;
 }
 
 function requireNumber(value: unknown, field: string): number {
@@ -200,6 +215,20 @@ function parseFrontMatter(raw: string): {
     frontMatter: parsed as RawWorkflow,
     body: bodySource.trim(),
   };
+}
+
+async function readWorkflowSource(workflowPath: string): Promise<string> {
+  try {
+    return await fs.readFile(workflowPath, "utf8");
+  } catch (error) {
+    throw new WorkflowError(`Failed to read workflow file at ${workflowPath}`, {
+      cause: error as Error,
+    });
+  }
+}
+
+async function readParsedWorkflow(workflowPath: string): Promise<ParsedWorkflow> {
+  return parseFrontMatter(await readWorkflowSource(workflowPath));
 }
 
 function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
@@ -359,7 +388,7 @@ function resolveLinearTrackerConfig(
     endpoint:
       tracker["endpoint"] === undefined
         ? DEFAULT_LINEAR_ENDPOINT
-        : requireString(tracker["endpoint"], "tracker.endpoint"),
+        : requireUrlString(tracker["endpoint"], "tracker.endpoint"),
     apiKey,
     projectSlug,
     assignee: resolveOptionalEnvBackedSecret(
@@ -412,19 +441,35 @@ function resolveRetryConfig(value: unknown): {
 export async function loadWorkflow(
   workflowPath: string,
 ): Promise<WorkflowDefinition> {
-  let raw: string;
-  try {
-    raw = await fs.readFile(workflowPath, "utf8");
-  } catch (error) {
-    throw new WorkflowError(`Failed to read workflow file at ${workflowPath}`, {
-      cause: error as Error,
-    });
-  }
-
-  const parsed = parseFrontMatter(raw);
+  const parsed = await readParsedWorkflow(workflowPath);
   return {
     config: resolveConfig(parsed.frontMatter, workflowPath),
     promptTemplate: parsed.body,
+  };
+}
+
+export async function loadWorkflowWorkspaceRoot(
+  workflowPath: string,
+): Promise<string> {
+  const parsed = await readParsedWorkflow(workflowPath);
+  const workspace = requireObject(parsed.frontMatter.workspace, "workspace");
+  return path.resolve(
+    path.dirname(workflowPath),
+    requireString(workspace["root"], "workspace.root"),
+  );
+}
+
+function redactPromptConfig(config: ResolvedConfig): ResolvedConfig {
+  if (config.tracker.kind !== "linear") {
+    return config;
+  }
+
+  return {
+    ...config,
+    tracker: {
+      ...config.tracker,
+      apiKey: "[redacted]",
+    },
   };
 }
 
@@ -437,7 +482,7 @@ async function renderPromptTemplate(
       issue: input.issue,
       attempt: input.attempt,
       pull_request: input.pullRequest,
-      config: input.config,
+      config: redactPromptConfig(input.config),
     });
   } catch (error) {
     throw new WorkflowError(

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -92,6 +92,17 @@ function requireStringArray(value: unknown, field: string): readonly string[] {
   return value;
 }
 
+function requireNonEmptyStringArray(
+  value: unknown,
+  field: string,
+): readonly string[] {
+  const items = requireStringArray(value, field);
+  if (items.length === 0) {
+    throw new ConfigError(`Expected non-empty string array for ${field}`);
+  }
+  return items;
+}
+
 function normalizeSecretValue(value: string | null | undefined): string | null {
   if (typeof value !== "string") {
     return null;
@@ -131,6 +142,26 @@ function resolveEnvBackedSecret(
   }
 
   return normalizeSecretValue(referencedValue);
+}
+
+function resolveOptionalEnvBackedSecret(
+  value: unknown,
+  field: string,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new ConfigError(`Expected string for ${field}`);
+  }
+
+  const trimmed = value.trim();
+  const referencedEnvName = resolveEnvReferenceName(trimmed);
+  if (referencedEnvName === null) {
+    return normalizeSecretValue(trimmed);
+  }
+
+  return normalizeSecretValue(process.env[referencedEnvName]);
 }
 
 function isSupportedTrackerKind(value: string): value is SupportedTrackerKind {
@@ -243,17 +274,23 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
 function resolveTrackerConfig(
   tracker: Readonly<Record<string, unknown>>,
 ): TrackerConfig {
-  const kind = resolveTrackerKind(tracker["kind"]);
-  if (kind === "github-bootstrap") {
-    return resolveGitHubBootstrapTrackerConfig(tracker);
+  const kind = resolveTrackerKind(tracker);
+  switch (kind) {
+    case "github-bootstrap":
+      return resolveGitHubBootstrapTrackerConfig(tracker);
+    case "linear":
+      return resolveLinearTrackerConfig(tracker);
   }
-  return resolveLinearTrackerConfig(tracker);
 }
 
-function resolveTrackerKind(value: unknown): TrackerConfig["kind"] {
-  if (value === undefined || value === null) {
+function resolveTrackerKind(
+  tracker: Readonly<Record<string, unknown>>,
+): TrackerConfig["kind"] {
+  if (!Object.hasOwn(tracker, "kind")) {
     return "github-bootstrap";
   }
+
+  const value = tracker["kind"];
   if (typeof value !== "string" || value.trim() === "") {
     throw new ConfigError("Expected non-empty string for tracker.kind");
   }
@@ -325,19 +362,21 @@ function resolveLinearTrackerConfig(
         : requireString(tracker["endpoint"], "tracker.endpoint"),
     apiKey,
     projectSlug,
-    assignee: resolveEnvBackedSecret(
+    assignee: resolveOptionalEnvBackedSecret(
       tracker["assignee"],
       "tracker.assignee",
-      "LINEAR_ASSIGNEE",
     ),
     activeStates:
       tracker["active_states"] === undefined
         ? DEFAULT_LINEAR_ACTIVE_STATES
-        : requireStringArray(tracker["active_states"], "tracker.active_states"),
+        : requireNonEmptyStringArray(
+            tracker["active_states"],
+            "tracker.active_states",
+          ),
     terminalStates:
       tracker["terminal_states"] === undefined
         ? DEFAULT_LINEAR_TERMINAL_STATES
-        : requireStringArray(
+        : requireNonEmptyStringArray(
             tracker["terminal_states"],
             "tracker.terminal_states",
           ),

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -227,7 +227,9 @@ async function readWorkflowSource(workflowPath: string): Promise<string> {
   }
 }
 
-async function readParsedWorkflow(workflowPath: string): Promise<ParsedWorkflow> {
+async function readParsedWorkflow(
+  workflowPath: string,
+): Promise<ParsedWorkflow> {
   return parseFrontMatter(await readWorkflowSource(workflowPath));
 }
 

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -36,6 +36,7 @@ const DEFAULT_LINEAR_TERMINAL_STATES = [
   "Done",
 ] as const;
 const SUPPORTED_TRACKER_KINDS = ["github-bootstrap", "linear"] as const;
+type SupportedTrackerKind = (typeof SUPPORTED_TRACKER_KINDS)[number];
 
 interface PromptRenderInput {
   readonly issue: {
@@ -122,12 +123,18 @@ function resolveEnvBackedSecret(
     return normalizeSecretValue(trimmed);
   }
 
+  // Match the Elixir config seam: an unset explicit env reference falls back
+  // to the default env var for this field instead of failing immediately.
   const referencedValue = process.env[referencedEnvName];
   if (referencedValue === undefined) {
     return normalizeSecretValue(process.env[fallbackEnvName]);
   }
 
   return normalizeSecretValue(referencedValue);
+}
+
+function isSupportedTrackerKind(value: string): value is SupportedTrackerKind {
+  return (SUPPORTED_TRACKER_KINDS as readonly string[]).includes(value);
 }
 
 function parseFrontMatter(raw: string): {
@@ -252,7 +259,7 @@ function resolveTrackerKind(value: unknown): TrackerConfig["kind"] {
   }
 
   const normalizedKind = value.trim();
-  if (normalizedKind === "github-bootstrap" || normalizedKind === "linear") {
+  if (isSupportedTrackerKind(normalizedKind)) {
     return normalizedKind;
   }
 

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -7,7 +7,7 @@ export interface RetryPolicy {
   readonly backoffMs: number;
 }
 
-export interface TrackerConfig {
+export interface GitHubBootstrapTrackerConfig {
   readonly kind: "github-bootstrap";
   readonly repo: string;
   readonly apiUrl: string;
@@ -17,6 +17,18 @@ export interface TrackerConfig {
   readonly successComment: string;
   readonly reviewBotLogins: readonly string[];
 }
+
+export interface LinearTrackerConfig {
+  readonly kind: "linear";
+  readonly endpoint: string;
+  readonly apiKey: string;
+  readonly projectSlug: string;
+  readonly assignee: string | null;
+  readonly activeStates: readonly string[];
+  readonly terminalStates: readonly string[];
+}
+
+export type TrackerConfig = GitHubBootstrapTrackerConfig | LinearTrackerConfig;
 
 export interface PollingConfig {
   readonly intervalMs: number;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -4,7 +4,11 @@ import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RetryState } from "../domain/retry.js";
 import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
-import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
+import type {
+  GitHubBootstrapTrackerConfig,
+  PromptBuilder,
+  ResolvedConfig,
+} from "../domain/workflow.js";
 import type {
   IssueArtifactAttemptSnapshot,
   IssueArtifactCheckSnapshot,
@@ -60,8 +64,23 @@ interface QueueEntry {
   readonly source: "ready" | "running";
 }
 
+function requireBootstrapConfig(
+  config: ResolvedConfig,
+): ResolvedConfig & { readonly tracker: GitHubBootstrapTrackerConfig } {
+  if (config.tracker.kind !== "github-bootstrap") {
+    throw new Error(
+      "BootstrapOrchestrator requires tracker.kind 'github-bootstrap'",
+    );
+  }
+  return config as ResolvedConfig & {
+    readonly tracker: GitHubBootstrapTrackerConfig;
+  };
+}
+
 export class BootstrapOrchestrator implements Orchestrator {
-  readonly #config: ResolvedConfig;
+  readonly #config: ResolvedConfig & {
+    readonly tracker: GitHubBootstrapTrackerConfig;
+  };
   readonly #promptBuilder: PromptBuilder;
   readonly #tracker: Tracker;
   readonly #workspaceManager: WorkspaceManager;
@@ -83,7 +102,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     logger: Logger,
     issueArtifactStore?: IssueArtifactStore,
   ) {
-    this.#config = config;
+    this.#config = requireBootstrapConfig(config);
     this.#promptBuilder = promptBuilder;
     this.#tracker = tracker;
     this.#workspaceManager = workspaceManager;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -68,7 +68,7 @@ function requireBootstrapConfig(
   config: ResolvedConfig,
 ): ResolvedConfig & { readonly tracker: GitHubBootstrapTrackerConfig } {
   if (config.tracker.kind !== "github-bootstrap") {
-    throw new Error(
+    throw new OrchestratorError(
       "BootstrapOrchestrator requires tracker.kind 'github-bootstrap'",
     );
   }

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -1,4 +1,5 @@
 import type { TrackerConfig } from "../domain/workflow.js";
+import { TrackerError } from "../domain/errors.js";
 import type { Logger } from "../observability/logger.js";
 import type { Tracker } from "./service.js";
 import { GitHubBootstrapTracker } from "./github-bootstrap.js";
@@ -8,7 +9,7 @@ export function createTracker(config: TrackerConfig, logger: Logger): Tracker {
     case "github-bootstrap":
       return new GitHubBootstrapTracker(config, logger);
     case "linear":
-      throw new Error(
+      throw new TrackerError(
         "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
       );
     default:

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -11,5 +11,11 @@ export function createTracker(config: TrackerConfig, logger: Logger): Tracker {
       throw new Error(
         "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
       );
+    default:
+      return exhaustiveTrackerConfig(config);
   }
+}
+
+function exhaustiveTrackerConfig(config: never): never {
+  throw new Error(`Unsupported tracker config '${JSON.stringify(config)}'`);
 }

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -1,0 +1,15 @@
+import type { TrackerConfig } from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import type { Tracker } from "./service.js";
+import { GitHubBootstrapTracker } from "./github-bootstrap.js";
+
+export function createTracker(config: TrackerConfig, logger: Logger): Tracker {
+  switch (config.kind) {
+    case "github-bootstrap":
+      return new GitHubBootstrapTracker(config, logger);
+    case "linear":
+      throw new Error(
+        "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
+      );
+  }
+}

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -1,6 +1,6 @@
 import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
-import type { TrackerConfig } from "../domain/workflow.js";
+import type { GitHubBootstrapTrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { GitHubClient } from "./github-client.js";
 import { evaluatePlanReviewProtocol } from "./plan-review-policy.js";
@@ -13,7 +13,7 @@ import { createPullRequestSnapshot } from "./pull-request-snapshot.js";
 import type { Tracker } from "./service.js";
 
 export class GitHubBootstrapTracker implements Tracker {
-  readonly #config: TrackerConfig;
+  readonly #config: GitHubBootstrapTrackerConfig;
   readonly #logger: Logger;
   readonly #client: GitHubClient;
   #ensureLabelsPromise: Promise<void> | null = null;
@@ -26,7 +26,7 @@ export class GitHubBootstrapTracker implements Tracker {
     }
   >();
 
-  constructor(config: TrackerConfig, logger: Logger) {
+  constructor(config: GitHubBootstrapTrackerConfig, logger: Logger) {
     this.#config = config;
     this.#logger = logger;
     this.#client = new GitHubClient(config);

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -6,7 +6,7 @@ import type {
   PullRequestCheck,
   PullRequestCheckStatus,
 } from "../domain/pull-request.js";
-import type { TrackerConfig } from "../domain/workflow.js";
+import type { GitHubBootstrapTrackerConfig } from "../domain/workflow.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -336,12 +336,12 @@ export function toRuntimeIssue(
 }
 
 export class GitHubClient {
-  readonly #config: TrackerConfig;
+  readonly #config: GitHubBootstrapTrackerConfig;
   readonly #tokenPromise: Promise<string>;
   readonly #repoOwner: string;
   readonly #repoName: string;
 
-  constructor(config: TrackerConfig) {
+  constructor(config: GitHubBootstrapTrackerConfig) {
     this.#config = config;
     this.#tokenPromise = resolveToken();
     const [repoOwner, repoName] = config.repo.split("/");

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -95,6 +95,9 @@ async function createOrchestrator(
   workflowPath: string,
 ): Promise<BootstrapOrchestrator> {
   const workflow = await loadWorkflow(workflowPath);
+  if (workflow.config.tracker.kind !== "github-bootstrap") {
+    throw new Error("expected github-bootstrap tracker config");
+  }
   const logger = new JsonLogger();
   const promptBuilder = createPromptBuilder(workflow);
   const tracker = new GitHubBootstrapTracker(workflow.config.tracker, logger);

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -147,10 +147,13 @@ describe("report CLI", () => {
     tempRoots.push(tempDir);
     const workflowPath = path.join(tempDir, "WORKFLOW.md");
     const previousApiKey = process.env.LINEAR_API_KEY;
-    delete process.env.LINEAR_API_KEY;
-    await fs.writeFile(
-      workflowPath,
-      `---
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+
+    try {
+      delete process.env.LINEAR_API_KEY;
+      await fs.writeFile(
+        workflowPath,
+        `---
 tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
@@ -177,12 +180,10 @@ agent:
 ---
 Prompt body
 `,
-      "utf8",
-    );
-    const workspaceRoot = deriveWorkspaceRoot(tempDir);
-    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+        "utf8",
+      );
+      await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
 
-    try {
       await expect(
         runReportCli([
           "node",

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -141,4 +141,72 @@ describe("report CLI", () => {
       `No local issue artifacts found for issue #44 at ${path.join(tempDir, ".var", "factory", "issues", "44")}`,
     );
   });
+
+  it("derives the workspace root for report generation without requiring a linear API key", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-linear-");
+    tempRoots.push(tempDir);
+    const workflowPath = path.join(tempDir, "WORKFLOW.md");
+    const previousApiKey = process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_API_KEY;
+    await fs.writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-linear
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: /tmp/repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+      "utf8",
+    );
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    try {
+      await expect(
+        runReportCli([
+          "node",
+          "symphony-report",
+          "issue",
+          "--issue",
+          "44",
+          "--workflow",
+          workflowPath,
+        ]),
+      ).resolves.toBeUndefined();
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = previousApiKey;
+      }
+    }
+
+    await expect(
+      fs.readFile(
+        path.join(tempDir, ".var", "reports", "issues", "44", "report.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"githubActivity"');
+  });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -86,6 +86,42 @@ Prompt body
   return workflowPath;
 }
 
+async function writeLinearWorkflowWithoutToken(rootDir: string): Promise<string> {
+  const workflowPath = createWorkflow(rootDir);
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: symphony-linear
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: /tmp/repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
 function createSnapshot(): FactoryStatusSnapshot {
   return {
     version: 1,
@@ -243,6 +279,43 @@ describe("runCli status", () => {
     }
 
     expect(chunks.join("")).toBe(rawSnapshot);
+  });
+
+  it("derives the status snapshot path without requiring a linear API key", async () => {
+    const tempDir = await createTempDir("symphony-cli-status-linear-");
+    const workflowPath = await writeLinearWorkflowWithoutToken(tempDir);
+    const previousApiKey = process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_API_KEY;
+    const statusPath = path.join(tempDir, ".tmp", "status.json");
+    await fs.mkdir(path.dirname(statusPath), { recursive: true });
+    await fs.writeFile(
+      statusPath,
+      `${JSON.stringify(createSnapshot(), null, 2)}\n`,
+      "utf8",
+    );
+
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      chunks.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    try {
+      await runCli(["node", "symphony", "status", "--workflow", workflowPath]);
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = previousApiKey;
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(chunks.join("")).toContain("Factory: idle");
   });
 
   it("fails with a clear message when the snapshot is missing", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -86,7 +86,9 @@ Prompt body
   return workflowPath;
 }
 
-async function writeLinearWorkflowWithoutToken(rootDir: string): Promise<string> {
+async function writeLinearWorkflowWithoutToken(
+  rootDir: string,
+): Promise<string> {
   const workflowPath = createWorkflow(rootDir);
   await fs.writeFile(
     workflowPath,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -287,14 +287,7 @@ describe("runCli status", () => {
     const tempDir = await createTempDir("symphony-cli-status-linear-");
     const workflowPath = await writeLinearWorkflowWithoutToken(tempDir);
     const previousApiKey = process.env.LINEAR_API_KEY;
-    delete process.env.LINEAR_API_KEY;
     const statusPath = path.join(tempDir, ".tmp", "status.json");
-    await fs.mkdir(path.dirname(statusPath), { recursive: true });
-    await fs.writeFile(
-      statusPath,
-      `${JSON.stringify(createSnapshot(), null, 2)}\n`,
-      "utf8",
-    );
 
     const chunks: string[] = [];
     vi.spyOn(process.stdout, "write").mockImplementation(((
@@ -307,6 +300,14 @@ describe("runCli status", () => {
     }) as typeof process.stdout.write);
 
     try {
+      delete process.env.LINEAR_API_KEY;
+      await fs.mkdir(path.dirname(statusPath), { recursive: true });
+      await fs.writeFile(
+        statusPath,
+        `${JSON.stringify(createSnapshot(), null, 2)}\n`,
+        "utf8",
+      );
+
       await runCli(["node", "symphony", "status", "--workflow", workflowPath]);
     } finally {
       if (previousApiKey === undefined) {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -50,6 +50,42 @@ Prompt body
   return workflowPath;
 }
 
+async function writeLinearWorkflow(rootDir: string): Promise<string> {
+  const workflowPath = createWorkflow(rootDir);
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: symphony-linear
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: /tmp/repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
 function createSnapshot(): FactoryStatusSnapshot {
   return {
     version: 1,
@@ -293,5 +329,29 @@ describe("runCli status", () => {
     }
 
     expect(chunks.join("")).toContain('"factoryState": "idle"');
+  });
+});
+
+describe("runCli run", () => {
+  it("fails clearly when workflow config is linear but the runtime adapter is not implemented", async () => {
+    const tempDir = await createTempDir("symphony-cli-run-linear-");
+    const workflowPath = await writeLinearWorkflow(tempDir);
+
+    try {
+      await expect(
+        runCli([
+          "node",
+          "symphony",
+          "run",
+          "--once",
+          "--workflow",
+          workflowPath,
+        ]),
+      ).rejects.toThrowError(
+        "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -285,7 +285,6 @@ describe("runCli status", () => {
 
   it("derives the status snapshot path without requiring a linear API key", async () => {
     const tempDir = await createTempDir("symphony-cli-status-linear-");
-    const workflowPath = await writeLinearWorkflowWithoutToken(tempDir);
     const previousApiKey = process.env.LINEAR_API_KEY;
     const statusPath = path.join(tempDir, ".tmp", "status.json");
 
@@ -301,6 +300,7 @@ describe("runCli status", () => {
 
     try {
       delete process.env.LINEAR_API_KEY;
+      const workflowPath = await writeLinearWorkflowWithoutToken(tempDir);
       await fs.mkdir(path.dirname(statusPath), { recursive: true });
       await fs.writeFile(
         statusPath,
@@ -411,9 +411,9 @@ describe("runCli status", () => {
 describe("runCli run", () => {
   it("fails clearly when workflow config is linear but the runtime adapter is not implemented", async () => {
     const tempDir = await createTempDir("symphony-cli-run-linear-");
-    const workflowPath = await writeLinearWorkflow(tempDir);
 
     try {
+      const workflowPath = await writeLinearWorkflow(tempDir);
       await expect(
         runCli([
           "node",

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -363,6 +363,27 @@ ${buildSharedWorkflowSections()}`,
     );
   });
 
+  it("fails clearly when a linear workflow endpoint uses an unsupported URL scheme", async () => {
+    const dir = await createTempDir("workflow-linear-ftp-endpoint-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  endpoint: ftp://api.linear.app/graphql
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "tracker.endpoint must use https:// or http://, got 'ftp://api.linear.app/graphql'",
+    );
+  });
+
   it("fails clearly when a linear workflow is missing project scope", async () => {
     const dir = await createTempDir("workflow-linear-missing-project-");
     const workflowPath = path.join(dir, "WORKFLOW.md");

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -119,6 +119,50 @@ ${buildSharedWorkflowSections()}`,
     });
   });
 
+  it("redacts the linear API key from prompt rendering while preserving the runtime config", async () => {
+    const dir = await createTempDir("workflow-linear-redacted-prompt-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+        "token={{ config.tracker.apiKey }}",
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    if (workflow.config.tracker.kind !== "linear") {
+      throw new Error("expected linear tracker config");
+    }
+
+    expect(workflow.config.tracker.apiKey).toBe("linear-token");
+
+    const promptBuilder = createPromptBuilder(workflow);
+    const rendered = await promptBuilder.build({
+      issue: {
+        id: "1",
+        identifier: "repo#1",
+        number: 1,
+        title: "T",
+        description: "D",
+        labels: ["a"],
+        state: "open",
+        url: "https://example.test/issues/1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      attempt: null,
+      pullRequest: null,
+    });
+
+    expect(rendered).toBe("token=[redacted]");
+  });
+
   it("loads a linear workflow token and assignee from env-backed values", async () => {
     const dir = await createTempDir("workflow-linear-env-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
@@ -197,6 +241,41 @@ ${buildSharedWorkflowSections()}`,
     }
   });
 
+  it("treats an explicit unset assignee env reference as no assignee filter", async () => {
+    const dir = await createTempDir("workflow-linear-unset-assignee-env-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    const previousUnsetAssignee = process.env.MISSING_LINEAR_ASSIGNEE;
+    delete process.env.MISSING_LINEAR_ASSIGNEE;
+
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+  assignee: $MISSING_LINEAR_ASSIGNEE
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    try {
+      const workflow = await loadWorkflow(workflowPath);
+      if (workflow.config.tracker.kind !== "linear") {
+        throw new Error("expected linear tracker config");
+      }
+
+      expect(workflow.config.tracker.assignee).toBeNull();
+    } finally {
+      if (previousUnsetAssignee === undefined) {
+        delete process.env.MISSING_LINEAR_ASSIGNEE;
+      } else {
+        process.env.MISSING_LINEAR_ASSIGNEE = previousUnsetAssignee;
+      }
+    }
+  });
+
   it("fails clearly when tracker.kind is unsupported", async () => {
     const dir = await createTempDir("workflow-unsupported-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
@@ -261,6 +340,27 @@ ${buildSharedWorkflowSections()}`,
         process.env.LINEAR_API_KEY = previousApiKey;
       }
     }
+  });
+
+  it("fails clearly when a linear workflow endpoint is not a valid URL", async () => {
+    const dir = await createTempDir("workflow-linear-bad-endpoint-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  endpoint: api.linear.app/graphql
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "tracker.endpoint must be a valid URL, got 'api.linear.app/graphql'",
+    );
   });
 
   it("fails clearly when a linear workflow is missing project scope", async () => {

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -163,6 +163,40 @@ ${buildSharedWorkflowSections()}`,
     }
   });
 
+  it("does not inherit an assignee filter from ambient env when tracker.assignee is omitted", async () => {
+    const dir = await createTempDir("workflow-linear-no-assignee-env-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    const previousAssignee = process.env.LINEAR_ASSIGNEE;
+    process.env.LINEAR_ASSIGNEE = "ambient-worker@example.com";
+
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    try {
+      const workflow = await loadWorkflow(workflowPath);
+      if (workflow.config.tracker.kind !== "linear") {
+        throw new Error("expected linear tracker config");
+      }
+
+      expect(workflow.config.tracker.assignee).toBeNull();
+    } finally {
+      if (previousAssignee === undefined) {
+        delete process.env.LINEAR_ASSIGNEE;
+      } else {
+        process.env.LINEAR_ASSIGNEE = previousAssignee;
+      }
+    }
+  });
+
   it("fails clearly when tracker.kind is unsupported", async () => {
     const dir = await createTempDir("workflow-unsupported-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
@@ -178,6 +212,24 @@ ${buildSharedWorkflowSections()}`,
 
     await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
       "Unsupported tracker.kind 'linear-preview'. Supported kinds: github-bootstrap, linear",
+    );
+  });
+
+  it("fails clearly when tracker.kind is explicitly blank", async () => {
+    const dir = await createTempDir("workflow-blank-kind-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind:
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected non-empty string for tracker.kind",
     );
   });
 
@@ -248,6 +300,27 @@ ${buildSharedWorkflowSections()}`,
 
     await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
       "Expected string array for tracker.active_states",
+    );
+  });
+
+  it("fails clearly when linear state lists are empty", async () => {
+    const dir = await createTempDir("workflow-linear-empty-states-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+  active_states: []
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected non-empty string array for tracker.active_states",
     );
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -7,23 +7,19 @@ import {
 } from "../../src/config/workflow.js";
 import { createTempDir } from "../support/git.js";
 
-describe("workflow config", () => {
-  it("loads workflow config and renders prompt strictly", async () => {
-    const dir = await createTempDir("workflow-");
-    const workflowPath = path.join(dir, "WORKFLOW.md");
-    await fs.writeFile(
-      workflowPath,
-      `---
-tracker:
-  repo: sociotechnica-org/symphony-ts
-  api_url: https://api.github.com
-  ready_label: symphony:ready
-  running_label: symphony:running
-  failed_label: symphony:failed
-  success_comment: done
-  review_bot_logins:
-    - greptile[bot]
-polling:
+function buildWorkflow(
+  frontMatter: string,
+  promptBody = "Prompt body",
+): string {
+  return `---
+${frontMatter}
+---
+${promptBody}
+`;
+}
+
+function buildSharedWorkflowSections(): string {
+  return `polling:
   interval_ms: 1000
   max_concurrent_runs: 1
   retry:
@@ -43,9 +39,28 @@ agent:
   prompt_transport: stdin
   timeout_ms: 1000
   env:
-    FOO: bar
----
-Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
+    FOO: bar`;
+}
+
+describe("workflow config", () => {
+  it("loads workflow config and renders prompt strictly", async () => {
+    const dir = await createTempDir("workflow-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  review_bot_logins:
+    - greptile[bot]
+${buildSharedWorkflowSections()}`,
+        "Issue {{ issue.identifier }} / {{ config.tracker.repo }}",
+      ),
       "utf8",
     );
 
@@ -53,6 +68,7 @@ Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
     expect(workflow.config.workspace.root).toContain(
       `${path.sep}.tmp${path.sep}ws`,
     );
+    expect(workflow.config.tracker.kind).toBe("github-bootstrap");
     expect(workflow.config.polling.retry.maxAttempts).toBe(2);
     expect(workflow.config.polling.retry.maxFollowUpAttempts).toBe(3);
     const promptBuilder = createPromptBuilder(workflow);
@@ -74,5 +90,164 @@ Issue {{ issue.identifier }} / {{ config.tracker.repo }}`,
     });
     expect(rendered).toContain("repo#1");
     expect(rendered).toContain("sociotechnica-org/symphony-ts");
+  });
+
+  it("loads a valid linear workflow with upstream defaults", async () => {
+    const dir = await createTempDir("workflow-linear-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.tracker).toEqual({
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      projectSlug: "team-project",
+      assignee: null,
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
+    });
+  });
+
+  it("loads a linear workflow token and assignee from env-backed values", async () => {
+    const dir = await createTempDir("workflow-linear-env-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    const previousApiKey = process.env.LINEAR_API_KEY;
+    const previousWorker = process.env.LINEAR_WORKER;
+
+    process.env.LINEAR_API_KEY = "env-linear-token";
+    process.env.LINEAR_WORKER = "worker@example.com";
+
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: $MISSING_LINEAR_SECRET
+  project_slug: team-project
+  assignee: $LINEAR_WORKER
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    try {
+      const workflow = await loadWorkflow(workflowPath);
+      if (workflow.config.tracker.kind !== "linear") {
+        throw new Error("expected linear tracker config");
+      }
+
+      expect(workflow.config.tracker.apiKey).toBe("env-linear-token");
+      expect(workflow.config.tracker.assignee).toBe("worker@example.com");
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = previousApiKey;
+      }
+      if (previousWorker === undefined) {
+        delete process.env.LINEAR_WORKER;
+      } else {
+        process.env.LINEAR_WORKER = previousWorker;
+      }
+    }
+  });
+
+  it("fails clearly when tracker.kind is unsupported", async () => {
+    const dir = await createTempDir("workflow-unsupported-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear-preview
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Unsupported tracker.kind 'linear-preview'. Supported kinds: github-bootstrap, linear",
+    );
+  });
+
+  it("fails clearly when a linear workflow is missing a token", async () => {
+    const dir = await createTempDir("workflow-linear-missing-token-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    const previousApiKey = process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_API_KEY;
+
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  project_slug: team-project
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    try {
+      await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+        "Linear tracker requires tracker.api_key or LINEAR_API_KEY",
+      );
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.LINEAR_API_KEY;
+      } else {
+        process.env.LINEAR_API_KEY = previousApiKey;
+      }
+    }
+  });
+
+  it("fails clearly when a linear workflow is missing project scope", async () => {
+    const dir = await createTempDir("workflow-linear-missing-project-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Linear tracker requires tracker.project_slug",
+    );
+  });
+
+  it("fails clearly when linear state lists are malformed", async () => {
+    const dir = await createTempDir("workflow-linear-bad-states-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  api_key: linear-token
+  project_slug: team-project
+  active_states: not-a-list
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected string array for tracker.active_states",
+    );
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -314,6 +314,23 @@ ${buildSharedWorkflowSections()}`,
     );
   });
 
+  it("fails early when a top-level workflow section is explicitly null", async () => {
+    const dir = await createTempDir("workflow-null-tracker-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected object for tracker",
+    );
+  });
+
   it("fails clearly when a linear workflow is missing a token", async () => {
     const dir = await createTempDir("workflow-linear-missing-token-");
     const workflowPath = path.join(dir, "WORKFLOW.md");

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -169,23 +169,23 @@ ${buildSharedWorkflowSections()}`,
     const previousApiKey = process.env.LINEAR_API_KEY;
     const previousWorker = process.env.LINEAR_WORKER;
 
-    process.env.LINEAR_API_KEY = "env-linear-token";
-    process.env.LINEAR_WORKER = "worker@example.com";
+    try {
+      process.env.LINEAR_API_KEY = "env-linear-token";
+      process.env.LINEAR_WORKER = "worker@example.com";
 
-    await fs.writeFile(
-      workflowPath,
-      buildWorkflow(
-        `tracker:
+      await fs.writeFile(
+        workflowPath,
+        buildWorkflow(
+          `tracker:
   kind: linear
   api_key: $MISSING_LINEAR_SECRET
   project_slug: team-project
   assignee: $LINEAR_WORKER
 ${buildSharedWorkflowSections()}`,
-      ),
-      "utf8",
-    );
+        ),
+        "utf8",
+      );
 
-    try {
       const workflow = await loadWorkflow(workflowPath);
       if (workflow.config.tracker.kind !== "linear") {
         throw new Error("expected linear tracker config");
@@ -211,21 +211,22 @@ ${buildSharedWorkflowSections()}`,
     const dir = await createTempDir("workflow-linear-no-assignee-env-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
     const previousAssignee = process.env.LINEAR_ASSIGNEE;
-    process.env.LINEAR_ASSIGNEE = "ambient-worker@example.com";
 
-    await fs.writeFile(
-      workflowPath,
-      buildWorkflow(
-        `tracker:
+    try {
+      process.env.LINEAR_ASSIGNEE = "ambient-worker@example.com";
+
+      await fs.writeFile(
+        workflowPath,
+        buildWorkflow(
+          `tracker:
   kind: linear
   api_key: linear-token
   project_slug: team-project
 ${buildSharedWorkflowSections()}`,
-      ),
-      "utf8",
-    );
+        ),
+        "utf8",
+      );
 
-    try {
       const workflow = await loadWorkflow(workflowPath);
       if (workflow.config.tracker.kind !== "linear") {
         throw new Error("expected linear tracker config");
@@ -245,22 +246,23 @@ ${buildSharedWorkflowSections()}`,
     const dir = await createTempDir("workflow-linear-unset-assignee-env-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
     const previousUnsetAssignee = process.env.MISSING_LINEAR_ASSIGNEE;
-    delete process.env.MISSING_LINEAR_ASSIGNEE;
 
-    await fs.writeFile(
-      workflowPath,
-      buildWorkflow(
-        `tracker:
+    try {
+      delete process.env.MISSING_LINEAR_ASSIGNEE;
+
+      await fs.writeFile(
+        workflowPath,
+        buildWorkflow(
+          `tracker:
   kind: linear
   api_key: linear-token
   project_slug: team-project
   assignee: $MISSING_LINEAR_ASSIGNEE
 ${buildSharedWorkflowSections()}`,
-      ),
-      "utf8",
-    );
+        ),
+        "utf8",
+      );
 
-    try {
       const workflow = await loadWorkflow(workflowPath);
       if (workflow.config.tracker.kind !== "linear") {
         throw new Error("expected linear tracker config");
@@ -316,20 +318,21 @@ ${buildSharedWorkflowSections()}`,
     const dir = await createTempDir("workflow-linear-missing-token-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
     const previousApiKey = process.env.LINEAR_API_KEY;
-    delete process.env.LINEAR_API_KEY;
 
-    await fs.writeFile(
-      workflowPath,
-      buildWorkflow(
-        `tracker:
+    try {
+      delete process.env.LINEAR_API_KEY;
+
+      await fs.writeFile(
+        workflowPath,
+        buildWorkflow(
+          `tracker:
   kind: linear
   project_slug: team-project
 ${buildSharedWorkflowSections()}`,
-      ),
-      "utf8",
-    );
+        ),
+        "utf8",
+      );
 
-    try {
       await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
         "Linear tracker requires tracker.api_key or LINEAR_API_KEY",
       );


### PR DESCRIPTION
## Summary
- add a discriminated tracker config union with workflow parsing and validation for `tracker.kind: linear`
- apply upstream Linear defaults and env-backed token/assignee resolution at the config boundary
- document the Linear workflow snippet and add tests plus a narrow runtime guard until the Linear adapter exists

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

Refs #65