### PR TITLE
Linear Adapter 3: Normalize Linear Issue Snapshots

### DIFF
--- a/docs/plans/067-linear-issue-normalization/plan.md
+++ b/docs/plans/067-linear-issue-normalization/plan.md
@@ -1,0 +1,226 @@
+# Issue 67 Plan: Linear Issue Snapshot Normalization
+
+## Status
+
+- approved
+
+## Goal
+
+Normalize Linear GraphQL issue payloads into stable TypeScript tracker snapshots that match the upstream Elixir Linear issue shape where it is relevant to orchestration, while keeping raw GraphQL response structure and relation decoding inside the Linear adapter boundary.
+
+## Scope
+
+- expand the Linear read payload seam so the transport layer exposes the raw issue fields needed for normalization:
+  - `id`
+  - `identifier`
+  - `number`
+  - `title`
+  - `description`
+  - `priority`
+  - `state`
+  - `branchName`
+  - `url`
+  - assignee identity
+  - labels
+  - dependency / blocked-by relations
+  - `createdAt`
+  - `updatedAt`
+- normalize those raw fields into a richer `LinearIssueSnapshot` in `src/tracker/linear-normalize.ts`
+- preserve a tracker-neutral `RuntimeIssue` projection for the orchestrator without leaking raw Linear payload envelopes upward
+- add assignee-routing compatibility at the normalization boundary so the adapter can tell whether an issue is assigned to the configured worker
+- add focused tests for:
+  - partial payloads
+  - dependency decoding
+  - labels
+  - timestamps
+  - assignee routing behavior
+
+## Non-goals
+
+- adding Linear tracker writes or new state-mutation behavior
+- changing Linear lifecycle or workpad policy in `src/tracker/linear-policy.ts`
+- redesigning the generic `Tracker` interface or orchestrator runtime state
+- moving normalization logic into `src/tracker/linear-client.ts`
+- adding tracker writes for dependencies, labels, assignees, or branches
+- implementing viewer-resolution support such as a new `me` GraphQL lookup unless the checked-in config contract already requires it
+
+## Current Gaps
+
+- `src/tracker/linear-normalize.ts` currently normalizes only a narrow subset of the issue payload and drops `priority`, `branchName`, assignee identity, labels, and relations
+- the current `LinearIssueSnapshot` does not expose normalized blocked-by or dependency data, so policy above the transport seam cannot reason over stable relation snapshots later
+- `RuntimeIssue` is intentionally tracker-neutral, but the current normalization path does not clearly separate adapter-only fields from the generic issue projection
+- `src/tracker/linear-client.ts` query documents and raw types do not yet request or expose all fields needed for issue-67 normalization
+- `tests/support/mock-linear-server.ts` does not yet model the extra raw fields this slice needs to normalize
+- unit coverage currently only asserts one missing-project failure path in `tests/unit/linear-normalize.test.ts`
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: documenting that the Linear adapter should produce a stable snapshot with assignee-routing facts and decoded blocker relations
+  - does not belong: changing ready/running/failed/completed policy or workpad semantics in this issue
+- Configuration Layer
+  - belongs: reusing the existing checked-in Linear config contract, especially `tracker.assignee`
+  - does not belong: reparsing workflow front matter or inventing a second assignee config path inside the tracker
+- Coordination Layer
+  - belongs: no changes in this slice
+  - does not belong: GraphQL shape handling, relation decoding, or assignee identity parsing
+- Execution Layer
+  - belongs: no changes in this slice
+  - does not belong: tracker payload normalization
+- Integration Layer
+  - belongs: raw Linear query field selection, tracker-owned normalization, assignee routing interpretation, and blocked-by decoding
+  - does not belong: orchestrator retries, handoff policy, or generic runtime-state transitions
+- Observability Layer
+  - belongs: clear normalization failures with field-specific paths, plus tests that prove partial payload handling
+  - does not belong: new operator dashboards or orchestration status surfaces
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/tracker/linear-client.ts`
+  - only the raw GraphQL fields and TypeScript transport types needed so normalization can see the required data
+  - no tracker policy or relation interpretation beyond faithfully exposing the response shape
+- `src/tracker/linear-normalize.ts`
+  - the normalized `LinearIssueSnapshot` contract
+  - assignee normalization and configured-worker matching
+  - label normalization
+  - relation decoding into a stable adapter snapshot
+  - timestamp parsing / preservation rules at the adapter boundary
+- `src/tracker/linear.ts`
+  - only the minimal call-site changes needed to pass config or consume the richer normalized snapshot
+- `tests/unit/linear-normalize.test.ts`
+  - the main contract tests for issue normalization
+- `tests/support/mock-linear-server.ts`
+  - only the mock schema and fixture helpers needed to supply the new raw read fields
+
+### Does not belong in this issue
+
+- moving tracker relation policy into the orchestrator
+- teaching workspace or runner layers anything about Linear
+- coupling the generic `RuntimeIssue` shape to Linear-only fields unless a field is truly tracker-neutral and already needed above the adapter
+- mixing transport request execution and normalization logic in one file
+- broad end-to-end harness changes unrelated to the normalization seam
+
+## Slice Strategy And PR Seam
+
+This issue stays one reviewable PR by landing one adapter-boundary slice:
+
+1. extend the Linear read transport shape only enough to expose the raw fields needed for normalization
+2. normalize those fields into a stable `LinearIssueSnapshot`
+3. keep the orchestrator-facing `RuntimeIssue` projection narrow
+4. prove the contract with focused unit and mock-backed integration coverage
+
+This seam is reviewable on its own because it improves the adapter boundary without reopening lifecycle policy, tracker writes, or orchestrator control flow.
+
+Deferred from this PR:
+
+- any new lifecycle decisions that act on dependencies
+- any tracker writes for relations or assignees
+- any shared-domain redesign larger than the minimal projection needed for current callers
+
+## Runtime State Model
+
+Not applicable for this slice. The work is normalization-only and does not change retries, continuations, reconciliation, leases, or handoff states.
+
+## Failure-Class Matrix
+
+| Observed condition                                                   | Local facts available                           | Normalized tracker facts available | Expected behavior                                                                                                                      |
+| -------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| optional Linear field is missing or `null`                           | raw issue payload path                          | none yet                           | normalize to `null`, empty list, or a documented default when the field is optional                                                    |
+| required core field such as `id` or `identifier` is missing          | raw issue payload path                          | none yet                           | throw `TrackerError` with the field path                                                                                               |
+| relation entry exists but is not a `blocks`-style inverse relation   | raw relation type plus relation issue payload   | none yet                           | ignore that relation for blocked-by normalization                                                                                      |
+| relation entry is malformed                                          | raw relation node path                          | partial issue snapshot             | ignore the malformed relation if it is optional, or fail only when a required nested field is missing for an accepted blocker relation |
+| configured `tracker.assignee` is absent                              | workflow config                                 | issue assignee snapshot            | mark `assignedToWorker` as `true` without filtering away the issue                                                                     |
+| configured `tracker.assignee` is present and issue assignee is empty | workflow config plus normalized assignee fields | issue assignee snapshot            | mark `assignedToWorker` as `false`                                                                                                     |
+| configured `tracker.assignee` is present and issue assignee matches  | workflow config plus normalized assignee fields | issue assignee snapshot            | mark `assignedToWorker` as `true`                                                                                                      |
+| timestamp field is present but not valid ISO-8601                    | raw timestamp string                            | raw string preserved if needed     | keep the raw string on the snapshot field and avoid throwing unless the field is required to parse into a stricter type                |
+
+## Storage / Persistence Contract
+
+- no new durable storage is introduced
+- the normalized Linear issue snapshot remains in-memory tracker state
+- local issue artifacts and orchestrator state remain unchanged in this slice
+- remote Linear issue/project payloads remain the external source of truth for tracker facts
+
+## Observability Requirements
+
+- normalization errors must include the failing field path
+- tests must prove how partial payloads behave instead of leaving optionality implicit
+- the adapter should expose enough normalized data for later policy or recovery work without requiring callers to inspect raw GraphQL envelopes
+
+## Implementation Steps
+
+1. Update `src/tracker/linear-client.ts` raw issue types and GraphQL field selections to include the additional read-only fields needed by normalization.
+2. Extend `tests/support/mock-linear-server.ts` so mock issue payloads can emit assignee identity, labels, branch names, priorities, and inverse relation nodes.
+3. Refactor `src/tracker/linear-normalize.ts` to define stable normalized types for:
+   - assignee snapshot
+   - blocked-by / dependency relation snapshot
+   - richer issue snapshot fields aligned with the Elixir reference
+4. Add a normalization entry point that can evaluate configured assignee routing without moving that logic into the transport client.
+5. Keep or adjust the `RuntimeIssue` projection so higher layers receive only tracker-neutral fields they already rely on.
+6. Update `src/tracker/linear.ts` call sites to consume the new normalization contract with minimal policy change.
+7. Add focused unit coverage for the normalization contract and one small mock-backed regression test if needed to prove the client/normalizer seam.
+8. Run repo gates and self-review before opening the PR.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- normalizes a representative Linear issue payload into a stable `LinearIssueSnapshot`
+- preserves `priority`, `branchName`, `createdAt`, and `updatedAt`
+- lowercases or otherwise normalizes labels consistently with the upstream reference
+- decodes only `blocks` inverse relations into `blockedBy`
+- tolerates missing optional sub-objects such as `assignee`, `labels`, or relations
+- marks `assignedToWorker` correctly for:
+  - no configured assignee
+  - matching configured assignee
+  - non-matching configured assignee
+- fails clearly when required root fields are missing
+
+### Integration
+
+- `LinearTracker.fetchReadyIssues()` still returns the same `RuntimeIssue` projection after the richer snapshot lands
+- mock Linear reads can carry the added raw fields without leaking raw GraphQL structure above normalization
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. Given a representative Linear GraphQL issue payload with assignee, labels, branch name, priority, and inverse relations, the adapter produces a stable normalized snapshot without exposing raw `nodes`/GraphQL envelope structures to callers.
+2. Given a payload with missing optional assignee, label, or relation fields, normalization succeeds with documented defaults instead of throwing.
+3. Given a payload with malformed required fields, normalization fails with a field-specific `TrackerError`.
+4. Given a configured Linear assignee filter, normalization marks whether the issue is assigned to the configured worker in a way compatible with the existing config contract.
+5. Given inverse relations containing non-blocking relation types, only blocking relations are surfaced in the normalized blocked-by list.
+
+## Exit Criteria
+
+- the Linear adapter exposes a richer normalized issue snapshot aligned with the upstream Elixir Linear issue fields relevant to this repo
+- raw GraphQL transport structures remain confined to `src/tracker/linear-client.ts`
+- assignee routing, labels, and blocker decoding are covered by tests
+- tracker callers above normalization continue to consume a stable tracker-neutral issue projection
+- the change lands as one reviewable PR without bundling tracker writes or lifecycle-policy changes
+
+## Deferred To Later Issues Or PRs
+
+- using normalized dependencies to change dispatch or recovery decisions
+- viewer-based `tracker.assignee: me` resolution if the config contract expands to require it
+- tracker writes for dependency or assignee changes
+- any orchestrator/domain redesign driven by richer tracker-neutral issue metadata
+- richer end-to-end Linear scenarios that depend on blocker-aware policy
+
+## Decision Notes
+
+- The richer Linear shape should live in `LinearIssueSnapshot`, not in the generic orchestrator-facing `RuntimeIssue`, unless a field is clearly tracker-neutral and needed across adapters.
+- Extending the client query fields is part of this issue only as support work for normalization. Interpretation of those raw fields must remain in `src/tracker/linear-normalize.ts`.
+- Assignee-routing compatibility should reuse the checked-in config contract exactly as it exists today. This issue should not speculate about new workflow keywords or upstream viewer lookups unless later requirements force that expansion.
+
+## Revision Log
+
+- 2026-03-10: Initial plan created and marked `plan-ready` for issue #67.
+- 2026-03-10: Plan approved on the issue thread; implementation proceeded on the approved slice.

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -26,15 +26,50 @@ export interface LinearRawComment {
   readonly user: LinearRawCommentUser | null;
 }
 
+export interface LinearRawIssueAssignee {
+  readonly id: string;
+  readonly name: string | null;
+  readonly email: string | null;
+}
+
+export interface LinearRawIssueLabel {
+  readonly name: string | null;
+}
+
+export interface LinearRawIssueRelationIssueState {
+  readonly name: string;
+}
+
+export interface LinearRawIssueRelationIssue {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly state: LinearRawIssueRelationIssueState;
+}
+
+export interface LinearRawIssueRelation {
+  readonly type: string;
+  readonly issue: LinearRawIssueRelationIssue | null;
+}
+
 export interface LinearRawIssue {
   readonly id: string;
   readonly identifier: string;
   readonly number: number;
   readonly title: string;
   readonly description: string | null;
+  readonly priority: number | null;
+  readonly branchName: string | null;
   readonly url: string;
   readonly createdAt: string;
   readonly updatedAt: string;
+  readonly assignee: LinearRawIssueAssignee | null;
+  readonly labels: {
+    readonly nodes: readonly LinearRawIssueLabel[];
+  };
+  readonly inverseRelations: {
+    readonly nodes: readonly LinearRawIssueRelation[];
+  };
   readonly state: LinearRawWorkflowState;
   readonly comments: {
     readonly nodes: readonly LinearRawComment[];
@@ -135,9 +170,34 @@ const ISSUE_FIELDS = `
   number
   title
   description
