### PR TITLE
Publish issue reports and session logs to factory-runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,32 @@ Generate a per-issue report from local artifacts:
 pnpm tsx bin/symphony-report.ts issue --issue 44
 ```
 
+Publish one generated issue report into a checked-out `factory-runs` archive
+worktree:
+
+```bash
+pnpm tsx bin/symphony-report.ts publish --issue 44 --archive-root ../factory-runs
+```
+
+Archive publication stays detached from `symphony run` and `symphony-ts` CI. It
+copies the already-canonical local `report.json`, `report.md`, and available
+session logs into:
+
+```text
+<factory-runs-root>/
+  symphony-ts/
+    issues/
+      <issue-number>/
+        <publication-id>/
+          report.json
+          report.md
+          metadata.json
+          logs/
+```
+
+If publication fails, the local artifacts under `.var/factory/...` and
+`.var/reports/...` remain the source of truth.
+
 By default, the checked-in `WORKFLOW.md` targets:
 
 - repo: `sociotechnica-org/symphony-ts`

--- a/docs/plans/045-publish-issue-reports-and-session-logs-to-factory-runs/plan.md
+++ b/docs/plans/045-publish-issue-reports-and-session-logs-to-factory-runs/plan.md
@@ -1,0 +1,339 @@
+# Issue 45 Plan: Publish Issue Reports And Session Logs To `factory-runs`
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Add a detached archive-publication path that reads the canonical local issue artifacts under `.var/factory/issues/<issue-number>/...` plus the generated report outputs under `.var/reports/issues/<issue-number>/...`, then writes a stable per-publication directory into a checked-out `factory-runs` archive repository without making archive publication part of the normal `symphony-ts` run loop or CI contract.
+
+## Scope
+
+This slice covers:
+
+1. a stable target directory layout inside `factory-runs` for one published issue snapshot
+2. a versioned `metadata.json` contract that records publication facts, source facts, and copied-log outcomes
+3. a detached publication service that copies `report.json`, `report.md`, and available raw session logs or reference manifests into the archive tree
+4. a standalone CLI flow for publishing one issue from local canonical artifacts into a local `factory-runs` checkout
+5. tests and docs that prove publication failure does not mutate or redefine the canonical local artifact/report contracts
+
+## Non-goals
+
+This slice does not include:
+
+1. changing the canonical local artifact contract from `#43`
+2. changing the generated report schema from `#44`
+3. embedding archive publication into `symphony run`, orchestrator retries, or normal issue execution flow
+4. making `symphony-ts` CI depend on a reachable `factory-runs` remote or a real network publish
+5. batch publication, backfill sweeps, or scheduled archive sync loops
+6. updating local issue artifacts in place with archive locations after publish
+7. redesigning runner log capture beyond the existing log-pointer contract
+8. GitHub API automation around creating archive PRs or pushing commits to the archive remote
+
+## Current Gaps
+
+After `#43` and `#44`, `symphony-ts` can persist canonical local issue artifacts and generate detached per-issue reports, but it still lacks a defined publication seam into the separate archive repository:
+
+1. there is no stable `factory-runs` directory layout for published issue snapshots
+2. there is no canonical publication metadata contract for repo, issue, branch, PR, timing, session, and source revision facts
+3. existing local log pointers can reference raw logs, but there is no policy for copying readable logs versus archiving pointer references when the source is unavailable
+4. there is no detached CLI/service that stages issue outputs into an archive checkout while leaving local artifacts canonical and untouched
+5. there is no CI-safe test harness that simulates archive publication against a mock local git repository
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_45/docs/architecture.md).
+
+- Policy Layer: publication rules belong here, including the target archive tree shape, the rule that local artifacts remain canonical, the rule that missing logs degrade to copied references instead of blocking publication, and the rule that archive publication remains detached from normal runtime execution.
+- Configuration Layer: this slice should add only detached CLI input parsing and path resolution for the source workflow root and the archive checkout path. It should not add new `WORKFLOW.md` runtime settings or make archive publication part of the repository-owned worker contract.
+- Coordination Layer: untouched. The orchestrator must not gain publish/retry logic, publication status state, or archive side effects.
+- Execution Layer: untouched except for existing local files that the publisher reads. Runner and workspace layers must not change to satisfy archive layout needs.
+- Integration Layer: owns the `factory-runs` publication service, publication metadata composition from local/report/git facts, archive-path derivation, file copy/reference rules, and any archive-worktree validation. This is the primary layer touched by the issue.
+- Observability Layer: continues to own the canonical local artifact and generated report contracts plus read helpers. It may expose read-side loaders reused by the publisher, but it must not absorb archive-repo policy or git-worktree publication logic.
+
+## Architecture Boundaries
+
+### Integration
+
+Belongs here:
+
+1. the `factory-runs` target path contract and publication-id derivation
+2. archive metadata composition from local artifacts, generated reports, and source git facts
+3. copying published files into the archive checkout
+4. validation that the archive root looks like a writable checkout/worktree
+5. partial-success handling for raw logs when a pointer is present but a file cannot be copied
+
+Does not belong here:
+
+1. orchestrator lifecycle decisions
+2. markdown report rendering
+3. tracker transport or GitHub issue policy
+4. mutating the canonical local issue artifacts after publication
+
+### Observability
+
+Belongs here:
+
+1. canonical local artifact readers from `#43`
+2. generated report readers/writers from `#44`
+3. stable local paths under `.var/factory/...` and `.var/reports/...`
+
+Does not belong here:
+
+1. `factory-runs` directory layout policy
+2. archive metadata enrichment from source git state
+3. archive worktree writes or publication-side idempotency rules
+
+### CLI / Config
+
+Belongs here:
+
+1. argument parsing for a detached publish command
+2. resolving the source workflow path and archive checkout path
+3. printing publication results and copied/uncopied log summaries
+
+Does not belong here:
+
+1. publication business logic inline in argument parsing
+2. hidden default behavior that makes publication run during normal issue execution
+
+### Coordination / Orchestrator
+
+Belongs here:
+
+1. nothing new in this slice
+
+Does not belong here:
+
+1. archive publication triggers
+2. archive publication retries
+3. storing publication state inside active runtime state
+
+### Runner / Workspace
+
+Belongs here:
+
+1. no new responsibilities beyond existing session/log-pointer artifacts
+
+Does not belong here:
+
+1. direct writes into `factory-runs`
+2. publication metadata assembly
+3. archive-aware log-capture behavior
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR because it stays on one detached integration seam:
+
+1. reuse the existing local artifact and report contracts as read-only inputs
+2. add a focused archive publication service and CLI
+3. add tests against temporary source and archive repositories
+4. update docs for the detached publication workflow
+
+This PR deliberately defers:
+
+1. batch or campaign publication commands
+2. pushing or opening PRs against the archive remote
+3. back-writing archive locations into local artifacts
+4. richer source revision capture if later raw artifacts start storing commit SHAs directly
+5. any normal-runtime hook that auto-publishes on issue completion
+
+The seam is reviewable because it does not reopen orchestrator coordination or generated report composition; it only adds a new consumer that copies already-canonical local outputs into a separate archive worktree.
+
+## Publication Contract
+
+Write each publication into this stable archive tree:
+
+```text
+<factory-runs-root>/
+  symphony-ts/
+    issues/
+      <issue-number>/
+        <publication-id>/
+          report.json
+          report.md
+          metadata.json
+          logs/
+            <session-id>/
+              <log-name>...
+              <log-name>.pointer.json
+```
+
+### Publication ID
+
+Use a stable, filesystem-safe publication id derived from the generated report timestamp when available:
+
+1. prefer `report.generatedAt` rendered as a compact UTC identifier
+2. append a short source revision suffix when a relevant SHA is available so repeated publishes remain legible
+3. if the generated report is unavailable, fail loudly rather than inventing a publication id from partial inputs
+
+The publication id is archive-oriented, not a new canonical local identifier.
+
+### Published Files
+
+Required files:
+
+1. `report.json`: copied byte-for-byte from the generated local report
+2. `report.md`: copied byte-for-byte from the generated local markdown report
+3. `metadata.json`: generated by the publication service for archive consumers
+
+Optional files:
+
+1. `logs/<session-id>/<log-name>` when a log pointer resolves to a readable local file
+2. `logs/<session-id>/<log-name>.pointer.json` when the source log cannot or should not be copied but the original pointer can be preserved
+
+### `metadata.json`
+
+`metadata.json` should be versioned and include, at minimum:
+
+1. archive schema version
+2. publication id
+3. published-at timestamp
+4. source repo name
+5. issue number and issue identifier when available
+6. branch name
+7. pull request numbers and URLs when available
+8. report generated-at timestamp
+9. issue start/end timestamps when available
+10. orchestrator session/run identifiers when available
+11. runner session ids
+12. source revision facts:
+    - relevant SHA
+    - optional base SHA / commit range when derivable without changing local contracts
+    - source checkout path used for publication
+13. source artifact paths used to compose the publication
+14. per-log publication results, including copied archive path or preserved pointer reference
+15. an explicit partial/failure note when some logs could not be copied
+
+The metadata contract should permit nulls for unavailable facts rather than synthesizing guessed values.
+
+## Log Publication Rules
+
+Use the existing log-pointer contract as the archive input and apply these rules:
+
+1. if a log pointer location resolves to a readable local file, copy the file into `logs/<session-id>/`
+2. if the pointer location is present but not a readable local file, write `<log-name>.pointer.json` with the original pointer metadata and mark the log as `referenced`
+3. if both the location and archive location are absent, record the log entry in `metadata.json` as `unavailable` and continue
+4. log publication problems should make the publication partial, not silently complete
+5. missing or uncopiable logs must not block report and metadata publication unless the core report artifacts are missing
+
+## Read / Write Model
+
+This slice does not change orchestrator runtime state, but the publisher still needs an explicit detached write model.
+
+### Publication states
+
+1. `not-started`: no archive directory exists for the selected issue/publication id
+2. `staging`: the publisher has loaded local artifacts and is writing archive files into the target directory
+3. `published`: required files (`report.json`, `report.md`, `metadata.json`) were written successfully; logs may be complete or partial
+4. `failed`: required publication files could not be written; the archive directory may be absent or left only with temporary files
+
+### Rules
+
+1. local artifacts and generated reports are always the canonical source of truth
+2. publication writes must be atomic enough that `metadata.json`, `report.json`, and `report.md` are never left truncated
+3. a failed publish must not mutate local artifacts or generated reports
+4. rerunning the same publication command for the same inputs should either rewrite the same publication directory atomically or fail clearly on an unexpected conflict; it must not duplicate nested directory layers
+
+## Failure-Class Matrix
+
+| Observed condition                                                                       | Local facts available                             | Expected behavior                                                                                                 |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Generated report and local issue artifacts are both present                              | canonical report plus local raw artifacts         | publish archive snapshot successfully                                                                             |
+| Report files are missing for the issue                                                   | raw artifacts only, no generated report           | fail loudly and instruct the operator to generate the local report first                                          |
+| Some log pointers resolve to readable local files                                        | report, metadata inputs, readable log files       | copy those logs and record copied archive paths in `metadata.json`                                                |
+| Some log pointers are present but unreadable, remote-like, or already archived elsewhere | pointer metadata only                             | write pointer manifests and mark the publication partial without blocking the required files                      |
+| No session logs exist for the issue                                                      | report and local artifacts only                   | publish report and metadata with an explicit `no-logs-available` note                                             |
+| Archive target path is not a writable checkout/worktree                                  | source artifacts only                             | fail before mutating the archive tree                                                                             |
+| Archive write fails midway through required files                                        | source artifacts only                             | surface a typed publication error, clean up temp files when possible, and leave local artifacts untouched         |
+| Publication command is rerun for an existing publication id                              | full source inputs and existing archive directory | handle idempotently by atomic rewrite or explicit conflict error; never create duplicate nested publication trees |
+
+## Storage And Persistence Contract
+
+This issue adds a durable archive-output contract in the separate archive repository, not a new canonical local state contract.
+
+Contract rules:
+
+1. the archive tree is append-only at the publication-directory level; a later publish for the same issue gets a new publication directory unless it is an intentional idempotent rewrite of the same publication id
+2. `metadata.json` is the archive-side publication manifest and the only new canonical document introduced by this issue
+3. copied logs live under `logs/`, but pointer-reference JSON files are allowed when the raw file is not available
+4. archive publication must not require editing `.var/factory/...` or `.var/reports/...`
+5. archive publication must be testable against a local mock repo/worktree without real network access
+
+## Observability Requirements
+
+1. structured logs or CLI output should name the issue number, publication id, archive root, and per-log outcome
+2. publication errors should clearly distinguish missing local prerequisites from archive write failures
+3. partial log publication should be visible in the command result and in `metadata.json`
+4. no new status-surface coupling is required in this slice
+
+## Implementation Steps
+
+1. Add a focused archive publication module in a new integration seam, for example `src/integration/factory-runs/`, with typed publication contracts and path helpers.
+2. Reuse the existing read-side observability services to load the canonical local issue artifacts and generated report outputs for one issue.
+3. Add source-revision helpers that collect the relevant source SHA from the current source checkout without changing the local artifact schema; keep missing commit-range facts explicit instead of guessed.
+4. Implement `metadata.json` derivation from report facts, raw artifact facts, session ids, PR info, branch info, source revision facts, and per-log publication results.
+5. Implement required file writes and log copy/reference behavior with atomic writes for `report.json`, `report.md`, and `metadata.json`.
+6. Add a detached CLI entry point for publishing one issue into a provided archive checkout path.
+7. Update docs with the publish workflow, required prerequisites, and the rule that local artifacts remain canonical even when archive publication fails.
+8. Add tests for path derivation, metadata composition, log copy/reference fallback, and end-to-end publish behavior against a temp archive repo.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. publication paths derive `<archive-root>/symphony-ts/issues/<issue-number>/<publication-id>/...` from a source issue report plus archive root
+2. `metadata.json` includes the required repo, issue, branch, PR, timing, session, and source revision fields with explicit nulls for unavailable facts
+3. a readable local log pointer is copied into `logs/<session-id>/...`
+4. an unreadable or non-file pointer yields a `.pointer.json` file and marks the publication partial
+5. publication id derivation is filesystem-safe and stable for the same generated report timestamp/source revision inputs
+
+### Integration
+
+1. publishing a completed issue with generated reports writes `report.json`, `report.md`, `metadata.json`, and copied or referenced logs into a temporary archive repo
+2. publishing an issue with no logs still succeeds and records the absence in metadata
+3. publishing without generated report files fails clearly and leaves the archive repo unchanged
+4. rerunning publication for the same issue/publication id behaves idempotently or fails with an explicit conflict, according to the chosen implementation
+
+### End-to-end / Repo Gate
+
+1. a realistic local issue artifact tree and generated report from the current runtime can be published into a mock `factory-runs` repository without invoking the orchestrator
+2. `pnpm lint`
+3. `pnpm typecheck`
+4. `pnpm test`
+5. `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. Given canonical local artifacts and generated reports for issue `45`, when the operator runs the detached publish command with a local `factory-runs` checkout, then the archive repo contains `symphony-ts/issues/45/<publication-id>/report.json`, `report.md`, `metadata.json`, and any copied or referenced logs.
+2. Given a session log pointer that references a readable local file, when publication runs, then the raw log is copied under `logs/<session-id>/...` and `metadata.json` records the archive path.
+3. Given a session log pointer that cannot be copied, when publication runs, then publication still writes the required files, emits a partial result, and records a pointer manifest plus failure details in `metadata.json`.
+4. Given missing generated report files, when publication runs, then the command fails clearly and does not corrupt local artifacts or create a misleading archive snapshot.
+
+## Exit Criteria
+
+1. `factory-runs` archive structure is defined and implemented for one issue publication
+2. archive outputs have stable structure and versioned metadata
+3. local canonical artifacts and generated reports remain unchanged when publication succeeds or fails
+4. publication is operationally detached from `symphony-ts` CI and normal run execution
+5. tests prove archive publication works against a local mock repo and handles missing logs/report prerequisites correctly
+
+## Deferred Work
+
+1. batch publication commands and backfill tools
+2. archive-repo commit, push, or PR automation
+3. back-writing archive locations into local artifact pointers
+4. richer source commit-range capture if future artifacts or tracker facts expose it directly
+5. archive browsing or status surfaces over many published issues
+
+## Decision Notes
+
+1. The first publication slice should target a checked-out archive worktree, not a network push path, so the integration remains CI-testable and operationally separate from the source repo runtime.
+2. Local artifacts and generated reports stay canonical; archive publication is a downstream copy/export step, not a second writer into the local contracts.
+3. Pointer-reference files are preferable to silently dropping missing logs because archive consumers need to distinguish `copied`, `referenced`, and `unavailable`.
+4. The issue body names `https://github.com/sociotechinca-org/factory-runs`, which appears to contain an org-name typo relative to `sociotechnica-org/symphony-ts`; implementation should accept an explicit archive checkout path/remote instead of hard-coding that string.
+
+## Revision Log
+
+- 2026-03-10: Initial plan drafted and marked `plan-ready` for detached `factory-runs` publication.

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -1,20 +1,28 @@
 import path from "node:path";
 import { loadWorkflowWorkspaceRoot } from "../config/workflow.js";
