### PR TITLE
Add mocked Linear tracker coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,15 @@ tracker:
     - Done
 ```
 
-In this slice, `loadWorkflow` validates and normalizes that config, but `symphony run` still requires the GitHub bootstrap tracker until the Linear adapter lands.
+`symphony run` can now instantiate a Linear tracker as well. The current Linear slice is intentionally narrow:
+
+- project-scoped GraphQL polling
+- paginated issue reads
+- issue comment writes
+- a Symphony-owned workpad section in the issue description
+- active-to-terminal state transitions through the tracker edge
+
+CI coverage uses the checked-in mock Linear GraphQL server under `tests/support/mock-linear-server.ts`, so no real Linear workspace is required for integration or end-to-end tests.
 
 ## How to Use Symphony to Build Symphony
 

--- a/docs/plans/070-linear-mocked-integration-e2e/plan.md
+++ b/docs/plans/070-linear-mocked-integration-e2e/plan.md
@@ -1,0 +1,272 @@
+# Issue 70 Plan: Linear Mocked Integration And End-to-End Coverage
+
+## Status
+
+- approved
+
+## Goal
+
+Provide a CI-safe Linear GraphQL harness and the smallest real Linear tracker slice that can consume it, so the repository gains mock-backed integration coverage for transport, normalization, writes, and one end-to-end factory loop without depending on a live Linear workspace.
+
+## Scope
+
+- add a reusable in-process mock Linear GraphQL server and fixture builders under `tests/support/`
+- add a thin Linear production adapter split across:
+  - GraphQL transport/client
+  - payload normalization
+  - workpad and lifecycle policy
+  - tracker implementation
+- support the Linear operations required by the current factory contract:
+  - project and workflow-state lookup
+  - paginated issue reads
+  - issue lookup by project and number
+  - comment writes
+  - issue description updates for a Symphony-owned workpad section
+  - issue state transitions
+- update tracker factory and the narrow orchestrator seams required to run with `tracker.kind: linear`
+- add integration tests for the client and tracker against the mock Linear surface
+- add one realistic local-factory e2e scenario against mocked Linear
+- document the mock harness contract and the narrow Linear policy choices introduced in this slice
+
+## Non-goals
+
+- reproducing the entire Linear schema or agent-activity surface
+- moving Linear-specific workflow policy into the orchestrator core
+- redesigning the generic tracker contract beyond the minimum seam needed for Linear
+- replacing the existing GitHub mock harness or refactoring unrelated GitHub code
+- relying on a real Linear workspace, token, or external network in CI
+- introducing tracker-specific storage outside the existing status and issue-artifact contracts
+
+## Current Gaps
+
+- `tracker.kind: linear` loads successfully, but runtime tracker creation still throws
+- there is no Linear transport, normalization, or tracker policy implementation in `src/tracker/`
+- the orchestrator still assumes GitHub-only tracker metadata for artifact summaries
+- the repo has no mock Linear server, no Linear integration tests, and no Linear e2e coverage
+- a pure harness-first change would leave the mock without a real production consumer in this branch
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the Linear workpad marker format, readiness/running/failed classification, and handoff mapping kept at the tracker edge
+  - does not belong: Linear-specific branching in orchestrator retry or dispatch logic
+- Configuration Layer
+  - belongs: reusing the existing validated Linear workflow contract
+  - does not belong: reparsing raw workflow fields inside the tracker or mock server
+- Coordination Layer
+  - belongs: only the narrow orchestrator changes needed to stop assuming every tracker is GitHub-shaped
+  - does not belong: GraphQL queries, pagination cursors, or Linear state-name rules
+- Execution Layer
+  - belongs: reusing the existing workspace and local-runner seams in the e2e path
+  - does not belong: Linear transport or lifecycle decisions
+- Integration Layer
+  - belongs: GraphQL transport, normalization, workpad/state policy, tracker mapping, and the mock Linear service
+  - does not belong: leaking raw GraphQL payloads upward into orchestrator or prompt logic
+- Observability Layer
+  - belongs: preserving the existing status snapshot and issue-artifact contracts for Linear runs
+  - does not belong: new Linear-only telemetry surfaces unrelated to current runtime correctness
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/tracker/linear-client.ts`
+  - GraphQL request helper
+  - paginated project issue reads
+  - issue lookup and write mutations
+- `src/tracker/linear-normalize.ts`
+  - parse raw GraphQL payloads into typed Linear snapshots and `RuntimeIssue`
+- `src/tracker/linear-workpad.ts`
+  - render and parse the Symphony-owned issue-description workpad section
+- `src/tracker/linear-policy.ts`
+  - classify ready/running/failed issues and map Linear issue snapshots into `HandoffLifecycle`
+- `src/tracker/linear.ts`
+  - implement the `Tracker` contract by composing the modules above
+- `tests/support/mock-linear-server.ts`
+  - in-memory project/state/issue/comment store
+  - GraphQL handlers
+  - request-history capture
+  - configurable read/write failures
+- `tests/integration/`
+  - Linear client and tracker tests against the mock harness
+- `tests/e2e/`
+  - one local factory loop using the real Linear tracker against the mock harness
+- small README and plan updates documenting the current Linear seam
+
+### Does not belong in this issue
+
+- one large `src/tracker/linear.ts` that mixes transport, normalization, and policy
+- broad orchestrator refactors beyond removing GitHub-only assumptions
+- speculative agent-session activity support or OAuth-specific Linear behavior
+- workflow-schema redesign outside the already-landed Linear config contract
+- fake e2e shortcuts that bypass the tracker service
+
+## Slice Strategy And PR Seam
+
+The approved harness-first plan needs one narrow production consumer to make the issue real. This PR stays reviewable by landing a vertical slice with explicit boundaries:
+
+1. a reusable mock Linear GraphQL harness
+2. a thin Linear tracker that satisfies the existing `Tracker` contract
+3. integration tests for transport, normalization, writes, and lifecycle mapping
+4. one end-to-end factory scenario using the real tracker and existing workspace/runner/orchestrator seams
+
+This remains one reviewable PR because it still defers richer Linear policy:
+
+- no agent-session or webhook support
+- no full parity with GitHub PR-based review loops
+- no broader tracker-contract redesign
+- no extra lifecycle states beyond those required by the current factory handoff model
+
+## Runtime State Model
+
+The supported Linear tracker/runtime states in this slice are:
+
+1. `seeded-ready`
+   - issue is in a configured active Linear workflow state and has no active Symphony workpad status
+2. `claimed-running`
+   - tracker has written the Symphony workpad marker and, when possible, moved the issue into an in-progress active state
+3. `retry-scheduled`
+   - tracker keeps the issue active, records the retry in comments and the workpad, and exposes it as running rather than ready
+4. `failed`
+   - tracker records a failure marker in the workpad and exposes the issue via `fetchFailedIssues`
+5. `handoff-ready`
+   - tracker records a Symphony handoff-ready marker after a successful run
+6. `completed`
+   - tracker transitions the issue into a terminal Linear state and records final completion notes
+7. `transport-or-normalization-failed`
+   - GraphQL, HTTP, or boundary parsing prevents progress
+
+Allowed transitions:
+
+- `seeded-ready -> claimed-running`
+- `claimed-running -> retry-scheduled`
+- `claimed-running -> handoff-ready`
+- `retry-scheduled -> claimed-running`
+- `claimed-running -> failed`
+- `handoff-ready -> completed`
+- any read/write state -> `transport-or-normalization-failed`
+
+The orchestrator continues to consume only normalized `RuntimeIssue` values and generalized `HandoffLifecycle` states.
+
+## Failure-Class Matrix
+
+| Observed condition                                           | Local facts available            | Normalized tracker facts available | Expected decision                                                     |
+| ------------------------------------------------------------ | -------------------------------- | ---------------------------------- | --------------------------------------------------------------------- |
+| GraphQL page returns `hasNextPage: true` with another cursor | current page and end cursor      | none yet                           | continue pagination until exhaustion                                  |
+| GraphQL response includes an `errors` array                  | HTTP success plus GraphQL errors | none                               | raise `TrackerError`; do not accept partial data                      |
+| HTTP request fails or times out                              | request error only               | none                               | raise transport failure distinctly from GraphQL errors                |
+| required Linear field is missing or malformed                | raw project or issue payload     | partial raw data                   | fail at the normalization boundary                                    |
+| workpad mutation targets an unknown issue or workflow state  | mutation variables               | prior normalized issue snapshot    | fail clearly and preserve previous tracker state                      |
+| branch name does not map to a valid Linear issue number      | branch name only                 | none                               | return `missing-target` for handoff inspection                        |
+| successful run leaves no handoff-ready write                 | normalized issue snapshot        | workpad lacks ready marker         | surface `missing-target` and preserve existing retry/failure behavior |
+
+## Storage / Persistence Contract
+
+- production durability remains unchanged:
+  - status snapshots under `.tmp/status.json`
+  - issue artifacts under `.var/factory/issues/...`
+- Linear-specific ephemeral state lives only in:
+  - the remote Linear issue itself via the Symphony workpad section in the description
+  - test-only in-memory fixtures inside the mock server
+- the workpad format is tracker-edge policy and must stay parseable without orchestrator awareness
+
+## Observability Requirements
+
+- Linear transport failures must stay distinguishable from GraphQL error payloads in tests
+- integration tests should assert recorded GraphQL operations and mutation variables
+- the mock harness should expose enough request history to debug pagination and write sequencing
+- the e2e test should continue asserting the existing factory status and issue-artifact outputs rather than a Linear-only success channel
+
+## Implementation Steps
+
+1. Update this plan to record the narrow scope expansion from pure harness-first to thin real-consumer plus harness.
+2. Add `tests/support/mock-linear-server.ts` with:
+   - in-memory projects, workflow states, issues, and comments
+   - GraphQL handlers for the required queries and mutations
+   - request-history capture
+   - configurable error injection
+3. Add `src/tracker/linear-client.ts` for GraphQL transport and page traversal.
+4. Add `src/tracker/linear-normalize.ts` to parse project and issue payloads into stable snapshots.
+5. Add `src/tracker/linear-workpad.ts` to manage the Symphony-owned description section used for running/failed/handoff markers.
+6. Add `src/tracker/linear-policy.ts` to:
+   - classify ready/running/failed issues
+   - choose state transitions for claim and completion
+   - map issue state and workpad markers into `HandoffLifecycle`
+7. Add `src/tracker/linear.ts` and wire `src/tracker/factory.ts` to create it.
+8. Remove the narrow GitHub-only assumptions in the orchestrator that block non-GitHub tracker configs, while keeping tracker-specific policy at the edge.
+9. Add integration tests for:
+   - paginated reads
+   - GraphQL error handling
+   - normalization and runtime issue mapping
+   - comment/workpad writes
+   - state transitions and handoff mapping
+10. Add one e2e test that loads a Linear workflow config, polls the mock Linear server, runs a local agent, writes tracker updates, and reaches completion.
+11. Update minimal docs describing the current Linear test harness and runtime seam.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `linear-workpad` parser/renderer round-trips the Symphony section without destroying unrelated description content
+
+### Integration
+
+- Linear client follows connection pagination and aggregates project issues deterministically
+- GraphQL errors surface as tracker failures distinct from HTTP errors
+- tracker claim writes a comment, updates the workpad, and transitions into an in-progress active state when one is available
+- tracker retry and failure writes preserve remote state correctly and classify issues as running or failed
+- successful reconciliation writes a handoff-ready marker and `inspectIssueHandoff` maps it to `handoff-ready`
+- completion moves the issue into a configured terminal state and records the final comment/workpad state
+
+### End-to-End
+
+- a local factory loop can:
+  - load `tracker.kind: linear`
+  - poll mocked Linear project issues
+  - claim a ready issue
+  - run the local workspace and agent path
+  - write Linear comment/workpad/state updates
+  - reach `handoff-ready`
+  - complete the issue into a terminal state
+
+### Repo Gate
+
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. CI can start a mock Linear GraphQL surface locally and run tests without a real Linear workspace or token.
+2. Linear integration tests exercise real GraphQL request/response flow, pagination, normalization, and write mutations against the mock server.
+3. `symphony run` can execute at least one realistic local factory loop against `tracker.kind: linear` using the mock Linear server.
+4. The orchestrator remains tracker-neutral; Linear-specific lifecycle and workpad policy stay at the tracker edge.
+
+## Exit Criteria
+
+- the repository contains a reusable mock Linear GraphQL harness under `tests/support/`
+- the runtime can instantiate a Linear tracker for `tracker.kind: linear`
+- Linear transport, normalization, and policy stay split across focused modules
+- integration tests cover paginated reads, failure handling, writes, and lifecycle mapping
+- at least one e2e factory test runs against mocked Linear with no external dependency
+
+## Deferred To Later Issues Or PRs
+
+- richer Linear agent-session or webhook integration
+- non-comment activity surfaces beyond the current workpad/comment contract
+- full parity with GitHub review-loop behavior for `awaiting-human-handoff` or `awaiting-system-checks`
+- broader tracker-contract changes if future trackers need more handoff metadata than the current generalized lifecycle can express
+
+## Decision Notes
+
+- The original issue ordering expected a harness-first start for `#70`, but the absence of any Linear runtime consumer in this branch makes a pure harness slice too inert. This plan records the smallest real-consumer expansion that keeps the work reviewable.
+- The Symphony-owned description workpad keeps Linear-specific state at the tracker edge and avoids teaching the orchestrator how to infer running or failed state from raw Linear comments.
+- The e2e path must use the real tracker service. If a scenario cannot be expressed through the public `Tracker` contract and the existing orchestrator/workspace/runner seams, it does not belong in this slice.
+
+## Revision Log
+
+- 2026-03-10: Initial plan created and marked `plan-ready` for issue `#70`.
+- 2026-03-10: Plan approved on the issue thread.
+- 2026-03-10: Scope updated during implementation to include the thinnest real Linear tracker slice needed to make the mock-backed integration and e2e coverage real in this branch.

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -30,7 +30,6 @@ import {
 import type { Runner, RunnerSessionDescription } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
-import { linearTrackerSubject } from "../tracker/linear-policy.js";
 import {
   clearFollowUpRuntimeState,
   noteLifecycleObservation,
@@ -1028,9 +1027,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #trackerSubject(): string {
-    return this.#config.tracker.kind === "github-bootstrap"
-      ? this.#config.tracker.repo
-      : linearTrackerSubject(this.#config.tracker);
+    return this.#tracker.subject();
   }
 
   #createIssueEvent(
@@ -1520,17 +1517,8 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #hasHumanReviewFeedback(lifecycle: HandoffLifecycle): boolean {
-    const reviewBotLogins = new Set(
-      (this.#config.tracker.kind === "github-bootstrap"
-        ? this.#config.tracker.reviewBotLogins
-        : []
-      ).map((login) => login.toLowerCase()),
-    );
     return lifecycle.actionableReviewFeedback.some((feedback) => {
-      const authorLogin = feedback.authorLogin;
-      return (
-        authorLogin !== null && !reviewBotLogins.has(authorLogin.toLowerCase())
-      );
+      return this.#tracker.isHumanReviewFeedback(feedback.authorLogin);
     });
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -30,6 +30,7 @@ import {
 import type { Runner, RunnerSessionDescription } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
+import { linearTrackerSubject } from "../tracker/linear-policy.js";
 import {
   clearFollowUpRuntimeState,
   noteLifecycleObservation,
@@ -1029,7 +1030,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   #trackerSubject(): string {
     return this.#config.tracker.kind === "github-bootstrap"
       ? this.#config.tracker.repo
-      : `linear/${this.#config.tracker.projectSlug}`;
+      : linearTrackerSubject(this.#config.tracker);
   }
 
   #createIssueEvent(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -4,11 +4,7 @@ import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RetryState } from "../domain/retry.js";
 import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
-import type {
-  GitHubBootstrapTrackerConfig,
-  PromptBuilder,
-  ResolvedConfig,
-} from "../domain/workflow.js";
+import type { PromptBuilder, ResolvedConfig } from "../domain/workflow.js";
 import type {
   IssueArtifactAttemptSnapshot,
   IssueArtifactCheckSnapshot,
@@ -64,23 +60,8 @@ interface QueueEntry {
   readonly source: "ready" | "running";
 }
 
-function requireBootstrapConfig(
-  config: ResolvedConfig,
-): ResolvedConfig & { readonly tracker: GitHubBootstrapTrackerConfig } {
-  if (config.tracker.kind !== "github-bootstrap") {
-    throw new OrchestratorError(
-      "BootstrapOrchestrator requires tracker.kind 'github-bootstrap'",
-    );
-  }
-  return config as ResolvedConfig & {
-    readonly tracker: GitHubBootstrapTrackerConfig;
-  };
-}
-
 export class BootstrapOrchestrator implements Orchestrator {
-  readonly #config: ResolvedConfig & {
-    readonly tracker: GitHubBootstrapTrackerConfig;
-  };
+  readonly #config: ResolvedConfig;
   readonly #promptBuilder: PromptBuilder;
   readonly #tracker: Tracker;
   readonly #workspaceManager: WorkspaceManager;
@@ -102,7 +83,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     logger: Logger,
     issueArtifactStore?: IssueArtifactStore,
   ) {
-    this.#config = requireBootstrapConfig(config);
+    this.#config = config;
     this.#promptBuilder = promptBuilder;
     this.#tracker = tracker;
     this.#workspaceManager = workspaceManager;
@@ -1033,7 +1014,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     return {
       issueNumber: issue.number,
       issueIdentifier: issue.identifier,
-      repo: this.#config.tracker.repo,
+      repo: this.#trackerSubject(),
       title: issue.title,
       issueUrl: issue.url,
       branch: options.branchName,
@@ -1043,6 +1024,12 @@ export class BootstrapOrchestrator implements Orchestrator {
       latestAttemptNumber: options.latestAttemptNumber,
       latestSessionId: options.latestSessionId,
     } as const;
+  }
+
+  #trackerSubject(): string {
+    return this.#config.tracker.kind === "github-bootstrap"
+      ? this.#config.tracker.repo
+      : `linear/${this.#config.tracker.projectSlug}`;
   }
 
   #createIssueEvent(
@@ -1533,7 +1520,10 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   #hasHumanReviewFeedback(lifecycle: HandoffLifecycle): boolean {
     const reviewBotLogins = new Set(
-      this.#config.tracker.reviewBotLogins.map((login) => login.toLowerCase()),
+      (this.#config.tracker.kind === "github-bootstrap"
+        ? this.#config.tracker.reviewBotLogins
+        : []
+      ).map((login) => login.toLowerCase()),
     );
     return lifecycle.actionableReviewFeedback.some((feedback) => {
       const authorLogin = feedback.authorLogin;

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -1,17 +1,15 @@
 import type { TrackerConfig } from "../domain/workflow.js";
-import { TrackerError } from "../domain/errors.js";
 import type { Logger } from "../observability/logger.js";
 import type { Tracker } from "./service.js";
 import { GitHubBootstrapTracker } from "./github-bootstrap.js";
+import { LinearTracker } from "./linear.js";
 
 export function createTracker(config: TrackerConfig, logger: Logger): Tracker {
   switch (config.kind) {
     case "github-bootstrap":
       return new GitHubBootstrapTracker(config, logger);
     case "linear":
-      throw new TrackerError(
-        "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
-      );
+      return new LinearTracker(config, logger);
     default:
       return exhaustiveTrackerConfig(config);
   }

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -32,6 +32,19 @@ export class GitHubBootstrapTracker implements Tracker {
     this.#client = new GitHubClient(config);
   }
 
+  subject(): string {
+    return this.#config.repo;
+  }
+
+  isHumanReviewFeedback(authorLogin: string | null): boolean {
+    if (authorLogin === null) {
+      return false;
+    }
+    return !this.#config.reviewBotLogins
+      .map((login) => login.toLowerCase())
+      .includes(authorLogin.toLowerCase());
+  }
+
   async ensureLabels(): Promise<void> {
     if (this.#ensureLabelsPromise === null) {
       this.#ensureLabelsPromise = this.#doEnsureLabels().catch((error) => {

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -1,0 +1,217 @@
+import { TrackerError } from "../domain/errors.js";
+import type { LinearTrackerConfig } from "../domain/workflow.js";
+
+interface GraphQLErrorPayload {
+  readonly message?: unknown;
+}
+
+interface GraphQLResponse<T> {
+  readonly data?: T;
+  readonly errors?: readonly GraphQLErrorPayload[];
+}
+
+const PROJECT_FIELDS = `
+  id
+  slugId
+  name
+  states {
+    nodes {
+      id
+      name
+      type
+      position
+    }
+  }
+`;
+
+const ISSUE_FIELDS = `
+  id
+  identifier
+  number
+  title
+  description
+  url
+  createdAt
+  updatedAt
+  state {
+    id
+    name
+    type
+    position
+  }
+  comments {
+    nodes {
+      id
+      body
+      createdAt
+      user {
+        name
+        email
+      }
+    }
+  }
+`;
+
+const GET_PROJECT_QUERY = `
+  query GetProject($slugId: String!) {
+    project(slugId: $slugId) {
+      ${PROJECT_FIELDS}
+    }
+  }
+`;
+
+const GET_PROJECT_ISSUES_PAGE_QUERY = `
+  query GetProjectIssuesPage($slugId: String!, $after: String, $assignee: String) {
+    project(slugId: $slugId) {
+      ${PROJECT_FIELDS}
+      issues(first: 2, after: $after, assignee: $assignee) {
+        nodes {
+          ${ISSUE_FIELDS}
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+const GET_PROJECT_ISSUE_QUERY = `
+  query GetProjectIssue($slugId: String!, $number: Int!) {
+    project(slugId: $slugId) {
+      ${PROJECT_FIELDS}
+      issue(number: $number) {
+        ${ISSUE_FIELDS}
+      }
+    }
+  }
+`;
+
+const ISSUE_UPDATE_MUTATION = `
+  mutation UpdateIssue($id: String!, $description: String, $stateId: String) {
+    issueUpdate(id: $id, input: { description: $description, stateId: $stateId }) {
+      success
+      issue {
+        ${ISSUE_FIELDS}
+      }
+    }
+  }
+`;
+
+const COMMENT_CREATE_MUTATION = `
+  mutation CreateComment($issueId: String!, $body: String!) {
+    commentCreate(input: { issueId: $issueId, body: $body }) {
+      success
+      issue {
+        ${ISSUE_FIELDS}
+      }
+    }
+  }
+`;
+
+export class LinearClient {
+  readonly #config: LinearTrackerConfig;
+
+  constructor(config: LinearTrackerConfig) {
+    this.#config = config;
+  }
+
+  async fetchProject(): Promise<unknown> {
+    return await this.#request("GetProject", GET_PROJECT_QUERY, {
+      slugId: this.#config.projectSlug,
+    });
+  }
+
+  async fetchProjectIssuesPage(after: string | null): Promise<unknown> {
+    return await this.#request(
+      "GetProjectIssuesPage",
+      GET_PROJECT_ISSUES_PAGE_QUERY,
+      {
+        slugId: this.#config.projectSlug,
+        after,
+        assignee: this.#config.assignee,
+      },
+    );
+  }
+
+  async fetchProjectIssue(issueNumber: number): Promise<unknown> {
+    return await this.#request("GetProjectIssue", GET_PROJECT_ISSUE_QUERY, {
+      slugId: this.#config.projectSlug,
+      number: issueNumber,
+    });
+  }
+
+  async updateIssue(input: {
+    readonly id: string;
+    readonly description?: string;
+    readonly stateId?: string;
+  }): Promise<unknown> {
+    return await this.#request("UpdateIssue", ISSUE_UPDATE_MUTATION, {
+      id: input.id,
+      description: input.description ?? null,
+      stateId: input.stateId ?? null,
+    });
+  }
+
+  async createComment(issueId: string, body: string): Promise<unknown> {
+    return await this.#request("CreateComment", COMMENT_CREATE_MUTATION, {
+      issueId,
+      body,
+    });
+  }
+
+  async #request<T>(
+    operationName: string,
+    query: string,
+    variables: Readonly<Record<string, unknown>>,
+  ): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(this.#config.endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.#config.apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          operationName,
+          query,
+          variables,
+        }),
+      });
+    } catch (error) {
+      throw new TrackerError(
+        `Linear GraphQL request failed for ${operationName}: ${(error as Error).message}`,
+        { cause: error as Error },
+      );
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new TrackerError(
+        `Linear GraphQL request failed for ${operationName}: HTTP ${response.status} ${body}`.trim(),
+      );
+    }
+
+    const payload = (await response.json()) as GraphQLResponse<T>;
+    if ((payload.errors?.length ?? 0) > 0) {
+      const messages = payload.errors
+        ?.map((entry) =>
+          typeof entry.message === "string"
+            ? entry.message
+            : "Unknown GraphQL error",
+        )
+        .join("; ");
+      throw new TrackerError(
+        `Linear GraphQL request failed for ${operationName}: ${messages}`,
+      );
+    }
+    if (payload.data === undefined) {
+      throw new TrackerError(
+        `Linear GraphQL request failed for ${operationName}: missing data payload`,
+      );
+    }
+    return payload.data;
+  }
+}

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -10,6 +10,14 @@ interface GraphQLResponse<T> {
   readonly errors?: readonly GraphQLErrorPayload[];
 }
 
+interface UpdateIssueRequest {
+  readonly id: string;
+  readonly description?: string;
+  readonly stateId?: string;
+}
+
+const LINEAR_PROJECT_ISSUES_PAGE_SIZE = 50;
+
 const PROJECT_FIELDS = `
   id
   slugId
@@ -64,7 +72,7 @@ const GET_PROJECT_ISSUES_PAGE_QUERY = `
   query GetProjectIssuesPage($slugId: String!, $after: String, $assignee: String) {
     project(slugId: $slugId) {
       ${PROJECT_FIELDS}
-      issues(first: 2, after: $after, assignee: $assignee) {
+      issues(first: ${LINEAR_PROJECT_ISSUES_PAGE_SIZE}, after: $after, assignee: $assignee) {
         nodes {
           ${ISSUE_FIELDS}
         }
@@ -88,8 +96,30 @@ const GET_PROJECT_ISSUE_QUERY = `
   }
 `;
 
-const ISSUE_UPDATE_MUTATION = `
-  mutation UpdateIssue($id: String!, $description: String, $stateId: String) {
+const ISSUE_UPDATE_DESCRIPTION_MUTATION = `
+  mutation UpdateIssueDescription($id: String!, $description: String) {
+    issueUpdate(id: $id, input: { description: $description }) {
+      success
+      issue {
+        ${ISSUE_FIELDS}
+      }
+    }
+  }
+`;
+
+const ISSUE_UPDATE_STATE_MUTATION = `
+  mutation UpdateIssueState($id: String!, $stateId: String) {
+    issueUpdate(id: $id, input: { stateId: $stateId }) {
+      success
+      issue {
+        ${ISSUE_FIELDS}
+      }
+    }
+  }
+`;
+
+const ISSUE_UPDATE_DESCRIPTION_AND_STATE_MUTATION = `
+  mutation UpdateIssueDescriptionAndState($id: String!, $description: String, $stateId: String) {
     issueUpdate(id: $id, input: { description: $description, stateId: $stateId }) {
       success
       issue {
@@ -142,16 +172,12 @@ export class LinearClient {
     });
   }
 
-  async updateIssue(input: {
-    readonly id: string;
-    readonly description?: string;
-    readonly stateId?: string;
-  }): Promise<unknown> {
-    return await this.#request("UpdateIssue", ISSUE_UPDATE_MUTATION, {
-      id: input.id,
-      description: input.description ?? null,
-      stateId: input.stateId ?? null,
-    });
+  async updateIssue(input: UpdateIssueRequest): Promise<unknown> {
+    return await this.#request(
+      this.#updateIssueOperation(input),
+      this.#updateIssueMutation(input),
+      this.#updateIssueVariables(input),
+    );
   }
 
   async createComment(issueId: string, body: string): Promise<unknown> {
@@ -213,5 +239,48 @@ export class LinearClient {
       );
     }
     return payload.data;
+  }
+
+  #updateIssueOperation(input: UpdateIssueRequest): string {
+    const hasDescription = input.description !== undefined;
+    const hasStateId = input.stateId !== undefined;
+    if (hasDescription && hasStateId) {
+      return "UpdateIssueDescriptionAndState";
+    }
+    if (hasDescription) {
+      return "UpdateIssueDescription";
+    }
+    if (hasStateId) {
+      return "UpdateIssueState";
+    }
+    throw new TrackerError("Linear issue update requires at least one field");
+  }
+
+  #updateIssueMutation(input: UpdateIssueRequest): string {
+    const hasDescription = input.description !== undefined;
+    const hasStateId = input.stateId !== undefined;
+    if (hasDescription && hasStateId) {
+      return ISSUE_UPDATE_DESCRIPTION_AND_STATE_MUTATION;
+    }
+    if (hasDescription) {
+      return ISSUE_UPDATE_DESCRIPTION_MUTATION;
+    }
+    if (hasStateId) {
+      return ISSUE_UPDATE_STATE_MUTATION;
+    }
+    throw new TrackerError("Linear issue update requires at least one field");
+  }
+
+  #updateIssueVariables(
+    input: UpdateIssueRequest,
+  ): Readonly<Record<string, unknown>> {
+    const variables: Record<string, unknown> = { id: input.id };
+    if (input.description !== undefined) {
+      variables["description"] = input.description;
+    }
+    if (input.stateId !== undefined) {
+      variables["stateId"] = input.stateId;
+    }
+    return variables;
   }
 }

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -1,0 +1,267 @@
+import type { RuntimeIssue } from "../domain/issue.js";
+import { TrackerError } from "../domain/errors.js";
+import {
+  parseLinearWorkpad,
+  type LinearWorkpadEntry,
+} from "./linear-workpad.js";
+
+export interface LinearWorkflowState {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly position: number;
+}
+
+export interface LinearComment {
+  readonly id: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly userName: string | null;
+  readonly userEmail: string | null;
+}
+
+export interface LinearIssueSnapshot {
+  readonly id: string;
+  readonly identifier: string;
+  readonly number: number;
+  readonly title: string;
+  readonly description: string;
+  readonly url: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly state: LinearWorkflowState;
+  readonly comments: readonly LinearComment[];
+  readonly workpad: LinearWorkpadEntry | null;
+  readonly runtimeIssue: RuntimeIssue;
+}
+
+export interface LinearProjectSnapshot {
+  readonly id: string;
+  readonly slugId: string;
+  readonly name: string;
+  readonly states: readonly LinearWorkflowState[];
+}
+
+export interface LinearIssuePageSnapshot {
+  readonly project: LinearProjectSnapshot;
+  readonly issues: readonly LinearIssueSnapshot[];
+  readonly hasNextPage: boolean;
+  readonly endCursor: string | null;
+}
+
+export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
+  const record = requireObject(value, "project");
+  const statesConnection = requireObject(record["states"], "project.states");
+  const states = requireArray(
+    statesConnection["nodes"],
+    "project.states.nodes",
+  ).map((entry, index) =>
+    normalizeLinearWorkflowState(entry, `project.states.nodes[${index}]`),
+  );
+
+  return {
+    id: requireString(record["id"], "project.id"),
+    slugId: requireString(record["slugId"], "project.slugId"),
+    name: requireString(record["name"], "project.name"),
+    states,
+  };
+}
+
+export function normalizeLinearIssuePage(
+  value: unknown,
+): LinearIssuePageSnapshot {
+  const record = requireObject(value, "page");
+  const project = normalizeLinearProject(record["project"]);
+  const issuesConnection = requireObject(
+    requireObject(record["project"], "project")["issues"],
+    "project.issues",
+  );
+  const issues = requireArray(
+    issuesConnection["nodes"],
+    "project.issues.nodes",
+  ).map((entry, index) =>
+    normalizeLinearIssue(entry, `project.issues.nodes[${index}]`),
+  );
+  const pageInfo = requireObject(
+    issuesConnection["pageInfo"],
+    "project.issues.pageInfo",
+  );
+
+  return {
+    project,
+    issues,
+    hasNextPage: requireBoolean(
+      pageInfo["hasNextPage"],
+      "project.issues.pageInfo.hasNextPage",
+    ),
+    endCursor: requireNullableString(
+      pageInfo["endCursor"],
+      "project.issues.pageInfo.endCursor",
+    ),
+  };
+}
+
+export function normalizeLinearIssueResult(value: unknown): {
+  readonly project: LinearProjectSnapshot;
+  readonly issue: LinearIssueSnapshot | null;
+} {
+  const record = requireObject(value, "projectIssue");
+  const projectRecord = requireObject(record["project"], "project");
+
+  return {
+    project: normalizeLinearProject(projectRecord),
+    issue:
+      projectRecord["issue"] === null || projectRecord["issue"] === undefined
+        ? null
+        : normalizeLinearIssue(projectRecord["issue"], "project.issue"),
+  };
+}
+
+export function normalizeLinearIssueMutationResult(
+  value: unknown,
+  field: "issueUpdate" | "commentCreate",
+): LinearIssueSnapshot {
+  const root = requireObject(value, field);
+  const mutation = requireObject(root[field], field);
+  const success = requireBoolean(mutation["success"], `${field}.success`);
+  if (!success) {
+    throw new TrackerError(`Linear mutation ${field} reported success=false`);
+  }
+  return normalizeLinearIssue(mutation["issue"], `${field}.issue`);
+}
+
+function normalizeLinearIssue(
+  value: unknown,
+  field: string,
+): LinearIssueSnapshot {
+  const record = requireObject(value, field);
+  const description = requireNullableString(
+    record["description"],
+    `${field}.description`,
+  );
+  const commentsConnection = requireObject(
+    record["comments"],
+    `${field}.comments`,
+  );
+  const comments = requireArray(
+    commentsConnection["nodes"],
+    `${field}.comments.nodes`,
+  ).map((entry, index) =>
+    normalizeLinearComment(entry, `${field}.comments.nodes[${index}]`),
+  );
+  const workpad = parseLinearWorkpad(description);
+
+  const runtimeIssue: RuntimeIssue = {
+    id: requireString(record["id"], `${field}.id`),
+    identifier: requireString(record["identifier"], `${field}.identifier`),
+    number: requireNumber(record["number"], `${field}.number`),
+    title: requireString(record["title"], `${field}.title`),
+    description: description ?? "",
+    labels: [],
+    state: requireString(
+      requireObject(record["state"], `${field}.state`)["name"],
+      `${field}.state.name`,
+    ),
+    url: requireString(record["url"], `${field}.url`),
+    createdAt: requireString(record["createdAt"], `${field}.createdAt`),
+    updatedAt: requireString(record["updatedAt"], `${field}.updatedAt`),
+  };
+
+  return {
+    id: runtimeIssue.id,
+    identifier: runtimeIssue.identifier,
+    number: runtimeIssue.number,
+    title: runtimeIssue.title,
+    description: runtimeIssue.description,
+    url: runtimeIssue.url,
+    createdAt: runtimeIssue.createdAt,
+    updatedAt: runtimeIssue.updatedAt,
+    state: normalizeLinearWorkflowState(record["state"], `${field}.state`),
+    comments,
+    workpad,
+    runtimeIssue,
+  };
+}
+
+function normalizeLinearWorkflowState(
+  value: unknown,
+  field: string,
+): LinearWorkflowState {
+  const record = requireObject(value, field);
+  return {
+    id: requireString(record["id"], `${field}.id`),
+    name: requireString(record["name"], `${field}.name`),
+    type: requireString(record["type"], `${field}.type`),
+    position: requireNumber(record["position"], `${field}.position`),
+  };
+}
+
+function normalizeLinearComment(value: unknown, field: string): LinearComment {
+  const record = requireObject(value, field);
+  const user =
+    record["user"] === null || record["user"] === undefined
+      ? null
+      : requireObject(record["user"], `${field}.user`);
+
+  return {
+    id: requireString(record["id"], `${field}.id`),
+    body: requireString(record["body"], `${field}.body`),
+    createdAt: requireString(record["createdAt"], `${field}.createdAt`),
+    userName:
+      user === null
+        ? null
+        : requireNullableString(user["name"], `${field}.user.name`),
+    userEmail:
+      user === null
+        ? null
+        : requireNullableString(user["email"], `${field}.user.email`),
+  };
+}
+
+function requireObject(
+  value: unknown,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TrackerError(`Expected object for ${field}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, field: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TrackerError(`Expected array for ${field}`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TrackerError(`Expected non-empty string for ${field}`);
+  }
+  return value;
+}
+
+function requireNullableString(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new TrackerError(`Expected string or null for ${field}`);
+  }
+  return value;
+}
+
+function requireNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new TrackerError(`Expected number for ${field}`);
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TrackerError(`Expected boolean for ${field}`);
+  }
+  return value;
+}

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -71,9 +71,10 @@ export function normalizeLinearIssuePage(
   value: unknown,
 ): LinearIssuePageSnapshot {
   const record = requireObject(value, "page");
-  const project = normalizeLinearProject(record["project"]);
+  const projectRecord = requireObject(record["project"], "project");
+  const project = normalizeLinearProject(projectRecord);
   const issuesConnection = requireObject(
-    requireObject(record["project"], "project")["issues"],
+    projectRecord["issues"],
     "project.issues",
   );
   const issues = requireArray(

--- a/src/tracker/linear-policy.ts
+++ b/src/tracker/linear-policy.ts
@@ -135,7 +135,8 @@ export function linearTrackerSubject(config: LinearTrackerConfig): string {
 export function extractIssueNumberFromBranchName(
   branchName: string,
 ): number | null {
-  const match = branchName.match(/(\d+)$/u);
+  const branchLeaf = branchName.split("/").at(-1) ?? branchName;
+  const match = branchLeaf.match(/^(\d+)(?:-|$)/u);
   if (!match || match[1] === undefined) {
     return null;
   }

--- a/src/tracker/linear-policy.ts
+++ b/src/tracker/linear-policy.ts
@@ -1,0 +1,157 @@
+import { TrackerError } from "../domain/errors.js";
+import type { HandoffLifecycle } from "../domain/handoff.js";
+import type { LinearTrackerConfig } from "../domain/workflow.js";
+import type {
+  LinearIssueSnapshot,
+  LinearProjectSnapshot,
+  LinearWorkflowState,
+} from "./linear-normalize.js";
+
+export type LinearIssueClassification =
+  | "ready"
+  | "running"
+  | "failed"
+  | "completed"
+  | "ignored";
+
+export function classifyLinearIssue(
+  issue: LinearIssueSnapshot,
+  config: LinearTrackerConfig,
+): LinearIssueClassification {
+  if (config.terminalStates.includes(issue.state.name)) {
+    return "completed";
+  }
+
+  switch (issue.workpad?.status) {
+    case "failed":
+      return "failed";
+    case "running":
+    case "retry-scheduled":
+    case "handoff-ready":
+      return "running";
+    case "completed":
+      return "completed";
+    default:
+      break;
+  }
+
+  if (config.activeStates.includes(issue.state.name)) {
+    return "ready";
+  }
+
+  return "ignored";
+}
+
+export function resolveLinearClaimState(
+  project: LinearProjectSnapshot,
+  issue: LinearIssueSnapshot,
+  config: LinearTrackerConfig,
+): LinearWorkflowState | null {
+  const currentIndex = config.activeStates.indexOf(issue.state.name);
+  if (currentIndex < 0) {
+    return null;
+  }
+
+  const nextStateName = config.activeStates[currentIndex + 1] ?? null;
+  if (nextStateName === null || nextStateName === issue.state.name) {
+    return null;
+  }
+
+  return resolveStateByName(project, nextStateName);
+}
+
+export function resolveLinearTerminalState(
+  project: LinearProjectSnapshot,
+  config: LinearTrackerConfig,
+): LinearWorkflowState {
+  for (const stateName of config.terminalStates) {
+    const match = project.states.find((state) => state.name === stateName);
+    if (match !== undefined) {
+      return match;
+    }
+  }
+  throw new TrackerError(
+    `Linear project ${project.slugId} does not expose any configured terminal state`,
+  );
+}
+
+export function createLinearHandoffLifecycle(
+  issue: LinearIssueSnapshot | null,
+  branchName: string,
+  config: LinearTrackerConfig,
+): HandoffLifecycle {
+  if (issue === null) {
+    return missingLinearLifecycle(
+      branchName,
+      `No Linear issue found for branch ${branchName}`,
+    );
+  }
+
+  if (
+    issue.workpad?.status === "handoff-ready" ||
+    issue.workpad?.status === "completed" ||
+    config.terminalStates.includes(issue.state.name)
+  ) {
+    return {
+      kind: "handoff-ready",
+      branchName,
+      pullRequest: null,
+      checks: [],
+      pendingCheckNames: [],
+      failingCheckNames: [],
+      actionableReviewFeedback: [],
+      unresolvedThreadIds: [],
+      summary: `Linear issue ${issue.identifier} is ready for completion`,
+    };
+  }
+
+  return missingLinearLifecycle(
+    branchName,
+    `Linear issue ${issue.identifier} has not reached handoff-ready`,
+  );
+}
+
+export function missingLinearLifecycle(
+  branchName: string,
+  summary: string,
+): HandoffLifecycle {
+  return {
+    kind: "missing-target",
+    branchName,
+    pullRequest: null,
+    checks: [],
+    pendingCheckNames: [],
+    failingCheckNames: [],
+    actionableReviewFeedback: [],
+    unresolvedThreadIds: [],
+    summary,
+  };
+}
+
+export function linearTrackerSubject(config: LinearTrackerConfig): string {
+  return `linear/${config.projectSlug}`;
+}
+
+export function extractIssueNumberFromBranchName(
+  branchName: string,
+): number | null {
+  const match = branchName.match(/(\d+)$/u);
+  if (!match || match[1] === undefined) {
+    return null;
+  }
+  const issueNumber = Number(match[1]);
+  return Number.isNaN(issueNumber) ? null : issueNumber;
+}
+
+function resolveStateByName(
+  project: LinearProjectSnapshot,
+  stateName: string,
+): LinearWorkflowState {
+  const match = project.states.find((state) => state.name === stateName);
+  if (match !== undefined) {
+    return match;
+  }
+  throw new TrackerError(
+    `Linear project ${project.slugId} is missing configured state '${stateName}'`,
+  );
+}

--- a/src/tracker/linear-workpad.ts
+++ b/src/tracker/linear-workpad.ts
@@ -1,0 +1,137 @@
+import { TrackerError } from "../domain/errors.js";
+
+export type LinearWorkpadStatus =
+  | "running"
+  | "retry-scheduled"
+  | "failed"
+  | "handoff-ready"
+  | "completed";
+
+export interface LinearWorkpadEntry {
+  readonly status: LinearWorkpadStatus;
+  readonly summary: string;
+  readonly branchName: string | null;
+  readonly updatedAt: string;
+}
+
+const WORKPAD_START = "<!-- symphony-linear-workpad:start -->";
+const WORKPAD_END = "<!-- symphony-linear-workpad:end -->";
+
+export function parseLinearWorkpad(
+  description: string | null | undefined,
+): LinearWorkpadEntry | null {
+  const content = description ?? "";
+  const start = content.indexOf(WORKPAD_START);
+  const end = content.indexOf(WORKPAD_END);
+  if (start < 0 || end < 0 || end <= start) {
+    return null;
+  }
+
+  const payload = content.slice(start + WORKPAD_START.length, end).trim();
+  if (payload === "") {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch (error) {
+    throw new TrackerError("Linear issue workpad contains invalid JSON", {
+      cause: error as Error,
+    });
+  }
+
+  return normalizeWorkpadEntry(parsed);
+}
+
+export function writeLinearWorkpad(
+  description: string | null | undefined,
+  entry: LinearWorkpadEntry,
+): string {
+  const base = stripLinearWorkpad(description).trimEnd();
+  const block = [
+    WORKPAD_START,
+    JSON.stringify(entry, null, 2),
+    WORKPAD_END,
+  ].join("\n");
+
+  if (base === "") {
+    return `${block}\n`;
+  }
+
+  return `${base}\n\n${block}\n`;
+}
+
+function stripLinearWorkpad(description: string | null | undefined): string {
+  const content = description ?? "";
+  const start = content.indexOf(WORKPAD_START);
+  const end = content.indexOf(WORKPAD_END);
+  if (start < 0 || end < 0 || end <= start) {
+    return content;
+  }
+
+  const before = content.slice(0, start).trimEnd();
+  const after = content.slice(end + WORKPAD_END.length).trimStart();
+
+  if (before === "") {
+    return after;
+  }
+  if (after === "") {
+    return before;
+  }
+  return `${before}\n\n${after}`;
+}
+
+function normalizeWorkpadEntry(value: unknown): LinearWorkpadEntry {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TrackerError("Linear issue workpad must be an object");
+  }
+  const record = value as Record<string, unknown>;
+
+  const status = requireStatus(record["status"]);
+  const summary = requireString(record["summary"], "summary");
+  const updatedAt = requireString(record["updatedAt"], "updatedAt");
+  const branchName = requireOptionalString(record["branchName"], "branchName");
+
+  return {
+    status,
+    summary,
+    updatedAt,
+    branchName,
+  };
+}
+
+function requireStatus(value: unknown): LinearWorkpadStatus {
+  if (
+    value === "running" ||
+    value === "retry-scheduled" ||
+    value === "failed" ||
+    value === "handoff-ready" ||
+    value === "completed"
+  ) {
+    return value;
+  }
+  throw new TrackerError(
+    `Unsupported Linear workpad status '${String(value)}'`,
+  );
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TrackerError(`Linear issue workpad requires ${field}`);
+  }
+  return value;
+}
+
+function requireOptionalString(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new TrackerError(
+      `Linear issue workpad field ${field} must be a string`,
+    );
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -1,0 +1,249 @@
+import type { HandoffLifecycle } from "../domain/handoff.js";
+import type { RuntimeIssue } from "../domain/issue.js";
+import { TrackerError } from "../domain/errors.js";
+import type { LinearTrackerConfig } from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import type { Tracker } from "./service.js";
+import { LinearClient } from "./linear-client.js";
+import {
+  classifyLinearIssue,
+  createLinearHandoffLifecycle,
+  extractIssueNumberFromBranchName,
+  missingLinearLifecycle,
+  resolveLinearClaimState,
+  resolveLinearTerminalState,
+} from "./linear-policy.js";
+import {
+  normalizeLinearIssueMutationResult,
+  normalizeLinearIssuePage,
+  normalizeLinearIssueResult,
+  normalizeLinearProject,
+  type LinearIssueSnapshot,
+  type LinearProjectSnapshot,
+} from "./linear-normalize.js";
+import { writeLinearWorkpad } from "./linear-workpad.js";
+
+const CLAIM_COMMENT = "Symphony claimed this issue for implementation.";
+const RETRY_PREFIX = "Symphony scheduled a retry:";
+const FAILURE_PREFIX = "Symphony failed this run:";
+const HANDOFF_READY_COMMENT =
+  "Symphony run finished and marked this issue handoff-ready.";
+const COMPLETION_COMMENT = "Symphony completed this issue successfully.";
+
+export class LinearTracker implements Tracker {
+  readonly #config: LinearTrackerConfig;
+  readonly #logger: Logger;
+  readonly #client: LinearClient;
+  #projectPromise: Promise<LinearProjectSnapshot> | null = null;
+
+  constructor(config: LinearTrackerConfig, logger: Logger) {
+    this.#config = config;
+    this.#logger = logger;
+    this.#client = new LinearClient(config);
+  }
+
+  async ensureLabels(): Promise<void> {
+    await this.#project();
+  }
+
+  async fetchReadyIssues(): Promise<readonly RuntimeIssue[]> {
+    const issues = await this.#fetchProjectIssues();
+    return issues
+      .filter((issue) => classifyLinearIssue(issue, this.#config) === "ready")
+      .map((issue) => issue.runtimeIssue);
+  }
+
+  async fetchRunningIssues(): Promise<readonly RuntimeIssue[]> {
+    const issues = await this.#fetchProjectIssues();
+    return issues
+      .filter((issue) => classifyLinearIssue(issue, this.#config) === "running")
+      .map((issue) => issue.runtimeIssue);
+  }
+
+  async fetchFailedIssues(): Promise<readonly RuntimeIssue[]> {
+    const issues = await this.#fetchProjectIssues();
+    return issues
+      .filter((issue) => classifyLinearIssue(issue, this.#config) === "failed")
+      .map((issue) => issue.runtimeIssue);
+  }
+
+  async getIssue(issueNumber: number): Promise<RuntimeIssue> {
+    return (await this.#getIssueSnapshot(issueNumber)).runtimeIssue;
+  }
+
+  async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
+    const project = await this.#project();
+    const issue = await this.#getIssueSnapshot(issueNumber);
+    if (classifyLinearIssue(issue, this.#config) !== "ready") {
+      return null;
+    }
+
+    const nextState = resolveLinearClaimState(project, issue, this.#config);
+    const updatedDescription = writeLinearWorkpad(issue.description, {
+      status: "running",
+      summary: "Claimed by Symphony",
+      branchName: null,
+      updatedAt: new Date().toISOString(),
+    });
+
+    let updated = normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: issue.id,
+        description: updatedDescription,
+        ...(nextState === null ? {} : { stateId: nextState.id }),
+      }),
+      "issueUpdate",
+    );
+    updated = normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issue.id, CLAIM_COMMENT),
+      "commentCreate",
+    );
+    this.#logger.info("Claimed Linear issue", {
+      issueNumber,
+      identifier: updated.identifier,
+      nextState: nextState?.name ?? updated.state.name,
+    });
+    return updated.runtimeIssue;
+  }
+
+  async inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle> {
+    const issueNumber = extractIssueNumberFromBranchName(branchName);
+    if (issueNumber === null) {
+      return missingLinearLifecycle(
+        branchName,
+        `Could not extract issue number from branch ${branchName}`,
+      );
+    }
+    const issue = await this.#getIssueSnapshotOrNull(issueNumber);
+    return createLinearHandoffLifecycle(issue, branchName, this.#config);
+  }
+
+  async reconcileSuccessfulRun(
+    branchName: string,
+    _lifecycle: HandoffLifecycle | null,
+  ): Promise<HandoffLifecycle> {
+    const issueNumber = extractIssueNumberFromBranchName(branchName);
+    if (issueNumber === null) {
+      return missingLinearLifecycle(
+        branchName,
+        `Could not extract issue number from branch ${branchName}`,
+      );
+    }
+    const issue = await this.#getIssueSnapshot(issueNumber);
+    const updatedDescription = writeLinearWorkpad(issue.description, {
+      status: "handoff-ready",
+      summary: `Run finished for ${branchName}`,
+      branchName,
+      updatedAt: new Date().toISOString(),
+    });
+    await this.#client.updateIssue({
+      id: issue.id,
+      description: updatedDescription,
+    });
+    await this.#client.createComment(issue.id, HANDOFF_READY_COMMENT);
+    return await this.inspectIssueHandoff(branchName);
+  }
+
+  async recordRetry(issueNumber: number, reason: string): Promise<void> {
+    const issue = await this.#getIssueSnapshot(issueNumber);
+    await this.#client.updateIssue({
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "retry-scheduled",
+        summary: reason,
+        branchName: null,
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+    await this.#client.createComment(issue.id, `${RETRY_PREFIX} ${reason}`);
+  }
+
+  async completeIssue(issueNumber: number): Promise<void> {
+    const project = await this.#project();
+    const issue = await this.#getIssueSnapshot(issueNumber);
+    const terminalState = resolveLinearTerminalState(project, this.#config);
+    await this.#client.updateIssue({
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "completed",
+        summary: "Completed by Symphony",
+        branchName: null,
+        updatedAt: new Date().toISOString(),
+      }),
+      stateId: terminalState.id,
+    });
+    await this.#client.createComment(issue.id, COMPLETION_COMMENT);
+  }
+
+  async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
+    const issue = await this.#getIssueSnapshot(issueNumber);
+    await this.#client.updateIssue({
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "failed",
+        summary: reason,
+        branchName: null,
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+    await this.#client.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`);
+  }
+
+  async #project(): Promise<LinearProjectSnapshot> {
+    if (this.#projectPromise === null) {
+      this.#projectPromise = this.#loadProject().catch((error) => {
+        this.#projectPromise = null;
+        throw error;
+      });
+    }
+    return await this.#projectPromise;
+  }
+
+  async #loadProject(): Promise<LinearProjectSnapshot> {
+    const data = (await this.#client.fetchProject()) as {
+      readonly project: unknown;
+    };
+    return normalizeLinearProject(data.project);
+  }
+
+  async #fetchProjectIssues(): Promise<readonly LinearIssueSnapshot[]> {
+    const issues: LinearIssueSnapshot[] = [];
+    let after: string | null = null;
+
+    while (true) {
+      const page = normalizeLinearIssuePage(
+        await this.#client.fetchProjectIssuesPage(after),
+      );
+      if (this.#projectPromise === null) {
+        this.#projectPromise = Promise.resolve(page.project);
+      }
+      issues.push(...page.issues);
+      if (!page.hasNextPage) {
+        break;
+      }
+      after = page.endCursor;
+    }
+
+    return issues;
+  }
+
+  async #getIssueSnapshot(issueNumber: number): Promise<LinearIssueSnapshot> {
+    const issue = await this.#getIssueSnapshotOrNull(issueNumber);
+    if (issue === null) {
+      throw new TrackerError(`Linear issue ${issueNumber} not found`);
+    }
+    return issue;
+  }
+
+  async #getIssueSnapshotOrNull(
+    issueNumber: number,
+  ): Promise<LinearIssueSnapshot | null> {
+    const result = normalizeLinearIssueResult(
+      await this.#client.fetchProjectIssue(issueNumber),
+    );
+    if (this.#projectPromise === null) {
+      this.#projectPromise = Promise.resolve(result.project);
+    }
+    return result.issue;
+  }
+}

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -9,6 +9,7 @@ import {
   classifyLinearIssue,
   createLinearHandoffLifecycle,
   extractIssueNumberFromBranchName,
+  linearTrackerSubject,
   missingLinearLifecycle,
   resolveLinearClaimState,
   resolveLinearTerminalState,
@@ -40,6 +41,14 @@ export class LinearTracker implements Tracker {
     this.#config = config;
     this.#logger = logger;
     this.#client = new LinearClient(config);
+  }
+
+  subject(): string {
+    return linearTrackerSubject(this.#config);
+  }
+
+  isHumanReviewFeedback(authorLogin: string | null): boolean {
+    return authorLogin !== null;
   }
 
   async ensureLabels(): Promise<void> {
@@ -136,57 +145,81 @@ export class LinearTracker implements Tracker {
       branchName,
       updatedAt: new Date().toISOString(),
     });
-    await this.#client.updateIssue({
-      id: issue.id,
-      description: updatedDescription,
-    });
-    await this.#client.createComment(issue.id, HANDOFF_READY_COMMENT);
+    normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: issue.id,
+        description: updatedDescription,
+      }),
+      "issueUpdate",
+    );
+    normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issue.id, HANDOFF_READY_COMMENT),
+      "commentCreate",
+    );
     return await this.inspectIssueHandoff(branchName);
   }
 
   async recordRetry(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    await this.#client.updateIssue({
-      id: issue.id,
-      description: writeLinearWorkpad(issue.description, {
-        status: "retry-scheduled",
-        summary: reason,
-        branchName: null,
-        updatedAt: new Date().toISOString(),
+    normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: issue.id,
+        description: writeLinearWorkpad(issue.description, {
+          status: "retry-scheduled",
+          summary: reason,
+          branchName: null,
+          updatedAt: new Date().toISOString(),
+        }),
       }),
-    });
-    await this.#client.createComment(issue.id, `${RETRY_PREFIX} ${reason}`);
+      "issueUpdate",
+    );
+    normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issue.id, `${RETRY_PREFIX} ${reason}`),
+      "commentCreate",
+    );
   }
 
   async completeIssue(issueNumber: number): Promise<void> {
     const project = await this.#project();
     const issue = await this.#getIssueSnapshot(issueNumber);
     const terminalState = resolveLinearTerminalState(project, this.#config);
-    await this.#client.updateIssue({
-      id: issue.id,
-      description: writeLinearWorkpad(issue.description, {
-        status: "completed",
-        summary: "Completed by Symphony",
-        branchName: null,
-        updatedAt: new Date().toISOString(),
+    normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: issue.id,
+        description: writeLinearWorkpad(issue.description, {
+          status: "completed",
+          summary: "Completed by Symphony",
+          branchName: null,
+          updatedAt: new Date().toISOString(),
+        }),
+        stateId: terminalState.id,
       }),
-      stateId: terminalState.id,
-    });
-    await this.#client.createComment(issue.id, COMPLETION_COMMENT);
+      "issueUpdate",
+    );
+    normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issue.id, COMPLETION_COMMENT),
+      "commentCreate",
+    );
   }
 
   async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    await this.#client.updateIssue({