+  priority
+  branchName
   url
   createdAt
   updatedAt
+  assignee {
+    id
+    name
+    email
+  }
+  labels {
+    nodes {
+      name
+    }
+  }
+  inverseRelations {
+    nodes {
+      type
+      issue {
+        id
+        identifier
+        title
+        state {
+          name
+        }
+      }
+    }
+  }
   state {
     id
     name
@@ -166,10 +226,10 @@ const GET_PROJECT_QUERY = `
 `;
 
 const GET_PROJECT_ISSUES_PAGE_QUERY = `
-  query GetProjectIssuesPage($slugId: String!, $after: String, $assignee: String) {
+  query GetProjectIssuesPage($slugId: String!, $after: String) {
     project(slugId: $slugId) {
       ${PROJECT_FIELDS}
-      issues(first: ${LINEAR_PROJECT_ISSUES_PAGE_SIZE}, after: $after, assignee: $assignee) {
+      issues(first: ${LINEAR_PROJECT_ISSUES_PAGE_SIZE}, after: $after) {
         nodes {
           ${ISSUE_FIELDS}
         }
@@ -340,7 +400,6 @@ export class LinearClient {
       {
         slugId: this.#config.projectSlug,
         after,
-        assignee: this.#config.assignee,
       },
     );
   }

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -225,6 +225,8 @@ const GET_PROJECT_QUERY = `
   }
 `;
 
+// Assignee routing stays in normalization/policy so the adapter can apply the
+// configured-worker contract without a separate viewer lookup.
 const GET_PROJECT_ISSUES_PAGE_QUERY = `
   query GetProjectIssuesPage($slugId: String!, $after: String) {
     project(slugId: $slugId) {

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -393,7 +393,7 @@ function matchesConfiguredAssignee(
   }
 
   const normalizedConfiguredAssignee = normalizeAssigneeKey(configuredAssignee);
-  return [assignee.id, assignee.name, assignee.email].some(
+  return [assignee.id, assignee.email].some(
     (value) =>
       value !== null &&
       normalizeAssigneeKey(value) === normalizedConfiguredAssignee,

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -373,7 +373,7 @@ function normalizeLinearPriority(value: unknown, field: string): number | null {
   if (normalized === 0) {
     return null;
   }
-  if (normalized < 1 || normalized > 4) {
+  if (!Number.isInteger(normalized) || normalized < 1 || normalized > 4) {
     throw new TrackerError(
       `Expected Linear priority in range 1-4 or 0 for ${field}, got ${normalized}`,
     );

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -157,6 +157,11 @@ export function normalizeLinearIssueMutationResult(
   if (!success) {
     throw new TrackerError(`Linear mutation ${field} reported success=false`);
   }
+  if (mutation["issue"] === null || mutation["issue"] === undefined) {
+    throw new TrackerError(
+      `Linear mutation ${field} reported success=true but returned no issue`,
+    );
+  }
   return normalizeLinearIssueSnapshot(
     mutation["issue"],
     `${field}.issue`,
@@ -365,7 +370,15 @@ function normalizeNullableNumber(value: unknown, field: string): number | null {
     return null;
   }
   const normalized = requireNumber(value, field);
-  return normalized === 0 ? null : normalized;
+  if (normalized === 0) {
+    return null;
+  }
+  if (normalized < 1 || normalized > 4) {
+    throw new TrackerError(
+      `Expected Linear priority in range 1-4 or 0 for ${field}, got ${normalized}`,
+    );
+  }
+  return normalized;
 }
 
 function matchesConfiguredAssignee(

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -336,7 +336,7 @@ function normalizeLinearBlockedBy(
       continue;
     }
     const relation = entry as Record<string, unknown>;
-    if (typeof relation["type"] !== "string" || relation["type"] !== "blocks") {
+    if (relation["type"] !== "blocks") {
       continue;
     }
     if (relation["issue"] === null || relation["issue"] === undefined) {

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -169,6 +169,14 @@ export function normalizeLinearIssueMutationResult(
   );
 }
 
+/**
+ * Normalize a raw Linear issue payload into a stable adapter snapshot.
+ *
+ * `options.configuredAssignee` controls the derived `assignedToWorker` flag:
+ * - `null` or blank (default) means no worker filter is configured, so
+ *   `assignedToWorker` is always `true`
+ * - a non-empty string matches only normalized assignee `id` or `email`
+ */
 export function normalizeLinearIssueSnapshot(
   value: unknown,
   field: string,

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -364,7 +364,8 @@ function normalizeNullableNumber(value: unknown, field: string): number | null {
   if (value === null || value === undefined) {
     return null;
   }
-  return requireNumber(value, field);
+  const normalized = requireNumber(value, field);
+  return normalized === 0 ? null : normalized;
 }
 
 function matchesConfiguredAssignee(

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -221,7 +221,7 @@ export function normalizeLinearIssueSnapshot(
     number: runtimeIssue.number,
     title: runtimeIssue.title,
     description: runtimeIssue.description,
-    priority: normalizeNullableNumber(record["priority"], `${field}.priority`),
+    priority: normalizeLinearPriority(record["priority"], `${field}.priority`),
     branchName: requireNullableString(
       record["branchName"],
       `${field}.branchName`,
@@ -365,7 +365,7 @@ function normalizeLinearBlockedBy(
   return blockedBy;
 }
 
-function normalizeNullableNumber(value: unknown, field: string): number | null {
+function normalizeLinearPriority(value: unknown, field: string): number | null {
   if (value === null || value === undefined) {
     return null;
   }

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -28,16 +28,39 @@ export interface LinearComment {
   readonly userEmail: string | null;
 }
 
+export interface LinearIssueAssigneeSnapshot {
+  readonly id: string;
+  readonly name: string | null;
+  readonly email: string | null;
+}
+
+export interface LinearIssueRelationSnapshot {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly state: string;
+}
+
+export interface LinearIssueNormalizationOptions {
+  readonly configuredAssignee: string | null;
+}
+
 export interface LinearIssueSnapshot {
   readonly id: string;
   readonly identifier: string;
   readonly number: number;
   readonly title: string;
   readonly description: string;
+  readonly priority: number | null;
+  readonly branchName: string | null;
   readonly url: string;
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly state: LinearWorkflowState;
+  readonly assignee: LinearIssueAssigneeSnapshot | null;
+  readonly assignedToWorker: boolean;
+  readonly labels: readonly string[];
+  readonly blockedBy: readonly LinearIssueRelationSnapshot[];
   readonly comments: readonly LinearComment[];
   readonly workpad: LinearWorkpadEntry | null;
   readonly runtimeIssue: RuntimeIssue;
@@ -54,6 +77,10 @@ export interface LinearProjectIssuesSnapshot {
   readonly project: LinearProjectSnapshot;
   readonly issues: readonly LinearIssueSnapshot[];
 }
+
+const DEFAULT_OPTIONS: LinearIssueNormalizationOptions = {
+  configuredAssignee: null,
+};
 
 export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
   const record = requireObject(value, "project");
@@ -75,11 +102,16 @@ export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
 
 export function normalizeLinearProjectIssuesResult(
   value: unknown,
+  options: LinearIssueNormalizationOptions = DEFAULT_OPTIONS,
 ): LinearProjectIssuesSnapshot {
   const record = requireObject(value, "projectIssues");
   const issues = requireArray(record["issues"], "projectIssues.issues").map(
     (entry, index) =>
-      normalizeLinearIssue(entry, `projectIssues.issues[${index}]`),
+      normalizeLinearIssueSnapshot(
+        entry,
+        `projectIssues.issues[${index}]`,
+        options,
+      ),
   );
 
   return {
@@ -88,7 +120,10 @@ export function normalizeLinearProjectIssuesResult(
   };
 }
 
-export function normalizeLinearIssueResult(value: unknown): {
+export function normalizeLinearIssueResult(
+  value: unknown,
+  options: LinearIssueNormalizationOptions = DEFAULT_OPTIONS,
+): {
   readonly project: LinearProjectSnapshot;
   readonly issue: LinearIssueSnapshot | null;
 } {
@@ -103,13 +138,18 @@ export function normalizeLinearIssueResult(value: unknown): {
     issue:
       projectRecord["issue"] === null || projectRecord["issue"] === undefined
         ? null
-        : normalizeLinearIssue(projectRecord["issue"], "project.issue"),
+        : normalizeLinearIssueSnapshot(
+            projectRecord["issue"],
+            "project.issue",
+            options,
+          ),
   };
 }
 
 export function normalizeLinearIssueMutationResult(
   value: unknown,
   field: "issueUpdate" | "commentCreate",
+  options: LinearIssueNormalizationOptions = DEFAULT_OPTIONS,
 ): LinearIssueSnapshot {
   const root = requireObject(value, field);
   const mutation = requireObject(root[field], field);
@@ -117,12 +157,17 @@ export function normalizeLinearIssueMutationResult(
   if (!success) {
     throw new TrackerError(`Linear mutation ${field} reported success=false`);
   }
-  return normalizeLinearIssue(mutation["issue"], `${field}.issue`);
+  return normalizeLinearIssueSnapshot(
+    mutation["issue"],
+    `${field}.issue`,
+    options,
+  );
 }
 
-function normalizeLinearIssue(
+export function normalizeLinearIssueSnapshot(
   value: unknown,
   field: string,
+  options: LinearIssueNormalizationOptions = DEFAULT_OPTIONS,
 ): LinearIssueSnapshot {
   const record = requireObject(value, field);
   const description = requireNullableString(
@@ -139,6 +184,17 @@ function normalizeLinearIssue(
   ).map((entry, index) =>
     normalizeLinearComment(entry, `${field}.comments.nodes[${index}]`),
   );
+  const state = normalizeLinearWorkflowState(record["state"], `${field}.state`);
+  const assignee = normalizeLinearAssignee(
+    record["assignee"],
+    `${field}.assignee`,
+  );
+  const labels = normalizeLinearLabels(record["labels"], `${field}.labels`);
+  const blockedBy = normalizeLinearBlockedBy(
+    record["inverseRelations"],
+    `${field}.inverseRelations`,
+  );
+  const normalizedDescription = description ?? "";
   const workpad = parseLinearWorkpad(description);
 
   const runtimeIssue: RuntimeIssue = {
@@ -146,12 +202,9 @@ function normalizeLinearIssue(
     identifier: requireString(record["identifier"], `${field}.identifier`),
     number: requireNumber(record["number"], `${field}.number`),
     title: requireString(record["title"], `${field}.title`),
-    description: description ?? "",
-    labels: [],
-    state: requireString(
-      requireObject(record["state"], `${field}.state`)["name"],
-      `${field}.state.name`,
-    ),
+    description: normalizedDescription,
+    labels,
+    state: state.name,
     url: requireString(record["url"], `${field}.url`),
     createdAt: requireString(record["createdAt"], `${field}.createdAt`),
     updatedAt: requireString(record["updatedAt"], `${field}.updatedAt`),
@@ -163,10 +216,22 @@ function normalizeLinearIssue(
     number: runtimeIssue.number,
     title: runtimeIssue.title,
     description: runtimeIssue.description,
+    priority: normalizeNullableNumber(record["priority"], `${field}.priority`),
+    branchName: requireNullableString(
+      record["branchName"],
+      `${field}.branchName`,
+    ),
     url: runtimeIssue.url,
     createdAt: runtimeIssue.createdAt,
     updatedAt: runtimeIssue.updatedAt,
-    state: normalizeLinearWorkflowState(record["state"], `${field}.state`),
+    state,
+    assignee,
+    assignedToWorker: matchesConfiguredAssignee(
+      assignee,
+      options.configuredAssignee,
+    ),
+    labels,
+    blockedBy,
     comments,
     workpad,
     runtimeIssue,
@@ -206,4 +271,129 @@ function normalizeLinearComment(value: unknown, field: string): LinearComment {
         ? null
         : requireNullableString(user["email"], `${field}.user.email`),
   };
+}
+
+function normalizeLinearAssignee(
+  value: unknown,
+  field: string,
+): LinearIssueAssigneeSnapshot | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const record = requireObject(value, field);
+  return {
+    id: requireString(record["id"], `${field}.id`),
+    name: requireNullableString(record["name"], `${field}.name`),
+    email: requireNullableString(record["email"], `${field}.email`),
+  };
+}
+
+function normalizeLinearLabels(
+  value: unknown,
+  field: string,
+): readonly string[] {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  const connection = requireObject(value, field);
+  return requireArray(connection["nodes"], `${field}.nodes`).flatMap(
+    (entry, index) => {
+      if (entry === null || entry === undefined) {
+        return [];
+      }
+      const record = requireObject(entry, `${field}.nodes[${index}]`);
+      const name = requireNullableString(
+        record["name"],
+        `${field}.nodes[${index}].name`,
+      );
+      const normalized = normalizeLabel(name);
+      return normalized === null ? [] : [normalized];
+    },
+  );
+}
+
+function normalizeLinearBlockedBy(
+  value: unknown,
+  field: string,
+): readonly LinearIssueRelationSnapshot[] {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  const connection = requireObject(value, field);
+  const nodes = requireArray(connection["nodes"], `${field}.nodes`);
+  const blockedBy: LinearIssueRelationSnapshot[] = [];
+
+  for (const [index, entry] of nodes.entries()) {
+    if (
+      entry === null ||
+      entry === undefined ||
+      typeof entry !== "object" ||
+      Array.isArray(entry)
+    ) {
+      continue;
+    }
+    const relation = entry as Record<string, unknown>;
+    if (typeof relation["type"] !== "string" || relation["type"] !== "blocks") {
+      continue;
+    }
+    if (relation["issue"] === null || relation["issue"] === undefined) {
+      continue;
+    }
+
+    const issueField = `${field}.nodes[${index}].issue`;
+    const issue = requireObject(relation["issue"], issueField);
+    const state = requireObject(issue["state"], `${issueField}.state`);
+    blockedBy.push({
+      id: requireString(issue["id"], `${issueField}.id`),
+      identifier: requireString(
+        issue["identifier"],
+        `${issueField}.identifier`,
+      ),
+      title: requireString(issue["title"], `${issueField}.title`),
+      state: requireString(state["name"], `${issueField}.state.name`),
+    });
+  }
+
+  return blockedBy;
+}
+
+function normalizeNullableNumber(value: unknown, field: string): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return requireNumber(value, field);
+}
+
+function matchesConfiguredAssignee(
+  assignee: LinearIssueAssigneeSnapshot | null,
+  configuredAssignee: string | null,
+): boolean {
+  if (configuredAssignee === null || configuredAssignee.trim() === "") {
+    return true;
+  }
+  if (assignee === null) {
+    return false;
+  }
+
+  const normalizedConfiguredAssignee = normalizeAssigneeKey(configuredAssignee);
+  return [assignee.id, assignee.name, assignee.email].some(
+    (value) =>
+      value !== null &&
+      normalizeAssigneeKey(value) === normalizedConfiguredAssignee,
+  );
+}
+
+function normalizeAssigneeKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeLabel(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "" ? null : normalized;
 }

--- a/src/tracker/linear-policy.ts
+++ b/src/tracker/linear-policy.ts
@@ -18,6 +18,10 @@ export function classifyLinearIssue(
   issue: LinearIssueSnapshot,
   config: LinearTrackerConfig,
 ): LinearIssueClassification {
+  if (!issue.assignedToWorker) {
+    return "ignored";
+  }
+
   if (config.terminalStates.includes(issue.state.name)) {
     return "completed";
   }

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -102,10 +102,12 @@ export class LinearTracker implements Tracker {
         ...(nextState === null ? {} : { stateId: nextState.id }),
       }),
       "issueUpdate",
+      this.#normalizeOptions(),
     );
     normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, CLAIM_COMMENT),
       "commentCreate",
+      this.#normalizeOptions(),
     );
     this.#logger.info("Claimed Linear issue", {
       issueNumber,
@@ -151,10 +153,12 @@ export class LinearTracker implements Tracker {
         description: updatedDescription,
       }),
       "issueUpdate",
+      this.#normalizeOptions(),
     );
     normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, HANDOFF_READY_COMMENT),
       "commentCreate",
+      this.#normalizeOptions(),
     );
     return await this.inspectIssueHandoff(branchName);
   }
@@ -172,10 +176,12 @@ export class LinearTracker implements Tracker {
         }),
       }),
       "issueUpdate",
+      this.#normalizeOptions(),
     );
     normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, `${RETRY_PREFIX} ${reason}`),
       "commentCreate",
+      this.#normalizeOptions(),
     );
   }
 
@@ -195,10 +201,12 @@ export class LinearTracker implements Tracker {
         stateId: terminalState.id,
       }),
       "issueUpdate",
+      this.#normalizeOptions(),
     );
     normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, COMPLETION_COMMENT),
       "commentCreate",
+      this.#normalizeOptions(),
     );
   }
 
@@ -215,10 +223,12 @@ export class LinearTracker implements Tracker {
         }),
       }),
       "issueUpdate",
+      this.#normalizeOptions(),
     );
     normalizeLinearIssueMutationResult(
       await this.#client.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`),
       "commentCreate",
+      this.#normalizeOptions(),
     );
   }
 
@@ -245,6 +255,7 @@ export class LinearTracker implements Tracker {
   async #fetchProjectIssues(): Promise<readonly LinearIssueSnapshot[]> {
     const result = normalizeLinearProjectIssuesResult(
       await this.#client.fetchProjectIssues(),
+      this.#normalizeOptions(),
     );
     if (this.#projectPromise === null) {
       this.#projectPromise = Promise.resolve(result.project);
@@ -265,10 +276,17 @@ export class LinearTracker implements Tracker {
   ): Promise<LinearIssueSnapshot | null> {
     const result = normalizeLinearIssueResult(
       await this.#client.fetchProjectIssue(issueNumber),
+      this.#normalizeOptions(),
     );
     if (this.#projectPromise === null) {
       this.#projectPromise = Promise.resolve(result.project);
     }
     return result.issue;
+  }
+
+  #normalizeOptions() {
+    return {
+      configuredAssignee: this.#config.assignee,
+    } as const;
   }
 }

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -62,7 +62,7 @@ describe("LinearClient", () => {
       number: 2,
       title: "Issue 2",
       stateName: "Todo",
-      assigneeEmail: "worker@example.test",
+      assigneeEmail: "other@example.test",
     });
     server.seedIssue({
       projectSlug: "symphony-linear",
@@ -74,9 +74,14 @@ describe("LinearClient", () => {
 
     const client = new LinearClient(createConfig(server));
     const result = await client.fetchProjectIssues();
+    const request = server.requests("GetProjectIssuesPage")[0];
 
     expect(result.project.slugId).toBe("symphony-linear");
     expect(result.issues.map((issue) => issue.number)).toEqual([1, 2, 3]);
+    expect(request?.variables).toEqual({
+      slugId: "symphony-linear",
+      after: null,
+    });
     // The mock Linear server pages two issues at a time, so 3 seeded issues require 2 requests.
     expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
   });
@@ -114,13 +119,26 @@ describe("LinearClient", () => {
   });
 
   it("returns typed project issue and mutation payloads", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 6,
+      title: "Dependency",
+      stateName: "In Progress",
+      assigneeEmail: "worker@example.test",
+    });
     const issue = server.seedIssue({
       projectSlug: "symphony-linear",
       number: 7,
       title: "Issue 7",
       description: "Before",
       stateName: "Todo",
+      assigneeId: "user-7",
+      assigneeName: "Worker Example",
       assigneeEmail: "worker@example.test",
+      labels: ["Backend", "Needs Review"],
+      priority: 3,
+      branchName: "feature/linear-7",
+      inverseRelations: [{ type: "blocks", issueNumber: 6 }],
     });
     const client = new LinearClient(createConfig(server));
 
@@ -132,6 +150,30 @@ describe("LinearClient", () => {
     const commentResult = await client.createComment(issue.id, "Tracked");
 
     expect(projectIssue.project?.issue?.number).toBe(7);
+    expect(projectIssue.project?.issue?.assignee).toEqual({
+      id: "user-7",
+      name: "Worker Example",
+      email: "worker@example.test",
+    });
+    expect(projectIssue.project?.issue?.labels.nodes).toEqual([
+      { name: "Backend" },
+      { name: "Needs Review" },
+    ]);
+    expect(projectIssue.project?.issue?.priority).toBe(3);
+    expect(projectIssue.project?.issue?.branchName).toBe("feature/linear-7");
+    expect(projectIssue.project?.issue?.inverseRelations.nodes).toEqual([
+      {
+        type: "blocks",
+        issue: {
+          id: expect.any(String),
+          identifier: "SYMPHONY-LINEAR-6",
+          title: "Dependency",
+          state: {
+            name: "In Progress",
+          },
+        },
+      },
+    ]);
     expect(updateResult.issueUpdate.success).toBe(true);
     expect(updateResult.issueUpdate.issue?.description).toBe("After");
     expect(commentResult.commentCreate.success).toBe(true);

--- a/tests/integration/linear-client.test.ts
+++ b/tests/integration/linear-client.test.ts
@@ -181,6 +181,21 @@ describe("LinearClient", () => {
     expect(server.getIssue("symphony-linear", 7).comments).toContain("Tracked");
   });
 
+  it("treats explicit null assignee seed fields as an unassigned issue", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 8,
+      title: "Issue 8",
+      stateName: "Todo",
+      assigneeEmail: null,
+    });
+    const client = new LinearClient(createConfig(server));
+
+    const projectIssue = await client.fetchProjectIssue(8);
+
+    expect(projectIssue.project?.issue?.assignee).toBeNull();
+  });
+
   it("surfaces GraphQL errors distinctly from HTTP failures", async () => {
     const client = new LinearClient(createConfig(server));
     server.enqueueGraphQLError("GetProject", "simulated GraphQL failure");

--- a/tests/integration/linear.test.ts
+++ b/tests/integration/linear.test.ts
@@ -45,6 +45,7 @@ describe("LinearTracker", () => {
       title: "Issue 1",
       stateName: "Todo",
       assigneeEmail: "worker@example.test",
+      labels: ["Backend"],
     });
     server.seedIssue({
       projectSlug: "symphony-linear",
@@ -52,6 +53,7 @@ describe("LinearTracker", () => {
       title: "Issue 2",
       stateName: "Todo",
       assigneeEmail: "worker@example.test",
+      labels: ["Needs Review"],
     });
     server.seedIssue({
       projectSlug: "symphony-linear",
@@ -65,7 +67,42 @@ describe("LinearTracker", () => {
     const ready = await tracker.fetchReadyIssues();
 
     expect(ready.map((issue) => issue.number)).toEqual([1, 2, 3]);
+    expect(ready[0]?.labels).toEqual(["backend"]);
+    expect(ready[1]?.labels).toEqual(["needs review"]);
     expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
+  });
+
+  it("filters ready issues by normalized assignee routing instead of GraphQL query parameters", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Assigned to worker",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 2,
+      title: "Assigned elsewhere",
+      stateName: "Todo",
+      assigneeEmail: "other@example.test",
+    });
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 3,
+      title: "Unassigned",
+      stateName: "Todo",
+    });
+
+    const tracker = new LinearTracker(createConfig(server), new JsonLogger());
+    const ready = await tracker.fetchReadyIssues();
+    const request = server.requests("GetProjectIssuesPage")[0];
+
+    expect(ready.map((issue) => issue.number)).toEqual([1]);
+    expect(request?.variables).toEqual({
+      slugId: "symphony-linear",
+      after: null,
+    });
   });
 
   it("breaks defensively when Linear reports another page without an end cursor", async () => {

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -27,7 +27,11 @@ interface MockLinearIssue {
   readonly createdAt: string;
   updatedAt: string;
   stateId: string;
-  readonly assigneeEmail: string | null;
+  readonly assignee: MockLinearAssignee | null;
+  readonly labels: readonly string[];
+  readonly priority: number | null;
+  readonly branchName: string | null;
+  readonly inverseRelations: readonly MockLinearIssueRelation[];
   readonly comments: MockLinearComment[];
 }
 
@@ -39,6 +43,17 @@ interface MockLinearComment {
     readonly name: string | null;
     readonly email: string | null;
   };
+}
+
+interface MockLinearAssignee {
+  readonly id: string;
+  readonly name: string | null;
+  readonly email: string | null;
+}
+
+interface MockLinearIssueRelation {
+  readonly type: string;
+  readonly issueId: string | null;
 }
 
 interface MockLinearRequest {
@@ -142,7 +157,16 @@ export class MockLinearServer {
     readonly title: string;
     readonly description?: string;
     readonly stateName: string;
+    readonly assigneeId?: string | null;
+    readonly assigneeName?: string | null;
     readonly assigneeEmail?: string | null;
+    readonly labels?: readonly string[];
+    readonly priority?: number | null;
+    readonly branchName?: string | null;
+    readonly inverseRelations?: ReadonlyArray<{
+      readonly type: string;
+      readonly issueNumber?: number | null;
+    }>;
     readonly identifier?: string;
   }): MockLinearIssue {
     const project = this.#requireProject(input.projectSlug);
@@ -161,7 +185,26 @@ export class MockLinearServer {
       createdAt: now,
       updatedAt: now,
       stateId: state.id,
-      assigneeEmail: input.assigneeEmail ?? null,
+      assignee:
+        input.assigneeEmail === undefined &&
+        input.assigneeId === undefined &&
+        input.assigneeName === undefined
+          ? null
+          : {
+              id: input.assigneeId ?? randomUUID(),
+              name: input.assigneeName ?? null,
+              email: input.assigneeEmail ?? null,
+            },
+      labels: input.labels ?? [],
+      priority: input.priority ?? null,
+      branchName: input.branchName ?? null,
+      inverseRelations: (input.inverseRelations ?? []).map((relation) => ({
+        type: relation.type,
+        issueId:
+          relation.issueNumber === undefined || relation.issueNumber === null
+            ? null
+            : this.#requireIssue(input.projectSlug, relation.issueNumber).id,
+      })),
       comments: [],
     };
     this.#issues.set(issue.id, issue);
@@ -180,6 +223,9 @@ export class MockLinearServer {
     readonly title: string;
     readonly description: string;
     readonly stateName: string;
+    readonly labels: readonly string[];
+    readonly branchName: string | null;
+    readonly priority: number | null;
     readonly comments: readonly string[];
   } {
     const issue = this.#requireIssue(projectSlug, issueNumber);
@@ -189,6 +235,9 @@ export class MockLinearServer {
       title: issue.title,
       description: issue.description,
       stateName: this.#requireStateById(project, issue.stateId).name,
+      labels: issue.labels,
+      branchName: issue.branchName,
+      priority: issue.priority,
       comments: issue.comments.map((comment) => comment.body),
     };
   }
@@ -345,11 +394,8 @@ export class MockLinearServer {
     const project = this.#requireProject(
       requireString(variables["slugId"], "slugId"),
     );
-    const assignee = requireOptionalString(variables["assignee"], "assignee");
     const after = requireOptionalString(variables["after"], "after");
-    const issues = this.#projectIssues(project.slugId).filter(
-      (issue) => assignee === null || issue.assigneeEmail === assignee,
-    );
+    const issues = this.#projectIssues(project.slugId);
 
     const startIndex =
       after === null ? 0 : issues.findIndex((issue) => issue.id === after) + 1;
@@ -463,9 +509,33 @@ export class MockLinearServer {
       number: issue.number,
       title: issue.title,
       description: issue.description,
+      priority: issue.priority,
+      branchName: issue.branchName,
       url: issue.url,
       createdAt: issue.createdAt,
       updatedAt: issue.updatedAt,
+      assignee:
+        issue.assignee === null
+          ? null
+          : {
+              id: issue.assignee.id,
+              name: issue.assignee.name,
+              email: issue.assignee.email,
+            },
+      labels: {
+        nodes: issue.labels.map((name) => ({
+          name,
+        })),
+      },
+      inverseRelations: {
+        nodes: issue.inverseRelations.map((relation) => ({
+          type: relation.type,
+          issue:
+            relation.issueId === null
+              ? null
+              : this.#serializeRelationIssue(relation.issueId),
+        })),
+      },
       state: {
         id: state.id,
         name: state.name,
@@ -482,6 +552,20 @@ export class MockLinearServer {
             email: comment.user.email,
           },
         })),
+      },
+    };
+  }
+
+  #serializeRelationIssue(issueId: string) {
+    const issue = this.#requireIssueById(issueId);
+    const project = this.#projectForIssue(issue);
+    const state = this.#requireStateById(project, issue.stateId);
+    return {
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      state: {
+        name: state.name,
       },
     };
   }

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -192,9 +192,9 @@ export class MockLinearServer {
       updatedAt: now,
       stateId: state.id,
       assignee:
-        input.assigneeEmail === undefined &&
-        input.assigneeId === undefined &&
-        input.assigneeName === undefined
+        input.assigneeEmail == null &&
+        input.assigneeId == null &&
+        input.assigneeName == null
           ? null
           : {
               id: input.assigneeId ?? randomUUID(),

--- a/tests/support/mock-linear-server.ts
+++ b/tests/support/mock-linear-server.ts
@@ -151,6 +151,12 @@ export class MockLinearServer {
     return project;
   }
 
+  /**
+   * Seed a mock issue.
+   *
+   * When `inverseRelations` references other issues by `issueNumber`, those
+   * issues must already exist in the same project before this call.
+   */
   seedIssue(input: {
     readonly projectSlug: string;
     readonly number: number;

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -133,6 +133,19 @@ describe("normalizeLinearIssueSnapshot", () => {
     expect(snapshot.priority).toBeNull();
   });
 
+  it("silently skips a 'blocks' relation whose issue is null", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload({
+        inverseRelations: {
+          nodes: [{ type: "blocks", issue: null }],
+        },
+      }),
+      "issue",
+    );
+
+    expect(snapshot.blockedBy).toEqual([]);
+  });
+
   it("fails clearly when the priority is outside Linear's supported range", () => {
     expect(() =>
       normalizeLinearIssueSnapshot(

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -174,13 +174,29 @@ describe("normalizeLinearIssueSnapshot", () => {
   });
 
   it("accepts assignee identity matches by id as well as email", () => {
-    const snapshot = normalizeLinearIssueSnapshot(
+    const byId = normalizeLinearIssueSnapshot(
       createIssuePayload(),
       "issue",
       { configuredAssignee: "USER-1" },
     );
+    const byEmail = normalizeLinearIssueSnapshot(
+      createIssuePayload(),
+      "issue",
+      { configuredAssignee: "worker@example.test" },
+    );
 
-    expect(snapshot.assignedToWorker).toBe(true);
+    expect(byId.assignedToWorker).toBe(true);
+    expect(byEmail.assignedToWorker).toBe(true);
+  });
+
+  it("does not treat assignee display names as stable routing identities", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload(),
+      "issue",
+      { configuredAssignee: "Worker Example" },
+    );
+
+    expect(snapshot.assignedToWorker).toBe(false);
   });
 
   it("fails clearly when required fields are missing", () => {

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -123,6 +123,15 @@ describe("normalizeLinearIssueSnapshot", () => {
     expect(snapshot.blockedBy).toEqual([]);
   });
 
+  it("normalizes Linear priority 0 to null for unset priority", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload({ priority: 0 }),
+      "issue",
+    );
+
+    expect(snapshot.priority).toBeNull();
+  });
+
   it("marks unassigned or differently assigned issues as not routed to the worker", () => {
     const unassigned = normalizeLinearIssueSnapshot(
       createIssuePayload({ assignee: null }),

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -174,11 +174,9 @@ describe("normalizeLinearIssueSnapshot", () => {
   });
 
   it("accepts assignee identity matches by id as well as email", () => {
-    const byId = normalizeLinearIssueSnapshot(
-      createIssuePayload(),
-      "issue",
-      { configuredAssignee: "USER-1" },
-    );
+    const byId = normalizeLinearIssueSnapshot(createIssuePayload(), "issue", {
+      configuredAssignee: "USER-1",
+    });
     const byEmail = normalizeLinearIssueSnapshot(
       createIssuePayload(),
       "issue",

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   normalizeLinearIssueResult,
+  normalizeLinearIssueMutationResult,
   normalizeLinearIssueSnapshot,
 } from "../../src/tracker/linear-normalize.js";
 
@@ -132,6 +133,15 @@ describe("normalizeLinearIssueSnapshot", () => {
     expect(snapshot.priority).toBeNull();
   });
 
+  it("fails clearly when the priority is outside Linear's supported range", () => {
+    expect(() =>
+      normalizeLinearIssueSnapshot(
+        createIssuePayload({ priority: 5 }),
+        "issue",
+      ),
+    ).toThrowError(/Expected Linear priority in range 1-4 or 0/i);
+  });
+
   it("marks unassigned or differently assigned issues as not routed to the worker", () => {
     const unassigned = normalizeLinearIssueSnapshot(
       createIssuePayload({ assignee: null }),
@@ -181,5 +191,23 @@ describe("normalizeLinearIssueResult", () => {
         project: null,
       }),
     ).toThrowError(/Linear project not found in issue result/);
+  });
+});
+
+describe("normalizeLinearIssueMutationResult", () => {
+  it("throws a clear error when a successful mutation returns no issue", () => {
+    expect(() =>
+      normalizeLinearIssueMutationResult(
+        {
+          issueUpdate: {
+            success: true,
+            issue: null,
+          },
+        },
+        "issueUpdate",
+      ),
+    ).toThrowError(
+      /Linear mutation issueUpdate reported success=true but returned no issue/i,
+    );
   });
 });

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -142,6 +142,15 @@ describe("normalizeLinearIssueSnapshot", () => {
     ).toThrowError(/Expected Linear priority in range 1-4 or 0/i);
   });
 
+  it("fails clearly when the priority is not a Linear enum integer", () => {
+    expect(() =>
+      normalizeLinearIssueSnapshot(
+        createIssuePayload({ priority: 1.5 }),
+        "issue",
+      ),
+    ).toThrowError(/Expected Linear priority in range 1-4 or 0/i);
+  });
+
   it("marks unassigned or differently assigned issues as not routed to the worker", () => {
     const unassigned = normalizeLinearIssueSnapshot(
       createIssuePayload({ assignee: null }),

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -1,5 +1,169 @@
 import { describe, expect, it } from "vitest";
-import { normalizeLinearIssueResult } from "../../src/tracker/linear-normalize.js";
+import {
+  normalizeLinearIssueResult,
+  normalizeLinearIssueSnapshot,
+} from "../../src/tracker/linear-normalize.js";
+
+function createIssuePayload(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: "issue-1",
+    identifier: "SYM-1",
+    number: 1,
+    title: "Implement normalization",
+    description: "Issue body",
+    priority: 2,
+    branchName: "feature/linear-normalize",
+    url: "https://linear.example/SYM-1",
+    createdAt: "2026-03-01T10:00:00.000Z",
+    updatedAt: "2026-03-02T12:00:00.000Z",
+    assignee: {
+      id: "user-1",
+      name: "Worker Example",
+      email: "worker@example.test",
+    },
+    labels: {
+      nodes: [{ name: "Backend" }, { name: "Needs Review" }, { name: "" }],
+    },
+    inverseRelations: {
+      nodes: [
+        {
+          type: "blocks",
+          issue: {
+            id: "issue-0",
+            identifier: "SYM-0",
+            title: "Upstream dependency",
+            state: {
+              name: "In Progress",
+            },
+          },
+        },
+        {
+          type: "related",
+          issue: {
+            id: "issue-2",
+            identifier: "SYM-2",
+            title: "Non-blocker",
+            state: {
+              name: "Todo",
+            },
+          },
+        },
+      ],
+    },
+    state: {
+      id: "state-1",
+      name: "Todo",
+      type: "unstarted",
+      position: 0,
+    },
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Tracked",
+          createdAt: "2026-03-02T12:05:00.000Z",
+          user: {
+            name: "Symphony",
+            email: "symphony@example.test",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("normalizeLinearIssueSnapshot", () => {
+  it("normalizes labels, blocker relations, assignee routing, and timestamps", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload(),
+      "issue",
+      { configuredAssignee: "worker@example.test" },
+    );
+
+    expect(snapshot.priority).toBe(2);
+    expect(snapshot.branchName).toBe("feature/linear-normalize");
+    expect(snapshot.createdAt).toBe("2026-03-01T10:00:00.000Z");
+    expect(snapshot.updatedAt).toBe("2026-03-02T12:00:00.000Z");
+    expect(snapshot.assignedToWorker).toBe(true);
+    expect(snapshot.labels).toEqual(["backend", "needs review"]);
+    expect(snapshot.runtimeIssue.labels).toEqual(["backend", "needs review"]);
+    expect(snapshot.blockedBy).toEqual([
+      {
+        id: "issue-0",
+        identifier: "SYM-0",
+        title: "Upstream dependency",
+        state: "In Progress",
+      },
+    ]);
+  });
+
+  it("tolerates missing optional assignee, labels, relations, and branch metadata", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload({
+        description: null,
+        priority: null,
+        branchName: null,
+        assignee: null,
+        labels: null,
+        inverseRelations: null,
+      }),
+      "issue",
+      { configuredAssignee: null },
+    );
+
+    expect(snapshot.description).toBe("");
+    expect(snapshot.priority).toBeNull();
+    expect(snapshot.branchName).toBeNull();
+    expect(snapshot.assignee).toBeNull();
+    expect(snapshot.assignedToWorker).toBe(true);
+    expect(snapshot.labels).toEqual([]);
+    expect(snapshot.blockedBy).toEqual([]);
+  });
+
+  it("marks unassigned or differently assigned issues as not routed to the worker", () => {
+    const unassigned = normalizeLinearIssueSnapshot(
+      createIssuePayload({ assignee: null }),
+      "issue",
+      { configuredAssignee: "worker@example.test" },
+    );
+    const differentAssignee = normalizeLinearIssueSnapshot(
+      createIssuePayload({
+        assignee: {
+          id: "user-2",
+          name: "Another Worker",
+          email: "other@example.test",
+        },
+      }),
+      "issue",
+      { configuredAssignee: "worker@example.test" },
+    );
+
+    expect(unassigned.assignedToWorker).toBe(false);
+    expect(differentAssignee.assignedToWorker).toBe(false);
+  });
+
+  it("accepts assignee identity matches by id as well as email", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload(),
+      "issue",
+      { configuredAssignee: "USER-1" },
+    );
+
+    expect(snapshot.assignedToWorker).toBe(true);
+  });
+
+  it("fails clearly when required fields are missing", () => {
+    expect(() =>
+      normalizeLinearIssueSnapshot(
+        createIssuePayload({ identifier: null }),
+        "issue",
+      ),
+    ).toThrowError(/issue\.identifier/i);
+  });
+});
 
 describe("normalizeLinearIssueResult", () => {
   it("throws a clear error when the project payload is missing", () => {


### PR DESCRIPTION
## Summary
- extend the Linear read payload and mock server fixtures with assignee, labels, branch name, priority, and inverse relation fields
- normalize richer Linear issue snapshots, including assignee routing, labels, and blocked-by relations, while keeping the orchestrator-facing RuntimeIssue projection tracker-neutral
- add unit and integration coverage for partial payloads, dependency decoding, labels, timestamps, and worker-routing behavior

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- codex review --base origin/main

Closes #67
Plan: docs/plans/067-linear-issue-normalization/plan.md