+import { publishIssueToFactoryRuns } from "../integration/factory-runs.js";
 import { writeIssueReport } from "../observability/issue-report.js";
 
-export interface ReportCliArgs {
-  readonly command: "issue";
-  readonly issueNumber: number;
-  readonly workflowPath: string;
-}
+export type ReportCliArgs =
+  | {
+      readonly command: "issue";
+      readonly issueNumber: number;
+      readonly workflowPath: string;
+    }
+  | {
+      readonly command: "publish";
+      readonly issueNumber: number;
+      readonly workflowPath: string;
+      readonly archiveRoot: string;
+    };
 
 export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   const args = argv.slice(2);
   const command = args[0];
 
-  if (command !== "issue") {
+  if (command !== "issue" && command !== "publish") {
     throw new Error(
-      "Usage: symphony-report issue --issue <number> [--workflow <path>]",
+      "Usage: symphony-report <issue|publish> --issue <number> [--workflow <path>] [--archive-root <path>]",
     );
   }
 
@@ -28,19 +36,46 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   const issueNumber = Number.parseInt(issueValue, 10);
 
   const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
+  if (command === "issue") {
+    return {
+      command: "issue",
+      issueNumber,
+      workflowPath: path.resolve(process.cwd(), workflowPath),
+    };
+  }
+
+  const archiveRoot = readOptionValue(args, "--archive-root");
+  if (archiveRoot === null) {
+    throw new Error("Missing required --archive-root <path> option");
+  }
+
   return {
-    command: "issue",
+    command: "publish",
     issueNumber,
     workflowPath: path.resolve(process.cwd(), workflowPath),
+    archiveRoot: path.resolve(process.cwd(), archiveRoot),
   };
 }
 
 export async function runReportCli(argv: readonly string[]): Promise<void> {
   const args = parseReportArgs(argv);
   const workspaceRoot = await loadWorkflowWorkspaceRoot(args.workflowPath);
-  const generated = await writeIssueReport(workspaceRoot, args.issueNumber);
+  if (args.command === "issue") {
+    const generated = await writeIssueReport(workspaceRoot, args.issueNumber);
+    process.stdout.write(
+      `Generated issue report for #${args.issueNumber.toString()}\nreport.json: ${generated.outputPaths.reportJsonFile}\nreport.md: ${generated.outputPaths.reportMarkdownFile}\n`,
+    );
+    return;
+  }
+
+  const published = await publishIssueToFactoryRuns({
+    workspaceRoot,
+    sourceRoot: path.dirname(args.workflowPath),
+    archiveRoot: args.archiveRoot,
+    issueNumber: args.issueNumber,
+  });
   process.stdout.write(
-    `Generated issue report for #${args.issueNumber.toString()}\nreport.json: ${generated.outputPaths.reportJsonFile}\nreport.md: ${generated.outputPaths.reportMarkdownFile}\n`,
+    `Published issue #${args.issueNumber.toString()} to factory-runs\npublication id: ${published.publicationId}\nstatus: ${published.status}\narchive root: ${args.archiveRoot}\npublication dir: ${published.paths.publicationRoot}\nmetadata.json: ${published.paths.metadataFile}\nlogs copied: ${published.metadata.logs.copiedCount.toString()}\nlogs referenced: ${published.metadata.logs.referencedCount.toString()}\nlogs unavailable: ${published.metadata.logs.unavailableCount.toString()}\n`,
   );
 }
 

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -26,6 +26,12 @@ export class TrackerError extends SymphonyError {
   }
 }
 
