### PR TITLE
Linear Adapter 2: GraphQL Transport Client

### DIFF
--- a/docs/plans/066-linear-graphql-transport-client/plan.md
+++ b/docs/plans/066-linear-graphql-transport-client/plan.md
@@ -1,0 +1,208 @@
+# Issue 66 Plan: Linear GraphQL Transport Client
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Refine the existing Linear GraphQL client into a clearly transport-owned seam for polling and tracker writes, with typed raw response helpers, explicit pagination support, and deterministic surfacing of HTTP and GraphQL failures.
+
+## Scope
+
+- keep the Linear GraphQL transport boundary in `src/tracker/linear-client.ts`
+- move project-issue pagination traversal into the client instead of leaving it in `LinearTracker`
+- add typed transport response shapes for:
+  - project lookup
+  - paginated project issue reads
+  - project issue lookup by number
+  - issue update mutations
+  - comment creation mutations
+- preserve explicit auth/header handling and endpoint configuration for Linear
+- make HTTP and GraphQL failures deterministic and distinguishable in tests
+- add focused client coverage for:
+  - successful requests
+  - multi-page issue polling
+  - GraphQL error payloads
+  - transport / HTTP failures
+
+## Non-goals
+
+- changing Linear normalization rules in `src/tracker/linear-normalize.ts`
+- changing Linear lifecycle/workpad policy in `src/tracker/linear-policy.ts` or `src/tracker/linear-workpad.ts`
+- changing orchestrator retry, dispatch, or handoff behavior
+- redesigning the generic tracker contract
+- expanding the mock Linear schema beyond what current reads/writes require
+- depending on a real Linear workspace or external network in tests
+
+## Current Gaps
+
+- `src/tracker/linear-client.ts` exists, but its public methods mostly return `unknown` instead of typed transport payloads
+- `src/tracker/linear.ts` currently owns the page-traversal loop for project issue polling, so pagination leaks above the transport boundary
+- current tests exercise Linear mostly through `LinearTracker`, not through a dedicated client contract surface
+- GraphQL and HTTP failures are surfaced through `TrackerError`, but the client contract is not yet the clearly test-owned seam for those failure classes
+- the broader Linear slice from issue `#70` is already merged, so this issue should land as a narrow transport-hardening refactor rather than reopening normalization or policy review surfaces
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: documenting that this issue stays transport-only and does not alter Linear lifecycle policy
+  - does not belong: ready/running/failed classification or workpad semantics
+- Configuration Layer
+  - belongs: reusing the existing validated Linear config fields for endpoint and API key resolution
+  - does not belong: reparsing workflow config inside the client
+- Coordination Layer
+  - belongs: no changes in this slice
+  - does not belong: pagination cursors, GraphQL operation names, or HTTP error handling
+- Execution Layer
+  - belongs: no changes in this slice
+  - does not belong: tracker transport concerns
+- Integration Layer
+  - belongs: GraphQL transport, request helpers, typed raw payloads, pagination traversal, and mutation/query boundary handling
+  - does not belong: normalization into `RuntimeIssue` or tracker lifecycle decisions
+- Observability Layer
+  - belongs: clear, deterministic error messages and test assertions for HTTP and GraphQL failure classes
+  - does not belong: new status surfaces or orchestrator-facing telemetry redesign
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/tracker/linear-client.ts`
+  - GraphQL documents and operation names
+  - authenticated request helper
+  - typed raw response contracts
+  - explicit multi-page polling helper
+  - clear HTTP / GraphQL error handling
+- `src/tracker/linear.ts`
+  - only the narrow call-site changes needed to consume the refactored client API
+- `tests/integration/`
+  - dedicated Linear client contract tests
+  - small tracker adjustments only where client method signatures change
+- `tests/support/mock-linear-server.ts`
+  - only the harness changes needed to assert client transport behavior or inject failures more directly
+
+### Does not belong in this issue
+
+- moving normalization into the client
+- adding policy branches in the orchestrator
+- mixing workpad or lifecycle updates into client abstractions
+- broad changes across tracker factory, workspace, runner, or status surfaces
+- a single hot file that mixes transport, normalization, and policy concerns
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR because it narrows the Linear surface rather than extending it:
+
+1. make `LinearClient` the explicit owner of GraphQL request typing and page traversal
+2. update `LinearTracker` to consume those helpers without changing policy behavior
+3. add focused transport tests so future Linear work can depend on a stable client seam
+
+This slice deliberately defers:
+
+- any new Linear workflow policy
+- any tracker-contract redesign
+- any orchestrator or runtime-state changes
+- any end-to-end behavior beyond preserving the already-landed Linear path
+
+## Runtime State Model
+
+Not applicable for this slice. The work is transport-only and does not change orchestrator retries, continuations, reconciliation, leases, or handoff states.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected client behavior |
+| --- | --- | --- |
+| request cannot reach the Linear endpoint | operation name, endpoint, thrown fetch error | throw `TrackerError` naming the operation and transport failure |
+| Linear returns non-2xx HTTP status | operation name, status code, response body text if available | throw `TrackerError` naming the operation and HTTP status |
+| Linear returns `errors` in a 200 GraphQL payload | operation name, GraphQL error messages | throw `TrackerError` naming the operation and GraphQL error text |
+| Linear returns no `data` field and no GraphQL errors | operation name, parsed JSON payload | throw `TrackerError` naming the missing data payload |
+| page response reports `hasNextPage: true` with a usable cursor | current page payload | continue fetching subsequent pages in the client helper |
+| page response reports `hasNextPage: true` with `endCursor: null` | current page payload | stop defensively and return accumulated results without looping forever |
+
+## Storage / Persistence Contract
+
+- no new durable storage is introduced
+- the client continues to use only in-memory request/response values
+- remote Linear state remains the system of record for issue/project payloads
+- test fixtures remain in the in-process mock Linear server
+
+## Observability Requirements
+
+- error messages must include the GraphQL operation name
+- tests must cover HTTP failure and GraphQL failure as distinct classes
+- request-history assertions should prove that pagination is driven by the client rather than the tracker
+- call sites above the client should not need to inspect raw GraphQL envelopes to decide whether a transport failure occurred
+
+## Implementation Steps
+
+1. Refactor `src/tracker/linear-client.ts` to define explicit raw transport types for the supported queries and mutations.
+2. Add a client-owned helper for paginated project issue polling that performs the cursor loop internally.
+3. Keep the low-level request method responsible for auth headers, endpoint calls, HTTP handling, GraphQL error handling, and missing-data validation.
+4. Narrow `src/tracker/linear.ts` so it consumes typed client helpers instead of looping through cursors itself.
+5. Add focused integration tests for the client covering:
+   - successful project lookup
+   - successful multi-page project issue polling
+   - GraphQL error payloads
+   - HTTP failure payloads
+   - defensive stop when `hasNextPage` is true but `endCursor` is `null`
+6. Preserve or lightly update tracker integration coverage only where it protects the unchanged higher-level behavior.
+7. Run repo gates and self-review before opening the PR.
+
+## Tests And Acceptance Scenarios
+
+### Integration
+
+- `LinearClient.fetchProject()` sends the expected auth header and returns the typed project payload
+- `LinearClient.fetchProjectIssues()` traverses all pages and returns accumulated typed issue payloads
+- `LinearClient.fetchProjectIssue()` returns a typed issue lookup payload
+- `LinearClient.updateIssue()` and `LinearClient.createComment()` return typed mutation payloads
+- GraphQL errors are surfaced distinctly from HTTP failures
+- pagination stops defensively when the API claims another page but omits the cursor
+
+### Regression
+
+- `LinearTracker.fetchReadyIssues()` still returns the same normalized issue numbers after the client refactor
+- existing Linear tracker writes still succeed against the mock server
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. The client can fetch all paginated project issues from the mock Linear GraphQL server without the tracker owning the cursor loop.
+2. The client can fetch a single project-scoped issue and return a typed raw payload to normalization code.
+3. The client can perform issue-update and comment-create mutations with the configured Linear auth header.
+4. A GraphQL `errors` payload fails deterministically with an operation-specific `TrackerError`.
+5. A non-2xx HTTP response fails deterministically with an operation-specific `TrackerError`.
+6. Existing tracker behavior remains unchanged apart from consuming the narrower transport API.
+
+## Exit Criteria
+
+- `LinearClient` is the transport owner for Linear GraphQL requests and project-issue pagination
+- supported client methods return typed raw payloads instead of `unknown`
+- HTTP and GraphQL failures are covered directly in client-focused tests
+- `LinearTracker` no longer owns the cursor loop for paginated issue polling
+- the change lands as one reviewable PR without reopening normalization or lifecycle-policy concerns
+
+## Deferred To Later Issues Or PRs
+
+- further normalization tightening inside `src/tracker/linear-normalize.ts`
+- lifecycle/workpad policy changes
+- broader tracker service redesign
+- additional Linear operations beyond the current polling and write needs
+- richer observability surfaces beyond error clarity at the transport seam
+
+## Decision Notes
+
+- The client should return typed raw transport payloads, not normalized runtime models. That keeps parsing at the boundary while preserving the transport/normalization split.
+- Pagination belongs in the client because cursor traversal is a transport concern, while issue classification belongs in the tracker because it is policy.
+- This issue should not duplicate the broader Linear work already merged through issue `#70`; it should tighten the transport seam that broader slice currently depends on.
+
+## Revision Log
+
+- 2026-03-10: Initial plan created and marked `plan-ready` for issue #66.

