### PR TITLE
Linear Adapter 4: comments and state transitions

### DIFF
--- a/docs/plans/068-linear-comments-and-state-transitions/plan.md
+++ b/docs/plans/068-linear-comments-and-state-transitions/plan.md
@@ -1,0 +1,239 @@
+# Issue 68 Plan: Linear Comments And State Transitions
+
+## Status
+
+- approved
+
+## Goal
+
+Backfill the Linear write seam requested by issue `#68` so comment creation, workpad description updates, workflow-state resolution, and issue-state mutations live behind a focused adapter boundary with explicit failure handling, while keeping GraphQL transport details and Linear-specific state names out of the orchestrator.
+
+## Scope
+
+- keep Linear write behavior at the tracker edge and separate it from read normalization
+- add a focused write seam for:
+  - create comment on a Linear issue
+  - resolve a project workflow state by configured state name
+  - update a Linear issue description and/or state
+- keep workpad rendering in `linear-workpad`, but route the resulting description writes through the focused write seam
+- preserve the repository-owned plan review / acknowledgement comment body protocol by ensuring Linear comment writes can carry the same checked-in message bodies without GraphQL details leaking upward
+- add focused tests for:
+  - successful comment creation
+  - successful state resolution and issue state updates
+  - missing configured workflow states
+  - failed write mutations
+
+## Non-goals
+
+- changing Linear read transport pagination or read normalization contracts
+- adding full Linear comment-read support for plan review inspection in `inspectIssueHandoff`
+- adding GitHub-style PR, review-thread, or rework lifecycle policy to the Linear tracker
+- redesigning the generic `Tracker` interface beyond the write seam needed here
+- broad orchestrator, runner, workspace, or status-surface changes
+
+## Current Gaps
+
+- the repository already contains a broader Linear tracker slice from issue `#70`, but the issue-`#68` write seam is still implicit inside [`src/tracker/linear.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/src/tracker/linear.ts)
+- comment creation, workpad description writes, and state mutations are currently orchestrated inline in tracker lifecycle methods instead of a dedicated write-focused module
+- state resolution by configured name exists in [`src/tracker/linear-policy.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/src/tracker/linear-policy.ts), but issue `#68` does not yet have direct plan-traceable coverage for missing-state failures
+- current Linear tests prove broad happy-path tracker behavior, but issue-specific failure coverage for missing states and failed mutations is not isolated as its own reviewable surface
+- because the write seam is implicit, future Linear comment-backed protocol work would otherwise keep patching `linear.ts` directly
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: checked-in comment body contracts, configured Linear state names, and the rule that tracker-specific workflow-state policy stays at the edge
+  - does not belong: hard-coded Linear state enums inside orchestrator control flow
+- Configuration Layer
+  - belongs: reusing the existing `tracker.active_states` and `tracker.terminal_states` workflow inputs
+  - does not belong: GraphQL mutation construction or project-state lookup logic
+- Coordination Layer
+  - belongs: no new orchestrator behavior in this slice
+  - does not belong: GraphQL mutation variables, state-id lookup, or comment body formatting
+- Execution Layer
+  - belongs: no new workspace or runner behavior
+  - does not belong: tracker writes or Linear workflow-state handling
+- Integration Layer
+  - belongs: comment-create mutations, issue-update mutations, project-state lookup by configured name, and composition of workpad writes at the tracker edge
+  - does not belong: leaking raw GraphQL envelopes or operation names into the orchestrator
+- Observability Layer
+  - belongs: deterministic `TrackerError` failures for missing states and failed writes, plus tests that prove those messages stay actionable
+  - does not belong: a new Linear-only operator dashboard or status model
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- [`src/tracker/linear.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/src/tracker/linear.ts)
+  - narrow call-site changes so the tracker composes a dedicated write seam instead of inlining comment/state mutation steps
+- a new focused Linear write module, for example `src/tracker/linear-write.ts`
+  - state resolution by configured name against a normalized project snapshot
+  - comment-create calls
+  - description/state mutation calls
+  - failure handling that stays tracker-owned rather than orchestrator-owned
+- [`src/tracker/linear-policy.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/src/tracker/linear-policy.ts)
+  - only the minimal changes needed if state-selection helpers should return configured state names while the write seam owns id resolution
+- [`tests/integration/linear-client.test.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/tests/integration/linear-client.test.ts) and/or [`tests/integration/linear.test.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/tests/integration/linear.test.ts)
+  - focused coverage for comment creation, state updates, and write failures against the mock Linear surface
+- [`tests/unit/linear-policy.test.ts`](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_68/tests/unit/linear-policy.test.ts) or a new focused write-module unit test
+  - direct coverage for missing configured state names and deterministic error text
+
+### Does not belong in this issue
+
+- moving Linear read normalization into the client or mixing it with writes
+- adding comment-read pagination or plan-review comment inspection for Linear
+- changing orchestrator retry, continuation, reconciliation, lease, or handoff-state logic
+- reopening the full vertical slice from issue `#70`
+- one hot file that mixes read transport, write transport, normalization, and lifecycle policy
+
+## Layering Notes
+
+- config/workflow
+  - owns the configured state-name inputs
+  - does not own Linear project-state lookup or mutations
+- tracker
+  - owns comment/state write behavior and the mapping from tracker policy decisions to write calls
+  - does not push GraphQL payload parsing or mutation envelopes upward
+- workspace
+  - untouched
+- runner
+  - untouched
+- orchestrator
+  - remains tracker-neutral and consumes only the existing `Tracker` contract
+- observability
+  - keeps typed, actionable tracker failures without adding tracker-specific control flow
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR by carving the existing broader Linear implementation at the write boundary instead of adding a new vertical feature:
+
+1. extract a dedicated Linear write seam from `linear.ts`
+2. keep state-name selection policy and state-id resolution separated
+3. add focused tests for the issue-`#68` write and failure cases
+4. avoid touching orchestrator behavior or broader Linear read paths
+
+This seam is reviewable because it deliberately defers:
+
+- Linear comment-read protocol handling
+- PR/review lifecycle parity with GitHub
+- any tracker-contract redesign
+- any broader status-surface or artifact changes
+
+## Runtime State Model
+
+Not applicable for this slice. The work is limited to tracker-edge write seams and does not change retries, continuations, reconciliation, leases, or orchestrator handoff-state transitions.
+
+## Failure-Class Matrix
+
+| Observed condition                                                          | Local facts available                          | Normalized tracker facts available | Expected behavior                                                                  |
+| --------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------- |
+| configured claim/terminal state name is not present in the project workflow | workflow-config state names                    | normalized project states          | throw `TrackerError` naming the missing configured state before sending a mutation |
+| comment-create GraphQL mutation returns `errors`                            | operation name and GraphQL errors              | none                               | surface the existing operation-specific `TrackerError` from the transport boundary |
+| issue-update mutation returns `success: false`                              | normalized mutation payload                    | prior normalized issue snapshot    | throw `TrackerError` naming the failed mutation                                    |
+| issue-update mutation reports success but omits the issue payload           | normalized mutation payload                    | none                               | throw `TrackerError` from mutation normalization                                   |
+| issue-update HTTP request fails                                             | operation name, status code or transport error | none                               | surface deterministic transport failure without fallback                           |
+| description-only write succeeds but state update is not requested           | mutation input                                 | prior project snapshot             | update the workpad/comment state without requiring a state transition              |
+
+## Storage / Persistence Contract
+
+- no new durable storage is introduced
+- remote Linear issues remain the system of record for comments, descriptions, and workflow states
+- local factory status and issue artifacts remain unchanged
+- the new write seam, if added, remains an in-memory composition boundary inside the tracker layer
+
+## Observability Requirements
+
+- missing-state errors must name the configured state and project slug
+- failed write operations must preserve the existing operation-specific `TrackerError` messages
+- tests should prove that callers above the tracker do not need to inspect GraphQL envelopes to diagnose failures
+- no new log surface is required beyond existing tracker logging unless the extraction naturally preserves current messages
+
+## Implementation Steps
+
+1. Add `docs/plans/068-linear-comments-and-state-transitions/plan.md` and drive it through the required issue-comment review station.
+2. Extract a focused Linear write seam from `linear.ts` that owns:
+   - comment creation
+   - issue description writes
+   - issue state writes
+   - resolution of workflow state ids from configured state names
+3. Keep `linear-policy.ts` responsible for choosing which configured state name should be used for claim/completion, while the write seam resolves that name against the current project snapshot.
+4. Update `LinearTracker` to compose the write seam for:
+   - claim
+   - retry recording
+   - failure recording
+   - handoff-ready workpad/comment writes
+   - completion state transitions
+5. Add focused tests for:
+   - successful comment creation
+   - successful state update using a configured state name
+   - missing configured claim or terminal state
+   - failed comment-create or issue-update mutations
+6. Run repo gates and self-review:
+   - `pnpm format:check`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+   - `codex review --base origin/main`
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- resolving a configured Linear state name returns the matching workflow state id
+- resolving a missing configured state name throws a `TrackerError` that names the project and state
+- choosing a claim state does not require hard-coded orchestrator enums
+
+### Integration
+
+- the Linear adapter can create a comment against the mock GraphQL surface and the tracker caller only receives normalized issue data
+- the Linear adapter can update issue state by configured state name without exposing GraphQL details above the tracker
+- a failed `CreateComment` mutation surfaces a deterministic `TrackerError`
+- a failed `UpdateIssueState` or combined issue-update mutation surfaces a deterministic `TrackerError`
+- claim and completion paths still move issues into the configured workflow states through the dedicated write seam
+
+### End-to-End Regression
+
+- the existing mocked Linear factory e2e path still completes successfully after the write-seam extraction
+
+### Repo Gate
+
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. Given a mocked Linear project with configured active and terminal workflow states, Symphony can resolve the corresponding state ids and move an issue between those states.
+2. Given a mocked Linear issue, Symphony can create issue comments and workpad-backed description updates without leaking GraphQL envelopes into the orchestrator.
+3. Given a configured state name that is absent from the Linear project workflow, Symphony fails loudly with a tracker-owned error.
+4. Given a failed comment-create or issue-update mutation, Symphony surfaces a deterministic failure and does not silently continue.
+5. The existing Linear end-to-end factory loop still succeeds after the write seam is extracted.
+
+## Exit Criteria
+
+- Linear comment creation, workpad description writes, and state transitions are owned by a focused tracker-edge write seam
+- configured workflow state names remain workflow inputs, not orchestrator enums
+- missing states and failed writes are covered by focused tests
+- raw GraphQL response details remain confined to the Linear transport and tracker layers
+- the change lands as one reviewable PR without bundling broader Linear lifecycle work
+
+## Deferred To Later Issues Or PRs
+
+- reading Linear comments to evaluate plan-review handoff decisions
+- full plan-review acknowledgement behavior on Linear issue comments
+- richer Linear lifecycle policy beyond the current claim/retry/failure/handoff/completion paths
+- tracker-contract changes for arbitrary tracker comment surfaces
+- webhook, agent-session, or PR-style Linear review features
+
+## Decision Notes
+
+- The repository already merged a broader Linear vertical slice in PR `#73` for issue `#70`. This issue should not reopen that broad surface. It should extract and harden the write seam that `#68` originally called for so the change remains traceable and reviewable.
+- State names remain a policy/config concern. State ids are transport/integration details and should be resolved at the tracker edge immediately before mutation calls.
+- Preserving the plan-review comment protocol here means preserving the checked-in comment-body contract on the Linear comment surface, not implementing full Linear comment-read handoff policy in this slice.
+
+## Revision Log
+
+- 2026-03-10: Initial plan created and marked `plan-ready` for issue `#68`.
+- 2026-03-10: Plan approved in the issue review station; implementation started on the extracted Linear write seam.