+export class IntegrationError extends SymphonyError {
+  constructor(message: string, options?: ErrorOptions) {
+    super("integration_error", message, options);
+  }
+}
+
 export class WorkspaceError extends SymphonyError {
   constructor(message: string, options?: ErrorOptions) {
     super("workspace_error", message, options);

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -186,9 +186,10 @@ export async function publishIssueToFactoryRuns(
   await fs
     .rm(stagingRoot, { recursive: true, force: true })
     .catch(() => undefined);
-  await fs.mkdir(stagingRoot, { recursive: true });
 
   try {
+    await fs.mkdir(stagingRoot, { recursive: true });
+
     await fs.writeFile(
       path.join(stagingRoot, "report.json"),
       reportInput.rawReportJson,
@@ -281,7 +282,7 @@ export function buildFactoryRunsPublicationMetadata(args: {
     version: FACTORY_RUNS_PUBLICATION_SCHEMA_VERSION,
     publicationId: args.publicationId,
     publishedAt: args.publishedAt,
-    publicationStatus: logStatus === "partial" ? "partial" : "complete",
+    publicationStatus: logStatus === "complete" ? "complete" : "partial",
     notes,
     repo: args.report.summary.repo,
     repoName: args.repoName,

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -1,0 +1,658 @@
+import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { IntegrationError } from "../domain/errors.js";
+import type { IssueArtifactLogPointer } from "../observability/issue-artifacts.js";
+import {
+  loadIssueArtifacts,
+  readIssueReport,
+  type IssueReportDocument,
+  type LoadedIssueArtifacts,
+} from "../observability/issue-report.js";
+
+const execFileAsync = promisify(execFile);
+
+export const FACTORY_RUNS_PUBLICATION_SCHEMA_VERSION = 1 as const;
+
+export type FactoryRunsLogPublicationStatus =
+  | "copied"
+  | "referenced"
+  | "unavailable";
+
+export interface FactoryRunsSourceRevision {
+  readonly checkoutPath: string;
+  readonly currentBranch: string | null;
+  readonly relevantSha: string | null;
+  readonly baseSha: string | null;
+  readonly commitRange: string | null;
+}
+
+export interface FactoryRunsPublicationPaths {
+  readonly repoRoot: string;
+  readonly issueRoot: string;
+  readonly publicationRoot: string;
+  readonly reportJsonFile: string;
+  readonly reportMarkdownFile: string;
+  readonly metadataFile: string;
+  readonly logsDir: string;
+}
+
+export interface FactoryRunsLogPublicationResult {
+  readonly sessionId: string;
+  readonly logName: string;
+  readonly status: FactoryRunsLogPublicationStatus;
+  readonly sourceLocation: string | null;
+  readonly sourceArchiveLocation: string | null;
+  readonly archivePath: string | null;
+  readonly pointerFile: string | null;
+  readonly note: string | null;
+}
+
+export interface FactoryRunsPublicationMetadata {
+  readonly version: typeof FACTORY_RUNS_PUBLICATION_SCHEMA_VERSION;
+  readonly publicationId: string;
+  readonly publishedAt: string;
+  readonly publicationStatus: "complete" | "partial";
+  readonly notes: readonly string[];
+  readonly repo: string | null;
+  readonly repoName: string;
+  readonly issueNumber: number;
+  readonly issueIdentifier: string | null;
+  readonly title: string | null;
+  readonly issueUrl: string | null;
+  readonly branchName: string | null;
+  readonly pullRequests: readonly {
+    readonly number: number;
+    readonly url: string;
+  }[];
+  readonly reportGeneratedAt: string;
+  readonly startedAt: string | null;
+  readonly endedAt: string | null;
+  readonly latestSessionId: string | null;
+  readonly sessionIds: readonly string[];
+  readonly attempts: readonly {
+    readonly attemptNumber: number;
+    readonly sessionId: string | null;
+    readonly runnerPid: number | null;
+  }[];
+  readonly sourceRevision: FactoryRunsSourceRevision;
+  readonly sourceArtifacts: {
+    readonly rawIssueRoot: string;
+    readonly issueFile: string | null;
+    readonly eventsFile: string | null;
+    readonly attemptFiles: readonly string[];
+    readonly sessionFiles: readonly string[];
+    readonly logPointersFile: string | null;
+    readonly reportJsonFile: string;
+    readonly reportMarkdownFile: string;
+  };
+  readonly logs: {
+    readonly status: "complete" | "partial" | "unavailable";
+    readonly copiedCount: number;
+    readonly referencedCount: number;
+    readonly unavailableCount: number;
+    readonly entries: readonly FactoryRunsLogPublicationResult[];
+  };
+}
+
+export interface PublishIssueToFactoryRunsOptions {
+  readonly workspaceRoot: string;
+  readonly sourceRoot: string;
+  readonly archiveRoot: string;
+  readonly issueNumber: number;
+  readonly publishedAt?: string | undefined;
+}
+
+export interface PublishedIssueToFactoryRuns {
+  readonly publicationId: string;
+  readonly status: "complete" | "partial";
+  readonly paths: FactoryRunsPublicationPaths;
+  readonly metadata: FactoryRunsPublicationMetadata;
+}
+
+interface SessionLogSource {
+  readonly sessionId: string;
+  readonly logName: string;
+  readonly pointer: IssueArtifactLogPointer;
+}
+
+export function deriveFactoryRunsPublicationId(
+  reportGeneratedAt: string,
+  relevantSha: string | null,
+): string {
+  const normalizedTimestamp = normalizePublicationTimestamp(reportGeneratedAt);
+  const shortSha =
+    relevantSha !== null && /^[0-9a-f]{7,40}$/u.test(relevantSha)
+      ? relevantSha.slice(0, 8)
+      : null;
+  return shortSha === null
+    ? normalizedTimestamp
+    : `${normalizedTimestamp}-${shortSha}`;
+}
+
+export function deriveFactoryRunsPublicationPaths(args: {
+  readonly archiveRoot: string;
+  readonly repoName: string;
+  readonly issueNumber: number;
+  readonly publicationId: string;
+}): FactoryRunsPublicationPaths {
+  const repoRoot = path.join(args.archiveRoot, args.repoName);
+  const issueRoot = path.join(repoRoot, "issues", args.issueNumber.toString());
+  const publicationRoot = path.join(issueRoot, args.publicationId);
+  return {
+    repoRoot,
+    issueRoot,
+    publicationRoot,
+    reportJsonFile: path.join(publicationRoot, "report.json"),
+    reportMarkdownFile: path.join(publicationRoot, "report.md"),
+    metadataFile: path.join(publicationRoot, "metadata.json"),
+    logsDir: path.join(publicationRoot, "logs"),
+  };
+}
+
+export async function publishIssueToFactoryRuns(
+  options: PublishIssueToFactoryRunsOptions,
+): Promise<PublishedIssueToFactoryRuns> {
+  const sourceRoot = path.resolve(options.sourceRoot);
+  const archiveRoot = path.resolve(options.archiveRoot);
+  const publishedAt = options.publishedAt ?? new Date().toISOString();
+
+  await validateArchiveRoot(archiveRoot);
+
+  const [reportInput, loadedArtifacts, sourceRevision] = await Promise.all([
+    readIssueReport(options.workspaceRoot, options.issueNumber),
+    loadIssueArtifacts(options.workspaceRoot, options.issueNumber),
+    collectSourceRevision(sourceRoot),
+  ]);
+
+  const repoName = deriveRepoName(reportInput.report, sourceRoot);
+  const publicationId = deriveFactoryRunsPublicationId(
+    reportInput.report.generatedAt,
+    sourceRevision.relevantSha,
+  );
+  const paths = deriveFactoryRunsPublicationPaths({
+    archiveRoot,
+    repoName,
+    issueNumber: options.issueNumber,
+    publicationId,
+  });
+  const stagingRoot = path.join(
+    paths.issueRoot,
+    `.factory-runs.${publicationId}.${process.pid.toString()}.tmp`,
+  );
+
+  await fs
+    .rm(stagingRoot, { recursive: true, force: true })
+    .catch(() => undefined);
+  await fs.mkdir(stagingRoot, { recursive: true });
+
+  try {
+    await fs.writeFile(
+      path.join(stagingRoot, "report.json"),
+      reportInput.rawReportJson,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(stagingRoot, "report.md"),
+      reportInput.rawReportMarkdown,
+      "utf8",
+    );
+
+    const logEntries = await publishSessionLogs({
+      stagingRoot,
+      archiveRoot,
+      publicationPaths: paths,
+      loadedArtifacts,
+    });
+    const metadata = buildFactoryRunsPublicationMetadata({
+      report: reportInput.report,
+      reportJsonFile: reportInput.outputPaths.reportJsonFile,
+      reportMarkdownFile: reportInput.outputPaths.reportMarkdownFile,
+      loadedArtifacts,
+      publishedAt,
+      publicationId,
+      repoName,
+      sourceRevision,
+      logEntries,
+    });
+
+    await fs.writeFile(
+      path.join(stagingRoot, "metadata.json"),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      "utf8",
+    );
+
+    await replacePublicationDirectory(stagingRoot, paths.publicationRoot);
+
+    return {
+      publicationId,
+      status: metadata.publicationStatus,
+      paths,
+      metadata,
+    };
+  } catch (error) {
+    await fs
+      .rm(stagingRoot, { recursive: true, force: true })
+      .catch(() => undefined);
+    throw error;
+  }
+}
+
+export function buildFactoryRunsPublicationMetadata(args: {
+  readonly report: IssueReportDocument;
+  readonly reportJsonFile: string;
+  readonly reportMarkdownFile: string;
+  readonly loadedArtifacts: LoadedIssueArtifacts;
+  readonly publishedAt: string;
+  readonly publicationId: string;
+  readonly repoName: string;
+  readonly sourceRevision: FactoryRunsSourceRevision;
+  readonly logEntries: readonly FactoryRunsLogPublicationResult[];
+}): FactoryRunsPublicationMetadata {
+  const copiedCount = args.logEntries.filter(
+    (entry) => entry.status === "copied",
+  ).length;
+  const referencedCount = args.logEntries.filter(
+    (entry) => entry.status === "referenced",
+  ).length;
+  const unavailableCount = args.logEntries.filter(
+    (entry) => entry.status === "unavailable",
+  ).length;
+  const logStatus =
+    args.logEntries.length === 0
+      ? "unavailable"
+      : referencedCount > 0 || unavailableCount > 0
+        ? "partial"
+        : "complete";
+  const notes: string[] = [];
+
+  if (args.logEntries.length === 0) {
+    notes.push("No session logs were available for publication.");
+  } else if (logStatus === "partial") {
+    notes.push(
+      "Publication completed with partial log coverage; see logs.entries for per-log outcomes.",
+    );
+  }
+
+  return {
+    version: FACTORY_RUNS_PUBLICATION_SCHEMA_VERSION,
+    publicationId: args.publicationId,
+    publishedAt: args.publishedAt,
+    publicationStatus: logStatus === "partial" ? "partial" : "complete",
+    notes,
+    repo: args.report.summary.repo,
+    repoName: args.repoName,
+    issueNumber: args.report.summary.issueNumber,
+    issueIdentifier: args.report.summary.issueIdentifier,
+    title: args.report.summary.title,
+    issueUrl: args.report.summary.issueUrl,
+    branchName: args.report.summary.branch,
+    pullRequests: args.report.githubActivity.pullRequests.map(
+      (pullRequest) => ({
+        number: pullRequest.number,
+        url: pullRequest.url,
+      }),
+    ),
+    reportGeneratedAt: args.report.generatedAt,
+    startedAt: args.report.summary.startedAt,
+    endedAt: args.report.summary.endedAt,
+    latestSessionId: args.loadedArtifacts.issue?.latestSessionId ?? null,
+    sessionIds: collectSessionIds(args.loadedArtifacts),
+    attempts: args.loadedArtifacts.attempts.map((attempt) => ({
+      attemptNumber: attempt.attemptNumber,
+      sessionId: attempt.sessionId,
+      runnerPid: attempt.runnerPid,
+    })),
+    sourceRevision: args.sourceRevision,
+    sourceArtifacts: {
+      rawIssueRoot: args.report.artifacts.rawIssueRoot,
+      issueFile: args.report.artifacts.issueFile,
+      eventsFile: args.report.artifacts.eventsFile,
+      attemptFiles: args.report.artifacts.attemptFiles,
+      sessionFiles: args.report.artifacts.sessionFiles,
+      logPointersFile: args.report.artifacts.logPointersFile,
+      reportJsonFile: args.reportJsonFile,
+      reportMarkdownFile: args.reportMarkdownFile,
+    },
+    logs: {
+      status: logStatus,
+      copiedCount,
+      referencedCount,
+      unavailableCount,
+      entries: args.logEntries,
+    },
+  };
+}
+
+function normalizePublicationTimestamp(reportGeneratedAt: string): string {
+  const parsed = new Date(reportGeneratedAt);
+  if (Number.isNaN(parsed.valueOf())) {
+    throw new IntegrationError(
+      `Generated report timestamp is not a valid ISO date: ${reportGeneratedAt}`,
+    );
+  }
+
+  return parsed.toISOString().replace(/[-:]/gu, "").replace(/\./gu, "");
+}
+
+function deriveRepoName(
+  report: IssueReportDocument,
+  sourceRoot: string,
+): string {
+  const repo = report.summary.repo?.trim();
+  if (repo !== undefined && repo !== "") {
+    const segments = repo.split("/").filter((segment) => segment.length > 0);
+    if (segments.length > 0) {
+      return segments[segments.length - 1] ?? path.basename(sourceRoot);
+    }
+  }
+  return path.basename(sourceRoot);
+}
+
+async function validateArchiveRoot(archiveRoot: string): Promise<void> {
+  const stat = await fs.stat(archiveRoot).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new IntegrationError(
+        `Archive root does not exist at ${archiveRoot}; provide a checked-out factory-runs worktree.`,
+      );
+    }
+    throw error;
+  });
+
+  if (!stat.isDirectory()) {
+    throw new IntegrationError(
+      `Archive root ${archiveRoot} is not a directory; provide a checked-out factory-runs worktree.`,
+    );
+  }
+
+  await fs.access(archiveRoot, fsConstants.W_OK).catch((error) => {
+    throw new IntegrationError(`Archive root ${archiveRoot} is not writable.`, {
+      cause: error as Error,
+    });
+  });
+
+  const result = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+    cwd: archiveRoot,
+  }).catch((error) => {
+    throw new IntegrationError(
+      `Archive root ${archiveRoot} must be the root of a checked-out git worktree.`,
+      { cause: error as Error },
+    );
+  });
+
+  const [resolvedArchiveRoot, resolvedTopLevel] = await Promise.all([
+    fs.realpath(archiveRoot),
+    fs.realpath(result.stdout.trim()),
+  ]);
+
+  if (resolvedTopLevel !== resolvedArchiveRoot) {
+    throw new IntegrationError(
+      `Archive root ${archiveRoot} must point at the git worktree root, not a nested subdirectory.`,
+    );
+  }
+}
+
+async function collectSourceRevision(
+  sourceRoot: string,
+): Promise<FactoryRunsSourceRevision> {
+  const currentBranch = await readGitValue(sourceRoot, [
+    "branch",
+    "--show-current",
+  ]);
+  const relevantSha = await readGitValue(sourceRoot, ["rev-parse", "HEAD"]);
+  const originMainSha = await readGitValue(sourceRoot, [
+    "rev-parse",
+    "--verify",
+    "origin/main",
+  ]);
+  const baseSha =
+    relevantSha !== null && originMainSha !== null
+      ? await readGitValue(sourceRoot, ["merge-base", "HEAD", "origin/main"])
+      : null;
+
+  return {
+    checkoutPath: sourceRoot,
+    currentBranch,
+    relevantSha,
+    baseSha,
+    commitRange:
+      baseSha !== null && relevantSha !== null
+        ? `${baseSha}..${relevantSha}`
+        : null,
+  };
+}
+
+async function readGitValue(
+  cwd: string,
+  args: readonly string[],
+): Promise<string | null> {
+  const result = await execFileAsync("git", [...args], { cwd }).catch(
+    () => null,
+  );
+  if (result === null) {
+    return null;
+  }
+  const value = result.stdout.trim();
+  return value === "" ? null : value;
+}
+
+async function publishSessionLogs(args: {
+  readonly stagingRoot: string;
+  readonly archiveRoot: string;
+  readonly publicationPaths: FactoryRunsPublicationPaths;
+  readonly loadedArtifacts: LoadedIssueArtifacts;
+}): Promise<readonly FactoryRunsLogPublicationResult[]> {
+  const logSources = collectSessionLogSources(args.loadedArtifacts);
+  const results: FactoryRunsLogPublicationResult[] = [];
+
+  for (const source of logSources) {
+    const encodedSessionId = encodeURIComponent(source.sessionId);
+    const encodedLogName = encodeURIComponent(source.logName);
+    const stagedSessionDir = path.join(
+      args.stagingRoot,
+      "logs",
+      encodedSessionId,
+    );
+    const stagedCopiedPath = path.join(stagedSessionDir, encodedLogName);
+    const stagedPointerFile = path.join(
+      stagedSessionDir,
+      `${encodedLogName}.pointer.json`,
+    );
+    const finalCopiedPath = path.join(
+      args.publicationPaths.logsDir,
+      encodedSessionId,
+      encodedLogName,
+    );
+    const finalPointerFile = path.join(
+      args.publicationPaths.logsDir,
+      encodedSessionId,
+      `${encodedLogName}.pointer.json`,
+    );
+
+    if (await isReadableFile(source.pointer.location)) {
+      await fs.mkdir(stagedSessionDir, { recursive: true });
+      await fs.copyFile(source.pointer.location as string, stagedCopiedPath);
+      results.push({
+        sessionId: source.sessionId,
+        logName: source.logName,
+        status: "copied",
+        sourceLocation: source.pointer.location,
+        sourceArchiveLocation: source.pointer.archiveLocation,
+        archivePath: toArchiveRelativePath(args.archiveRoot, finalCopiedPath),
+        pointerFile: null,
+        note: null,
+      });
+      continue;
+    }
+
+    if (
+      source.pointer.location !== null ||
+      source.pointer.archiveLocation !== null
+    ) {
+      const note =
+        source.pointer.location === null
+          ? "Local log file was not recorded; preserved the original pointer metadata."
+          : "Local log file was not readable during publication; preserved the original pointer metadata.";
+      await fs.mkdir(stagedSessionDir, { recursive: true });
+      await fs.writeFile(
+        stagedPointerFile,
+        `${JSON.stringify(
+          {
+            version: FACTORY_RUNS_PUBLICATION_SCHEMA_VERSION,
+            sessionId: source.sessionId,
+            logName: source.logName,
+            pointer: source.pointer,
+            note,
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      results.push({
+        sessionId: source.sessionId,
+        logName: source.logName,
+        status: "referenced",
+        sourceLocation: source.pointer.location,
+        sourceArchiveLocation: source.pointer.archiveLocation,
+        archivePath: null,
+        pointerFile: toArchiveRelativePath(args.archiveRoot, finalPointerFile),
+        note,
+      });
+      continue;
+    }
+
+    results.push({
+      sessionId: source.sessionId,
+      logName: source.logName,
+      status: "unavailable",
+      sourceLocation: null,
+      sourceArchiveLocation: null,
+      archivePath: null,
+      pointerFile: null,
+      note: "No local or archived log reference was available for this session log.",
+    });
+  }
+
+  return results;
+}
+
+function collectSessionIds(
+  loadedArtifacts: LoadedIssueArtifacts,
+): readonly string[] {
+  const sessionIds = new Set<string>();
+  if (loadedArtifacts.issue?.latestSessionId !== undefined) {
+    const latestSessionId = loadedArtifacts.issue.latestSessionId;
+    if (latestSessionId !== null) {
+      sessionIds.add(latestSessionId);
+    }
+  }
+  for (const attempt of loadedArtifacts.attempts) {
+    if (attempt.sessionId !== null) {
+      sessionIds.add(attempt.sessionId);
+    }
+  }
+  for (const session of loadedArtifacts.sessions) {
+    sessionIds.add(session.sessionId);
+  }
+  for (const sessionEntry of Object.values(
+    loadedArtifacts.logPointers?.sessions ?? {},
+  )) {
+    if (sessionEntry !== undefined) {
+      sessionIds.add(sessionEntry.sessionId);
+    }
+  }
+  return [...sessionIds];
+}
+
+function collectSessionLogSources(
+  loadedArtifacts: LoadedIssueArtifacts,
+): readonly SessionLogSource[] {
+  const seen = new Set<string>();
+  const entries: SessionLogSource[] = [];
+  const pushPointer = (
+    sessionId: string,
+    pointers: readonly IssueArtifactLogPointer[],
+  ): void => {
+    for (const pointer of pointers) {
+      const key = `${sessionId}\u0000${pointer.name}\u0000${pointer.location ?? ""}\u0000${pointer.archiveLocation ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      entries.push({
+        sessionId,
+        logName: pointer.name,
+        pointer,
+      });
+    }
+  };
+
+  for (const session of loadedArtifacts.sessions) {
+    pushPointer(session.sessionId, session.logPointers);
+  }
+
+  for (const sessionEntry of Object.values(
+    loadedArtifacts.logPointers?.sessions ?? {},
+  )) {
+    if (sessionEntry === undefined) {
+      continue;
+    }
+    pushPointer(sessionEntry.sessionId, sessionEntry.pointers);
+  }
+
+  return entries;
+}
+
+async function isReadableFile(filePath: string | null): Promise<boolean> {
+  if (filePath === null) {
+    return false;
+  }
+  const stat = await fs.stat(filePath).catch(() => null);
+  return stat?.isFile() ?? false;
+}
+
+async function replacePublicationDirectory(
+  stagingRoot: string,
+  publicationRoot: string,
+): Promise<void> {
+  await fs.mkdir(path.dirname(publicationRoot), { recursive: true });
+  const backupRoot = `${publicationRoot}.backup.${process.pid.toString()}.${Date.now().toString()}`;
+  let replacedExisting = false;
+
+  try {
+    await fs.rename(publicationRoot, backupRoot);
+    replacedExisting = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  try {
+    await fs.rename(stagingRoot, publicationRoot);
+  } catch (error) {
+    if (replacedExisting) {
+      await fs.rename(backupRoot, publicationRoot).catch(() => undefined);
+    }
+    throw new IntegrationError(
+      `Failed to finalize publication at ${publicationRoot}`,
+      { cause: error as Error },
+    );
+  }
+
+  if (replacedExisting) {
+    await fs
+      .rm(backupRoot, { recursive: true, force: true })
+      .catch(() => undefined);
+  }
+}
+
+function toArchiveRelativePath(
+  archiveRoot: string,
+  targetPath: string,
+): string {
+  return path.relative(archiveRoot, targetPath).split(path.sep).join("/");
+}

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -522,6 +522,7 @@ async function publishSessionLogs(args: {
         });
         continue;
       } catch {
+        await fs.rm(stagedCopiedPath, { force: true }).catch(() => undefined);
         pointerNoteOverride =
           "Local log file could not be copied during publication; preserved the original pointer metadata.";
       }

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -577,7 +577,7 @@ function collectSessionLogSources(
     pointers: readonly IssueArtifactLogPointer[],
   ): void => {
     for (const pointer of pointers) {
-      const key = `${sessionId}\u0000${pointer.name}\u0000${pointer.location ?? ""}\u0000${pointer.archiveLocation ?? ""}`;
+      const key = `${sessionId}\u0000${pointer.name}`;
       if (seen.has(key)) {
         continue;
       }
@@ -611,7 +611,13 @@ async function isReadableFile(filePath: string | null): Promise<boolean> {
     return false;
   }
   const stat = await fs.stat(filePath).catch(() => null);
-  return stat?.isFile() ?? false;
+  if (!stat?.isFile()) {
+    return false;
+  }
+  return await fs
+    .access(filePath, fsConstants.R_OK)
+    .then(() => true)
+    .catch(() => false);
 }
 
 async function replacePublicationDirectory(

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -343,7 +343,11 @@ function deriveRepoName(
 ): string {
   const repo = report.summary.repo?.trim();
   if (repo !== undefined && repo !== "") {
-    const segments = repo.split("/").filter((segment) => segment.length > 0);
+    const segments = repo
+      .split(/[/\\]/u)
+      .filter(
+        (segment) => segment.length > 0 && segment !== "." && segment !== "..",
+      );
     if (segments.length > 0) {
       return segments[segments.length - 1] ?? path.basename(sourceRoot);
     }
@@ -402,14 +406,10 @@ async function collectSourceRevision(
     "--show-current",
   ]);
   const relevantSha = await readGitValue(sourceRoot, ["rev-parse", "HEAD"]);
-  const originMainSha = await readGitValue(sourceRoot, [
-    "rev-parse",
-    "--verify",
-    "origin/main",
-  ]);
+  const remoteBaseRef = await resolveRemoteBaseRef(sourceRoot);
   const baseSha =
-    relevantSha !== null && originMainSha !== null
-      ? await readGitValue(sourceRoot, ["merge-base", "HEAD", "origin/main"])
+    relevantSha !== null && remoteBaseRef !== null
+      ? await readGitValue(sourceRoot, ["merge-base", "HEAD", remoteBaseRef])
       : null;
 
   return {
@@ -422,6 +422,39 @@ async function collectSourceRevision(
         ? `${baseSha}..${relevantSha}`
         : null,
   };
+}
+
+async function resolveRemoteBaseRef(
+  sourceRoot: string,
+): Promise<string | null> {
+  const remoteHead = await readGitValue(sourceRoot, [
+    "symbolic-ref",
+    "--quiet",
+    "refs/remotes/origin/HEAD",
+  ]);
+  const candidates = [
+    remoteHead?.replace(/^refs\/remotes\//u, "") ?? null,
+    "origin/main",
+    "origin/master",
+  ];
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (candidate === null || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    const resolved = await readGitValue(sourceRoot, [
+      "rev-parse",
+      "--verify",
+      candidate,
+    ]);
+    if (resolved !== null) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 async function readGitValue(

--- a/src/integration/factory-runs.ts
+++ b/src/integration/factory-runs.ts
@@ -236,6 +236,7 @@ export async function publishIssueToFactoryRuns(
     await fs
       .rm(stagingRoot, { recursive: true, force: true })
       .catch(() => undefined);
+    await cleanupEmptyPublicationDirectories(paths);
     throw error;
   }
 }
@@ -503,21 +504,27 @@ async function publishSessionLogs(args: {
       encodedSessionId,
       `${encodedLogName}.pointer.json`,
     );
+    let pointerNoteOverride: string | null = null;
 
     if (await isReadableFile(source.pointer.location)) {
-      await fs.mkdir(stagedSessionDir, { recursive: true });
-      await fs.copyFile(source.pointer.location as string, stagedCopiedPath);
-      results.push({
-        sessionId: source.sessionId,
-        logName: source.logName,
-        status: "copied",
-        sourceLocation: source.pointer.location,
-        sourceArchiveLocation: source.pointer.archiveLocation,
-        archivePath: toArchiveRelativePath(args.archiveRoot, finalCopiedPath),
-        pointerFile: null,
-        note: null,
-      });
-      continue;
+      try {
+        await fs.mkdir(stagedSessionDir, { recursive: true });
+        await fs.copyFile(source.pointer.location as string, stagedCopiedPath);
+        results.push({
+          sessionId: source.sessionId,
+          logName: source.logName,
+          status: "copied",
+          sourceLocation: source.pointer.location,
+          sourceArchiveLocation: source.pointer.archiveLocation,
+          archivePath: toArchiveRelativePath(args.archiveRoot, finalCopiedPath),
+          pointerFile: null,
+          note: null,
+        });
+        continue;
+      } catch {
+        pointerNoteOverride =
+          "Local log file could not be copied during publication; preserved the original pointer metadata.";
+      }
     }
 
     if (
@@ -525,9 +532,10 @@ async function publishSessionLogs(args: {
       source.pointer.archiveLocation !== null
     ) {
       const note =
-        source.pointer.location === null
+        pointerNoteOverride ??
+        (source.pointer.location === null
           ? "Local log file was not recorded; preserved the original pointer metadata."
-          : "Local log file was not readable during publication; preserved the original pointer metadata.";
+          : "Local log file was not readable during publication; preserved the original pointer metadata.");
       await fs.mkdir(stagedSessionDir, { recursive: true });
       await fs.writeFile(
         stagedPointerFile,
@@ -686,6 +694,20 @@ async function replacePublicationDirectory(
     await fs
       .rm(backupRoot, { recursive: true, force: true })
       .catch(() => undefined);
+  }
+}
+
+async function cleanupEmptyPublicationDirectories(
+  paths: FactoryRunsPublicationPaths,
+): Promise<void> {
+  const candidates = [
+    paths.issueRoot,
+    path.dirname(paths.issueRoot),
+    paths.repoRoot,
+  ];
+
+  for (const directory of candidates) {
+    await fs.rmdir(directory).catch(() => undefined);
   }
 }
 

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -34,6 +34,14 @@ export interface IssueReportPaths {
   readonly reportMarkdownFile: string;
 }
 
+export interface StoredIssueReport {
+  readonly report: IssueReportDocument;
+  readonly markdown: string;
+  readonly rawReportJson: string;
+  readonly rawReportMarkdown: string;
+  readonly outputPaths: IssueReportPaths;
+}
+
 export interface IssueReportSummary {
   readonly status: IssueReportAvailability;
   readonly issueNumber: number;
@@ -173,7 +181,7 @@ export interface IssueReportDocument {
   readonly operatorInterventions: IssueReportOperatorInterventions;
 }
 
-interface LoadedIssueArtifacts {
+export interface LoadedIssueArtifacts {
   readonly issueNumber: number;
   readonly paths: ReturnType<typeof deriveIssueArtifactPaths>;
   readonly issue: IssueArtifactSummary | null;
@@ -190,7 +198,7 @@ export interface GeneratedIssueReport {
   readonly outputPaths: IssueReportPaths;
 }
 
-function deriveIssueReportsRoot(workspaceRoot: string): string {
+export function deriveIssueReportsRoot(workspaceRoot: string): string {
   return path.join(
     path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
     "reports",
@@ -198,7 +206,7 @@ function deriveIssueReportsRoot(workspaceRoot: string): string {
   );
 }
 
-function deriveIssueReportPaths(
+export function deriveIssueReportPaths(
   workspaceRoot: string,
   issueNumber: number,
 ): IssueReportPaths {
@@ -255,7 +263,48 @@ export async function writeIssueReport(
   return generated;
 }
 
-async function loadIssueArtifacts(
+export async function readIssueReport(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<StoredIssueReport> {
+  const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
+  const [rawReportJson, rawReportMarkdown] = await Promise.all([
+    fs.readFile(outputPaths.reportJsonFile, "utf8"),
+    fs.readFile(outputPaths.reportMarkdownFile, "utf8"),
+  ]).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ObservabilityError(
+        `No generated issue report found for issue #${issueNumber.toString()} at ${outputPaths.issueRoot}; run 'symphony-report issue --issue ${issueNumber.toString()}' first.`,
+        {
+          cause: error as Error,
+        },
+      );
+    }
+    throw error;
+  });
+
+  let report: IssueReportDocument;
+  try {
+    report = JSON.parse(rawReportJson) as IssueReportDocument;
+  } catch (error) {
+    throw new ObservabilityError(
+      `Failed to parse generated issue report JSON at ${outputPaths.reportJsonFile}`,
+      {
+        cause: error as Error,
+      },
+    );
+  }
+
+  return {
+    report,
+    markdown: rawReportMarkdown,
+    rawReportJson,
+    rawReportMarkdown,
+    outputPaths,
+  };
+}
+
+export async function loadIssueArtifacts(
   workspaceRoot: string,
   issueNumber: number,
 ): Promise<LoadedIssueArtifacts> {

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -268,19 +268,17 @@ export async function readIssueReport(
 ): Promise<StoredIssueReport> {
   const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
   const [rawReportJson, rawReportMarkdown] = await Promise.all([
-    fs.readFile(outputPaths.reportJsonFile, "utf8"),
-    fs.readFile(outputPaths.reportMarkdownFile, "utf8"),
-  ]).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new ObservabilityError(
-        `No generated issue report found for issue #${issueNumber.toString()} at ${outputPaths.issueRoot}; run 'symphony-report issue --issue ${issueNumber.toString()}' first.`,
-        {
-          cause: error as Error,
-        },
-      );
-    }
-    throw error;
-  });
+    readRequiredIssueReportFile(
+      outputPaths.reportJsonFile,
+      issueNumber,
+      "JSON",
+    ),
+    readRequiredIssueReportFile(
+      outputPaths.reportMarkdownFile,
+      issueNumber,
+      "markdown",
+    ),
+  ]);
 
   let report: IssueReportDocument;
   try {
@@ -300,6 +298,26 @@ export async function readIssueReport(
     rawReportMarkdown,
     outputPaths,
   };
+}
+
+async function readRequiredIssueReportFile(
+  filePath: string,
+  issueNumber: number,
+  fileKind: "JSON" | "markdown",
+): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ObservabilityError(
+        `No generated issue report ${fileKind} found for issue #${issueNumber.toString()} at ${filePath}; run 'symphony-report issue --issue ${issueNumber.toString()}' first.`,
+        {
+          cause: error as Error,
+        },
+      );
+    }
+    throw error;
+  }
 }
 
 export async function loadIssueArtifacts(

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -36,7 +36,6 @@ export interface IssueReportPaths {
 
 export interface StoredIssueReport {
   readonly report: IssueReportDocument;
-  readonly markdown: string;
   readonly rawReportJson: string;
   readonly rawReportMarkdown: string;
   readonly outputPaths: IssueReportPaths;
@@ -198,7 +197,7 @@ export interface GeneratedIssueReport {
   readonly outputPaths: IssueReportPaths;
 }
 
-export function deriveIssueReportsRoot(workspaceRoot: string): string {
+function deriveIssueReportsRoot(workspaceRoot: string): string {
   return path.join(
     path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
     "reports",
@@ -297,7 +296,6 @@ export async function readIssueReport(
 
   return {
     report,
-    markdown: rawReportMarkdown,
     rawReportJson,
     rawReportMarkdown,
     outputPaths,

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runReportCli } from "../../src/cli/report.js";
 import {
@@ -24,6 +26,7 @@ import {
   writeReportWorkflow,
 } from "../support/issue-report-fixtures.js";
 
+const execFileAsync = promisify(execFile);
 const tempRoots: string[] = [];
 
 afterEach(async () => {
@@ -144,6 +147,10 @@ describe("factory-runs publication", () => {
   });
 
   it("falls back to pointer manifests when a log is unreadable", async () => {
+    if (process.getuid?.() === 0) {
+      return;
+    }
+
     const sourceRoot = await createTempDir("symphony-factory-runs-pointer-");
     const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
     tempRoots.push(sourceRoot, archiveRoot);
@@ -206,6 +213,66 @@ describe("factory-runs publication", () => {
     expect(published.metadata.notes).toContain(
       "Publication completed with partial log coverage; see logs.entries for per-log outcomes.",
     );
+  });
+
+  it("keeps publication paths inside the archive root when report repo names contain traversal segments", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-traversal-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const readableLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    await fs.mkdir(path.dirname(readableLogPath), { recursive: true });
+    await fs.writeFile(readableLogPath, "runner log contents\n", "utf8");
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const rawReport = JSON.parse(
+      await fs.readFile(generated.outputPaths.reportJsonFile, "utf8"),
+    ) as {
+      readonly summary: Record<string, unknown>;
+    };
+    await fs.writeFile(
+      generated.outputPaths.reportJsonFile,
+      `${JSON.stringify(
+        {
+          ...rawReport,
+          summary: {
+            ...rawReport.summary,
+            repo: "owner/..",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await commitAllFiles(sourceRoot, "seed sanitized repo publish inputs");
+
+    await initializeGitRepo(archiveRoot);
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    const relativePublicationRoot = path.relative(
+      archiveRoot,
+      published.paths.publicationRoot,
+    );
+    const publicationStat = await fs.stat(published.paths.publicationRoot);
+
+    expect(path.isAbsolute(relativePublicationRoot)).toBe(false);
+    expect(relativePublicationRoot).not.toMatch(/^\.{2}(?:\/|\\|$)/u);
+    expect(publicationStat.isDirectory()).toBe(true);
   });
 
   it("deduplicates session log pointers by session id and log name", async () => {
@@ -299,6 +366,53 @@ describe("factory-runs publication", () => {
     expect(published.metadata.logs.entries).toHaveLength(1);
     await expect(fs.readFile(archivedLogPath, "utf8")).resolves.toBe(
       "primary log contents\n",
+    );
+  });
+
+  it("captures commit-range metadata when the source remote default branch is origin/master", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-master-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    const remoteRoot = await createTempDir("symphony-factory-runs-remote-");
+    const remotePath = path.join(remoteRoot, "origin.git");
+    tempRoots.push(sourceRoot, archiveRoot, remoteRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot, { branch: "master" });
+    const baseSha = await commitAllFiles(sourceRoot, "seed master base");
+    await execFileAsync("git", ["init", "--bare", "-b", "master", remotePath], {
+      cwd: remoteRoot,
+    });
+    await execFileAsync("git", ["remote", "add", "origin", remotePath], {
+      cwd: sourceRoot,
+    });
+    await execFileAsync("git", ["push", "-u", "origin", "master"], {
+      cwd: sourceRoot,
+    });
+
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const sourceHeadSha = await commitAllFiles(
+      sourceRoot,
+      "seed master-derived publish inputs",
+    );
+
+    await initializeGitRepo(archiveRoot);
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    expect(published.metadata.sourceRevision.baseSha).toBe(baseSha);
+    expect(published.metadata.sourceRevision.commitRange).toBe(
+      `${baseSha}..${sourceHeadSha}`,
     );
   });
 

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -215,6 +215,75 @@ describe("factory-runs publication", () => {
     );
   });
 
+  it("falls back to a pointer manifest when copying a readable log fails", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-copyfail-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const readableLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    await fs.mkdir(path.dirname(readableLogPath), { recursive: true });
+    await fs.writeFile(readableLogPath, "runner log contents\n", "utf8");
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const sourceHeadSha = await commitAllFiles(
+      sourceRoot,
+      "seed copy-failure publish inputs",
+    );
+
+    await initializeGitRepo(archiveRoot);
+
+    const copyFile = fs.copyFile.bind(fs);
+    vi.spyOn(fs, "copyFile").mockImplementation(async (source, destination) => {
+      if (source === readableLogPath) {
+        throw Object.assign(new Error("simulated copy failure"), {
+          code: "EIO",
+        });
+      }
+      return await copyFile(source, destination);
+    });
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    const publicationRoot = path.join(
+      archiveRoot,
+      "symphony-ts",
+      "issues",
+      "44",
+      deriveFactoryRunsPublicationId("2026-03-09T10:25:30.123Z", sourceHeadSha),
+    );
+    const pointerFile = path.join(
+      publicationRoot,
+      "logs",
+      encodeURIComponent(
+        "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
+      ),
+      "runner.log.pointer.json",
+    );
+
+    expect(published.status).toBe("partial");
+    expect(published.metadata.logs.copiedCount).toBe(0);
+    expect(published.metadata.logs.referencedCount).toBe(1);
+    expect(published.metadata.logs.entries[0]?.note).toBe(
+      "Local log file could not be copied during publication; preserved the original pointer metadata.",
+    );
+    await expect(fs.readFile(pointerFile, "utf8")).resolves.toContain(
+      "could not be copied during publication",
+    );
+  });
+
   it("keeps publication paths inside the archive root when report repo names contain traversal segments", async () => {
     const sourceRoot = await createTempDir("symphony-factory-runs-traversal-");
     const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
@@ -454,6 +523,45 @@ describe("factory-runs publication", () => {
       fs.readFile(path.join(archiveRoot, "README.md"), "utf8"),
     ).resolves.toBe("# archive\n");
     expect(workflowPath).toContain("WORKFLOW.md");
+  });
+
+  it("cleans up empty archive directories when publication fails after staging starts", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-cleanup-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    await commitAllFiles(sourceRoot, "seed cleanup publish inputs");
+
+    await initializeGitRepo(archiveRoot);
+
+    vi.spyOn(fs, "writeFile").mockRejectedValueOnce(
+      new Error("simulated staging failure"),
+    );
+
+    await expect(
+      publishIssueToFactoryRuns({
+        workspaceRoot,
+        sourceRoot,
+        archiveRoot,
+        issueNumber: 44,
+      }),
+    ).rejects.toThrowError("simulated staging failure");
+
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts", "issues", "44")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("publishes successfully when an issue has no session logs", async () => {

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -243,6 +243,7 @@ describe("factory-runs publication", () => {
     const copyFile = fs.copyFile.bind(fs);
     vi.spyOn(fs, "copyFile").mockImplementation(async (source, destination) => {
       if (source === readableLogPath) {
+        await fs.writeFile(destination, "partial log contents\n", "utf8");
         throw Object.assign(new Error("simulated copy failure"), {
           code: "EIO",
         });
@@ -272,6 +273,14 @@ describe("factory-runs publication", () => {
       ),
       "runner.log.pointer.json",
     );
+    const archivedLogPath = path.join(
+      publicationRoot,
+      "logs",
+      encodeURIComponent(
+        "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
+      ),
+      "runner.log",
+    );
 
     expect(published.status).toBe("partial");
     expect(published.metadata.logs.copiedCount).toBe(0);
@@ -279,6 +288,9 @@ describe("factory-runs publication", () => {
     expect(published.metadata.logs.entries[0]?.note).toBe(
       "Local log file could not be copied during publication; preserved the original pointer metadata.",
     );
+    await expect(fs.stat(archivedLogPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     await expect(fs.readFile(pointerFile, "utf8")).resolves.toContain(
       "could not be copied during publication",
     );

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -576,6 +576,62 @@ describe("factory-runs publication", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("cleans up empty archive directories when staging directory creation fails", async () => {
+    const sourceRoot = await createTempDir(
+      "symphony-factory-runs-staging-mkdir-",
+    );
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    await commitAllFiles(sourceRoot, "seed staging mkdir failure inputs");
+
+    await initializeGitRepo(archiveRoot);
+
+    const originalMkdir = fs.mkdir.bind(fs);
+    const stagingRootSuffix = path.join(
+      "issues",
+      "44",
+      `.factory-runs.20260309T102530123Z`,
+    );
+    vi.spyOn(fs, "mkdir").mockImplementation(async (target, options) => {
+      if (
+        typeof target === "string" &&
+        target.includes(stagingRootSuffix) &&
+        target.endsWith(".tmp")
+      ) {
+        await originalMkdir(path.dirname(target), { recursive: true });
+        throw new Error("simulated staging mkdir failure");
+      }
+
+      return await originalMkdir(target, options);
+    });
+
+    await expect(
+      publishIssueToFactoryRuns({
+        workspaceRoot,
+        sourceRoot,
+        archiveRoot,
+        issueNumber: 44,
+      }),
+    ).rejects.toThrowError("simulated staging mkdir failure");
+
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts", "issues", "44")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("publishes successfully when an issue has no session logs", async () => {
     const sourceRoot = await createTempDir("symphony-factory-runs-no-logs-");
     const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
@@ -601,7 +657,7 @@ describe("factory-runs publication", () => {
       issueNumber: 44,
     });
 
-    expect(published.status).toBe("complete");
+    expect(published.status).toBe("partial");
     expect(published.metadata.logs.status).toBe("unavailable");
     expect(published.metadata.logs.copiedCount).toBe(0);
     expect(published.metadata.logs.referencedCount).toBe(0);

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -6,6 +6,10 @@ import {
   deriveFactoryRunsPublicationId,
   publishIssueToFactoryRuns,
 } from "../../src/integration/factory-runs.js";
+import {
+  deriveIssueArtifactPaths,
+  type IssueArtifactLogPointersDocument,
+} from "../../src/observability/issue-artifacts.js";
 import { writeIssueReport } from "../../src/observability/issue-report.js";
 import {
   checkoutGitBranch,
@@ -139,7 +143,7 @@ describe("factory-runs publication", () => {
     ).resolves.toContain('"githubActivity"');
   });
 
-  it("falls back to pointer manifests when a log cannot be copied", async () => {
+  it("falls back to pointer manifests when a log is unreadable", async () => {
     const sourceRoot = await createTempDir("symphony-factory-runs-pointer-");
     const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
     tempRoots.push(sourceRoot, archiveRoot);
@@ -147,6 +151,9 @@ describe("factory-runs publication", () => {
     await writeReportWorkflow(sourceRoot);
     const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
     await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+    const unreadableLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    await fs.mkdir(path.dirname(unreadableLogPath), { recursive: true });
+    await fs.writeFile(unreadableLogPath, "runner log contents\n", "utf8");
 
     await initializeGitRepo(sourceRoot);
     await checkoutGitBranch(sourceRoot, "symphony/44");
@@ -160,12 +167,19 @@ describe("factory-runs publication", () => {
 
     await initializeGitRepo(archiveRoot);
 
-    const published = await publishIssueToFactoryRuns({
-      workspaceRoot,
-      sourceRoot,
-      archiveRoot,
-      issueNumber: 44,
-    });
+    const published = await (async () => {
+      await fs.chmod(unreadableLogPath, 0o000);
+      try {
+        return await publishIssueToFactoryRuns({
+          workspaceRoot,
+          sourceRoot,
+          archiveRoot,
+          issueNumber: 44,
+        });
+      } finally {
+        await fs.chmod(unreadableLogPath, 0o644);
+      }
+    })();
 
     const publicationRoot = path.join(
       archiveRoot,
@@ -191,6 +205,100 @@ describe("factory-runs publication", () => {
     expect(published.metadata.logs.referencedCount).toBe(1);
     expect(published.metadata.notes).toContain(
       "Publication completed with partial log coverage; see logs.entries for per-log outcomes.",
+    );
+  });
+
+  it("deduplicates session log pointers by session id and log name", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-dedupe-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const primaryLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    const duplicateLogPath = path.join(
+      workspaceRoot,
+      "logs",
+      "runner-copy.log",
+    );
+    const artifactPaths = deriveIssueArtifactPaths(workspaceRoot, 44);
+    await fs.mkdir(path.dirname(primaryLogPath), { recursive: true });
+    await fs.writeFile(primaryLogPath, "primary log contents\n", "utf8");
+    await fs.writeFile(duplicateLogPath, "duplicate log contents\n", "utf8");
+
+    const logPointers = JSON.parse(
+      await fs.readFile(artifactPaths.logPointersFile, "utf8"),
+    ) as IssueArtifactLogPointersDocument;
+    const sessionId = "sociotechnica-org/symphony-ts#44/attempt-1/session-1";
+    const existingSession = logPointers.sessions[sessionId];
+    if (existingSession === undefined) {
+      throw new Error(`Expected log pointers for ${sessionId}`);
+    }
+    await fs.writeFile(
+      artifactPaths.logPointersFile,
+      `${JSON.stringify(
+        {
+          ...logPointers,
+          sessions: {
+            ...logPointers.sessions,
+            [sessionId]: {
+              ...existingSession,
+              pointers: [
+                {
+                  name: "runner.log",
+                  location: duplicateLogPath,
+                  archiveLocation: "archive://runner.log",
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const sourceHeadSha = await commitAllFiles(
+      sourceRoot,
+      "seed deduplicated publish inputs",
+    );
+
+    await initializeGitRepo(archiveRoot);
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    const publicationRoot = path.join(
+      archiveRoot,
+      "symphony-ts",
+      "issues",
+      "44",
+      deriveFactoryRunsPublicationId("2026-03-09T10:25:30.123Z", sourceHeadSha),
+    );
+    const archivedLogPath = path.join(
+      publicationRoot,
+      "logs",
+      encodeURIComponent(sessionId),
+      "runner.log",
+    );
+
+    expect(published.metadata.logs.copiedCount).toBe(1);
+    expect(published.metadata.logs.referencedCount).toBe(0);
+    expect(published.metadata.logs.entries).toHaveLength(1);
+    await expect(fs.readFile(archivedLogPath, "utf8")).resolves.toBe(
+      "primary log contents\n",
     );
   });
 

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -525,7 +525,7 @@ describe("factory-runs publication", () => {
         issueNumber: 44,
       }),
     ).rejects.toThrowError(
-      `No generated issue report found for issue #44 at ${path.join(sourceRoot, ".var", "reports", "issues", "44")}; run 'symphony-report issue --issue 44' first.`,
+      `No generated issue report JSON found for issue #44 at ${path.join(sourceRoot, ".var", "reports", "issues", "44", "report.json")}; run 'symphony-report issue --issue 44' first.`,
     );
 
     await expect(

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runReportCli } from "../../src/cli/report.js";
+import {
+  deriveFactoryRunsPublicationId,
+  publishIssueToFactoryRuns,
+} from "../../src/integration/factory-runs.js";
+import { writeIssueReport } from "../../src/observability/issue-report.js";
+import {
+  checkoutGitBranch,
+  commitAllFiles,
+  createTempDir,
+  initializeGitRepo,
+} from "../support/git.js";
+import {
+  deriveWorkspaceRoot,
+  seedFailedIssueArtifacts,
+  seedSuccessfulIssueArtifacts,
+  writeReportWorkflow,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("factory-runs publication", () => {
+  it("publishes generated issue outputs and copied logs into the archive repo", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-source-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    const workflowPath = await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const readableLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    await fs.mkdir(path.dirname(readableLogPath), { recursive: true });
+    await fs.writeFile(readableLogPath, "runner log contents\n", "utf8");
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const sourceHeadSha = await commitAllFiles(
+      sourceRoot,
+      "seed publish inputs",
+    );
+
+    await initializeGitRepo(archiveRoot);
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "publish",
+      "--issue",
+      "44",
+      "--workflow",
+      workflowPath,
+      "--archive-root",
+      archiveRoot,
+    ]);
+
+    const publicationId = deriveFactoryRunsPublicationId(
+      generated.report.generatedAt,
+      sourceHeadSha,
+    );
+    const publicationRoot = path.join(
+      archiveRoot,
+      "symphony-ts",
+      "issues",
+      "44",
+      publicationId,
+    );
+    const metadata = JSON.parse(
+      await fs.readFile(path.join(publicationRoot, "metadata.json"), "utf8"),
+    ) as {
+      readonly repo: string;
+      readonly branchName: string;
+      readonly pullRequests: readonly { readonly number: number }[];
+      readonly sourceRevision: { readonly relevantSha: string | null };
+      readonly logs: {
+        readonly copiedCount: number;
+        readonly referencedCount: number;
+      };
+    };
+
+    await expect(
+      fs.readFile(path.join(publicationRoot, "report.json"), "utf8"),
+    ).resolves.toContain('"issueNumber": 44');
+    await expect(
+      fs.readFile(path.join(publicationRoot, "report.md"), "utf8"),
+    ).resolves.toContain("## Summary");
+    await expect(
+      fs.readFile(
+        path.join(
+          publicationRoot,
+          "logs",
+          encodeURIComponent(
+            "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
+          ),
+          "runner.log",
+        ),
+        "utf8",
+      ),
+    ).resolves.toBe("runner log contents\n");
+
+    expect(metadata.repo).toBe("sociotechnica-org/symphony-ts");
+    expect(metadata.branchName).toBe("symphony/44");
+    expect(metadata.pullRequests).toContainEqual({
+      number: 144,
+      url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
+    });
+    expect(metadata.sourceRevision.relevantSha).toBe(sourceHeadSha);
+    expect(metadata.logs.copiedCount).toBe(1);
+    expect(metadata.logs.referencedCount).toBe(0);
+    expect(stdout.join("")).toContain(`publication id: ${publicationId}`);
+
+    await expect(
+      fs.readFile(generated.outputPaths.reportJsonFile, "utf8"),
+    ).resolves.toContain('"githubActivity"');
+  });
+
+  it("falls back to pointer manifests when a log cannot be copied", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-pointer-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    const sourceHeadSha = await commitAllFiles(
+      sourceRoot,
+      "seed partial publish inputs",
+    );
+
+    await initializeGitRepo(archiveRoot);
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    const publicationRoot = path.join(
+      archiveRoot,
+      "symphony-ts",
+      "issues",
+      "44",
+      deriveFactoryRunsPublicationId("2026-03-09T10:25:30.123Z", sourceHeadSha),
+    );
+    const pointerFile = path.join(
+      publicationRoot,
+      "logs",
+      encodeURIComponent(
+        "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
+      ),
+      "runner.log.pointer.json",
+    );
+
+    expect(published.status).toBe("partial");
+    await expect(fs.readFile(pointerFile, "utf8")).resolves.toContain(
+      '"archiveLocation": null',
+    );
+    expect(published.metadata.logs.copiedCount).toBe(0);
+    expect(published.metadata.logs.referencedCount).toBe(1);
+    expect(published.metadata.notes).toContain(
+      "Publication completed with partial log coverage; see logs.entries for per-log outcomes.",
+    );
+  });
+
+  it("fails clearly when generated reports are missing and leaves the archive unchanged", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-missing-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    const workflowPath = await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await commitAllFiles(sourceRoot, "seed raw artifacts only");
+
+    await initializeGitRepo(archiveRoot);
+    await fs.writeFile(
+      path.join(archiveRoot, "README.md"),
+      "# archive\n",
+      "utf8",
+    );
+
+    await expect(
+      publishIssueToFactoryRuns({
+        workspaceRoot,
+        sourceRoot,
+        archiveRoot,
+        issueNumber: 44,
+      }),
+    ).rejects.toThrowError(
+      `No generated issue report found for issue #44 at ${path.join(sourceRoot, ".var", "reports", "issues", "44")}; run 'symphony-report issue --issue 44' first.`,
+    );
+
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts", "issues", "44")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.readFile(path.join(archiveRoot, "README.md"), "utf8"),
+    ).resolves.toBe("# archive\n");
+    expect(workflowPath).toContain("WORKFLOW.md");
+  });
+
+  it("publishes successfully when an issue has no session logs", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-no-logs-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    const workflowPath = await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedFailedIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T11:15:00.000Z",
+    });
+    await commitAllFiles(sourceRoot, "seed no-log publish inputs");
+
+    await initializeGitRepo(archiveRoot);
+
+    const published = await publishIssueToFactoryRuns({
+      workspaceRoot,
+      sourceRoot,
+      archiveRoot,
+      issueNumber: 44,
+    });
+
+    expect(published.status).toBe("complete");
+    expect(published.metadata.logs.status).toBe("unavailable");
+    expect(published.metadata.logs.copiedCount).toBe(0);
+    expect(published.metadata.logs.referencedCount).toBe(0);
+    expect(published.metadata.notes).toContain(
+      "No session logs were available for publication.",
+    );
+    expect(workflowPath).toContain("WORKFLOW.md");
+  });
+});

--- a/tests/support/git.ts
+++ b/tests/support/git.ts
@@ -10,6 +10,44 @@ export async function createTempDir(prefix: string): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+export async function initializeGitRepo(
+  repoRoot: string,
+  options?: {
+    readonly branch?: string | undefined;
+  },
+): Promise<void> {
+  await execFileAsync("git", ["init", "-b", options?.branch ?? "main"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["config", "user.name", "Symphony Test"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync(
+    "git",
+    ["config", "user.email", "symphony-test@example.com"],
+    { cwd: repoRoot },
+  );
+}
+
+export async function checkoutGitBranch(
+  repoRoot: string,
+  branchName: string,
+): Promise<void> {
+  await execFileAsync("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+}
+
+export async function commitAllFiles(
+  repoRoot: string,
+  message: string,
+): Promise<string> {
+  await execFileAsync("git", ["add", "."], { cwd: repoRoot });
+  await execFileAsync("git", ["commit", "-m", message], { cwd: repoRoot });
+  const result = await execFileAsync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+  });
+  return result.stdout.trim();
+}
+
 export async function createSeedRemote(): Promise<{
   readonly rootDir: string;
   readonly remotePath: string;

--- a/tests/unit/factory-runs.test.ts
+++ b/tests/unit/factory-runs.test.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deriveFactoryRunsPublicationId,
+  deriveFactoryRunsPublicationPaths,
+} from "../../src/integration/factory-runs.js";
+
+describe("factory-runs publication helpers", () => {
+  it("derives a stable filesystem-safe publication id", () => {
+    expect(
+      deriveFactoryRunsPublicationId(
+        "2026-03-09T10:25:30.123Z",
+        "abcdef1234567890abcdef1234567890abcdef12",
+      ),
+    ).toBe("20260309T102530123Z-abcdef12");
+  });
+
+  it("derives the expected archive layout for one issue publication", () => {
+    const publicationPaths = deriveFactoryRunsPublicationPaths({
+      archiveRoot: "/tmp/factory-runs",
+      repoName: "symphony-ts",
+      issueNumber: 45,
+      publicationId: "20260309T102530123Z-abcdef12",
+    });
+
+    expect(publicationPaths.repoRoot).toBe(
+      path.join("/tmp/factory-runs", "symphony-ts"),
+    );
+    expect(publicationPaths.issueRoot).toBe(
+      path.join("/tmp/factory-runs", "symphony-ts", "issues", "45"),
+    );
+    expect(publicationPaths.publicationRoot).toBe(
+      path.join(
+        "/tmp/factory-runs",
+        "symphony-ts",
+        "issues",
+        "45",
+        "20260309T102530123Z-abcdef12",
+      ),
+    );
+    expect(publicationPaths.metadataFile).toBe(
+      path.join(
+        "/tmp/factory-runs",
+        "symphony-ts",
+        "issues",
+        "45",
+        "20260309T102530123Z-abcdef12",
+        "metadata.json",
+      ),
+    );
+  });
+});

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   generateIssueReport,
+  readIssueReport,
   writeIssueReport,
 } from "../../src/observability/issue-report.js";
 import {
@@ -252,6 +253,35 @@ describe("issue report generation", () => {
 
       expect(generated.report.summary.outcome).toBe("claimed");
       expect(generated.report.summary.outcome).not.toBe("awaiting-plan-review");
+    },
+  );
+
+  it.each([
+    {
+      fileName: "report.json",
+      fileKind: "JSON",
+    },
+    {
+      fileName: "report.md",
+      fileKind: "markdown",
+    },
+  ] as const)(
+    "names the missing %s artifact when reading a stored issue report",
+    async ({ fileName, fileKind }) => {
+      const tempDir = await createTempDir("symphony-issue-report-read-");
+      tempRoots.push(tempDir);
+      const workspaceRoot = deriveWorkspaceRoot(tempDir);
+      await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+      const generated = await writeIssueReport(workspaceRoot, 44, {
+        generatedAt: "2026-03-09T14:00:00.000Z",
+      });
+
+      await fs.rm(path.join(generated.outputPaths.issueRoot, fileName));
+
+      await expect(readIssueReport(workspaceRoot, 44)).rejects.toThrowError(
+        `No generated issue report ${fileKind} found for issue #44 at ${path.join(generated.outputPaths.issueRoot, fileName)}; run 'symphony-report issue --issue 44' first.`,
+      );
     },
   );
 });

--- a/tests/unit/report-cli.test.ts
+++ b/tests/unit/report-cli.test.ts
@@ -11,6 +11,23 @@ describe("parseReportArgs", () => {
     });
   });
 
+  it("parses the publish command", () => {
+    expect(
+      parseReportArgs([
+        "node",
+        "symphony-report",
+        "publish",
+        "--issue",
+        "44",
+        "--archive-root",
+        "../factory-runs",
+      ]),
+    ).toMatchObject({
+      command: "publish",
+      issueNumber: 44,
+    });
+  });
+
   it("requires a valid issue number", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "issue", "--issue", "abc"]),
@@ -33,7 +50,13 @@ describe("parseReportArgs", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "status"]),
     ).toThrowError(
-      "Usage: symphony-report issue --issue <number> [--workflow <path>]",
+      "Usage: symphony-report <issue|publish> --issue <number> [--workflow <path>] [--archive-root <path>]",
     );
+  });
+
+  it("requires the archive root for publish", () => {
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "publish", "--issue", "44"]),
+    ).toThrowError("Missing required --archive-root <path> option");
   });
 });


### PR DESCRIPTION
## Summary
- add a detached `factory-runs` publication service that copies generated issue reports, metadata, and available session logs into the archive worktree
- add `symphony-report publish` plus read-side helpers and archive metadata/log fallback tests
- document the detached archive workflow and include the approved issue plan in-repo

Closes #45

## Checks
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- codex review --base origin/main (timed out after 180s in this environment without returning findings)