--- a/docs/plans/066-linear-graphql-transport-client/plan.md
+++ b/docs/plans/066-linear-graphql-transport-client/plan.md
@@ -111,14 +111,14 @@ Not applicable for this slice. The work is transport-only and does not change or
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected client behavior |
-| --- | --- | --- |
-| request cannot reach the Linear endpoint | operation name, endpoint, thrown fetch error | throw `TrackerError` naming the operation and transport failure |
-| Linear returns non-2xx HTTP status | operation name, status code, response body text if available | throw `TrackerError` naming the operation and HTTP status |
-| Linear returns `errors` in a 200 GraphQL payload | operation name, GraphQL error messages | throw `TrackerError` naming the operation and GraphQL error text |
-| Linear returns no `data` field and no GraphQL errors | operation name, parsed JSON payload | throw `TrackerError` naming the missing data payload |
-| page response reports `hasNextPage: true` with a usable cursor | current page payload | continue fetching subsequent pages in the client helper |
-| page response reports `hasNextPage: true` with `endCursor: null` | current page payload | stop defensively and return accumulated results without looping forever |
+| Observed condition                                               | Local facts available                                        | Expected client behavior                                                |
+| ---------------------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| request cannot reach the Linear endpoint                         | operation name, endpoint, thrown fetch error                 | throw `TrackerError` naming the operation and transport failure         |
+| Linear returns non-2xx HTTP status                               | operation name, status code, response body text if available | throw `TrackerError` naming the operation and HTTP status               |
+| Linear returns `errors` in a 200 GraphQL payload                 | operation name, GraphQL error messages                       | throw `TrackerError` naming the operation and GraphQL error text        |
+| Linear returns no `data` field and no GraphQL errors             | operation name, parsed JSON payload                          | throw `TrackerError` naming the missing data payload                    |
+| page response reports `hasNextPage: true` with a usable cursor   | current page payload                                         | continue fetching subsequent pages in the client helper                 |
+| page response reports `hasNextPage: true` with `endCursor: null` | current page payload                                         | stop defensively and return accumulated results without looping forever |
 
 ## Storage / Persistence Contract
 

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -453,6 +453,9 @@ export class LinearClient {
       "GetProjectIssuesPage.data.project.issues.pageInfo.endCursor",
       GRAPHQL_VALIDATION_PREFIX,
     );