-      id: issue.id,
-      description: writeLinearWorkpad(issue.description, {
-        status: "failed",
-        summary: reason,
-        branchName: null,
-        updatedAt: new Date().toISOString(),
+    normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: issue.id,
+        description: writeLinearWorkpad(issue.description, {
+          status: "failed",
+          summary: reason,
+          branchName: null,
+          updatedAt: new Date().toISOString(),
+        }),
       }),
-    });
-    await this.#client.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`);
+      "issueUpdate",
+    );
+    normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`),
+      "commentCreate",
+    );
   }
 
   async #project(): Promise<LinearProjectSnapshot> {

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -95,7 +95,7 @@ export class LinearTracker implements Tracker {
       updatedAt: new Date().toISOString(),
     });
 
-    normalizeLinearIssueMutationResult(
+    const claimed = normalizeLinearIssueMutationResult(
       await this.#client.updateIssue({
         id: issue.id,
         description: updatedDescription,
@@ -103,16 +103,16 @@ export class LinearTracker implements Tracker {
       }),
       "issueUpdate",
     );
-    const updated = normalizeLinearIssueMutationResult(
+    normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, CLAIM_COMMENT),
       "commentCreate",
     );
     this.#logger.info("Claimed Linear issue", {
       issueNumber,
-      identifier: updated.identifier,
-      nextState: nextState?.name ?? updated.state.name,
+      identifier: claimed.identifier,
+      nextState: nextState?.name ?? claimed.state.name,
     });
-    return updated.runtimeIssue;
+    return claimed.runtimeIssue;
   }
 
   async inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle> {
@@ -251,7 +251,7 @@ export class LinearTracker implements Tracker {
         this.#projectPromise = Promise.resolve(page.project);
       }
       issues.push(...page.issues);
-      if (!page.hasNextPage) {
+      if (!page.hasNextPage || page.endCursor === null) {
         break;
       }
       after = page.endCursor;

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -86,7 +86,7 @@ export class LinearTracker implements Tracker {
       updatedAt: new Date().toISOString(),
     });
 
-    let updated = normalizeLinearIssueMutationResult(
+    normalizeLinearIssueMutationResult(
       await this.#client.updateIssue({
         id: issue.id,
         description: updatedDescription,
@@ -94,7 +94,7 @@ export class LinearTracker implements Tracker {
       }),
       "issueUpdate",
     );
-    updated = normalizeLinearIssueMutationResult(
+    const updated = normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, CLAIM_COMMENT),
       "commentCreate",
     );

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -2,6 +2,8 @@ import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 
 export interface Tracker {
+  subject(): string;
+  isHumanReviewFeedback(authorLogin: string | null): boolean;
   ensureLabels(): Promise<void>;
   fetchReadyIssues(): Promise<readonly RuntimeIssue[]>;
   fetchRunningIssues(): Promise<readonly RuntimeIssue[]>;

--- a/tests/e2e/linear-factory.test.ts
+++ b/tests/e2e/linear-factory.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPromptBuilder,
+  loadWorkflow,
+} from "../../src/config/workflow.js";
+import {
+  readIssueArtifactSummary,
+  readIssueArtifactEvents,
+} from "../../src/observability/issue-artifacts.js";
+import { JsonLogger } from "../../src/observability/logger.js";
+import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
+import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
+import { LocalRunner } from "../../src/runner/local.js";
+import { createTracker } from "../../src/tracker/factory.js";
+import { LocalWorkspaceManager } from "../../src/workspace/local.js";
+import {
+  countRemoteBranchCommits,
+  createSeedRemote,
+  createTempDir,
+  readRemoteBranchFile,
+} from "../support/git.js";
+import { MockLinearServer } from "../support/mock-linear-server.js";
+
+async function writeWorkflow(options: {
+  readonly rootDir: string;
+  readonly remotePath: string;
+  readonly endpoint: string;
+  readonly agentCommand: string;
+}): Promise<string> {
+  const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: linear
+  endpoint: ${options.endpoint}
+  api_key: linear-token
+  project_slug: symphony-linear
+  assignee: worker@example.test
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Canceled
+polling:
+  interval_ms: 5
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 2
+    backoff_ms: 0
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: ${options.remotePath}
+  branch_prefix: symphony/
+  cleanup_on_success: false
+hooks:
+  after_create: []
+agent:
+  command: ${options.agentCommand}
+  prompt_transport: stdin
+  timeout_ms: 30000
+  env: {}
+---
+You are working on issue {{ issue.identifier }}: {{ issue.title }}.
+Description: {{ issue.description }}
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
+async function createOrchestrator(
+  workflowPath: string,
+): Promise<BootstrapOrchestrator> {
+  const workflow = await loadWorkflow(workflowPath);
+  const logger = new JsonLogger();
+  const promptBuilder = createPromptBuilder(workflow);
+  const tracker = createTracker(workflow.config.tracker, logger);
+  const workspace = new LocalWorkspaceManager(
+    workflow.config.workspace,
+    workflow.config.hooks.afterCreate,
+    logger,
+  );
+  const runner = new LocalRunner(workflow.config.agent, logger);
+  return new BootstrapOrchestrator(
+    workflow.config,
+    promptBuilder,
+    tracker,
+    workspace,
+    runner,
+    logger,
+  );
+}
+
+describe("Linear factory e2e", () => {
+  let server: MockLinearServer;
+  let tempDir: string;
+  let remotePath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("symphony-linear-e2e-");
+    const remote = await createSeedRemote();
+    remotePath = remote.remotePath;
+    server = new MockLinearServer();
+    await server.start();
+    server.seedProject({
+      slugId: "symphony-linear",
+      name: "Symphony Linear",
+      states: [
+        { name: "Todo", type: "unstarted" },
+        { name: "In Progress", type: "started" },
+        { name: "Done", type: "completed" },
+        { name: "Canceled", type: "canceled" },
+      ],
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Implement Linear adapter coverage",
+      description: "Drive the Linear flow",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+      identifier: "SYM-1",
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("runs a complete factory loop against mocked Linear", async () => {
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      endpoint: server.baseUrl,
+      agentCommand: `bash ${path.resolve("tests/fixtures/fake-agent-linear-success.sh")}`,
+    });
+
+    const orchestrator = await createOrchestrator(workflowPath);
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue("symphony-linear", 1);
+    expect(issue.stateName).toBe("Done");
+    expect(issue.comments).toContain(
+      "Symphony claimed this issue for implementation.",
+    );
+    expect(issue.comments).toContain(
+      "Symphony run finished and marked this issue handoff-ready.",
+    );
+    expect(issue.comments).toContain(
+      "Symphony completed this issue successfully.",
+    );
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+    );
+    expect(artifactSummary.currentOutcome).toBe("succeeded");
+    expect(artifactSummary.repo).toBe("linear/symphony-linear");
+
+    const artifactEvents = await readIssueArtifactEvents(
+      path.join(tempDir, ".tmp", "workspaces"),
+      1,
+    );
+    expect(artifactEvents.map((event) => event.kind)).toEqual(
+      expect.arrayContaining(["claimed", "runner-spawned", "succeeded"]),
+    );
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.counts.running).toBe(0);
+    expect(status.lastAction?.kind).toBe("issue-completed");
+
+    expect(await countRemoteBranchCommits(remotePath, "symphony/1")).toBe(1);
+    expect(
+      await readRemoteBranchFile(remotePath, "symphony/1", "IMPLEMENTED.txt"),
+    ).toContain("implemented SYM-1");
+  });
+});

--- a/tests/fixtures/fake-agent-linear-success.sh
+++ b/tests/fixtures/fake-agent-linear-success.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT="$(cat)"
+printf '%s' "$PROMPT" > .agent-prompt.txt
+
+git config user.name "Symphony Test Agent"
+git config user.email "symphony-agent@example.com"
+
+echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER}" > IMPLEMENTED.txt
+git add .agent-prompt.txt IMPLEMENTED.txt
+git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER}"
+git push origin "HEAD:${SYMPHONY_BRANCH_NAME}"

--- a/tests/integration/linear.test.ts
+++ b/tests/integration/linear.test.ts
@@ -68,6 +68,37 @@ describe("LinearTracker", () => {
     expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
   });
 
+  it("breaks defensively when Linear reports another page without an end cursor", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Issue 1",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 2,
+      title: "Issue 2",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 3,
+      title: "Issue 3",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.forceNullEndCursorWithNextPage();
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+    const ready = await tracker.fetchReadyIssues();
+
+    expect(ready.map((issue) => issue.number)).toEqual([1, 2]);
+    expect(server.countRequests("GetProjectIssuesPage")).toBe(1);
+  });
+
   it("surfaces GraphQL errors distinctly from transport success", async () => {
     server.enqueueGraphQLError(
       "GetProjectIssuesPage",

--- a/tests/integration/linear.test.ts
+++ b/tests/integration/linear.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JsonLogger } from "../../src/observability/logger.js";
+import type { LinearTrackerConfig } from "../../src/domain/workflow.js";
+import { LinearTracker } from "../../src/tracker/linear.js";
+import { MockLinearServer } from "../support/mock-linear-server.js";
+
+function createConfig(server: MockLinearServer): LinearTrackerConfig {
+  return {
+    kind: "linear",
+    endpoint: server.baseUrl,
+    apiKey: "linear-token",
+    projectSlug: "symphony-linear",
+    assignee: "worker@example.test",
+    activeStates: ["Todo", "In Progress"],
+    terminalStates: ["Done", "Canceled"],
+  };
+}
+
+describe("LinearTracker", () => {
+  let server: MockLinearServer;
+
+  beforeEach(async () => {
+    server = new MockLinearServer();
+    await server.start();
+    server.seedProject({
+      slugId: "symphony-linear",
+      name: "Symphony Linear",
+      states: [
+        { name: "Todo", type: "unstarted" },
+        { name: "In Progress", type: "started" },
+        { name: "Done", type: "completed" },
+        { name: "Canceled", type: "canceled" },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("reads paginated ready issues from the mock Linear GraphQL surface", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Issue 1",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 2,
+      title: "Issue 2",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 3,
+      title: "Issue 3",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+    const ready = await tracker.fetchReadyIssues();
+
+    expect(ready.map((issue) => issue.number)).toEqual([1, 2, 3]);
+    expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
+  });
+
+  it("surfaces GraphQL errors distinctly from transport success", async () => {
+    server.enqueueGraphQLError(
+      "GetProjectIssuesPage",
+      "simulated GraphQL failure",
+    );
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+
+    await expect(tracker.fetchReadyIssues()).rejects.toThrowError(
+      /simulated GraphQL failure/i,
+    );
+  });
+
+  it("claims, marks handoff-ready, and completes issues against the mock server", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 7,
+      title: "Implement Linear flow",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+
+    const claimed = await tracker.claimIssue(7);
+    expect(claimed?.state).toBe("In Progress");
+    const claimedIssue = server.getIssue("symphony-linear", 7);
+    expect(claimedIssue.stateName).toBe("In Progress");
+    expect(claimedIssue.description).toContain("symphony-linear-workpad");
+    expect(claimedIssue.comments).toContain(
+      "Symphony claimed this issue for implementation.",
+    );
+
+    const lifecycle = await tracker.reconcileSuccessfulRun("symphony/7", null);
+    expect(lifecycle.kind).toBe("handoff-ready");
+    const handoffIssue = server.getIssue("symphony-linear", 7);
+    expect(handoffIssue.comments).toContain(
+      "Symphony run finished and marked this issue handoff-ready.",
+    );
+
+    await tracker.completeIssue(7);
+    const completedIssue = server.getIssue("symphony-linear", 7);
+    expect(completedIssue.stateName).toBe("Done");
+    expect(completedIssue.comments).toContain(
+      "Symphony completed this issue successfully.",
+    );
+  });
+
+  it("marks failed issues in the workpad and exposes them via fetchFailedIssues", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 9,
+      title: "Broken issue",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+
+    await tracker.markIssueFailed(9, "runner exited with 1");
+    const failed = await tracker.fetchFailedIssues();
+
+    expect(failed.map((issue) => issue.number)).toEqual([9]);
+    expect(server.getIssue("symphony-linear", 9).comments).toContain(
+      "Symphony failed this run: runner exited with 1",
+    );
+  });
+});

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -87,6 +87,7 @@ export class MockLinearServer {
   readonly #failures = new Map<string, MockOperationFailure[]>();
   readonly #server = http.createServer(this.#handle.bind(this));
   #baseUrl = "";
+  #forceNullEndCursorWithNextPage = false;
 
   async start(): Promise<void> {
     this.#server.listen(0, "127.0.0.1");
@@ -223,6 +224,10 @@ export class MockLinearServer {
     });
   }
 
+  forceNullEndCursorWithNextPage(): void {
+    this.#forceNullEndCursorWithNextPage = true;
+  }
+
   async #handle(
     request: IncomingMessage,
     response: ServerResponse,
@@ -339,8 +344,13 @@ export class MockLinearServer {
     const startIndex =
       after === null ? 0 : issues.findIndex((issue) => issue.id === after) + 1;
     const pageIssues = issues.slice(startIndex, startIndex + PAGE_SIZE);
+    const hasNextPage = startIndex + PAGE_SIZE < issues.length;
     const endCursor =
-      pageIssues.length === 0 ? null : pageIssues[pageIssues.length - 1]!.id;
+      this.#forceNullEndCursorWithNextPage && hasNextPage
+        ? null
+        : pageIssues.length === 0
+          ? null
+          : pageIssues[pageIssues.length - 1]!.id;
 
     return {
       project: {
@@ -350,7 +360,7 @@ export class MockLinearServer {
             this.#serializeIssue(project, issue),
           ),
           pageInfo: {
-            hasNextPage: startIndex + PAGE_SIZE < issues.length,
+            hasNextPage,
             endCursor,
           },
         },

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -1,0 +1,593 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+import { randomUUID } from "node:crypto";
+
+interface MockLinearProject {
+  readonly id: string;
+  readonly slugId: string;
+  readonly name: string;
+  readonly states: MockLinearWorkflowState[];
+}
+
+interface MockLinearWorkflowState {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly position: number;
+}
+
+interface MockLinearIssue {
+  readonly id: string;
+  readonly projectId: string;
+  readonly number: number;
+  readonly identifier: string;
+  title: string;
+  description: string;
+  readonly url: string;
+  readonly createdAt: string;
+  updatedAt: string;
+  stateId: string;
+  readonly assigneeEmail: string | null;
+  readonly comments: MockLinearComment[];
+}
+
+interface MockLinearComment {
+  readonly id: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly user: {
+    readonly name: string | null;
+    readonly email: string | null;
+  };
+}
+
+interface MockLinearRequest {
+  readonly operationName: string;
+  readonly query: string;
+  readonly variables: Readonly<Record<string, unknown>>;
+}
+
+type MockOperationFailure =
+  | {
+      readonly kind: "graphql";
+      readonly messages: readonly string[];
+    }
+  | {
+      readonly kind: "http";
+      readonly statusCode: number;
+      readonly body: unknown;
+    };
+
+const PAGE_SIZE = 2;
+
+function json(
+  response: ServerResponse,
+  statusCode: number,
+  payload: unknown,
+): void {
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(payload));
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw === "" ? {} : JSON.parse(raw);
+}
+
+export class MockLinearServer {
+  readonly #projects = new Map<string, MockLinearProject>();
+  readonly #issues = new Map<string, MockLinearIssue>();
+  readonly #issuesByNumber = new Map<string, MockLinearIssue>();
+  readonly #requests: MockLinearRequest[] = [];
+  readonly #failures = new Map<string, MockOperationFailure[]>();
+  readonly #server = http.createServer(this.#handle.bind(this));
+  #baseUrl = "";
+
+  async start(): Promise<void> {
+    this.#server.listen(0, "127.0.0.1");
+    await once(this.#server, "listening");
+    const address = this.#server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("Mock Linear server failed to bind");
+    }
+    this.#baseUrl = `http://127.0.0.1:${address.port}/graphql`;
+  }
+
+  async stop(): Promise<void> {
+    this.#server.closeAllConnections();
+    this.#server.close();
+    await once(this.#server, "close");
+  }
+
+  get baseUrl(): string {
+    return this.#baseUrl;
+  }
+
+  seedProject(input: {
+    readonly slugId: string;
+    readonly name: string;
+    readonly states: ReadonlyArray<{
+      readonly id?: string;
+      readonly name: string;
+      readonly type: string;
+      readonly position?: number;
+    }>;
+  }): MockLinearProject {
+    const project: MockLinearProject = {
+      id: randomUUID(),
+      slugId: input.slugId,
+      name: input.name,
+      states: input.states.map((state, index) => ({
+        id: state.id ?? randomUUID(),
+        name: state.name,
+        type: state.type,
+        position: state.position ?? index,
+      })),
+    };
+    this.#projects.set(project.slugId, project);
+    return project;
+  }
+
+  seedIssue(input: {
+    readonly projectSlug: string;
+    readonly number: number;
+    readonly title: string;
+    readonly description?: string;
+    readonly stateName: string;
+    readonly assigneeEmail?: string | null;
+    readonly identifier?: string;
+  }): MockLinearIssue {
+    const project = this.#requireProject(input.projectSlug);
+    const state = this.#requireProjectState(project, input.stateName);
+    const now = new Date().toISOString();
+    const identifier =
+      input.identifier ?? `${project.slugId.toUpperCase()}-${input.number}`;
+    const issue: MockLinearIssue = {
+      id: randomUUID(),
+      projectId: project.id,
+      number: input.number,
+      identifier,
+      title: input.title,
+      description: input.description ?? "",
+      url: `${this.#baseUrl.replace(/\/graphql$/u, "")}/issues/${identifier}`,
+      createdAt: now,
+      updatedAt: now,
+      stateId: state.id,
+      assigneeEmail: input.assigneeEmail ?? null,
+      comments: [],
+    };
+    this.#issues.set(issue.id, issue);
+    this.#issuesByNumber.set(
+      this.#issueKey(project.slugId, issue.number),
+      issue,
+    );
+    return issue;
+  }
+
+  getIssue(
+    projectSlug: string,
+    issueNumber: number,
+  ): {
+    readonly identifier: string;
+    readonly title: string;
+    readonly description: string;
+    readonly stateName: string;
+    readonly comments: readonly string[];
+  } {
+    const issue = this.#requireIssue(projectSlug, issueNumber);
+    const project = this.#requireProject(projectSlug);
+    return {
+      identifier: issue.identifier,
+      title: issue.title,
+      description: issue.description,
+      stateName: this.#requireStateById(project, issue.stateId).name,
+      comments: issue.comments.map((comment) => comment.body),
+    };
+  }
+
+  countRequests(operationName: string): number {
+    return this.#requests.filter(
+      (request) => request.operationName === operationName,
+    ).length;
+  }
+
+  requests(operationName?: string): readonly MockLinearRequest[] {
+    return operationName === undefined
+      ? [...this.#requests]
+      : this.#requests.filter(
+          (request) => request.operationName === operationName,
+        );
+  }
+
+  enqueueGraphQLError(operationName: string, message: string): void {
+    this.#enqueueFailure(operationName, {
+      kind: "graphql",
+      messages: [message],
+    });
+  }
+
+  enqueueHttpError(
+    operationName: string,
+    statusCode: number,
+    body: unknown,
+  ): void {
+    this.#enqueueFailure(operationName, {
+      kind: "http",
+      statusCode,
+      body,
+    });
+  }
+
+  async #handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (request.method !== "POST" || request.url !== "/graphql") {
+      json(response, 404, { error: "not found" });
+      return;
+    }
+
+    const auth = request.headers.authorization;
+    if (typeof auth !== "string" || !auth.startsWith("Bearer ")) {
+      json(response, 401, { errors: [{ message: "missing authorization" }] });
+      return;
+    }
+
+    const body = await readJson(request);
+    if (body === null || typeof body !== "object" || Array.isArray(body)) {
+      json(response, 400, { errors: [{ message: "invalid graphql payload" }] });
+      return;
+    }
+
+    const payload = body as Record<string, unknown>;
+    const operationName =
+      typeof payload["operationName"] === "string"
+        ? payload["operationName"]
+        : null;
+    const query = typeof payload["query"] === "string" ? payload["query"] : "";
+    const variables =
+      payload["variables"] !== null &&
+      typeof payload["variables"] === "object" &&
+      !Array.isArray(payload["variables"])
+        ? (payload["variables"] as Record<string, unknown>)
+        : {};
+
+    if (operationName === null) {
+      json(response, 400, { errors: [{ message: "missing operationName" }] });
+      return;
+    }
+
+    this.#requests.push({
+      operationName,
+      query,
+      variables,
+    });
+
+    const failure = this.#shiftFailure(operationName);
+    if (failure?.kind === "http") {
+      json(response, failure.statusCode, failure.body);
+      return;
+    }
+    if (failure?.kind === "graphql") {
+      json(response, 200, {
+        errors: failure.messages.map((message) => ({ message })),
+      });
+      return;
+    }
+
+    switch (operationName) {
+      case "GetProject":
+        json(response, 200, {
+          data: {
+            project: this.#serializeProject(
+              this.#requireProject(
+                requireString(variables["slugId"], "slugId"),
+              ),
+            ),
+          },
+        });
+        return;
+      case "GetProjectIssuesPage":
+        json(response, 200, {
+          data: this.#handleProjectIssuesPage(variables),
+        });
+        return;
+      case "GetProjectIssue":
+        json(response, 200, {
+          data: this.#handleProjectIssue(variables),
+        });
+        return;
+      case "UpdateIssue":
+        json(response, 200, {
+          data: {
+            issueUpdate: this.#handleIssueUpdate(variables),
+          },
+        });
+        return;
+      case "CreateComment":
+        json(response, 200, {
+          data: {
+            commentCreate: this.#handleCommentCreate(variables),
+          },
+        });
+        return;
+      default:
+        json(response, 400, {
+          errors: [{ message: `unsupported operation ${operationName}` }],
+        });
+    }
+  }
+
+  #handleProjectIssuesPage(variables: Readonly<Record<string, unknown>>) {
+    const project = this.#requireProject(
+      requireString(variables["slugId"], "slugId"),
+    );
+    const assignee = requireOptionalString(variables["assignee"], "assignee");
+    const after = requireOptionalString(variables["after"], "after");
+    const issues = this.#projectIssues(project.slugId).filter(
+      (issue) => assignee === null || issue.assigneeEmail === assignee,
+    );
+
+    const startIndex =
+      after === null ? 0 : issues.findIndex((issue) => issue.id === after) + 1;
+    const pageIssues = issues.slice(startIndex, startIndex + PAGE_SIZE);
+    const endCursor =
+      pageIssues.length === 0 ? null : pageIssues[pageIssues.length - 1]!.id;
+
+    return {
+      project: {
+        ...this.#serializeProject(project),
+        issues: {
+          nodes: pageIssues.map((issue) =>
+            this.#serializeIssue(project, issue),
+          ),
+          pageInfo: {
+            hasNextPage: startIndex + PAGE_SIZE < issues.length,
+            endCursor,
+          },
+        },
+      },
+    };
+  }
+
+  #handleProjectIssue(variables: Readonly<Record<string, unknown>>) {
+    const slugId = requireString(variables["slugId"], "slugId");
+    const project = this.#requireProject(slugId);
+    const issueNumber = requireNumber(variables["number"], "number");
+    const issue =
+      this.#issuesByNumber.get(this.#issueKey(slugId, issueNumber)) ?? null;
+
+    return {
+      project: {
+        ...this.#serializeProject(project),
+        issue: issue === null ? null : this.#serializeIssue(project, issue),
+      },
+    };
+  }
+
+  #handleIssueUpdate(variables: Readonly<Record<string, unknown>>) {
+    const issue = this.#requireIssueById(requireString(variables["id"], "id"));
+    if ("description" in variables) {
+      const description = requireNullableString(
+        variables["description"],
+        "description",
+      );
+      issue.description = description ?? "";
+    }
+
+    if ("stateId" in variables && variables["stateId"] !== null) {
+      const stateId = requireString(variables["stateId"], "stateId");
+      const project = this.#projectForIssue(issue);
+      this.#requireStateById(project, stateId);
+      issue.stateId = stateId;
+    }
+    issue.updatedAt = new Date().toISOString();
+
+    const project = this.#projectForIssue(issue);
+    return {
+      success: true,
+      issue: this.#serializeIssue(project, issue),
+    };
+  }
+
+  #handleCommentCreate(variables: Readonly<Record<string, unknown>>) {
+    const issue = this.#requireIssueById(
+      requireString(variables["issueId"], "issueId"),
+    );
+    issue.comments.push({
+      id: randomUUID(),
+      body: requireString(variables["body"], "body"),
+      createdAt: new Date().toISOString(),
+      user: {
+        name: "Symphony",
+        email: "symphony@example.test",
+      },
+    });
+    issue.updatedAt = new Date().toISOString();
+    const project = this.#projectForIssue(issue);
+    return {
+      success: true,
+      issue: this.#serializeIssue(project, issue),
+    };
+  }
+
+  #serializeProject(project: MockLinearProject) {
+    return {
+      id: project.id,
+      slugId: project.slugId,
+      name: project.name,
+      states: {
+        nodes: project.states.map((state) => ({
+          id: state.id,
+          name: state.name,
+          type: state.type,
+          position: state.position,
+        })),
+      },
+    };
+  }
+
+  #serializeIssue(project: MockLinearProject, issue: MockLinearIssue) {
+    const state = this.#requireStateById(project, issue.stateId);
+    return {
+      id: issue.id,
+      identifier: issue.identifier,
+      number: issue.number,
+      title: issue.title,
+      description: issue.description,
+      url: issue.url,
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+      state: {
+        id: state.id,
+        name: state.name,
+        type: state.type,
+        position: state.position,
+      },
+      comments: {
+        nodes: issue.comments.map((comment) => ({
+          id: comment.id,
+          body: comment.body,
+          createdAt: comment.createdAt,
+          user: {
+            name: comment.user.name,
+            email: comment.user.email,
+          },
+        })),
+      },
+    };
+  }
+
+  #projectIssues(projectSlug: string): readonly MockLinearIssue[] {
+    const project = this.#requireProject(projectSlug);
+    return [...this.#issues.values()]
+      .filter((issue) => issue.projectId === project.id)
+      .sort((left, right) => left.number - right.number);
+  }
+
+  #projectForIssue(issue: MockLinearIssue): MockLinearProject {
+    const project = [...this.#projects.values()].find(
+      (entry) => entry.id === issue.projectId,
+    );
+    if (project === undefined) {
+      throw new Error(`Project ${issue.projectId} not found`);
+    }
+    return project;
+  }
+
+  #requireProject(projectSlug: string): MockLinearProject {
+    const project = this.#projects.get(projectSlug);
+    if (project === undefined) {
+      throw new Error(`Linear project ${projectSlug} not found`);
+    }
+    return project;
+  }
+
+  #requireIssue(projectSlug: string, issueNumber: number): MockLinearIssue {
+    const issue = this.#issuesByNumber.get(
+      this.#issueKey(projectSlug, issueNumber),
+    );
+    if (issue === undefined) {
+      throw new Error(
+        `Linear issue ${projectSlug}#${issueNumber.toString()} not found`,
+      );
+    }
+    return issue;
+  }
+
+  #requireIssueById(issueId: string): MockLinearIssue {
+    const issue = this.#issues.get(issueId);
+    if (issue === undefined) {
+      throw new Error(`Linear issue ${issueId} not found`);
+    }
+    return issue;
+  }
+
+  #requireProjectState(
+    project: MockLinearProject,
+    stateName: string,
+  ): MockLinearWorkflowState {
+    const state = project.states.find((entry) => entry.name === stateName);
+    if (state === undefined) {
+      throw new Error(
+        `Linear state '${stateName}' not found in project ${project.slugId}`,
+      );
+    }
+    return state;
+  }
+
+  #requireStateById(
+    project: MockLinearProject,
+    stateId: string,
+  ): MockLinearWorkflowState {
+    const state = project.states.find((entry) => entry.id === stateId);
+    if (state === undefined) {
+      throw new Error(
+        `Linear state ${stateId} not found in project ${project.slugId}`,
+      );
+    }
+    return state;
+  }
+
+  #issueKey(projectSlug: string, issueNumber: number): string {
+    return `${projectSlug}:${issueNumber.toString()}`;
+  }
+
+  #enqueueFailure(operationName: string, failure: MockOperationFailure): void {
+    const queue = this.#failures.get(operationName) ?? [];
+    queue.push(failure);
+    this.#failures.set(operationName, queue);
+  }
+
+  #shiftFailure(operationName: string): MockOperationFailure | null {
+    const queue = this.#failures.get(operationName);
+    if (queue === undefined || queue.length === 0) {
+      return null;
+    }
+    const next = queue.shift() ?? null;
+    if (queue.length === 0) {
+      this.#failures.delete(operationName);
+    }
+    return next;
+  }
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Expected string for ${field}`);
+  }
+  return value;
+}
+
+function requireOptionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Expected string or null for ${field}`);
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function requireNullableString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Expected string or null for ${field}`);
+  }
+  return value;
+}
+
+function requireNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new Error(`Expected number for ${field}`);
+  }
+  return value;
+}

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -303,6 +303,9 @@ export class MockLinearServer {
         });
         return;
       case "UpdateIssue":
+      case "UpdateIssueDescription":
+      case "UpdateIssueState":
+      case "UpdateIssueDescriptionAndState":
         json(response, 200, {
           data: {
             issueUpdate: this.#handleIssueUpdate(variables),

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -50,42 +50,6 @@ Prompt body
   return workflowPath;
 }
 
-async function writeLinearWorkflow(rootDir: string): Promise<string> {
-  const workflowPath = createWorkflow(rootDir);
-  await fs.writeFile(
-    workflowPath,
-    `---
-tracker:
-  kind: linear
-  api_key: linear-token
-  project_slug: symphony-linear
-polling:
-  interval_ms: 1000
-  max_concurrent_runs: 1
-  retry:
-    max_attempts: 2
-    max_follow_up_attempts: 2
-    backoff_ms: 0
-workspace:
-  root: ./.tmp/workspaces
-  repo_url: /tmp/repo.git
-  branch_prefix: symphony/
-  cleanup_on_success: false
-hooks:
-  after_create: []
-agent:
-  command: codex
-  prompt_transport: stdin
-  timeout_ms: 1000
-  env: {}
----
-Prompt body
-`,
-    "utf8",
-  );
-  return workflowPath;
-}
-
 async function writeLinearWorkflowWithoutToken(
   rootDir: string,
 ): Promise<string> {
@@ -405,29 +369,5 @@ describe("runCli status", () => {
     }
 
     expect(chunks.join("")).toContain('"factoryState": "idle"');
-  });
-});
-
-describe("runCli run", () => {
-  it("fails clearly when workflow config is linear but the runtime adapter is not implemented", async () => {
-    const tempDir = await createTempDir("symphony-cli-run-linear-");
-
-    try {
-      const workflowPath = await writeLinearWorkflow(tempDir);
-      await expect(
-        runCli([
-          "node",
-          "symphony",
-          "run",
-          "--once",
-          "--workflow",
-          workflowPath,
-        ]),
-      ).rejects.toThrowError(
-        "tracker.kind 'linear' is not yet supported by `symphony run`; workflow loading and validation are available, but the Linear tracker adapter has not been implemented yet.",
-      );
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
   });
 });

--- a/tests/unit/linear-policy.test.ts
+++ b/tests/unit/linear-policy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { extractIssueNumberFromBranchName } from "../../src/tracker/linear-policy.js";
+
+describe("extractIssueNumberFromBranchName", () => {
+  it("reads issue numbers from the standard symphony branch format", () => {
+    expect(extractIssueNumberFromBranchName("symphony/70")).toBe(70);
+  });
+
+  it("reads issue numbers when the branch leaf carries a slug suffix", () => {
+    expect(
+      extractIssueNumberFromBranchName("symphony/70-linear-mocked-integration"),
+    ).toBe(70);
+  });
+
+  it("returns null when the branch leaf does not start with an issue number", () => {
+    expect(extractIssueNumberFromBranchName("symphony/linear-70")).toBeNull();
+  });
+});

--- a/tests/unit/linear-workpad.test.ts
+++ b/tests/unit/linear-workpad.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseLinearWorkpad,
+  writeLinearWorkpad,
+} from "../../src/tracker/linear-workpad.js";
+
+describe("linear-workpad", () => {
+  it("round-trips the Symphony workpad while preserving surrounding text", () => {
+    const description = ["# Work item", "", "Keep this content."].join("\n");
+
+    const next = writeLinearWorkpad(description, {
+      status: "running",
+      summary: "Claimed by Symphony",
+      branchName: "symphony/70",
+      updatedAt: "2026-03-10T12:00:00.000Z",
+    });
+
+    expect(next).toContain("Keep this content.");
+    expect(parseLinearWorkpad(next)).toEqual({
+      status: "running",
+      summary: "Claimed by Symphony",
+      branchName: "symphony/70",
+      updatedAt: "2026-03-10T12:00:00.000Z",
+    });
+  });
+});

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -140,6 +140,14 @@ class SequencedTracker implements Tracker {
     }
   }
 
+  subject(): string {
+    return "test/tracker";
+  }
+
+  isHumanReviewFeedback(authorLogin: string | null): boolean {
+    return authorLogin !== null && authorLogin !== "greptile[bot]";
+  }
+
   setLifecycleSequence(
     issueNumber: number,
     sequence: readonly HandoffLifecycle[],


### PR DESCRIPTION
Closes #70\n\nImplements the mock Linear GraphQL harness plus the thinnest real Linear tracker slice needed to exercise mocked integration and end-to-end coverage.