--- a/src/tracker/linear-policy.ts
+++ b/src/tracker/linear-policy.ts
@@ -55,6 +55,8 @@ export function resolveLinearClaimStateName(
   }
 
   const nextStateName = config.activeStates[currentIndex + 1] ?? null;
+  // Treat duplicate adjacent entries as a degenerate no-op transition rather
+  // than attempting to "advance" the issue into the state it already has.
   if (nextStateName === null || nextStateName === issue.state.name) {
     return null;
   }

--- a/src/tracker/linear-policy.ts
+++ b/src/tracker/linear-policy.ts
@@ -4,7 +4,6 @@ import type { LinearTrackerConfig } from "../domain/workflow.js";
 import type {
   LinearIssueSnapshot,
   LinearProjectSnapshot,
-  LinearWorkflowState,
 } from "./linear-normalize.js";
 
 export type LinearIssueClassification =
@@ -46,11 +45,10 @@ export function classifyLinearIssue(
   return "ignored";
 }
 
-export function resolveLinearClaimState(
-  project: LinearProjectSnapshot,
+export function resolveLinearClaimStateName(
   issue: LinearIssueSnapshot,
   config: LinearTrackerConfig,
-): LinearWorkflowState | null {
+): string | null {
   const currentIndex = config.activeStates.indexOf(issue.state.name);
   if (currentIndex < 0) {
     return null;
@@ -61,17 +59,16 @@ export function resolveLinearClaimState(
     return null;
   }
 
-  return resolveStateByName(project, nextStateName);
+  return nextStateName;
 }
 
-export function resolveLinearTerminalState(
+export function resolveLinearTerminalStateName(
   project: LinearProjectSnapshot,
   config: LinearTrackerConfig,
-): LinearWorkflowState {
+): string {
   for (const stateName of config.terminalStates) {
-    const match = project.states.find((state) => state.name === stateName);
-    if (match !== undefined) {
-      return match;
+    if (project.states.some((state) => state.name === stateName)) {
+      return stateName;
     }
   }
   throw new TrackerError(
@@ -146,17 +143,4 @@ export function extractIssueNumberFromBranchName(
   }
   const issueNumber = Number(match[1]);
   return Number.isNaN(issueNumber) ? null : issueNumber;
-}
-
-function resolveStateByName(
-  project: LinearProjectSnapshot,
-  stateName: string,
-): LinearWorkflowState {
-  const match = project.states.find((state) => state.name === stateName);
-  if (match !== undefined) {
-    return match;
-  }
-  throw new TrackerError(
-    `Linear project ${project.slugId} is missing configured state '${stateName}'`,
-  );
 }

--- a/src/tracker/linear-write.ts
+++ b/src/tracker/linear-write.ts
@@ -49,16 +49,12 @@ export class LinearIssueWriter {
       throw new TrackerError("Linear issue update requires at least one field");
     }
 
-    if (hasStateName && project === undefined) {
-      throw new TrackerError(
-        `Linear issue update for ${input.id} requires project workflow state lookup`,
-      );
-    }
-
-    const stateId =
-      !hasStateName || project === undefined
-        ? undefined
-        : resolveLinearStateByName(project, input.stateName).id;
+    const stateId = !hasStateName
+      ? undefined
+      : resolveLinearStateByName(
+          requireProjectForStateUpdate(project, input.id),
+          input.stateName,
+        ).id;
 
     return normalizeLinearIssueMutationResult(
       await this.#client.updateIssue({
@@ -82,5 +78,18 @@ export function resolveLinearStateByName(
   }
   throw new TrackerError(
     `Linear project ${project.slugId} is missing configured state '${stateName}'`,
+  );
+}
+
+function requireProjectForStateUpdate(
+  project: LinearProjectSnapshot | undefined,
+  issueId: string,
+): LinearProjectSnapshot {
+  if (project !== undefined) {
+    return project;
+  }
+
+  throw new TrackerError(
+    `Linear issue update for ${issueId} requires project workflow state lookup`,
   );
 }

--- a/src/tracker/linear-write.ts
+++ b/src/tracker/linear-write.ts
@@ -1,0 +1,74 @@
+import { TrackerError } from "../domain/errors.js";
+import { LinearClient } from "./linear-client.js";
+import {
+  normalizeLinearIssueMutationResult,
+  type LinearIssueNormalizationOptions,
+  type LinearIssueSnapshot,
+  type LinearProjectSnapshot,
+  type LinearWorkflowState,
+} from "./linear-normalize.js";
+
+interface LinearIssueWriteInput {
+  readonly id: string;
+  readonly description?: string;
+  readonly stateName?: string | null;
+}
+
+export class LinearIssueWriter {
+  readonly #client: LinearClient;
+  readonly #normalizeOptions: LinearIssueNormalizationOptions;
+
+  constructor(
+    client: LinearClient,
+    normalizeOptions: LinearIssueNormalizationOptions,
+  ) {
+    this.#client = client;
+    this.#normalizeOptions = normalizeOptions;
+  }
+
+  async createComment(
+    issueId: string,
+    body: string,
+  ): Promise<LinearIssueSnapshot> {
+    return normalizeLinearIssueMutationResult(
+      await this.#client.createComment(issueId, body),
+      "commentCreate",
+      this.#normalizeOptions,
+    );
+  }
+
+  async updateIssue(
+    project: LinearProjectSnapshot,
+    input: LinearIssueWriteInput,
+  ): Promise<LinearIssueSnapshot> {
+    const stateId =
+      input.stateName === undefined || input.stateName === null
+        ? undefined
+        : resolveLinearStateByName(project, input.stateName).id;
+
+    return normalizeLinearIssueMutationResult(
+      await this.#client.updateIssue({
+        id: input.id,
+        ...(input.description === undefined
+          ? {}
+          : { description: input.description }),
+        ...(stateId === undefined ? {} : { stateId }),
+      }),
+      "issueUpdate",
+      this.#normalizeOptions,
+    );
+  }
+}
+
+export function resolveLinearStateByName(
+  project: LinearProjectSnapshot,
+  stateName: string,
+): LinearWorkflowState {
+  const match = project.states.find((state) => state.name === stateName);
+  if (match !== undefined) {
+    return match;
+  }
+  throw new TrackerError(
+    `Linear project ${project.slugId} is missing configured state '${stateName}'`,
+  );
+}

--- a/src/tracker/linear-write.ts
+++ b/src/tracker/linear-write.ts
@@ -38,20 +38,32 @@ export class LinearIssueWriter {
   }
 
   async updateIssue(
-    project: LinearProjectSnapshot,
     input: LinearIssueWriteInput,
+    project?: LinearProjectSnapshot,
   ): Promise<LinearIssueSnapshot> {
+    const hasDescription = input.description !== undefined;
+    const hasStateName =
+      input.stateName !== undefined && input.stateName !== null;
+
+    if (!hasDescription && !hasStateName) {
+      throw new TrackerError("Linear issue update requires at least one field");
+    }
+
+    if (hasStateName && project === undefined) {
+      throw new TrackerError(
+        `Linear issue update for ${input.id} requires project workflow state lookup`,
+      );
+    }
+
     const stateId =
-      input.stateName === undefined || input.stateName === null
+      !hasStateName || project === undefined
         ? undefined
         : resolveLinearStateByName(project, input.stateName).id;
 
     return normalizeLinearIssueMutationResult(
       await this.#client.updateIssue({
         id: input.id,
-        ...(input.description === undefined
-          ? {}
-          : { description: input.description }),
+        ...(hasDescription ? { description: input.description } : {}),
         ...(stateId === undefined ? {} : { stateId }),
       }),
       "issueUpdate",

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -11,17 +11,17 @@ import {
   extractIssueNumberFromBranchName,
   linearTrackerSubject,
   missingLinearLifecycle,
-  resolveLinearClaimState,
-  resolveLinearTerminalState,
+  resolveLinearClaimStateName,
+  resolveLinearTerminalStateName,
 } from "./linear-policy.js";
 import {
-  normalizeLinearIssueMutationResult,
   normalizeLinearProjectIssuesResult,
   normalizeLinearIssueResult,
   normalizeLinearProject,
   type LinearIssueSnapshot,
   type LinearProjectSnapshot,
 } from "./linear-normalize.js";
+import { LinearIssueWriter } from "./linear-write.js";
 import { writeLinearWorkpad } from "./linear-workpad.js";
 
 const CLAIM_COMMENT = "Symphony claimed this issue for implementation.";
@@ -35,12 +35,17 @@ export class LinearTracker implements Tracker {
   readonly #config: LinearTrackerConfig;
   readonly #logger: Logger;
   readonly #client: LinearClient;
+  readonly #writer: LinearIssueWriter;
   #projectPromise: Promise<LinearProjectSnapshot> | null = null;
 
   constructor(config: LinearTrackerConfig, logger: Logger) {
     this.#config = config;
     this.#logger = logger;
     this.#client = new LinearClient(config);
+    this.#writer = new LinearIssueWriter(
+      this.#client,
+      this.#normalizeOptions(),
+    );
   }
 
   subject(): string {
@@ -87,7 +92,7 @@ export class LinearTracker implements Tracker {
       return null;
     }
 
-    const nextState = resolveLinearClaimState(project, issue, this.#config);
+    const nextStateName = resolveLinearClaimStateName(issue, this.#config);
     const updatedDescription = writeLinearWorkpad(issue.description, {
       status: "running",
       summary: "Claimed by Symphony",
@@ -95,24 +100,16 @@ export class LinearTracker implements Tracker {
       updatedAt: new Date().toISOString(),
     });
 
-    const claimed = normalizeLinearIssueMutationResult(
-      await this.#client.updateIssue({
-        id: issue.id,
-        description: updatedDescription,
-        ...(nextState === null ? {} : { stateId: nextState.id }),
-      }),
-      "issueUpdate",
-      this.#normalizeOptions(),
-    );
-    normalizeLinearIssueMutationResult(
-      await this.#client.createComment(issue.id, CLAIM_COMMENT),
-      "commentCreate",
-      this.#normalizeOptions(),
-    );
+    const claimed = await this.#writer.updateIssue(project, {
+      id: issue.id,
+      description: updatedDescription,
+      ...(nextStateName === null ? {} : { stateName: nextStateName }),
+    });
+    await this.#writer.createComment(issue.id, CLAIM_COMMENT);
     this.#logger.info("Claimed Linear issue", {
       issueNumber,
       identifier: claimed.identifier,
-      nextState: nextState?.name ?? claimed.state.name,
+      nextState: nextStateName ?? claimed.state.name,
     });
     return claimed.runtimeIssue;
   }