+    // Only pagination-critical fields are validated here. Base project fields
+    // such as id, slugId, name, and states are validated downstream in
+    // normalizeLinearProject().
     return project as unknown as LinearRawProjectWithIssues;
   }
 

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -68,7 +68,7 @@ export interface LinearRawProjectWithIssue extends LinearRawProject {
   readonly issue: LinearRawIssue | null;
 }
 
-interface LinearRawIssueMutation {
+export interface LinearRawIssueMutation {
   readonly success: boolean;
   readonly issue: LinearRawIssue | null;
 }

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -239,6 +239,20 @@ const COMMENT_CREATE_MUTATION = `
 
 const GRAPHQL_VALIDATION_PREFIX = "Linear GraphQL request failed";
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
+function errorOptions(error: unknown): ErrorOptions | undefined {
+  return error instanceof Error ? { cause: error } : undefined;
+}
+
 export class LinearClient {
   readonly #config: LinearTrackerConfig;
   readonly #fetch: typeof fetch;
@@ -352,8 +366,8 @@ export class LinearClient {
       });
     } catch (error) {
       throw new TrackerError(
-        `Linear GraphQL request failed for ${operationName}: ${(error as Error).message}`,
-        { cause: error as Error },
+        `Linear GraphQL request failed for ${operationName}: ${errorMessage(error)}`,
+        errorOptions(error),
       );
     }
 
@@ -370,7 +384,7 @@ export class LinearClient {
     } catch (error) {
       throw new TrackerError(
         `Linear GraphQL request failed for ${operationName}: invalid JSON response`,
-        { cause: error as Error },
+        errorOptions(error),
       );
     }
 

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -400,7 +400,7 @@ export class LinearClient {
         `Linear GraphQL request failed for ${operationName}: ${messages}`,
       );
     }
-    if (payload.data === undefined) {
+    if (payload.data === undefined || payload.data === null) {
       throw new TrackerError(
         `Linear GraphQL request failed for ${operationName}: missing data payload`,
       );

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -1,6 +1,139 @@
 import { TrackerError } from "../domain/errors.js";
 import type { LinearTrackerConfig } from "../domain/workflow.js";
 
+export interface LinearRawWorkflowState {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly position: number;
+}
+
+export interface LinearRawCommentUser {
+  readonly name: string | null;
+  readonly email: string | null;
+}
+
+export interface LinearRawComment {
+  readonly id: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly user: LinearRawCommentUser | null;
+}
+
+export interface LinearRawIssue {
+  readonly id: string;
+  readonly identifier: string;
+  readonly number: number;
+  readonly title: string;
+  readonly description: string | null;
+  readonly url: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly state: LinearRawWorkflowState;
+  readonly comments: {
+    readonly nodes: readonly LinearRawComment[];
+  };
+}
+
+export interface LinearRawProject {
+  readonly id: string;
+  readonly slugId: string;
+  readonly name: string;
+  readonly states: {
+    readonly nodes: readonly LinearRawWorkflowState[];
+  };
+}
+
+interface LinearRawPageInfo {
+  readonly hasNextPage: boolean;
+  readonly endCursor: string | null;
+}
+
+interface LinearRawProjectIssuesConnection {
+  readonly nodes: readonly LinearRawIssue[];
+  readonly pageInfo: LinearRawPageInfo;
+}
+
+interface LinearRawProjectWithIssues extends LinearRawProject {
+  readonly issues: LinearRawProjectIssuesConnection;
+}
+
+interface LinearRawProjectWithIssue extends LinearRawProject {
+  readonly issue: LinearRawIssue | null;
+}
+
+interface LinearRawIssueMutation {
+  readonly success: boolean;
+  readonly issue: LinearRawIssue | null;
+}
+
+export interface LinearProjectQueryResult {
+  readonly project: LinearRawProject | null;
+}
+
+interface LinearProjectIssuesPageResult {
+  readonly project: LinearRawProjectWithIssues | null;
+}
+
+export interface LinearProjectIssuesResult {
+  readonly project: LinearRawProject;
+  readonly issues: readonly LinearRawIssue[];
+}
+
+export interface LinearProjectIssueResult {
+  readonly project: LinearRawProjectWithIssue | null;
+}
+
+export interface LinearIssueUpdateResult {
+  readonly issueUpdate: LinearRawIssueMutation;
+}
+
+export interface LinearCommentCreateResult {
+  readonly commentCreate: LinearRawIssueMutation;
+}
+
+function requireObject(
+  value: unknown,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TrackerError(
+      `Linear GraphQL request failed: expected object for ${field}`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, field: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TrackerError(
+      `Linear GraphQL request failed: expected array for ${field}`,
+    );
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TrackerError(
+      `Linear GraphQL request failed: expected boolean for ${field}`,
+    );
+  }
+  return value;
+}
+
+function requireNullableString(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new TrackerError(
+      `Linear GraphQL request failed: expected string or null for ${field}`,
+    );
+  }
+  return value;
+}
+
 interface GraphQLErrorPayload {
   readonly message?: unknown;
 }
@@ -14,6 +147,10 @@ interface UpdateIssueRequest {
   readonly id: string;
   readonly description?: string;
   readonly stateId?: string;
+}
+
+interface LinearClientOptions {
+  readonly fetch?: typeof fetch;
 }
 
 const LINEAR_PROJECT_ISSUES_PAGE_SIZE = 50;
@@ -142,18 +279,85 @@ const COMMENT_CREATE_MUTATION = `
 
 export class LinearClient {
   readonly #config: LinearTrackerConfig;
+  readonly #fetch: typeof fetch;
 
-  constructor(config: LinearTrackerConfig) {
+  constructor(config: LinearTrackerConfig, options: LinearClientOptions = {}) {
     this.#config = config;
+    this.#fetch = options.fetch ?? fetch;
   }
 
-  async fetchProject(): Promise<unknown> {
+  async fetchProject(): Promise<LinearProjectQueryResult> {
     return await this.#request("GetProject", GET_PROJECT_QUERY, {
       slugId: this.#config.projectSlug,
     });
   }
 
-  async fetchProjectIssuesPage(after: string | null): Promise<unknown> {
+  async fetchProjectIssues(): Promise<LinearProjectIssuesResult> {
+    const issues: LinearRawIssue[] = [];
+    let after: string | null = null;
+    let project: LinearRawProject | null = null;
+
+    while (true) {
+      const page = this.#requireProjectIssuesPage(
+        await this.#fetchProjectIssuesPage(after),
+      );
+
+      if (project === null) {
+        project = this.#projectFromIssuePage(page);
+      }
+      issues.push(...page.issues.nodes);
+
+      const pageInfo = page.issues.pageInfo;
+      if (!pageInfo.hasNextPage || pageInfo.endCursor === null) {
+        break;
+      }
+      after = pageInfo.endCursor;
+    }
+
+    if (project === null) {
+      throw new TrackerError(
+        "Linear GraphQL request failed for GetProjectIssuesPage: missing project payload",
+      );
+    }
+
+    return {
+      project,
+      issues,
+    };
+  }
+
+  async fetchProjectIssue(
+    issueNumber: number,
+  ): Promise<LinearProjectIssueResult> {
+    return await this.#request("GetProjectIssue", GET_PROJECT_ISSUE_QUERY, {
+      slugId: this.#config.projectSlug,
+      number: issueNumber,
+    });
+  }
+
+  async updateIssue(
+    input: UpdateIssueRequest,
+  ): Promise<LinearIssueUpdateResult> {
+    return await this.#request(
+      this.#updateIssueOperation(input),
+      this.#updateIssueMutation(input),
+      this.#updateIssueVariables(input),
+    );
+  }
+
+  async createComment(
+    issueId: string,
+    body: string,
+  ): Promise<LinearCommentCreateResult> {
+    return await this.#request("CreateComment", COMMENT_CREATE_MUTATION, {
+      issueId,
+      body,
+    });
+  }
+
+  async #fetchProjectIssuesPage(
+    after: string | null,
+  ): Promise<LinearProjectIssuesPageResult> {
     return await this.#request(
       "GetProjectIssuesPage",
       GET_PROJECT_ISSUES_PAGE_QUERY,
@@ -165,28 +369,6 @@ export class LinearClient {
     );
   }
 
-  async fetchProjectIssue(issueNumber: number): Promise<unknown> {
-    return await this.#request("GetProjectIssue", GET_PROJECT_ISSUE_QUERY, {
-      slugId: this.#config.projectSlug,
-      number: issueNumber,
-    });
-  }
-
-  async updateIssue(input: UpdateIssueRequest): Promise<unknown> {
-    return await this.#request(
-      this.#updateIssueOperation(input),
-      this.#updateIssueMutation(input),
-      this.#updateIssueVariables(input),
-    );
-  }
-
-  async createComment(issueId: string, body: string): Promise<unknown> {
-    return await this.#request("CreateComment", COMMENT_CREATE_MUTATION, {
-      issueId,
-      body,
-    });
-  }
-
   async #request<T>(
     operationName: string,
     query: string,
@@ -194,7 +376,7 @@ export class LinearClient {
   ): Promise<T> {
     let response: Response;
     try {
-      response = await fetch(this.#config.endpoint, {
+      response = await this.#fetch(this.#config.endpoint, {
         method: "POST",
         headers: {
           authorization: `Bearer ${this.#config.apiKey}`,
@@ -220,7 +402,16 @@ export class LinearClient {
       );
     }
 
-    const payload = (await response.json()) as GraphQLResponse<T>;
+    let payload: GraphQLResponse<T>;
+    try {
+      payload = (await response.json()) as GraphQLResponse<T>;
+    } catch (error) {
+      throw new TrackerError(
+        `Linear GraphQL request failed for ${operationName}: invalid JSON response`,
+        { cause: error as Error },
+      );
+    }
+
     if ((payload.errors?.length ?? 0) > 0) {
       const messages = payload.errors
         ?.map((entry) =>
@@ -239,6 +430,46 @@ export class LinearClient {
       );
     }
     return payload.data;
+  }
+
+  #projectFromIssuePage(project: LinearRawProjectWithIssues): LinearRawProject {
+    return {
+      id: project.id,
+      slugId: project.slugId,
+      name: project.name,
+      states: project.states,
+    };
+  }
+
+  #requireProjectIssuesPage(
+    page: LinearProjectIssuesPageResult,
+  ): LinearRawProjectWithIssues {
+    const root = requireObject(page, "GetProjectIssuesPage.data");
+    const project = requireObject(
+      root["project"],
+      "GetProjectIssuesPage.data.project",
+    );
+    const issues = requireObject(
+      project["issues"],
+      "GetProjectIssuesPage.data.project.issues",
+    );
+    requireArray(
+      issues["nodes"],
+      "GetProjectIssuesPage.data.project.issues.nodes",
+    );
+    const pageInfo = requireObject(
+      issues["pageInfo"],
+      "GetProjectIssuesPage.data.project.issues.pageInfo",
+    );
+    requireBoolean(
+      pageInfo["hasNextPage"],
+      "GetProjectIssuesPage.data.project.issues.pageInfo.hasNextPage",
+    );
+    requireNullableString(
+      pageInfo["endCursor"],
+      "GetProjectIssuesPage.data.project.issues.pageInfo.endCursor",
+    );
+    return project as unknown as LinearRawProjectWithIssues;
   }
 
   #updateIssueOperation(input: UpdateIssueRequest): string {

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -319,9 +319,7 @@ export class LinearClient {
     });
   }
 