@@ -147,89 +144,60 @@ export class LinearTracker implements Tracker {
       branchName,
       updatedAt: new Date().toISOString(),
     });
-    normalizeLinearIssueMutationResult(
-      await this.#client.updateIssue({
-        id: issue.id,
-        description: updatedDescription,
-      }),
-      "issueUpdate",
-      this.#normalizeOptions(),
-    );
-    normalizeLinearIssueMutationResult(
-      await this.#client.createComment(issue.id, HANDOFF_READY_COMMENT),
-      "commentCreate",
-      this.#normalizeOptions(),
-    );
+    await this.#writer.updateIssue(await this.#project(), {
+      id: issue.id,
+      description: updatedDescription,
+    });
+    await this.#writer.createComment(issue.id, HANDOFF_READY_COMMENT);
     return await this.inspectIssueHandoff(branchName);
   }
 
   async recordRetry(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    normalizeLinearIssueMutationResult(
-      await this.#client.updateIssue({
-        id: issue.id,
-        description: writeLinearWorkpad(issue.description, {
-          status: "retry-scheduled",
-          summary: reason,
-          branchName: null,
-          updatedAt: new Date().toISOString(),
-        }),
+    await this.#writer.updateIssue(await this.#project(), {
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "retry-scheduled",
+        summary: reason,
+        branchName: null,
+        updatedAt: new Date().toISOString(),
       }),