-  async #fetchProjectIssuesPage(
-    after: string | null,
-  ): Promise<unknown> {
+  async #fetchProjectIssuesPage(after: string | null): Promise<unknown> {
     return await this.#request<unknown>(
       "GetProjectIssuesPage",
       GET_PROJECT_ISSUES_PAGE_QUERY,
@@ -405,9 +403,7 @@ export class LinearClient {
     };
   }
 
-  #requireProjectIssuesPage(
-    page: unknown,
-  ): LinearRawProjectWithIssues {
+  #requireProjectIssuesPage(page: unknown): LinearRawProjectWithIssues {
     const root = requireObject(
       page,
       "GetProjectIssuesPage.data",

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -99,7 +99,7 @@ interface GraphQLErrorPayload {
 }
 
 interface GraphQLResponse<T> {
-  readonly data?: T;
+  readonly data?: T | null;
   readonly errors?: readonly GraphQLErrorPayload[];
 }
 

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -1,5 +1,11 @@
-import { TrackerError } from "../domain/errors.js";
 import type { LinearTrackerConfig } from "../domain/workflow.js";
+import { TrackerError } from "../domain/errors.js";
+import {
+  requireArray,
+  requireBoolean,
+  requireNullableString,
+  requireObject,
+} from "./linear-parse.js";
 
 export interface LinearRawWorkflowState {
   readonly id: string;
@@ -90,48 +96,6 @@ export interface LinearIssueUpdateResult {
 
 export interface LinearCommentCreateResult {
   readonly commentCreate: LinearRawIssueMutation;
-}
-
-function requireObject(
-  value: unknown,
-  field: string,
-): Readonly<Record<string, unknown>> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new TrackerError(
-      `Linear GraphQL request failed: expected object for ${field}`,
-    );
-  }
-  return value as Record<string, unknown>;
-}
-
-function requireArray(value: unknown, field: string): readonly unknown[] {
-  if (!Array.isArray(value)) {
-    throw new TrackerError(
-      `Linear GraphQL request failed: expected array for ${field}`,
-    );
-  }
-  return value;
-}
-
-function requireBoolean(value: unknown, field: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new TrackerError(
-      `Linear GraphQL request failed: expected boolean for ${field}`,
-    );
-  }
-  return value;
-}
-
-function requireNullableString(value: unknown, field: string): string | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  if (typeof value !== "string") {
-    throw new TrackerError(
-      `Linear GraphQL request failed: expected string or null for ${field}`,
-    );
-  }
-  return value;
 }
 
 interface GraphQLErrorPayload {
@@ -277,6 +241,8 @@ const COMMENT_CREATE_MUTATION = `
   }
 `;
 
+const GRAPHQL_VALIDATION_PREFIX = "Linear GraphQL request failed";
+
 export class LinearClient {
   readonly #config: LinearTrackerConfig;
   readonly #fetch: typeof fetch;
@@ -314,6 +280,8 @@ export class LinearClient {
       after = pageInfo.endCursor;
     }
 
+    // TypeScript cannot prove the loop above runs at least once.
+    // #requireProjectIssuesPage throws before returning if project is null.
     if (project === null) {
       throw new TrackerError(
         "Linear GraphQL request failed for GetProjectIssuesPage: missing project payload",
@@ -444,30 +412,40 @@ export class LinearClient {
   #requireProjectIssuesPage(
     page: LinearProjectIssuesPageResult,
   ): LinearRawProjectWithIssues {
-    const root = requireObject(page, "GetProjectIssuesPage.data");
+    const root = requireObject(
+      page,
+      "GetProjectIssuesPage.data",
+      GRAPHQL_VALIDATION_PREFIX,
+    );
     const project = requireObject(
       root["project"],
       "GetProjectIssuesPage.data.project",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     const issues = requireObject(
       project["issues"],
       "GetProjectIssuesPage.data.project.issues",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     requireArray(
       issues["nodes"],
       "GetProjectIssuesPage.data.project.issues.nodes",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     const pageInfo = requireObject(
       issues["pageInfo"],
       "GetProjectIssuesPage.data.project.issues.pageInfo",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     requireBoolean(
       pageInfo["hasNextPage"],
       "GetProjectIssuesPage.data.project.issues.pageInfo.hasNextPage",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     requireNullableString(
       pageInfo["endCursor"],
       "GetProjectIssuesPage.data.project.issues.pageInfo.endCursor",
+      GRAPHQL_VALIDATION_PREFIX,
     );
     return project as unknown as LinearRawProjectWithIssues;
   }

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -77,10 +77,6 @@ export interface LinearProjectQueryResult {
   readonly project: LinearRawProject | null;
 }
 
-interface LinearProjectIssuesPageResult {
-  readonly project: LinearRawProjectWithIssues | null;
-}
-
 export interface LinearProjectIssuesResult {
   readonly project: LinearRawProject;
   readonly issues: readonly LinearRawIssue[];
@@ -325,8 +321,8 @@ export class LinearClient {
 
   async #fetchProjectIssuesPage(
     after: string | null,
-  ): Promise<LinearProjectIssuesPageResult> {
-    return await this.#request(
+  ): Promise<unknown> {
+    return await this.#request<unknown>(
       "GetProjectIssuesPage",
       GET_PROJECT_ISSUES_PAGE_QUERY,
       {
@@ -410,7 +406,7 @@ export class LinearClient {
   }
 
   #requireProjectIssuesPage(
-    page: LinearProjectIssuesPageResult,
+    page: unknown,
   ): LinearRawProjectWithIssues {
     const root = requireObject(
       page,

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -60,11 +60,11 @@ interface LinearRawProjectIssuesConnection {
   readonly pageInfo: LinearRawPageInfo;
 }
 
-interface LinearRawProjectWithIssues extends LinearRawProject {
+export interface LinearRawProjectWithIssues extends LinearRawProject {
   readonly issues: LinearRawProjectIssuesConnection;
 }
 
-interface LinearRawProjectWithIssue extends LinearRawProject {
+export interface LinearRawProjectWithIssue extends LinearRawProject {
   readonly issue: LinearRawIssue | null;
 }
 

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -50,12 +50,12 @@ export interface LinearRawProject {
   };
 }
 
-interface LinearRawPageInfo {
+export interface LinearRawPageInfo {
   readonly hasNextPage: boolean;
   readonly endCursor: string | null;
 }
 
-interface LinearRawProjectIssuesConnection {
+export interface LinearRawProjectIssuesConnection {
   readonly nodes: readonly LinearRawIssue[];
   readonly pageInfo: LinearRawPageInfo;
 }

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -93,6 +93,9 @@ export function normalizeLinearIssueResult(value: unknown): {
   readonly issue: LinearIssueSnapshot | null;
 } {
   const record = requireObject(value, "projectIssue");
+  if (record["project"] === null || record["project"] === undefined) {
+    throw new TrackerError("Linear project not found in issue result");
+  }
   const projectRecord = requireObject(record["project"], "project");
 
   return {

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -1,6 +1,14 @@
 import type { RuntimeIssue } from "../domain/issue.js";
 import { TrackerError } from "../domain/errors.js";
 import {
+  requireArray,
+  requireBoolean,
+  requireNullableString,
+  requireNumber,
+  requireObject,
+  requireString,
+} from "./linear-parse.js";
+import {
   parseLinearWorkpad,
   type LinearWorkpadEntry,
 } from "./linear-workpad.js";
@@ -42,13 +50,6 @@ export interface LinearProjectSnapshot {
   readonly states: readonly LinearWorkflowState[];
 }
 
-export interface LinearIssuePageSnapshot {
-  readonly project: LinearProjectSnapshot;
-  readonly issues: readonly LinearIssueSnapshot[];
-  readonly hasNextPage: boolean;
-  readonly endCursor: string | null;
-}
-
 export interface LinearProjectIssuesSnapshot {
   readonly project: LinearProjectSnapshot;
   readonly issues: readonly LinearIssueSnapshot[];
@@ -69,41 +70,6 @@ export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
     slugId: requireString(record["slugId"], "project.slugId"),
     name: requireString(record["name"], "project.name"),
     states,
-  };
-}
-
-export function normalizeLinearIssuePage(
-  value: unknown,
-): LinearIssuePageSnapshot {
-  const record = requireObject(value, "page");
-  const projectRecord = requireObject(record["project"], "project");
-  const project = normalizeLinearProject(projectRecord);
-  const issuesConnection = requireObject(
-    projectRecord["issues"],
-    "project.issues",
-  );
-  const issues = requireArray(
-    issuesConnection["nodes"],
-    "project.issues.nodes",
-  ).map((entry, index) =>
-    normalizeLinearIssue(entry, `project.issues.nodes[${index}]`),
-  );
-  const pageInfo = requireObject(
-    issuesConnection["pageInfo"],
-    "project.issues.pageInfo",
-  );
-
-  return {
-    project,
-    issues,
-    hasNextPage: requireBoolean(
-      pageInfo["hasNextPage"],
-      "project.issues.pageInfo.hasNextPage",
-    ),
-    endCursor: requireNullableString(
-      pageInfo["endCursor"],
-      "project.issues.pageInfo.endCursor",
-    ),
   };
 }
 
@@ -237,52 +203,4 @@ function normalizeLinearComment(value: unknown, field: string): LinearComment {
         ? null
         : requireNullableString(user["email"], `${field}.user.email`),
   };
-}
-
-function requireObject(
-  value: unknown,
-  field: string,
-): Readonly<Record<string, unknown>> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new TrackerError(`Expected object for ${field}`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function requireArray(value: unknown, field: string): readonly unknown[] {
-  if (!Array.isArray(value)) {
-    throw new TrackerError(`Expected array for ${field}`);
-  }
-  return value;
-}
-
-function requireString(value: unknown, field: string): string {
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new TrackerError(`Expected non-empty string for ${field}`);
-  }
-  return value;
-}
-
-function requireNullableString(value: unknown, field: string): string | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  if (typeof value !== "string") {
-    throw new TrackerError(`Expected string or null for ${field}`);
-  }
-  return value;
-}
-
-function requireNumber(value: unknown, field: string): number {
-  if (typeof value !== "number" || Number.isNaN(value)) {
-    throw new TrackerError(`Expected number for ${field}`);
-  }
-  return value;
-}
-
-function requireBoolean(value: unknown, field: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new TrackerError(`Expected boolean for ${field}`);
-  }
-  return value;
 }

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -49,6 +49,11 @@ export interface LinearIssuePageSnapshot {
   readonly endCursor: string | null;
 }
 
+export interface LinearProjectIssuesSnapshot {
+  readonly project: LinearProjectSnapshot;
+  readonly issues: readonly LinearIssueSnapshot[];
+}
+
 export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
   const record = requireObject(value, "project");
   const statesConnection = requireObject(record["states"], "project.states");
@@ -99,6 +104,21 @@ export function normalizeLinearIssuePage(
       pageInfo["endCursor"],
       "project.issues.pageInfo.endCursor",
     ),
+  };
+}
+
+export function normalizeLinearProjectIssuesResult(
+  value: unknown,
+): LinearProjectIssuesSnapshot {
+  const record = requireObject(value, "projectIssues");
+  const issues = requireArray(record["issues"], "projectIssues.issues").map(
+    (entry, index) =>
+      normalizeLinearIssue(entry, `projectIssues.issues[${index}]`),
+  );
+
+  return {
+    project: normalizeLinearProject(record["project"]),
+    issues,
   };
 }
 

--- a/src/tracker/linear-parse.ts
+++ b/src/tracker/linear-parse.ts
@@ -1,0 +1,85 @@
+import { TrackerError } from "../domain/errors.js";
+
+function formatValidationError(
+  expectation: string,
+  field: string,
+  prefix?: string,
+): string {
+  if (prefix === undefined) {
+    return `Expected ${expectation} for ${field}`;
+  }
+  return `${prefix}: expected ${expectation} for ${field}`;
+}
+
+export function requireObject(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TrackerError(formatValidationError("object", field, prefix));
+  }
+  return value as Record<string, unknown>;
+}
+
+export function requireArray(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TrackerError(formatValidationError("array", field, prefix));
+  }
+  return value;
+}
+
+export function requireBoolean(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): boolean {
+  if (typeof value !== "boolean") {
+    throw new TrackerError(formatValidationError("boolean", field, prefix));
+  }
+  return value;
+}
+
+export function requireString(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TrackerError(
+      formatValidationError("non-empty string", field, prefix),
+    );
+  }
+  return value;
+}
+
+export function requireNumber(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new TrackerError(formatValidationError("number", field, prefix));
+  }
+  return value;
+}
+
+export function requireNullableString(
+  value: unknown,
+  field: string,
+  prefix?: string,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new TrackerError(
+      formatValidationError("string or null", field, prefix),
+    );
+  }
+  return value;
+}

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -234,6 +234,11 @@ export class LinearTracker implements Tracker {
 
   async #loadProject(): Promise<LinearProjectSnapshot> {
     const data = await this.#client.fetchProject();
+    if (data.project === null) {
+      throw new TrackerError(
+        `Linear project not found: ${this.#config.projectSlug}`,
+      );
+    }
     return normalizeLinearProject(data.project);
   }
 

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -234,7 +234,7 @@ export class LinearTracker implements Tracker {
 
   async #loadProject(): Promise<LinearProjectSnapshot> {
     const data = await this.#client.fetchProject();
-    if (data.project === null) {
+    if (data.project == null) {
       throw new TrackerError(
         `Linear project not found: ${this.#config.projectSlug}`,
       );

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -16,7 +16,7 @@ import {
 } from "./linear-policy.js";
 import {
   normalizeLinearIssueMutationResult,
-  normalizeLinearIssuePage,
+  normalizeLinearProjectIssuesResult,
   normalizeLinearIssueResult,
   normalizeLinearProject,
   type LinearIssueSnapshot,
@@ -233,31 +233,18 @@ export class LinearTracker implements Tracker {
   }
 
   async #loadProject(): Promise<LinearProjectSnapshot> {
-    const data = (await this.#client.fetchProject()) as {
-      readonly project: unknown;
-    };
+    const data = await this.#client.fetchProject();
     return normalizeLinearProject(data.project);
   }
 
   async #fetchProjectIssues(): Promise<readonly LinearIssueSnapshot[]> {
-    const issues: LinearIssueSnapshot[] = [];
-    let after: string | null = null;
-
-    while (true) {
-      const page = normalizeLinearIssuePage(
-        await this.#client.fetchProjectIssuesPage(after),
-      );
-      if (this.#projectPromise === null) {
-        this.#projectPromise = Promise.resolve(page.project);
-      }
-      issues.push(...page.issues);
-      if (!page.hasNextPage || page.endCursor === null) {
-        break;
-      }
-      after = page.endCursor;
+    const result = normalizeLinearProjectIssuesResult(
+      await this.#client.fetchProjectIssues(),
+    );
+    if (this.#projectPromise === null) {
+      this.#projectPromise = Promise.resolve(result.project);
     }
-
-    return issues;
+    return result.issues;
   }
 
   async #getIssueSnapshot(issueNumber: number): Promise<LinearIssueSnapshot> {

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -157,6 +157,23 @@ describe("LinearClient", () => {
     );
   });
 
+  it("surfaces invalid JSON responses with the operation name", async () => {
+    const invalidJsonFetch: typeof fetch = async () =>
+      new Response("not json", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+        },
+      });
+    const client = new LinearClient(createConfig(server), {
+      fetch: invalidJsonFetch,
+    });
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: invalid JSON response/i,
+    );
+  });
+
   it("surfaces transport failures deterministically", async () => {
     const failingFetch: typeof fetch = async () => {
       throw new Error("simulated transport failure");

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { LinearTrackerConfig } from "../../src/domain/workflow.js";
+import { LinearClient } from "../../src/tracker/linear-client.js";
+import { MockLinearServer } from "../support/mock-linear-server.js";
+
+function createConfig(server: MockLinearServer): LinearTrackerConfig {
+  return {
+    kind: "linear",
+    endpoint: server.baseUrl,
+    apiKey: "linear-token",
+    projectSlug: "symphony-linear",
+    assignee: "worker@example.test",
+    activeStates: ["Todo", "In Progress"],
+    terminalStates: ["Done", "Canceled"],
+  };
+}
+
+describe("LinearClient", () => {
+  let server: MockLinearServer;
+
+  beforeEach(async () => {
+    server = new MockLinearServer();
+    await server.start();
+    server.seedProject({
+      slugId: "symphony-linear",
+      name: "Symphony Linear",
+      states: [
+        { name: "Todo", type: "unstarted" },
+        { name: "In Progress", type: "started" },
+        { name: "Done", type: "completed" },
+        { name: "Canceled", type: "canceled" },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("sends the configured auth headers and returns the typed project payload", async () => {
+    const client = new LinearClient(createConfig(server));
+
+    const result = await client.fetchProject();
+    const request = server.requests("GetProject")[0];
+
+    expect(result.project?.slugId).toBe("symphony-linear");
+    expect(request?.authorization).toBe("Bearer linear-token");
+    expect(request?.contentType).toBe("application/json");
+    expect(request?.variables).toEqual({ slugId: "symphony-linear" });
+  });
+
+  it("fetches project issues across multiple pages inside the client", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Issue 1",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 2,
+      title: "Issue 2",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 3,
+      title: "Issue 3",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const client = new LinearClient(createConfig(server));
+    const result = await client.fetchProjectIssues();
+
+    expect(result.project.slugId).toBe("symphony-linear");
+    expect(result.issues.map((issue) => issue.number)).toEqual([1, 2, 3]);
+    expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
+  });
+
+  it("stops pagination defensively when Linear omits the next-page cursor", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Issue 1",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 2,
+      title: "Issue 2",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 3,
+      title: "Issue 3",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.forceNullEndCursorWithNextPage();
+
+    const client = new LinearClient(createConfig(server));
+    const result = await client.fetchProjectIssues();
+
+    expect(result.issues.map((issue) => issue.number)).toEqual([1, 2]);
+    expect(server.countRequests("GetProjectIssuesPage")).toBe(1);
+  });
+
+  it("returns typed project issue and mutation payloads", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 7,
+      title: "Issue 7",
+      description: "Before",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+
+    const projectIssue = await client.fetchProjectIssue(7);
+    const updateResult = await client.updateIssue({
+      id: issue.id,
+      description: "After",
+    });
+    const commentResult = await client.createComment(issue.id, "Tracked");
+
+    expect(projectIssue.project?.issue?.number).toBe(7);
+    expect(updateResult.issueUpdate.success).toBe(true);
+    expect(updateResult.issueUpdate.issue?.description).toBe("After");
+    expect(commentResult.commentCreate.success).toBe(true);
+    expect(commentResult.commentCreate.issue?.comments.nodes).toHaveLength(1);
+    expect(server.getIssue("symphony-linear", 7).comments).toContain("Tracked");
+  });
+
+  it("surfaces GraphQL errors distinctly from HTTP failures", async () => {
+    const client = new LinearClient(createConfig(server));
+    server.enqueueGraphQLError("GetProject", "simulated GraphQL failure");
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: simulated GraphQL failure/i,
+    );
+  });
+
+  it("surfaces HTTP failures with the operation name", async () => {
+    const client = new LinearClient(createConfig(server));
+    server.enqueueHttpError("GetProject", 503, { error: "outage" });
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: HTTP 503/i,
+    );
+  });
+
+  it("surfaces transport failures deterministically", async () => {
+    const failingFetch: typeof fetch = async () => {
+      throw new Error("simulated transport failure");
+    };
+    const client = new LinearClient(createConfig(server), {
+      fetch: failingFetch,
+    });
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: simulated transport failure/i,
+    );
+  });
+
+  it("turns malformed paginated payloads into TrackerError failures", async () => {
+    const malformedFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            project: {
+              id: "project-1",
+              slugId: "symphony-linear",
+              name: "Symphony Linear",
+              states: { nodes: [] },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    const client = new LinearClient(createConfig(server), {
+      fetch: malformedFetch,
+    });
+
+    await expect(client.fetchProjectIssues()).rejects.toThrowError(
+      /GetProjectIssuesPage\.data\.project\.issues/i,
+    );
+  });
+});

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -77,6 +77,7 @@ describe("LinearClient", () => {
 
     expect(result.project.slugId).toBe("symphony-linear");
     expect(result.issues.map((issue) => issue.number)).toEqual([1, 2, 3]);
+    // The mock Linear server pages two issues at a time, so 3 seeded issues require 2 requests.
     expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
   });
 
@@ -107,6 +108,7 @@ describe("LinearClient", () => {
     const client = new LinearClient(createConfig(server));
     const result = await client.fetchProjectIssues();
 
+    // The first mock page returns issues 1 and 2; the client stops when hasNextPage=true but endCursor=null.
     expect(result.issues.map((issue) => issue.number)).toEqual([1, 2]);
     expect(server.countRequests("GetProjectIssuesPage")).toBe(1);
   });

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -174,6 +174,23 @@ describe("LinearClient", () => {
     );
   });
 
+  it("surfaces null GraphQL data payloads with the operation name", async () => {
+    const nullDataFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ data: null }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    const client = new LinearClient(createConfig(server), {
+      fetch: nullDataFetch,
+    });
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: missing data payload/i,
+    );
+  });
+
   it("surfaces transport failures deterministically", async () => {
     const failingFetch: typeof fetch = async () => {
       throw new Error("simulated transport failure");

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -168,6 +168,19 @@ describe("LinearClient", () => {
     );
   });
 
+  it("surfaces non-Error transport failures deterministically", async () => {
+    const failingFetch: typeof fetch = async () => {
+      throw "simulated string transport failure";
+    };
+    const client = new LinearClient(createConfig(server), {
+      fetch: failingFetch,
+    });
+
+    await expect(client.fetchProject()).rejects.toThrowError(
+      /GetProject: simulated string transport failure/i,
+    );
+  });
+
   it("turns malformed paginated payloads into TrackerError failures", async () => {
     const malformedFetch: typeof fetch = async () =>
       new Response(

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -45,6 +45,8 @@ interface MockLinearRequest {
   readonly operationName: string;
   readonly query: string;
   readonly variables: Readonly<Record<string, unknown>>;
+  readonly authorization: string | null;
+  readonly contentType: string | null;
 }
 
 type MockOperationFailure =
@@ -271,6 +273,14 @@ export class MockLinearServer {
       operationName,
       query,
       variables,
+      authorization:
+        typeof request.headers.authorization === "string"
+          ? request.headers.authorization
+          : null,
+      contentType:
+        typeof request.headers["content-type"] === "string"
+          ? request.headers["content-type"]
+          : null,
     });
 
     const failure = this.#shiftFailure(operationName);

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLinearIssueResult } from "../../src/tracker/linear-normalize.js";
+
+describe("normalizeLinearIssueResult", () => {
+  it("throws a clear error when the project payload is missing", () => {
+    expect(() =>
+      normalizeLinearIssueResult({
+        project: null,
+      }),
+    ).toThrowError(/Linear project not found in issue result/);
+  });
+});


### PR DESCRIPTION
## Summary
- add typed Linear GraphQL transport helpers for project reads, issue reads, mutations, and client-owned pagination
- keep Linear tracker policy/normalization separate while moving cursor traversal into the client
- add dedicated client integration coverage for auth headers, pagination, GraphQL/HTTP/transport failures, and malformed page payloads

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- codex review --base origin/main

Closes #66