-      "issueUpdate",
-      this.#normalizeOptions(),
-    );
-    normalizeLinearIssueMutationResult(
-      await this.#client.createComment(issue.id, `${RETRY_PREFIX} ${reason}`),
-      "commentCreate",
-      this.#normalizeOptions(),
-    );
+    });
+    await this.#writer.createComment(issue.id, `${RETRY_PREFIX} ${reason}`);
   }
 
   async completeIssue(issueNumber: number): Promise<void> {
     const project = await this.#project();
     const issue = await this.#getIssueSnapshot(issueNumber);
-    const terminalState = resolveLinearTerminalState(project, this.#config);
-    normalizeLinearIssueMutationResult(
-      await this.#client.updateIssue({
-        id: issue.id,
-        description: writeLinearWorkpad(issue.description, {
-          status: "completed",
-          summary: "Completed by Symphony",
-          branchName: null,
-          updatedAt: new Date().toISOString(),
-        }),
-        stateId: terminalState.id,
+    const terminalStateName = resolveLinearTerminalStateName(
+      project,
+      this.#config,
+    );
+    await this.#writer.updateIssue(project, {
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "completed",
+        summary: "Completed by Symphony",
+        branchName: null,
+        updatedAt: new Date().toISOString(),
       }),
-      "issueUpdate",
-      this.#normalizeOptions(),
-    );
-    normalizeLinearIssueMutationResult(
-      await this.#client.createComment(issue.id, COMPLETION_COMMENT),
-      "commentCreate",
-      this.#normalizeOptions(),
-    );
+      stateName: terminalStateName,
+    });
+    await this.#writer.createComment(issue.id, COMPLETION_COMMENT);
   }
 
   async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    normalizeLinearIssueMutationResult(
-      await this.#client.updateIssue({
-        id: issue.id,
-        description: writeLinearWorkpad(issue.description, {
-          status: "failed",
-          summary: reason,
-          branchName: null,
-          updatedAt: new Date().toISOString(),
-        }),
+    await this.#writer.updateIssue(await this.#project(), {
+      id: issue.id,
+      description: writeLinearWorkpad(issue.description, {
+        status: "failed",
+        summary: reason,
+        branchName: null,
+        updatedAt: new Date().toISOString(),
       }),
-      "issueUpdate",
-      this.#normalizeOptions(),
-    );
-    normalizeLinearIssueMutationResult(
-      await this.#client.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`),
-      "commentCreate",
-      this.#normalizeOptions(),
-    );
+    });
+    await this.#writer.createComment(issue.id, `${FAILURE_PREFIX} ${reason}`);
   }
 
   async #project(): Promise<LinearProjectSnapshot> {

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -100,11 +100,14 @@ export class LinearTracker implements Tracker {
       updatedAt: new Date().toISOString(),
     });
 
-    const claimed = await this.#writer.updateIssue(project, {
-      id: issue.id,
-      description: updatedDescription,
-      ...(nextStateName === null ? {} : { stateName: nextStateName }),
-    });
+    const claimed = await this.#writer.updateIssue(
+      {
+        id: issue.id,
+        description: updatedDescription,
+        ...(nextStateName === null ? {} : { stateName: nextStateName }),
+      },
+      project,
+    );
     await this.#writer.createComment(issue.id, CLAIM_COMMENT);
     this.#logger.info("Claimed Linear issue", {
       issueNumber,
@@ -144,7 +147,7 @@ export class LinearTracker implements Tracker {
       branchName,
       updatedAt: new Date().toISOString(),
     });
-    await this.#writer.updateIssue(await this.#project(), {
+    await this.#writer.updateIssue({
       id: issue.id,
       description: updatedDescription,
     });
@@ -154,7 +157,7 @@ export class LinearTracker implements Tracker {
 
   async recordRetry(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    await this.#writer.updateIssue(await this.#project(), {
+    await this.#writer.updateIssue({
       id: issue.id,
       description: writeLinearWorkpad(issue.description, {
         status: "retry-scheduled",
@@ -173,22 +176,25 @@ export class LinearTracker implements Tracker {
       project,
       this.#config,
     );
-    await this.#writer.updateIssue(project, {
-      id: issue.id,
-      description: writeLinearWorkpad(issue.description, {
-        status: "completed",
-        summary: "Completed by Symphony",
-        branchName: null,
-        updatedAt: new Date().toISOString(),
-      }),
-      stateName: terminalStateName,
-    });
+    await this.#writer.updateIssue(
+      {
+        id: issue.id,
+        description: writeLinearWorkpad(issue.description, {
+          status: "completed",
+          summary: "Completed by Symphony",
+          branchName: null,
+          updatedAt: new Date().toISOString(),
+        }),
+        stateName: terminalStateName,
+      },
+      project,
+    );
     await this.#writer.createComment(issue.id, COMPLETION_COMMENT);
   }
 
   async markIssueFailed(issueNumber: number, reason: string): Promise<void> {
     const issue = await this.#getIssueSnapshot(issueNumber);
-    await this.#writer.updateIssue(await this.#project(), {
+    await this.#writer.updateIssue({
       id: issue.id,
       description: writeLinearWorkpad(issue.description, {
         status: "failed",

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -86,8 +86,10 @@ export class LinearTracker implements Tracker {
   }
 
   async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
-    const project = await this.#project();
-    const issue = await this.#getIssueSnapshot(issueNumber);
+    const [project, issue] = await Promise.all([
+      this.#project(),
+      this.#getIssueSnapshot(issueNumber),
+    ]);
     if (classifyLinearIssue(issue, this.#config) !== "ready") {
       return null;
     }
@@ -170,8 +172,10 @@ export class LinearTracker implements Tracker {
   }
 
   async completeIssue(issueNumber: number): Promise<void> {
-    const project = await this.#project();
-    const issue = await this.#getIssueSnapshot(issueNumber);
+    const [project, issue] = await Promise.all([
+      this.#project(),
+      this.#getIssueSnapshot(issueNumber),
+    ]);
     const terminalStateName = resolveLinearTerminalStateName(
       project,
       this.#config,

--- a/tests/integration/linear-write.test.ts
+++ b/tests/integration/linear-write.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { LinearTrackerConfig } from "../../src/domain/workflow.js";
+import { LinearClient } from "../../src/tracker/linear-client.js";
+import { normalizeLinearProject } from "../../src/tracker/linear-normalize.js";
+import { LinearIssueWriter } from "../../src/tracker/linear-write.js";
+import { MockLinearServer } from "../support/mock-linear-server.js";
+
+function createConfig(server: MockLinearServer): LinearTrackerConfig {
+  return {
+    kind: "linear",
+    endpoint: server.baseUrl,
+    apiKey: "linear-token",
+    projectSlug: "symphony-linear",
+    assignee: "worker@example.test",
+    activeStates: ["Todo", "In Progress"],
+    terminalStates: ["Done", "Canceled"],
+  };
+}
+
+describe("LinearIssueWriter", () => {
+  let server: MockLinearServer;
+
+  beforeEach(async () => {
+    server = new MockLinearServer();
+    await server.start();
+    server.seedProject({
+      slugId: "symphony-linear",
+      name: "Symphony Linear",
+      states: [
+        { name: "Todo", type: "unstarted" },
+        { name: "In Progress", type: "started" },
+        { name: "Done", type: "completed" },
+        { name: "Canceled", type: "canceled" },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("creates Linear comments through the focused write seam", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 7,
+      title: "Issue 7",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+
+    const updated = await writer.createComment(issue.id, "Tracked");
+
+    expect(updated.comments).toHaveLength(1);
+    expect(updated.comments[0]?.body).toBe("Tracked");
+    expect(server.getIssue("symphony-linear", 7).comments).toContain("Tracked");
+  });
+
+  it("updates issue description and state by configured state name", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 8,
+      title: "Issue 8",
+      description: "Before",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+    const projectResult = await client.fetchProject();
+    if (projectResult.project === null) {
+      throw new Error("expected seeded project");
+    }
+    const project = normalizeLinearProject(projectResult.project);
+
+    const updated = await writer.updateIssue(project, {
+      id: issue.id,
+      description: "After",
+      stateName: "In Progress",
+    });
+    const request = server.requests("UpdateIssueDescriptionAndState")[0];
+
+    expect(updated.description).toBe("After");
+    expect(updated.state.name).toBe("In Progress");
+    expect(server.getIssue("symphony-linear", 8).description).toBe("After");
+    expect(server.getIssue("symphony-linear", 8).stateName).toBe("In Progress");
+    expect(request?.variables).toMatchObject({
+      id: issue.id,
+      description: "After",
+    });
+    expect(typeof request?.variables["stateId"]).toBe("string");
+  });
+
+  it("surfaces failed comment writes without leaking GraphQL parsing details", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 9,
+      title: "Issue 9",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+    server.enqueueGraphQLError("CreateComment", "simulated comment failure");
+
+    await expect(
+      writer.createComment(issue.id, "Tracked"),
+    ).rejects.toThrowError(/CreateComment: simulated comment failure/i);
+  });
+
+  it("surfaces failed issue updates without leaking GraphQL parsing details", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 10,
+      title: "Issue 10",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+    const projectResult = await client.fetchProject();
+    if (projectResult.project === null) {
+      throw new Error("expected seeded project");
+    }
+    const project = normalizeLinearProject(projectResult.project);
+    server.enqueueGraphQLError("UpdateIssueState", "simulated update failure");
+
+    await expect(
+      writer.updateIssue(project, {
+        id: issue.id,
+        stateName: "In Progress",
+      }),
+    ).rejects.toThrowError(/UpdateIssueState: simulated update failure/i);
+  });
+});

--- a/tests/integration/linear-write.test.ts
+++ b/tests/integration/linear-write.test.ts
@@ -78,11 +78,14 @@ describe("LinearIssueWriter", () => {
     }
     const project = normalizeLinearProject(projectResult.project);
 
-    const updated = await writer.updateIssue(project, {
-      id: issue.id,
-      description: "After",
-      stateName: "In Progress",
-    });
+    const updated = await writer.updateIssue(
+      {
+        id: issue.id,
+        description: "After",
+        stateName: "In Progress",
+      },
+      project,
+    );
     const request = server.requests("UpdateIssueDescriptionAndState")[0];
 
     expect(updated.description).toBe("After");
@@ -94,6 +97,38 @@ describe("LinearIssueWriter", () => {
       description: "After",
     });
     expect(typeof request?.variables["stateId"]).toBe("string");
+  });
+
+  it("updates issue description without requiring a project snapshot", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 11,
+      title: "Issue 11",
+      description: "Before",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+
+    const updated = await writer.updateIssue({
+      id: issue.id,
+      description: "After only",
+    });
+    const request = server.requests("UpdateIssueDescription")[0];
+
+    expect(updated.description).toBe("After only");
+    expect(updated.state.name).toBe("Todo");
+    expect(server.getIssue("symphony-linear", 11).description).toBe(
+      "After only",
+    );
+    expect(server.countRequests("GetProject")).toBe(0);
+    expect(request?.variables).toEqual({
+      id: issue.id,
+      description: "After only",
+    });
   });
 
   it("surfaces failed comment writes without leaking GraphQL parsing details", async () => {
@@ -135,10 +170,37 @@ describe("LinearIssueWriter", () => {
     server.enqueueGraphQLError("UpdateIssueState", "simulated update failure");
 
     await expect(
-      writer.updateIssue(project, {
-        id: issue.id,
-        stateName: "In Progress",
-      }),
+      writer.updateIssue(
+        {
+          id: issue.id,
+          stateName: "In Progress",
+        },
+        project,
+      ),
     ).rejects.toThrowError(/UpdateIssueState: simulated update failure/i);
+  });
+
+  it("fails fast when no issue fields are provided", async () => {
+    const issue = server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 12,
+      title: "Issue 12",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+    const client = new LinearClient(createConfig(server));
+    const writer = new LinearIssueWriter(client, {
+      configuredAssignee: "worker@example.test",
+    });
+
+    await expect(
+      writer.updateIssue({
+        id: issue.id,
+      }),
+    ).rejects.toThrowError(/Linear issue update requires at least one field/i);
+    expect(server.countRequests("UpdateIssue")).toBe(0);
+    expect(server.countRequests("UpdateIssueDescription")).toBe(0);
+    expect(server.countRequests("UpdateIssueState")).toBe(0);
+    expect(server.countRequests("UpdateIssueDescriptionAndState")).toBe(0);
   });
 });

--- a/tests/integration/linear.test.ts
+++ b/tests/integration/linear.test.ts
@@ -4,7 +4,10 @@ import type { LinearTrackerConfig } from "../../src/domain/workflow.js";
 import { LinearTracker } from "../../src/tracker/linear.js";
 import { MockLinearServer } from "../support/mock-linear-server.js";
 
-function createConfig(server: MockLinearServer): LinearTrackerConfig {
+function createConfig(
+  server: MockLinearServer,
+  overrides: Partial<LinearTrackerConfig> = {},
+): LinearTrackerConfig {
   return {
     kind: "linear",
     endpoint: server.baseUrl,
@@ -13,6 +16,7 @@ function createConfig(server: MockLinearServer): LinearTrackerConfig {
     assignee: "worker@example.test",
     activeStates: ["Todo", "In Progress"],
     terminalStates: ["Done", "Canceled"],
+    ...overrides,
   };
 }
 
@@ -201,6 +205,48 @@ describe("LinearTracker", () => {
     expect(failed.map((issue) => issue.number)).toEqual([9]);
     expect(server.getIssue("symphony-linear", 9).comments).toContain(
       "Symphony failed this run: runner exited with 1",
+    );
+  });
+
+  it("fails loudly when the configured claim state is missing from the project workflow", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 10,
+      title: "Issue 10",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const tracker = new LinearTracker(
+      createConfig(server, {
+        activeStates: ["Todo", "Working"],
+      }),
+      new JsonLogger(),
+    );
+
+    await expect(tracker.claimIssue(10)).rejects.toThrowError(
+      /Linear project symphony-linear is missing configured state 'Working'/i,
+    );
+  });
+
+  it("fails loudly when the configured terminal states are absent from the project workflow", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 11,
+      title: "Issue 11",
+      stateName: "In Progress",
+      assigneeEmail: "worker@example.test",
+    });
+
+    const tracker = new LinearTracker(
+      createConfig(server, {
+        terminalStates: ["Closed"],
+      }),
+      new JsonLogger(),
+    );
+
+    await expect(tracker.completeIssue(11)).rejects.toThrowError(
+      /Linear project symphony-linear does not expose any configured terminal state/i,
     );
   });
 });

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -231,6 +231,20 @@ describe("normalizeLinearIssueResult", () => {
 });
 
 describe("normalizeLinearIssueMutationResult", () => {
+  it("throws a clear error when a mutation reports success=false", () => {
+    expect(() =>
+      normalizeLinearIssueMutationResult(
+        {
+          issueUpdate: {
+            success: false,
+            issue: createIssuePayload(),
+          },
+        },
+        "issueUpdate",
+      ),
+    ).toThrowError(/Linear mutation issueUpdate reported success=false/i);
+  });
+
   it("throws a clear error when a successful mutation returns no issue", () => {
     expect(() =>
       normalizeLinearIssueMutationResult(

--- a/tests/unit/linear-policy.test.ts
+++ b/tests/unit/linear-policy.test.ts
@@ -127,6 +127,20 @@ describe("resolveLinearClaimStateName", () => {
       }),
     ).toBeNull();
   });
+
+  it("returns null when the next configured active state would be a duplicate no-op", () => {
+    expect(
+      resolveLinearClaimStateName(createIssue("In Progress"), {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress", "In Progress"],
+        terminalStates: ["Done"],
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("resolveLinearTerminalStateName", () => {

--- a/tests/unit/linear-policy.test.ts
+++ b/tests/unit/linear-policy.test.ts
@@ -1,5 +1,73 @@
 import { describe, expect, it } from "vitest";
-import { extractIssueNumberFromBranchName } from "../../src/tracker/linear-policy.js";
+import {
+  extractIssueNumberFromBranchName,
+  resolveLinearClaimStateName,
+  resolveLinearTerminalStateName,
+} from "../../src/tracker/linear-policy.js";
+import type {
+  LinearIssueSnapshot,
+  LinearProjectSnapshot,
+} from "../../src/tracker/linear-normalize.js";
+
+const PROJECT: LinearProjectSnapshot = {
+  id: "project-1",
+  slugId: "symphony-linear",
+  name: "Symphony Linear",
+  states: [
+    {
+      id: "state-todo",
+      name: "Todo",
+      type: "unstarted",
+      position: 0,
+    },
+    {
+      id: "state-in-progress",
+      name: "In Progress",
+      type: "started",
+      position: 1,
+    },
+    {
+      id: "state-done",
+      name: "Done",
+      type: "completed",
+      position: 2,
+    },
+  ],
+};
+
+function createIssue(stateName: string): LinearIssueSnapshot {
+  return {
+    id: "issue-1",
+    identifier: "SYM-1",
+    number: 1,
+    title: "Issue 1",
+    description: "",
+    priority: null,
+    branchName: null,
+    url: "https://linear.example/SYM-1",
+    createdAt: "2026-03-10T00:00:00.000Z",
+    updatedAt: "2026-03-10T00:00:00.000Z",
+    state: PROJECT.states.find((state) => state.name === stateName)!,
+    assignee: null,
+    assignedToWorker: true,
+    labels: [],
+    blockedBy: [],
+    comments: [],
+    workpad: null,
+    runtimeIssue: {
+      id: "issue-1",
+      identifier: "SYM-1",
+      number: 1,
+      title: "Issue 1",
+      description: "",
+      labels: [],
+      state: stateName,
+      url: "https://linear.example/SYM-1",
+      createdAt: "2026-03-10T00:00:00.000Z",
+      updatedAt: "2026-03-10T00:00:00.000Z",
+    },
+  };
+}
 
 describe("extractIssueNumberFromBranchName", () => {
   it("reads issue numbers from the standard symphony branch format", () => {
@@ -14,5 +82,67 @@ describe("extractIssueNumberFromBranchName", () => {
 
   it("returns null when the branch leaf does not start with an issue number", () => {
     expect(extractIssueNumberFromBranchName("symphony/linear-70")).toBeNull();
+  });
+});
+
+describe("resolveLinearClaimStateName", () => {
+  it("returns the next configured active state name", () => {
+    expect(
+      resolveLinearClaimStateName(createIssue("Todo"), {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress"],
+        terminalStates: ["Done"],
+      }),
+    ).toBe("In Progress");
+  });
+
+  it("returns null when the current state is outside the configured active list", () => {
+    expect(
+      resolveLinearClaimStateName(createIssue("Done"), {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress"],
+        terminalStates: ["Done"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveLinearTerminalStateName", () => {
+  it("returns the first configured terminal state that exists in the project", () => {
+    expect(
+      resolveLinearTerminalStateName(PROJECT, {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress"],
+        terminalStates: ["Closed", "Done"],
+      }),
+    ).toBe("Done");
+  });
+
+  it("fails clearly when the project exposes none of the configured terminal states", () => {
+    expect(() =>
+      resolveLinearTerminalStateName(PROJECT, {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress"],
+        terminalStates: ["Closed"],
+      }),
+    ).toThrowError(
+      /Linear project symphony-linear does not expose any configured terminal state/i,
+    );
   });
 });

--- a/tests/unit/linear-policy.test.ts
+++ b/tests/unit/linear-policy.test.ts
@@ -113,6 +113,20 @@ describe("resolveLinearClaimStateName", () => {
       }),
     ).toBeNull();
   });
+
+  it("returns null when the current state is the last configured active state", () => {
+    expect(
+      resolveLinearClaimStateName(createIssue("In Progress"), {
+        kind: "linear",
+        endpoint: "https://linear.example/graphql",
+        apiKey: "token",
+        projectSlug: "symphony-linear",
+        assignee: null,
+        activeStates: ["Todo", "In Progress"],
+        terminalStates: ["Done"],
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("resolveLinearTerminalStateName", () => {

--- a/tests/unit/linear-write.test.ts
+++ b/tests/unit/linear-write.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { LinearProjectSnapshot } from "../../src/tracker/linear-normalize.js";
-import { resolveLinearStateByName } from "../../src/tracker/linear-write.js";
+import {
+  LinearIssueWriter,
+  resolveLinearStateByName,
+} from "../../src/tracker/linear-write.js";
 
 const PROJECT: LinearProjectSnapshot = {
   id: "project-1",
@@ -35,6 +38,29 @@ describe("resolveLinearStateByName", () => {
   it("fails clearly when the configured state is absent from the project", () => {
     expect(() => resolveLinearStateByName(PROJECT, "Done")).toThrowError(
       /Linear project symphony-linear is missing configured state 'Done'/i,
+    );
+  });
+});
+
+describe("LinearIssueWriter.updateIssue", () => {
+  it("fails clearly when a state update is requested without a project snapshot", async () => {
+    const writer = new LinearIssueWriter(
+      {
+        createComment: vi.fn(),
+        updateIssue: vi.fn(),
+      } as never,
+      {
+        configuredAssignee: null,
+      },
+    );
+
+    await expect(
+      writer.updateIssue({
+        id: "issue-1",
+        stateName: "In Progress",
+      }),
+    ).rejects.toThrowError(
+      /Linear issue update for issue-1 requires project workflow state lookup/i,
     );
   });
 });

--- a/tests/unit/linear-write.test.ts
+++ b/tests/unit/linear-write.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { LinearProjectSnapshot } from "../../src/tracker/linear-normalize.js";
+import { resolveLinearStateByName } from "../../src/tracker/linear-write.js";
+
+const PROJECT: LinearProjectSnapshot = {
+  id: "project-1",
+  slugId: "symphony-linear",
+  name: "Symphony Linear",
+  states: [
+    {
+      id: "state-todo",
+      name: "Todo",
+      type: "unstarted",
+      position: 0,
+    },
+    {
+      id: "state-in-progress",
+      name: "In Progress",
+      type: "started",
+      position: 1,
+    },
+  ],
+};
+
+describe("resolveLinearStateByName", () => {
+  it("returns the matching workflow state", () => {
+    expect(resolveLinearStateByName(PROJECT, "In Progress")).toEqual({
+      id: "state-in-progress",
+      name: "In Progress",
+      type: "started",
+      position: 1,
+    });
+  });
+
+  it("fails clearly when the configured state is absent from the project", () => {
+    expect(() => resolveLinearStateByName(PROJECT, "Done")).toThrowError(
+      /Linear project symphony-linear is missing configured state 'Done'/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract a focused Linear write seam for comment creation and issue description/state updates
- keep state-name policy separate from write-time id resolution and add explicit missing-state failures
- add unit and integration coverage for state resolution, write failures, and tracker claim/completion behavior

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #68