### PR TITLE
Add runner-specific report log enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Generate a per-issue report from local artifacts:
 pnpm tsx bin/symphony-report.ts issue --issue 44
 ```
 
+When available, the report command also applies optional built-in runner-log
+enrichment. Today that means Codex JSONL sessions under `~/.codex/sessions/`.
+Missing, malformed, or ambiguous runner logs do not block report generation;
+the report stays partial and keeps the canonical local artifacts as the source
+of truth.
+
 Publish one generated issue report into a checked-out `factory-runs` archive
 worktree:
 

--- a/docs/plans/046-runner-log-report-enrichment/plan.md
+++ b/docs/plans/046-runner-log-report-enrichment/plan.md
@@ -1,0 +1,253 @@
+# Issue 46 Plan: Runner-Specific Log Enrichment For Reporting
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Add an explicit optional enrichment seam for runner-specific log readers so per-issue reports can incorporate Codex JSON log details now, and future runner-specific details later, without changing the canonical local artifact contract or making the core report generator depend on any one provider.
+
+## Scope
+
+This slice covers:
+
+1. a provider-neutral report-enrichment contract in `src/observability/` that report generation can invoke optionally
+2. merge rules so enrichers can add optional token usage, richer session detail, and evidence-backed final agent summaries without replacing canonical report state
+3. one Codex-specific enrichment adapter that reads local Codex JSONL session logs and returns optional additions when it can match them to canonical session artifacts
+4. a narrow `LocalRunner` metadata improvement so canonical session artifacts can identify Codex-backed sessions with provider/model facts while keeping the raw artifact schema unchanged
+5. tests and docs proving that reports still generate successfully when no enrichers are present or when Codex logs are missing, unreadable, or malformed
+
+## Non-goals
+
+This slice does not include:
+
+1. changing the canonical local issue artifact layout or schema from `#43`
+2. turning `report.json` or `report.md` into Codex-specific outputs
+3. requiring Codex logs for report generation success
+4. scraping raw runner logs to reconstruct canonical issue outcome, PR state, or tracker lifecycle facts
+5. adding Claude Code, VM-backed, or remote-runner enrichers in the same PR
+6. changing orchestrator retry, review-loop, or tracker policy
+
+## Current Gaps
+
+After `#44` and `#45`, report generation is intentionally provider-neutral, but it has no optional runner-enrichment seam:
+
+1. `src/observability/issue-report.ts` hard-codes token usage as unavailable and defers richer log-derived detail to `#46`
+2. there is no adapter interface for provider-specific log parsing; any Codex support would currently have to leak into the core report builder
+3. the real `LocalRunner` currently records provider `local-runner` with no backend-specific identity, so canonical session snapshots do not distinguish Codex-backed runs from other local commands
+4. Codex does persist local JSONL session files under `~/.codex/sessions/...`, but the report pipeline has no safe, optional path for reading or matching them
+5. there is no failure policy for malformed or unmatched runner logs beyond “ignore them and keep the canonical report working”
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_46/docs/architecture.md).
+
+- Policy Layer: owns the rule that canonical issue artifacts and the report core remain provider-neutral, enrichers are optional, and malformed runner logs never block report generation. This layer should define what counts as an optional addition and what stays canonical.
+- Configuration Layer: intentionally untouched for `WORKFLOW.md` schema. This issue should not add runtime config knobs for enrichers. If any selection logic is needed, it should stay in code defaults or runner/session metadata rather than new workflow policy.
+- Coordination Layer: untouched. The orchestrator must not gain new retry or lifecycle logic for report enrichment.
+- Execution Layer: owns only the narrow metadata improvement in `LocalRunner.describeSession()` so canonical session snapshots can carry backend identity such as `provider: "codex"` and parsed model when derivable from the configured command. Execution does not parse provider logs into report facts.
+- Integration Layer: runner-specific log parsing lives at the edge as explicit adapters. For this issue, the Codex adapter reads Codex JSONL session files and normalizes optional additions for the report layer. It must not mutate canonical artifacts or tracker state.
+- Observability Layer: owns the provider-neutral enrichment contract, merge rules, report-schema extensions that stay provider-neutral, and the report-generator orchestration that applies zero or more enrichers over canonical loaded artifacts.
+
+## Architecture Boundaries
+
+### Observability
+
+Belongs here:
+
+1. the provider-neutral `IssueReportEnricher` contract and enrichment input/output types
+2. merge rules for optional additions into the generated report
+3. report-level availability/explanation rules when enrichment is absent, partial, or malformed
+4. report-schema and markdown updates that remain provider-neutral
+
+Does not belong here:
+
+1. Codex JSONL parsing details
+2. runner-command parsing beyond already-normalized session metadata
+3. any second source of truth for canonical issue state
+
+### Runner
+
+Belongs here:
+
+1. backend identity in canonical session descriptions when the local command is recognizably Codex
+2. parsed model name when it is directly available from the configured runner command
+3. provider-specific enrichment adapters that sit at the runner edge and normalize optional log-derived facts for observability
+
+Does not belong here:
+
+1. report composition policy
+2. tracker or orchestrator decisions
+3. rewriting canonical report outcome from raw logs
+
+### CLI
+
+Belongs here:
+
+1. continuing to invoke report generation without requiring enrichment flags
+2. wiring built-in enrichers, if needed, as optional defaults for the detached report command
+
+Does not belong here:
+
+1. Codex JSON parsing inline in the command handler
+2. a new configuration surface for enabling enrichment in this slice
+
+### Orchestrator
+
+Belongs here:
+
+1. nothing new beyond continuing to emit canonical session snapshots and log pointers
+
+Does not belong here:
+
+1. report enrichment logic
+2. log-reader retries or fallback heuristics
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR because it stays on one narrow seam: optional read-side enrichment on top of existing report generation, plus the minimum execution metadata needed for future reports to identify Codex-backed sessions cleanly.
+
+The PR should include:
+
+1. provider-neutral enrichment contracts and merge logic under `src/observability/`
+2. one Codex adapter at the runner edge
+3. the small `LocalRunner.describeSession()` improvement for provider/model identity
+4. focused unit/integration coverage plus one realistic report-generation flow using Codex-style JSONL fixtures
+5. docs updates for the optional enrichment behavior
+
+This PR deliberately defers:
+
+1. additional runner enrichers for Claude Code or VM-backed runners
+2. any raw artifact schema expansion
+3. archive-publication changes in `factory-runs`
+4. richer runner-side log-pointer capture beyond what the current canonical contract already permits
+
+The seam is reviewable because it does not reopen tracker integration, orchestrator state, or the canonical artifact contract; it only adds an optional consumer path over existing artifacts.
+
+## Enrichment Model
+
+Introduce a provider-neutral enrichment flow:
+
+1. load canonical local issue artifacts exactly as today
+2. build the canonical core report exactly as today
+3. invoke zero or more `IssueReportEnricher`s with canonical session/attempt artifacts and report context
+4. merge any successful optional additions into provider-neutral report fields
+5. record explicit partial/unavailable notes when enrichers do not match, cannot parse logs, or produce only partial facts
+
+### Contract rules
+
+1. the core report must remain valid with an empty enricher list
+2. enrichers may only add optional detail; they may not overwrite canonical issue identity, lifecycle, PR counts, or final outcome
+3. enrichers must return normalized data, not raw provider payloads
+4. merge behavior must be deterministic when multiple enrichers contribute to different sessions
+5. malformed enrichment input must degrade to “no enrichment” plus notes, not a report-generation failure
+
+## Codex Adapter Strategy
+
+The Codex adapter should work from canonical session anchors plus local Codex session files:
+
+1. only consider canonical sessions that identify as Codex-backed after the runner metadata improvement
+2. scan local Codex JSONL session files under `~/.codex/sessions/...`
+3. match candidate JSONL sessions to canonical sessions using stable evidence such as workspace path (`cwd` in Codex `session_meta`), session timing, and session/provider identity
+4. extract only optional additions that are well-supported by the log format, such as token totals from `event_msg` `token_count` payloads, richer session/source detail from `session_meta`, and final assistant summaries from terminal assistant message items when available
+5. if matching is ambiguous or parsing fails, return no enrichment for that session and keep the report canonical
+
+### Decision notes
+
+1. The adapter should prefer evidence-backed matching over brittle assumptions about file names, because Codex session-file ids are not the same as Symphony run-session ids.
+2. The adapter should not rely on `--json` being added to the configured runtime command in this issue. Existing local Codex session persistence is the primary source.
+3. The report should expose enriched source artifact paths so operators can trace any token or summary detail back to the matched Codex JSONL file.
+
+## Runtime State / Failure Matrix
+
+This issue does not change long-running orchestration, retries, reconciliation, leases, or handoff states, so an orchestrator runtime state machine is not required.
+
+The read-side enrichment path still needs an explicit failure matrix:
+
+| Observed condition | Local facts available | Expected behavior |
+| --- | --- | --- |
+| No enrichers are registered | canonical raw artifacts only | generate the same provider-neutral report as today |
+| A session is not identified as Codex-backed | canonical session snapshot only | skip Codex enrichment for that session |
+| Codex-backed session has one clear JSONL match | canonical session snapshot plus readable Codex JSONL | merge optional token/session/summary detail into the report |
+| Codex-backed session has no matching JSONL file | canonical session snapshot only | keep the canonical report, leave token usage unavailable/partial, and record an explanatory note |
+| Codex-backed session has multiple plausible JSONL matches | canonical session snapshot plus multiple candidate JSONL files | skip ambiguous enrichment and record a note instead of guessing |
+| Matched Codex JSONL file is malformed or missing expected fields | canonical session snapshot plus unreadable or partial JSONL | ignore the malformed enrichment, keep report generation successful, and record a note |
+| Mixed sessions exist across providers | canonical sessions from multiple providers | enrich only the sessions with a matching adapter; leave the rest unchanged |
+
+## Storage / Persistence Contract
+
+This issue does not introduce a new durable artifact contract.
+
+Contract rules:
+
+1. canonical artifacts under `.var/factory/...` remain the source of truth
+2. generated reports under `.var/reports/...` remain detached derived outputs
+3. runner-specific log files remain external inputs referenced by enrichment, not new canonical persisted state
+4. any new report fields introduced for enrichment must be safely nullable and versioned within the generated report contract
+
+## Observability Requirements
+
+1. report JSON must make it clear whether token/session enrichments are unavailable, partial, or complete
+2. enriched session facts must retain source artifact references to the matched Codex JSONL files
+3. markdown rendering must remain readable when enrichment is absent
+4. if enrichment is skipped due to ambiguity or malformed input, the resulting note should be factual and provider-neutral from the report consumer’s perspective
+
+## Implementation Steps
+
+1. Extract provider-neutral enrichment types and merge helpers from `src/observability/issue-report.ts` into focused modules.
+2. Extend the report contract in a provider-neutral way so optional enriched token/session detail and evidence-backed final summaries can be represented without forcing provider-specific fields into canonical sections.
+3. Update `generateIssueReport()` / `writeIssueReport()` so report generation accepts an optional enricher list and applies enrichers after the canonical core report is built.
+4. Implement a Codex runner-log enricher at the runner edge that:
+   - finds candidate Codex JSONL files
+   - matches them to canonical Codex sessions
+   - extracts token totals, session metadata, and final assistant summaries when present
+   - returns normalized optional additions only
+5. Improve `LocalRunner.describeSession()` so Codex commands produce `provider: "codex"` and parsed model values when derivable, while unknown commands continue to fall back safely.
+6. Update markdown rendering to surface enriched token/session detail and any additional factual notes without making sections disappear when enrichment is absent.
+7. Add or refresh fixtures for Codex JSONL session logs that cover successful enrichment, missing logs, malformed logs, and ambiguous matches.
+8. Update README or reporting docs to describe enrichment as optional and Codex as the first built-in adapter.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. report generation with no enrichers preserves the current provider-neutral behavior
+2. merge logic applies optional enrichment without changing canonical outcome, issue identity, or PR facts
+3. `LocalRunner.describeSession()` identifies Codex commands and model flags while keeping unknown commands on the fallback path
+4. the Codex adapter parses token counts, source metadata, and final assistant summaries from representative JSONL fixtures
+5. ambiguous or malformed Codex JSONL inputs yield no enrichment rather than throwing
+
+### Integration
+
+1. `symphony-report issue --issue <n>` generates a report with enriched token usage and session detail when canonical artifacts plus matching Codex JSONL fixtures are present
+2. the same command still succeeds when Codex logs are missing, malformed, or unmatched, and the report explicitly stays partial/unavailable for those additions
+3. mixed-session fixtures enrich only the Codex-backed session entries and leave others unchanged
+
+### End-to-End
+
+1. a realistic issue-artifact fixture with Codex-backed sessions generates `report.json` and `report.md` that include optional Codex-derived token/session detail while preserving canonical outcome and artifact references
+
+## Acceptance Scenarios
+
+1. Reports consume zero enrichers and still generate successfully with the current provider-neutral output.
+2. Reports consume the built-in Codex enricher and surface optional token totals, richer session metadata, or final summaries when a Codex JSONL match is available.
+3. Missing, malformed, or ambiguous Codex logs do not fail report generation.
+4. The enrichment seam is explicit enough that a later Claude Code or VM-backed adapter can implement the same interface without changing the core report builder.
+
+## Exit Criteria
+
+1. the report generator has an explicit optional enricher interface
+2. Codex enrichment is implemented as one adapter, not embedded into the core report builder
+3. canonical local artifacts and canonical report conclusions remain provider-neutral
+4. real reports continue to generate with no enrichers or with broken Codex inputs
+5. tests cover both enriched and unenriched paths
+6. docs explain the optional enrichment behavior and its current Codex-first support
+
+## Deferred To Later Issues Or PRs
+
+1. Claude Code enrichment
+2. VM-backed runner enrichment
+3. stronger runner-side persistence of provider log pointers when future backends expose stable session ids or file paths
+4. cost estimation policies beyond raw token totals
+5. any canonical artifact changes that would make runner-log matching more direct

--- a/docs/plans/046-runner-log-report-enrichment/plan.md
+++ b/docs/plans/046-runner-log-report-enrichment/plan.md
@@ -165,15 +165,15 @@ This issue does not change long-running orchestration, retries, reconciliation, 
 
 The read-side enrichment path still needs an explicit failure matrix:
 
-| Observed condition | Local facts available | Expected behavior |
-| --- | --- | --- |
-| No enrichers are registered | canonical raw artifacts only | generate the same provider-neutral report as today |
-| A session is not identified as Codex-backed | canonical session snapshot only | skip Codex enrichment for that session |
-| Codex-backed session has one clear JSONL match | canonical session snapshot plus readable Codex JSONL | merge optional token/session/summary detail into the report |
-| Codex-backed session has no matching JSONL file | canonical session snapshot only | keep the canonical report, leave token usage unavailable/partial, and record an explanatory note |
-| Codex-backed session has multiple plausible JSONL matches | canonical session snapshot plus multiple candidate JSONL files | skip ambiguous enrichment and record a note instead of guessing |
-| Matched Codex JSONL file is malformed or missing expected fields | canonical session snapshot plus unreadable or partial JSONL | ignore the malformed enrichment, keep report generation successful, and record a note |
-| Mixed sessions exist across providers | canonical sessions from multiple providers | enrich only the sessions with a matching adapter; leave the rest unchanged |
+| Observed condition                                               | Local facts available                                          | Expected behavior                                                                                |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| No enrichers are registered                                      | canonical raw artifacts only                                   | generate the same provider-neutral report as today                                               |
+| A session is not identified as Codex-backed                      | canonical session snapshot only                                | skip Codex enrichment for that session                                                           |
+| Codex-backed session has one clear JSONL match                   | canonical session snapshot plus readable Codex JSONL           | merge optional token/session/summary detail into the report                                      |
+| Codex-backed session has no matching JSONL file                  | canonical session snapshot only                                | keep the canonical report, leave token usage unavailable/partial, and record an explanatory note |
+| Codex-backed session has multiple plausible JSONL matches        | canonical session snapshot plus multiple candidate JSONL files | skip ambiguous enrichment and record a note instead of guessing                                  |
+| Matched Codex JSONL file is malformed or missing expected fields | canonical session snapshot plus unreadable or partial JSONL    | ignore the malformed enrichment, keep report generation successful, and record a note            |
+| Mixed sessions exist across providers                            | canonical sessions from multiple providers                     | enrich only the sessions with a matching adapter; leave the rest unchanged                       |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/046-runner-log-report-enrichment/plan.md
+++ b/docs/plans/046-runner-log-report-enrichment/plan.md
@@ -185,6 +185,7 @@ Contract rules:
 2. generated reports under `.var/reports/...` remain detached derived outputs
 3. runner-specific log files remain external inputs referenced by enrichment, not new canonical persisted state
 4. any new report fields introduced for enrichment must be safely nullable and versioned within the generated report contract
+5. stored generated reports from older schema versions must either load through an explicit compatibility path or fail with a clear regeneration error; this slice should prefer the explicit regeneration guard over silently casting stale JSON into the current in-memory contract
 
 ## Observability Requirements
 
@@ -217,6 +218,7 @@ Contract rules:
 3. `LocalRunner.describeSession()` identifies Codex commands and model flags while keeping unknown commands on the fallback path
 4. the Codex adapter parses token counts, source metadata, and final assistant summaries from representative JSONL fixtures
 5. ambiguous or malformed Codex JSONL inputs yield no enrichment rather than throwing
+6. reading a stored generated report with an older schema version fails with a clear regeneration error instead of casting missing required fields into the current report contract
 
 ### Integration
 
@@ -234,6 +236,7 @@ Contract rules:
 2. Reports consume the built-in Codex enricher and surface optional token totals, richer session metadata, or final summaries when a Codex JSONL match is available.
 3. Missing, malformed, or ambiguous Codex logs do not fail report generation.
 4. The enrichment seam is explicit enough that a later Claude Code or VM-backed adapter can implement the same interface without changing the core report builder.
+5. Publishing or otherwise reading an older generated `report.json` fails clearly and instructs the operator to regenerate it, instead of crashing on missing v2-only fields.
 
 ## Exit Criteria
 

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 import { loadWorkflowWorkspaceRoot } from "../config/workflow.js";
 import { publishIssueToFactoryRuns } from "../integration/factory-runs.js";
+import { createDefaultIssueReportEnrichers } from "../runner/codex-report-enricher.js";
 import { writeIssueReport } from "../observability/issue-report.js";
+import type { IssueReportEnricher } from "../observability/issue-report-enrichment.js";
 
 export type ReportCliArgs =
   | {
@@ -57,11 +59,18 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   };
 }
 
-export async function runReportCli(argv: readonly string[]): Promise<void> {
+export async function runReportCli(
+  argv: readonly string[],
+  options?: {
+    readonly issueEnrichers?: readonly IssueReportEnricher[] | undefined;
+  },
+): Promise<void> {
   const args = parseReportArgs(argv);
   const workspaceRoot = await loadWorkflowWorkspaceRoot(args.workflowPath);
   if (args.command === "issue") {
-    const generated = await writeIssueReport(workspaceRoot, args.issueNumber);
+    const generated = await writeIssueReport(workspaceRoot, args.issueNumber, {
+      enrichers: options?.issueEnrichers ?? createDefaultIssueReportEnrichers(),
+    });
     process.stdout.write(
       `Generated issue report for #${args.issueNumber.toString()}\nreport.json: ${generated.outputPaths.reportJsonFile}\nreport.md: ${generated.outputPaths.reportMarkdownFile}\n`,
     );

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -199,7 +199,7 @@ function rebuildTokenUsage(
     string,
     {
       sessionCount: number;
-      totalTokens: number | null;
+      totalTokens: number;
       hasMissingTokens: boolean;
     }
   >();
@@ -216,11 +216,9 @@ function rebuildTokenUsage(
     agentsByName.set(label, {
       sessionCount: existing.sessionCount + 1,
       totalTokens:
-        existing.totalTokens === null
-          ? null
-          : session.totalTokens === null
-            ? existing.totalTokens
-            : existing.totalTokens + session.totalTokens,
+        session.totalTokens === null
+          ? existing.totalTokens
+          : existing.totalTokens + session.totalTokens,
       hasMissingTokens:
         existing.hasMissingTokens || session.totalTokens === null,
     });

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -98,10 +98,11 @@ export function mergeIssueReportEnrichment(
     return nextSession;
   });
 
-  const mergedTokenUsage = rebuildTokenUsage(report.tokenUsage, enrichedSessions, [
-    ...report.tokenUsage.notes,
-    ...(enrichment.notes ?? []),
-  ]);
+  const mergedTokenUsage = rebuildTokenUsage(
+    report.tokenUsage,
+    enrichedSessions,
+    [...report.tokenUsage.notes, ...(enrichment.notes ?? [])],
+  );
 
   return {
     ...report,
@@ -116,16 +117,13 @@ function mergeIssueReportSession(
   const tokenUsage = enrichment.tokenUsage;
   const next: IssueReportTokenUsageSession = {
     ...session,
-    inputTokens:
-      tokenUsage?.inputTokens ?? session.inputTokens,
+    inputTokens: tokenUsage?.inputTokens ?? session.inputTokens,
     cachedInputTokens:
       tokenUsage?.cachedInputTokens ?? session.cachedInputTokens,
-    outputTokens:
-      tokenUsage?.outputTokens ?? session.outputTokens,
+    outputTokens: tokenUsage?.outputTokens ?? session.outputTokens,
     reasoningOutputTokens:
       tokenUsage?.reasoningOutputTokens ?? session.reasoningOutputTokens,
-    totalTokens:
-      tokenUsage?.totalTokens ?? session.totalTokens,
+    totalTokens: tokenUsage?.totalTokens ?? session.totalTokens,
     originator: enrichment.originator ?? session.originator,
     sessionSource: enrichment.sessionSource ?? session.sessionSource,
     cliVersion: enrichment.cliVersion ?? session.cliVersion,
@@ -163,22 +161,20 @@ function rebuildTokenUsage(
   const someSessionTotalsAvailable =
     completeSessionCount > 0 && !allSessionTotalsAvailable;
 
-  const status =
-    allSessionTotalsAvailable
-      ? "complete"
-      : someSessionTotalsAvailable
+  const status = allSessionTotalsAvailable
+    ? "complete"
+    : someSessionTotalsAvailable
+      ? "partial"
+      : anySessionDetail
         ? "partial"
-        : anySessionDetail
-          ? "partial"
-          : base.status;
-  const explanation =
-    allSessionTotalsAvailable
-      ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
-      : someSessionTotalsAvailable
-        ? `Runner log enrichment supplied token totals for ${completeSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
-        : anySessionDetail
-          ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
-          : base.explanation;
+        : base.status;
+  const explanation = allSessionTotalsAvailable
+    ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
+    : someSessionTotalsAvailable
+      ? `Runner log enrichment supplied token totals for ${completeSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
+      : anySessionDetail
+        ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
+        : base.explanation;
 
   const attempts = base.attempts.map((attempt) => {
     const attemptSessions = sessions.filter((session) =>
@@ -240,7 +236,8 @@ function rebuildTokenUsage(
     .sort((left, right) => left.agent.localeCompare(right.agent));
 
   const totalTokens =
-    sessions.length > 0 && sessions.every((session) => session.totalTokens !== null)
+    sessions.length > 0 &&
+    sessions.every((session) => session.totalTokens !== null)
       ? sessions.reduce(
           (total, session) => total + (session.totalTokens ?? 0),
           0,

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -5,6 +5,8 @@ import type {
   LoadedIssueArtifacts,
 } from "./issue-report.js";
 
+const CANONICAL_SESSION_SOURCE_ARTIFACT_COUNT = 1;
+
 export interface IssueReportSessionTokenUsageEnrichment {
   readonly inputTokens?: number | null | undefined;
   readonly cachedInputTokens?: number | null | undefined;
@@ -273,11 +275,21 @@ function deriveSessionStatus(
     session.cliVersion !== null ||
     session.gitBranch !== null ||
     session.gitCommit !== null ||
-    session.sourceArtifacts.length > 1
+    hasRunnerEnrichmentSourceArtifacts(session)
   ) {
     return "partial";
   }
   return "unavailable";
+}
+
+function hasRunnerEnrichmentSourceArtifacts(
+  session: IssueReportTokenUsageSession,
+): boolean {
+  // Canonical sessions always start with one source artifact: the session
+  // snapshot JSON. Anything beyond that came from optional enrichment.
+  return (
+    session.sourceArtifacts.length > CANONICAL_SESSION_SOURCE_ARTIFACT_COUNT
+  );
 }
 
 function uniqueStrings(values: readonly string[]): readonly string[] {

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -1,0 +1,294 @@
+import type {
+  IssueReportDocument,
+  IssueReportTokenUsage,
+  IssueReportTokenUsageSession,
+  LoadedIssueArtifacts,
+} from "./issue-report.js";
+
+export interface IssueReportSessionTokenUsageEnrichment {
+  readonly inputTokens?: number | null | undefined;
+  readonly cachedInputTokens?: number | null | undefined;
+  readonly outputTokens?: number | null | undefined;
+  readonly reasoningOutputTokens?: number | null | undefined;
+  readonly totalTokens?: number | null | undefined;
+}
+
+export interface IssueReportSessionEnrichment {
+  readonly sessionId: string;
+  readonly tokenUsage?: IssueReportSessionTokenUsageEnrichment | undefined;
+  readonly originator?: string | null | undefined;
+  readonly sessionSource?: string | null | undefined;
+  readonly cliVersion?: string | null | undefined;
+  readonly modelProvider?: string | null | undefined;
+  readonly gitBranch?: string | null | undefined;
+  readonly gitCommit?: string | null | undefined;
+  readonly finalSummary?: string | null | undefined;
+  readonly sourceArtifacts?: readonly string[] | undefined;
+  readonly notes?: readonly string[] | undefined;
+}
+
+export interface IssueReportEnrichment {
+  readonly notes?: readonly string[] | undefined;
+  readonly sessions?: readonly IssueReportSessionEnrichment[] | undefined;
+}
+
+export interface IssueReportEnricherInput {
+  readonly workspaceRoot: string;
+  readonly loaded: LoadedIssueArtifacts;
+  readonly report: IssueReportDocument;
+}
+
+export interface IssueReportEnricher {
+  readonly id: string;
+  enrich(input: IssueReportEnricherInput): Promise<IssueReportEnrichment>;
+}
+
+export async function applyIssueReportEnrichers(
+  report: IssueReportDocument,
+  input: Omit<IssueReportEnricherInput, "report">,
+  enrichers: readonly IssueReportEnricher[],
+): Promise<IssueReportDocument> {
+  if (enrichers.length === 0) {
+    return report;
+  }
+
+  let nextReport = report;
+  for (const enricher of enrichers) {
+    try {
+      const enrichment = await enricher.enrich({
+        ...input,
+        report: nextReport,
+      });
+      nextReport = mergeIssueReportEnrichment(nextReport, enrichment);
+    } catch (error) {
+      nextReport = mergeIssueReportEnrichment(nextReport, {
+        notes: [
+          `A runner log enricher failed and its optional additions were skipped: ${formatErrorMessage(error)}`,
+        ],
+      });
+    }
+  }
+
+  return nextReport;
+}
+
+export function mergeIssueReportEnrichment(
+  report: IssueReportDocument,
+  enrichment: IssueReportEnrichment,
+): IssueReportDocument {
+  if (
+    (enrichment.notes === undefined || enrichment.notes.length === 0) &&
+    (enrichment.sessions === undefined || enrichment.sessions.length === 0)
+  ) {
+    return report;
+  }
+
+  const enrichedSessions = report.tokenUsage.sessions.map((session) => {
+    const matching = (enrichment.sessions ?? []).filter(
+      (candidate) => candidate.sessionId === session.sessionId,
+    );
+    if (matching.length === 0) {
+      return session;
+    }
+
+    let nextSession = session;
+    for (const candidate of matching) {
+      nextSession = mergeIssueReportSession(nextSession, candidate);
+    }
+    return nextSession;
+  });
+
+  const mergedTokenUsage = rebuildTokenUsage(report.tokenUsage, enrichedSessions, [
+    ...report.tokenUsage.notes,
+    ...(enrichment.notes ?? []),
+  ]);
+
+  return {
+    ...report,
+    tokenUsage: mergedTokenUsage,
+  };
+}
+
+function mergeIssueReportSession(
+  session: IssueReportTokenUsageSession,
+  enrichment: IssueReportSessionEnrichment,
+): IssueReportTokenUsageSession {
+  const tokenUsage = enrichment.tokenUsage;
+  const next: IssueReportTokenUsageSession = {
+    ...session,
+    inputTokens:
+      tokenUsage?.inputTokens ?? session.inputTokens,
+    cachedInputTokens:
+      tokenUsage?.cachedInputTokens ?? session.cachedInputTokens,
+    outputTokens:
+      tokenUsage?.outputTokens ?? session.outputTokens,
+    reasoningOutputTokens:
+      tokenUsage?.reasoningOutputTokens ?? session.reasoningOutputTokens,
+    totalTokens:
+      tokenUsage?.totalTokens ?? session.totalTokens,
+    originator: enrichment.originator ?? session.originator,
+    sessionSource: enrichment.sessionSource ?? session.sessionSource,
+    cliVersion: enrichment.cliVersion ?? session.cliVersion,
+    modelProvider: enrichment.modelProvider ?? session.modelProvider,
+    gitBranch: enrichment.gitBranch ?? session.gitBranch,
+    gitCommit: enrichment.gitCommit ?? session.gitCommit,
+    finalSummary: enrichment.finalSummary ?? session.finalSummary,
+    sourceArtifacts: uniqueStrings([
+      ...session.sourceArtifacts,
+      ...(enrichment.sourceArtifacts ?? []),
+    ]),
+    notes: uniqueStrings([...session.notes, ...(enrichment.notes ?? [])]),
+  };
+
+  return {
+    ...next,
+    status: deriveSessionStatus(next),
+  };
+}
+
+function rebuildTokenUsage(
+  base: IssueReportTokenUsage,
+  sessions: readonly IssueReportTokenUsageSession[],
+  notes: readonly string[],
+): IssueReportTokenUsage {
+  const enrichedSessionCount = sessions.filter(
+    (session) => session.status !== "unavailable",
+  ).length;
+  const completeSessionCount = sessions.filter(
+    (session) => session.totalTokens !== null,
+  ).length;
+  const anySessionDetail = enrichedSessionCount > 0;
+  const allSessionTotalsAvailable =
+    sessions.length > 0 && completeSessionCount === sessions.length;
+  const someSessionTotalsAvailable =
+    completeSessionCount > 0 && !allSessionTotalsAvailable;
+
+  const status =
+    allSessionTotalsAvailable
+      ? "complete"
+      : someSessionTotalsAvailable
+        ? "partial"
+        : anySessionDetail
+          ? "partial"
+          : base.status;
+  const explanation =
+    allSessionTotalsAvailable
+      ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
+      : someSessionTotalsAvailable
+        ? `Runner log enrichment supplied token totals for ${completeSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
+        : anySessionDetail
+          ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
+          : base.explanation;
+
+  const attempts = base.attempts.map((attempt) => {
+    const attemptSessions = sessions.filter((session) =>
+      attempt.sessionIds.includes(session.sessionId),
+    );
+    const totalTokens =
+      attemptSessions.length > 0 &&
+      attemptSessions.every((session) => session.totalTokens !== null)
+        ? attemptSessions.reduce(
+            (total, session) => total + (session.totalTokens ?? 0),
+            0,
+          )
+        : null;
+    return {
+      ...attempt,
+      totalTokens,
+      costUsd: null,
+    };
+  });
+
+  const agentsByName = new Map<
+    string,
+    {
+      sessionCount: number;
+      totalTokens: number | null;
+      hasMissingTokens: boolean;
+    }
+  >();
+  for (const session of sessions) {
+    const label =
+      session.model === null
+        ? session.provider
+        : `${session.provider} (${session.model})`;
+    const existing = agentsByName.get(label) ?? {
+      sessionCount: 0,
+      totalTokens: 0,
+      hasMissingTokens: false,
+    };
+    agentsByName.set(label, {
+      sessionCount: existing.sessionCount + 1,
+      totalTokens:
+        existing.totalTokens === null
+          ? null
+          : session.totalTokens === null
+            ? existing.totalTokens
+            : existing.totalTokens + session.totalTokens,
+      hasMissingTokens:
+        existing.hasMissingTokens || session.totalTokens === null,
+    });
+  }
+
+  const agents = [...agentsByName.entries()]
+    .map(([agent, value]) => ({
+      agent,
+      sessionCount: value.sessionCount,
+      totalTokens: value.hasMissingTokens ? null : value.totalTokens,
+      costUsd: null,
+    }))
+    .sort((left, right) => left.agent.localeCompare(right.agent));
+
+  const totalTokens =
+    sessions.length > 0 && sessions.every((session) => session.totalTokens !== null)
+      ? sessions.reduce(
+          (total, session) => total + (session.totalTokens ?? 0),
+          0,
+        )
+      : null;
+
+  return {
+    ...base,
+    status,
+    explanation,
+    totalTokens,
+    costUsd: null,
+    sessions,
+    attempts,
+    agents,
+    rawArtifacts: uniqueStrings([
+      ...base.rawArtifacts,
+      ...sessions.flatMap((session) => session.sourceArtifacts),
+    ]),
+    notes: uniqueStrings(notes),
+  };
+}
+
+function deriveSessionStatus(
+  session: IssueReportTokenUsageSession,
+): IssueReportTokenUsageSession["status"] {
+  if (session.totalTokens !== null) {
+    return "complete";
+  }
+  if (
+    session.originator !== null ||
+    session.sessionSource !== null ||
+    session.finalSummary !== null ||
+    session.modelProvider !== null ||
+    session.cliVersion !== null ||
+    session.gitBranch !== null ||
+    session.gitCommit !== null ||
+    session.sourceArtifacts.length > 1
+  ) {
+    return "partial";
+  }
+  return "unavailable";
+}
+
+function uniqueStrings(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/observability/issue-report-markdown.ts
+++ b/src/observability/issue-report-markdown.ts
@@ -121,7 +121,9 @@ export function renderIssueReportMarkdown(report: IssueReportDocument): string {
         );
       }
       if (session.sourceArtifacts.length > 0) {
-        lines.push(`  - Source artifacts: ${session.sourceArtifacts.join(", ")}`);
+        lines.push(
+          `  - Source artifacts: ${session.sourceArtifacts.join(", ")}`,
+        );
       }
       for (const note of session.notes) {
         lines.push(`  - Note: ${note}`);

--- a/src/observability/issue-report-markdown.ts
+++ b/src/observability/issue-report-markdown.ts
@@ -83,13 +83,49 @@ export function renderIssueReportMarkdown(report: IssueReportDocument): string {
   lines.push(
     `- Estimated cost (USD): ${renderCurrency(report.tokenUsage.costUsd)}`,
   );
+  for (const note of report.tokenUsage.notes) {
+    lines.push(`- Note: ${note}`);
+  }
   if (report.tokenUsage.sessions.length === 0) {
     lines.push("- Sessions: Unavailable");
   } else {
     for (const session of report.tokenUsage.sessions) {
       lines.push(
-        `- Session ${session.sessionId}: attempt ${session.attemptNumber.toString()}, agent ${session.provider}${session.model === null ? "" : ` (${session.model})`}, tokens ${renderNumber(session.totalTokens)}, cost ${renderCurrency(session.costUsd)}`,
+        `- Session ${session.sessionId}: attempt ${session.attemptNumber.toString()}, agent ${session.provider}${session.model === null ? "" : ` (${session.model})`}, status ${session.status}, tokens ${renderNumber(session.totalTokens)}, cost ${renderCurrency(session.costUsd)}`,
       );
+      if (session.inputTokens !== null || session.outputTokens !== null) {
+        lines.push(
+          `  - Token detail: input ${renderNumber(session.inputTokens)}, cached input ${renderNumber(session.cachedInputTokens)}, output ${renderNumber(session.outputTokens)}, reasoning output ${renderNumber(session.reasoningOutputTokens)}`,
+        );
+      }
+      if (
+        session.originator !== null ||
+        session.sessionSource !== null ||
+        session.cliVersion !== null
+      ) {
+        lines.push(
+          `  - Session detail: originator ${renderValue(session.originator)}, source ${renderValue(session.sessionSource)}, CLI ${renderValue(session.cliVersion)}`,
+        );
+      }
+      if (session.modelProvider !== null) {
+        lines.push(`  - Model provider: ${session.modelProvider}`);
+      }
+      if (session.gitBranch !== null || session.gitCommit !== null) {
+        lines.push(
+          `  - Git: branch ${renderValue(session.gitBranch)}, commit ${renderValue(session.gitCommit)}`,
+        );
+      }
+      if (session.finalSummary !== null) {
+        lines.push(
+          `  - Final summary: ${collapseWhitespace(session.finalSummary)}`,
+        );
+      }
+      if (session.sourceArtifacts.length > 0) {
+        lines.push(`  - Source artifacts: ${session.sourceArtifacts.join(", ")}`);
+      }
+      for (const note of session.notes) {
+        lines.push(`  - Note: ${note}`);
+      }
     }
   }
   lines.push("");
@@ -187,4 +223,8 @@ function renderNumberList(values: readonly number[]): string {
   return values.length === 0
     ? "Unavailable"
     : values.map((value) => value.toString()).join(", ");
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
 }

--- a/src/observability/issue-report-markdown.ts
+++ b/src/observability/issue-report-markdown.ts
@@ -116,9 +116,10 @@ export function renderIssueReportMarkdown(report: IssueReportDocument): string {
         );
       }
       if (session.finalSummary !== null) {
-        lines.push(
-          `  - Final summary: ${collapseWhitespace(session.finalSummary)}`,
-        );
+        lines.push("  - Final summary:");
+        for (const line of renderMultilineSummary(session.finalSummary)) {
+          lines.push(`    - ${line}`);
+        }
       }
       if (session.sourceArtifacts.length > 0) {
         lines.push(
@@ -227,6 +228,14 @@ function renderNumberList(values: readonly number[]): string {
     : values.map((value) => value.toString()).join(", ");
 }
 
-function collapseWhitespace(value: string): string {
-  return value.replace(/\s+/gu, " ").trim();
+function renderMultilineSummary(value: string): readonly string[] {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .flatMap((line) => {
+      if (line.length === 0) {
+        return [];
+      }
+      return [line.replace(/^[-*]\s+/u, "")];
+    });
 }

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -294,18 +294,16 @@ export async function readIssueReport(
   issueNumber: number,
 ): Promise<StoredIssueReport> {
   const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
-  const [rawReportJson, rawReportMarkdown] = await Promise.all([
-    readRequiredIssueReportFile(
-      outputPaths.reportJsonFile,
-      issueNumber,
-      "JSON",
-    ),
-    readRequiredIssueReportFile(
-      outputPaths.reportMarkdownFile,
-      issueNumber,
-      "markdown",
-    ),
-  ]);
+  const rawReportJson = await readRequiredIssueReportFile(
+    outputPaths.reportJsonFile,
+    issueNumber,
+    "JSON",
+  );
+  const rawReportMarkdown = await readRequiredIssueReportFile(
+    outputPaths.reportMarkdownFile,
+    issueNumber,
+    "markdown",
+  );
 
   let report: IssueReportDocument;
   try {

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -318,9 +318,9 @@ export async function readIssueReport(
   const rawReportJson = rawReportJsonResult.value;
   const rawReportMarkdown = rawReportMarkdownResult.value;
 
-  let report: IssueReportDocument;
+  let parsedReport: unknown;
   try {
-    report = JSON.parse(rawReportJson) as IssueReportDocument;
+    parsedReport = JSON.parse(rawReportJson);
   } catch (error) {
     throw new ObservabilityError(
       `Failed to parse generated issue report JSON at ${outputPaths.reportJsonFile}`,
@@ -329,6 +329,11 @@ export async function readIssueReport(
       },
     );
   }
+  const report = validateStoredIssueReport(
+    parsedReport,
+    outputPaths.reportJsonFile,
+    issueNumber,
+  );
 
   return {
     report,
@@ -336,6 +341,32 @@ export async function readIssueReport(
     rawReportMarkdown,
     outputPaths,
   };
+}
+
+function validateStoredIssueReport(
+  parsedReport: unknown,
+  reportJsonFile: string,
+  issueNumber: number,
+): IssueReportDocument {
+  if (typeof parsedReport !== "object" || parsedReport === null) {
+    throw new ObservabilityError(
+      `Generated issue report JSON at ${reportJsonFile} did not contain a report document object; run 'symphony-report issue --issue ${issueNumber.toString()}' first to regenerate it.`,
+    );
+  }
+
+  const versionValue = (parsedReport as { version?: unknown }).version;
+  if (typeof versionValue !== "number" || !Number.isInteger(versionValue)) {
+    throw new ObservabilityError(
+      `Generated issue report JSON at ${reportJsonFile} is missing a supported schema version; run 'symphony-report issue --issue ${issueNumber.toString()}' first to regenerate it.`,
+    );
+  }
+  if (versionValue !== ISSUE_REPORT_SCHEMA_VERSION) {
+    throw new ObservabilityError(
+      `Generated issue report JSON at ${reportJsonFile} uses schema version ${versionValue.toString()}, but this build expects ${ISSUE_REPORT_SCHEMA_VERSION.toString()}; run 'symphony-report issue --issue ${issueNumber.toString()}' first to regenerate it.`,
+    );
+  }
+
+  return parsedReport as IssueReportDocument;
 }
 
 async function readRequiredIssueReportFile(

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -294,16 +294,29 @@ export async function readIssueReport(
   issueNumber: number,
 ): Promise<StoredIssueReport> {
   const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
-  const rawReportJson = await readRequiredIssueReportFile(
-    outputPaths.reportJsonFile,
-    issueNumber,
-    "JSON",
-  );
-  const rawReportMarkdown = await readRequiredIssueReportFile(
-    outputPaths.reportMarkdownFile,
-    issueNumber,
-    "markdown",
-  );
+  const [rawReportJsonResult, rawReportMarkdownResult] =
+    await Promise.allSettled([
+      readRequiredIssueReportFile(
+        outputPaths.reportJsonFile,
+        issueNumber,
+        "JSON",
+      ),
+      readRequiredIssueReportFile(
+        outputPaths.reportMarkdownFile,
+        issueNumber,
+        "markdown",
+      ),
+    ]);
+
+  if (rawReportJsonResult.status === "rejected") {
+    throw rawReportJsonResult.reason;
+  }
+  if (rawReportMarkdownResult.status === "rejected") {
+    throw rawReportMarkdownResult.reason;
+  }
+
+  const rawReportJson = rawReportJsonResult.value;
+  const rawReportMarkdown = rawReportMarkdownResult.value;
 
   let report: IssueReportDocument;
   try {

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
 import { writeJsonFileAtomic, writeTextFileAtomic } from "./atomic-file.js";
+import type { IssueReportEnricher } from "./issue-report-enrichment.js";
+import { applyIssueReportEnrichers } from "./issue-report-enrichment.js";
 import type {
   IssueArtifactAttemptSnapshot,
   IssueArtifactCheckSnapshot,
@@ -19,7 +21,7 @@ import {
 } from "./issue-artifacts.js";
 import { renderIssueReportMarkdown } from "./issue-report-markdown.js";
 
-export const ISSUE_REPORT_SCHEMA_VERSION = 1 as const;
+export const ISSUE_REPORT_SCHEMA_VERSION = 2 as const;
 
 export type IssueReportAvailability = "complete" | "partial" | "unavailable";
 export type IssueReportTokenUsageStatus =
@@ -100,8 +102,21 @@ export interface IssueReportTokenUsageSession {
   readonly attemptNumber: number;
   readonly provider: string;
   readonly model: string | null;
+  readonly status: IssueReportTokenUsageStatus;
+  readonly inputTokens: number | null;
+  readonly cachedInputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly reasoningOutputTokens: number | null;
   readonly totalTokens: number | null;
   readonly costUsd: number | null;
+  readonly originator: string | null;
+  readonly sessionSource: string | null;
+  readonly cliVersion: string | null;
+  readonly modelProvider: string | null;
+  readonly gitBranch: string | null;
+  readonly gitCommit: string | null;
+  readonly finalSummary: string | null;
+  readonly notes: readonly string[];
   readonly sourceArtifacts: readonly string[];
 }
 
@@ -128,6 +143,7 @@ export interface IssueReportTokenUsage {
   readonly attempts: readonly IssueReportTokenUsageAttempt[];
   readonly agents: readonly IssueReportTokenUsageAgent[];
   readonly rawArtifacts: readonly string[];
+  readonly notes: readonly string[];
 }
 
 export interface IssueReportLearningItem {
@@ -225,12 +241,21 @@ export async function generateIssueReport(
   issueNumber: number,
   options?: {
     readonly generatedAt?: string | undefined;
+    readonly enrichers?: readonly IssueReportEnricher[] | undefined;
   },
 ): Promise<GeneratedIssueReport> {
   const loaded = await loadIssueArtifacts(workspaceRoot, issueNumber);
   const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
   const generatedAt = options?.generatedAt ?? new Date().toISOString();
-  const report = buildIssueReport(loaded, outputPaths, generatedAt);
+  const canonicalReport = buildIssueReport(loaded, outputPaths, generatedAt);
+  const report = await applyIssueReportEnrichers(
+    canonicalReport,
+    {
+      workspaceRoot,
+      loaded,
+    },
+    options?.enrichers ?? [],
+  );
   const markdown = renderIssueReportMarkdown(report);
   return {
     report,
@@ -244,10 +269,12 @@ export async function writeIssueReport(
   issueNumber: number,
   options?: {
     readonly generatedAt?: string | undefined;
+    readonly enrichers?: readonly IssueReportEnricher[] | undefined;
   },
 ): Promise<GeneratedIssueReport> {
   const generated = await generateIssueReport(workspaceRoot, issueNumber, {
     generatedAt: options?.generatedAt,
+    enrichers: options?.enrichers,
   });
   await writeJsonFileAtomic(
     generated.outputPaths.reportJsonFile,
@@ -612,8 +639,21 @@ function buildTokenUsage(
     attemptNumber: session.attemptNumber,
     provider: session.provider,
     model: session.model,
+    status: "unavailable" as const,
+    inputTokens: null,
+    cachedInputTokens: null,
+    outputTokens: null,
+    reasoningOutputTokens: null,
     totalTokens: null,
     costUsd: null,
+    originator: null,
+    sessionSource: null,
+    cliVersion: null,
+    modelProvider: null,
+    gitBranch: null,
+    gitCommit: null,
+    finalSummary: null,
+    notes: [],
     sourceArtifacts: [
       path.join(
         loaded.paths.sessionsDir,
@@ -644,6 +684,7 @@ function buildTokenUsage(
       ...sessions.flatMap((session) => session.sourceArtifacts),
       ...(loaded.logPointers === null ? [] : [loaded.paths.logPointersFile]),
     ],
+    notes: [],
   };
 }
 

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -1,0 +1,377 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { IssueArtifactSessionSnapshot } from "../observability/issue-artifacts.js";
+import type {
+  IssueReportEnricher,
+  IssueReportEnricherInput,
+  IssueReportEnrichment,
+  IssueReportSessionEnrichment,
+} from "../observability/issue-report-enrichment.js";
+
+const MATCH_WINDOW_BEFORE_START_MS = 30 * 60 * 1000;
+const MATCH_WINDOW_AFTER_FINISH_MS = 30 * 60 * 1000;
+const MATCH_WINDOW_WITHOUT_FINISH_MS = 4 * 60 * 60 * 1000;
+
+interface ParsedCodexSessionMeta {
+  readonly id: string | null;
+  readonly timestamp: string | null;
+  readonly cwd: string | null;
+  readonly originator: string | null;
+  readonly source: string | null;
+  readonly cliVersion: string | null;
+  readonly modelProvider: string | null;
+  readonly gitBranch: string | null;
+  readonly gitCommit: string | null;
+}
+
+interface ParsedCodexSession {
+  readonly filePath: string;
+  readonly meta: ParsedCodexSessionMeta;
+  readonly tokenUsage: {
+    readonly inputTokens: number | null;
+    readonly cachedInputTokens: number | null;
+    readonly outputTokens: number | null;
+    readonly reasoningOutputTokens: number | null;
+    readonly totalTokens: number | null;
+  };
+  readonly finalSummary: string | null;
+}
+
+export interface CodexIssueReportEnricherOptions {
+  readonly sessionsRoot?: string | undefined;
+}
+
+export class CodexIssueReportEnricher implements IssueReportEnricher {
+  readonly id = "codex-jsonl";
+  readonly #sessionsRoot: string;
+
+  constructor(options?: CodexIssueReportEnricherOptions) {
+    this.#sessionsRoot =
+      options?.sessionsRoot ?? path.join(os.homedir(), ".codex", "sessions");
+  }
+
+  async enrich(
+    input: IssueReportEnricherInput,
+  ): Promise<IssueReportEnrichment> {
+    const sessions = input.loaded.sessions.filter(
+      (session) => session.provider === "codex",
+    );
+
+    if (sessions.length === 0) {
+      return {};
+    }
+
+    const enrichments: IssueReportSessionEnrichment[] = [];
+    for (const session of sessions) {
+      const enrichment = await this.#enrichSession(session);
+      if (enrichment !== null) {
+        enrichments.push(enrichment);
+      }
+    }
+
+    return enrichments.length > 0 ? { sessions: enrichments } : {};
+  }
+
+  async #enrichSession(
+    session: IssueArtifactSessionSnapshot,
+  ): Promise<IssueReportSessionEnrichment | null> {
+    if (session.workspacePath === null) {
+      return {
+        sessionId: session.sessionId,
+        notes: [
+          "Runner log enrichment was skipped because the canonical session snapshot did not record a workspace path.",
+        ],
+      };
+    }
+
+    if (session.startedAt === null) {
+      return {
+        sessionId: session.sessionId,
+        notes: [
+          "Runner log enrichment was skipped because the canonical session snapshot did not record a start time.",
+        ],
+      };
+    }
+
+    const candidateFiles = await this.#findCandidateFiles(session);
+    let sawParseFailure = false;
+    const matches: ParsedCodexSession[] = [];
+
+    for (const filePath of candidateFiles) {
+      try {
+        const parsed = await parseCodexSessionFile(filePath);
+        if (matchesCodexSession(parsed.meta, session)) {
+          matches.push(parsed);
+        }
+      } catch {
+        sawParseFailure = true;
+      }
+    }
+
+    if (matches.length === 0) {
+      return {
+        sessionId: session.sessionId,
+        notes: [
+          sawParseFailure
+            ? "A runner log file in the matching time window could not be parsed, so enrichment was skipped."
+            : "No matching runner log file was found for this session.",
+        ],
+      };
+    }
+
+    if (matches.length > 1) {
+      return {
+        sessionId: session.sessionId,
+        notes: [
+          "Multiple runner log files matched this session, so enrichment was skipped to avoid guessing.",
+        ],
+      };
+    }
+
+    const matched = matches[0];
+    if (matched === undefined) {
+      return null;
+    }
+    return {
+      sessionId: session.sessionId,
+      tokenUsage: matched.tokenUsage,
+      originator: matched.meta.originator,
+      sessionSource: matched.meta.source,
+      cliVersion: matched.meta.cliVersion,
+      modelProvider: matched.meta.modelProvider,
+      gitBranch: matched.meta.gitBranch,
+      gitCommit: matched.meta.gitCommit,
+      finalSummary: matched.finalSummary,
+      sourceArtifacts: [matched.filePath],
+    };
+  }
+
+  async #findCandidateFiles(
+    session: IssueArtifactSessionSnapshot,
+  ): Promise<readonly string[]> {
+    const dayRoots = deriveCandidateDayRoots(this.#sessionsRoot, session);
+    const discovered: string[] = [];
+
+    for (const dayRoot of dayRoots) {
+      const entries = await fs.readdir(dayRoot, { withFileTypes: true }).catch(
+        (error) => {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        },
+      );
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+          discovered.push(path.join(dayRoot, entry.name));
+        }
+      }
+    }
+
+    return discovered.sort((left, right) => left.localeCompare(right));
+  }
+}
+
+export function createDefaultIssueReportEnrichers(): readonly IssueReportEnricher[] {
+  return [new CodexIssueReportEnricher()];
+}
+
+async function parseCodexSessionFile(filePath: string): Promise<ParsedCodexSession> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let meta: ParsedCodexSessionMeta | null = null;
+  let tokenUsage: ParsedCodexSession["tokenUsage"] = {
+    inputTokens: null,
+    cachedInputTokens: null,
+    outputTokens: null,
+    reasoningOutputTokens: null,
+    totalTokens: null,
+  };
+  let finalSummary: string | null = null;
+
+  for (const line of lines) {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    if (parsed["type"] === "session_meta") {
+      meta = parseSessionMeta(parsed);
+      continue;
+    }
+    if (parsed["type"] === "event_msg") {
+      const usage = parseTokenCount(parsed);
+      if (usage !== null) {
+        tokenUsage = usage;
+      }
+      continue;
+    }
+    if (parsed["type"] === "response_item") {
+      const assistantText = parseAssistantOutputText(parsed);
+      if (assistantText !== null) {
+        finalSummary = assistantText;
+      }
+    }
+  }
+
+  if (meta === null) {
+    throw new Error(`No Codex session metadata was found in ${filePath}`);
+  }
+
+  return {
+    filePath,
+    meta,
+    tokenUsage,
+    finalSummary,
+  };
+}
+
+function parseSessionMeta(record: Record<string, unknown>): ParsedCodexSessionMeta {
+  const payload = asRecord(record["payload"]);
+  const git = asRecord(payload?.["git"]);
+
+  return {
+    id: asString(payload?.["id"]),
+    timestamp: asString(payload?.["timestamp"]) ?? asString(record["timestamp"]),
+    cwd: asString(payload?.["cwd"]),
+    originator: asString(payload?.["originator"]),
+    source: asString(payload?.["source"]),
+    cliVersion: asString(payload?.["cli_version"]),
+    modelProvider: asString(payload?.["model_provider"]),
+    gitBranch: asString(git?.["branch"]),
+    gitCommit: asString(git?.["commit_hash"]),
+  };
+}
+
+function parseTokenCount(
+  record: Record<string, unknown>,
+): ParsedCodexSession["tokenUsage"] | null {
+  const payload = asRecord(record["payload"]);
+  if (payload?.["type"] !== "token_count") {
+    return null;
+  }
+  const info = asRecord(payload["info"]);
+  const total = asRecord(info?.["total_token_usage"]);
+  if (total === null) {
+    return null;
+  }
+  return {
+    inputTokens: asNumber(total["input_tokens"]),
+    cachedInputTokens: asNumber(total["cached_input_tokens"]),
+    outputTokens: asNumber(total["output_tokens"]),
+    reasoningOutputTokens: asNumber(total["reasoning_output_tokens"]),
+    totalTokens: asNumber(total["total_tokens"]),
+  };
+}
+
+function parseAssistantOutputText(record: Record<string, unknown>): string | null {
+  const payload = asRecord(record["payload"]);
+  if (payload?.["type"] !== "message" || payload["role"] !== "assistant") {
+    return null;
+  }
+  const content = payload["content"];
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const texts = content
+    .map((item) => asRecord(item))
+    .flatMap((item) => {
+      if (item?.["type"] !== "output_text") {
+        return [];
+      }
+      const text = asString(item["text"]);
+      return text === null || text.trim().length === 0 ? [] : [text.trim()];
+    });
+
+  if (texts.length === 0) {
+    return null;
+  }
+
+  return texts.join("\n\n");
+}
+
+function matchesCodexSession(
+  meta: ParsedCodexSessionMeta,
+  session: IssueArtifactSessionSnapshot,
+): boolean {
+  if (meta.cwd === null) {
+    return false;
+  }
+  if (path.resolve(meta.cwd) !== path.resolve(session.workspacePath ?? "")) {
+    return false;
+  }
+  if (
+    session.branch !== null &&
+    meta.gitBranch !== null &&
+    session.branch !== meta.gitBranch
+  ) {
+    return false;
+  }
+
+  const sessionStart = parseTimestamp(session.startedAt);
+  const sessionFinish =
+    parseTimestamp(session.finishedAt) ??
+    (sessionStart === null
+      ? null
+      : sessionStart + MATCH_WINDOW_WITHOUT_FINISH_MS);
+  const metaTimestamp = parseTimestamp(meta.timestamp);
+  if (sessionStart !== null && metaTimestamp !== null) {
+    const lowerBound = sessionStart - MATCH_WINDOW_BEFORE_START_MS;
+    const upperBound =
+      (sessionFinish ?? sessionStart + MATCH_WINDOW_WITHOUT_FINISH_MS) +
+      MATCH_WINDOW_AFTER_FINISH_MS;
+    if (metaTimestamp < lowerBound || metaTimestamp > upperBound) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function deriveCandidateDayRoots(
+  sessionsRoot: string,
+  session: IssueArtifactSessionSnapshot,
+): readonly string[] {
+  const startedAt = parseTimestamp(session.startedAt);
+  const finishedAt = parseTimestamp(session.finishedAt);
+  const anchors = [
+    startedAt,
+    finishedAt,
+    startedAt === null ? null : startedAt - 24 * 60 * 60 * 1000,
+    finishedAt === null ? null : finishedAt + 24 * 60 * 60 * 1000,
+  ].filter((value): value is number => value !== null);
+
+  return [...new Set(anchors.map((value) => path.join(sessionsRoot, formatDatePath(value))))];
+}
+
+function formatDatePath(timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const year = date.getUTCFullYear().toString().padStart(4, "0");
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = date.getUTCDate().toString().padStart(2, "0");
+  return path.join(year, month, day);
+}
+
+function parseTimestamp(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -350,6 +350,11 @@ function deriveCandidateDayRoots(
     startedAt,
     finishedAt,
     startedAt === null ? null : startedAt - 24 * 60 * 60 * 1000,
+    finishedAt === null
+      ? startedAt === null
+        ? null
+        : startedAt + MATCH_WINDOW_WITHOUT_FINISH_MS
+      : null,
     finishedAt === null ? null : finishedAt + 24 * 60 * 60 * 1000,
   ].filter((value): value is number => value !== null);
 

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -205,6 +205,8 @@ async function parseCodexSessionFile(
     if (parsed["type"] === "event_msg") {
       const usage = parseTokenCount(parsed);
       if (usage !== null) {
+        // Codex emits cumulative totals in `info.total_token_usage`, so the
+        // latest token_count snapshot is the full-session total for reporting.
         tokenUsage = usage;
       }
       continue;
@@ -327,7 +329,10 @@ function matchesCodexSession(
       ? null
       : sessionStart + MATCH_WINDOW_WITHOUT_FINISH_MS);
   const metaTimestamp = parseTimestamp(meta.timestamp);
-  if (sessionStart !== null && metaTimestamp !== null) {
+  if (sessionStart !== null) {
+    if (metaTimestamp === null) {
+      return false;
+    }
     const lowerBound = sessionStart - MATCH_WINDOW_BEFORE_START_MS;
     const upperBound =
       (sessionFinish ?? sessionStart + MATCH_WINDOW_WITHOUT_FINISH_MS) +

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -356,6 +356,12 @@ function deriveCandidateDayRoots(
 ): readonly string[] {
   const startedAt = parseTimestamp(session.startedAt);
   const finishedAt = parseTimestamp(session.finishedAt);
+  const unfinishedUpperBound =
+    startedAt === null
+      ? null
+      : startedAt +
+        MATCH_WINDOW_WITHOUT_FINISH_MS +
+        MATCH_WINDOW_AFTER_FINISH_MS;
   const anchors = [
     startedAt,
     finishedAt,
@@ -363,7 +369,7 @@ function deriveCandidateDayRoots(
     finishedAt === null
       ? startedAt === null
         ? null
-        : startedAt + MATCH_WINDOW_WITHOUT_FINISH_MS
+        : unfinishedUpperBound
       : null,
     finishedAt === null ? null : finishedAt + 24 * 60 * 60 * 1000,
   ].filter((value): value is number => value !== null);

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -154,14 +154,14 @@ export class CodexIssueReportEnricher implements IssueReportEnricher {
     const discovered: string[] = [];
 
     for (const dayRoot of dayRoots) {
-      const entries = await fs.readdir(dayRoot, { withFileTypes: true }).catch(
-        (error) => {
+      const entries = await fs
+        .readdir(dayRoot, { withFileTypes: true })
+        .catch((error) => {
           if ((error as NodeJS.ErrnoException).code === "ENOENT") {
             return [];
           }
           throw error;
-        },
-      );
+        });
       for (const entry of entries) {
         if (entry.isFile() && entry.name.endsWith(".jsonl")) {
           discovered.push(path.join(dayRoot, entry.name));
@@ -177,7 +177,9 @@ export function createDefaultIssueReportEnrichers(): readonly IssueReportEnriche
   return [new CodexIssueReportEnricher()];
 }
 
-async function parseCodexSessionFile(filePath: string): Promise<ParsedCodexSession> {
+async function parseCodexSessionFile(
+  filePath: string,
+): Promise<ParsedCodexSession> {
   const raw = await fs.readFile(filePath, "utf8");
   const lines = raw
     .split("\n")
@@ -227,13 +229,16 @@ async function parseCodexSessionFile(filePath: string): Promise<ParsedCodexSessi
   };
 }
 
-function parseSessionMeta(record: Record<string, unknown>): ParsedCodexSessionMeta {
+function parseSessionMeta(
+  record: Record<string, unknown>,
+): ParsedCodexSessionMeta {
   const payload = asRecord(record["payload"]);
   const git = asRecord(payload?.["git"]);
 
   return {
     id: asString(payload?.["id"]),
-    timestamp: asString(payload?.["timestamp"]) ?? asString(record["timestamp"]),
+    timestamp:
+      asString(payload?.["timestamp"]) ?? asString(record["timestamp"]),
     cwd: asString(payload?.["cwd"]),
     originator: asString(payload?.["originator"]),
     source: asString(payload?.["source"]),
@@ -265,7 +270,9 @@ function parseTokenCount(
   };
 }
 
-function parseAssistantOutputText(record: Record<string, unknown>): string | null {
+function parseAssistantOutputText(
+  record: Record<string, unknown>,
+): string | null {
   const payload = asRecord(record["payload"]);
   if (payload?.["type"] !== "message" || payload["role"] !== "assistant") {
     return null;
@@ -343,7 +350,11 @@ function deriveCandidateDayRoots(
     finishedAt === null ? null : finishedAt + 24 * 60 * 60 * 1000,
   ].filter((value): value is number => value !== null);
 
-  return [...new Set(anchors.map((value) => path.join(sessionsRoot, formatDatePath(value))))];
+  return [
+    ...new Set(
+      anchors.map((value) => path.join(sessionsRoot, formatDatePath(value))),
+    ),
+  ];
 }
 
 function formatDatePath(timestampMs: number): string {

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -64,9 +64,18 @@ export class CodexIssueReportEnricher implements IssueReportEnricher {
 
     const enrichments: IssueReportSessionEnrichment[] = [];
     for (const session of sessions) {
-      const enrichment = await this.#enrichSession(session);
-      if (enrichment !== null) {
-        enrichments.push(enrichment);
+      try {
+        const enrichment = await this.#enrichSession(session);
+        if (enrichment !== null) {
+          enrichments.push(enrichment);
+        }
+      } catch (error) {
+        enrichments.push({
+          sessionId: session.sessionId,
+          notes: [
+            `Runner log enrichment failed for this session and was skipped: ${formatErrorMessage(error)}`,
+          ],
+        });
       }
     }
 
@@ -409,4 +418,8 @@ function asString(value: unknown): string | null {
 
 function asNumber(value: unknown): number | null {
   return typeof value === "number" ? value : null;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -144,6 +144,11 @@ export class CodexIssueReportEnricher implements IssueReportEnricher {
       gitCommit: matched.meta.gitCommit,
       finalSummary: matched.finalSummary,
       sourceArtifacts: [matched.filePath],
+      notes: sawParseFailure
+        ? [
+            "At least one runner log file in the matching time window could not be parsed; enrichment used the only readable match.",
+          ]
+        : undefined,
     };
   }
 

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -306,7 +306,10 @@ function matchesCodexSession(
   if (meta.cwd === null) {
     return false;
   }
-  if (path.resolve(meta.cwd) !== path.resolve(session.workspacePath ?? "")) {
+  if (session.workspacePath === null) {
+    return false;
+  }
+  if (path.resolve(meta.cwd) !== path.resolve(session.workspacePath)) {
     return false;
   }
   if (

--- a/src/runner/local-command.ts
+++ b/src/runner/local-command.ts
@@ -74,7 +74,11 @@ function tokenizeShellWords(command: string): readonly string[] {
     }
 
     if (character === "\\") {
-      escaping = true;
+      if (quote === "'") {
+        current += character;
+      } else {
+        escaping = true;
+      }
       continue;
     }
 

--- a/src/runner/local-command.ts
+++ b/src/runner/local-command.ts
@@ -1,0 +1,111 @@
+import path from "node:path";
+
+export interface LocalRunnerBackendDescription {
+  readonly provider: string;
+  readonly model: string | null;
+}
+
+export function describeLocalRunnerBackend(
+  command: string,
+): LocalRunnerBackendDescription {
+  const tokens = tokenizeShellWords(command);
+  const executable = findExecutable(tokens);
+  if (executable === null) {
+    return {
+      provider: "local-runner",
+      model: null,
+    };
+  }
+
+  if (path.basename(executable) !== "codex") {
+    return {
+      provider: "local-runner",
+      model: null,
+    };
+  }
+
+  return {
+    provider: "codex",
+    model: readModelFlag(tokens),
+  };
+}
+
+function findExecutable(tokens: readonly string[]): string | null {
+  for (const token of tokens) {
+    if (!token.includes("=")) {
+      return token;
+    }
+  }
+  return null;
+}
+
+function readModelFlag(tokens: readonly string[]): string | null {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === undefined) {
+      continue;
+    }
+    if (token === "-m" || token === "--model") {
+      const value = tokens[index + 1];
+      if (value !== undefined && value.length > 0) {
+        return value;
+      }
+      continue;
+    }
+    if (token.startsWith("--model=")) {
+      const value = token.slice("--model=".length);
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+function tokenizeShellWords(command: string): readonly string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (const character of command) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote !== null) {
+      if (character === quote) {
+        quote = null;
+        continue;
+      }
+      current += character;
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/u.test(character)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}

--- a/src/runner/local-command.ts
+++ b/src/runner/local-command.ts
@@ -47,7 +47,7 @@ function readModelFlag(tokens: readonly string[]): string | null {
     }
     if (token === "-m" || token === "--model") {
       const value = tokens[index + 1];
-      if (value !== undefined && value.length > 0) {
+      if (value !== undefined && value.length > 0 && !value.startsWith("-")) {
         return value;
       }
       continue;

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -10,6 +10,7 @@ import type {
   RunnerRunOptions,
   RunnerSessionDescription,
 } from "./service.js";
+import { describeLocalRunnerBackend } from "./local-command.js";
 
 export class LocalRunner implements Runner {
   static readonly #terminationGraceMs = 200;
@@ -22,9 +23,10 @@ export class LocalRunner implements Runner {
   }
 
   describeSession(_session: RunSession): RunnerSessionDescription {
+    const backend = describeLocalRunnerBackend(this.#config.command);
     return {
-      provider: "local-runner",
-      model: null,
+      provider: backend.provider,
+      model: backend.model,
       logPointers: [],
     };
   }

--- a/tests/integration/factory-runs-cli.test.ts
+++ b/tests/integration/factory-runs-cli.test.ts
@@ -12,7 +12,10 @@ import {
   deriveIssueArtifactPaths,
   type IssueArtifactLogPointersDocument,
 } from "../../src/observability/issue-artifacts.js";
-import { writeIssueReport } from "../../src/observability/issue-report.js";
+import {
+  ISSUE_REPORT_SCHEMA_VERSION,
+  writeIssueReport,
+} from "../../src/observability/issue-report.js";
 import {
   checkoutGitBranch,
   commitAllFiles,
@@ -20,6 +23,7 @@ import {
   initializeGitRepo,
 } from "../support/git.js";
 import {
+  downgradeIssueReportSchemaVersion,
   deriveWorkspaceRoot,
   seedFailedIssueArtifacts,
   seedSuccessfulIssueArtifacts,
@@ -535,6 +539,51 @@ describe("factory-runs publication", () => {
       fs.readFile(path.join(archiveRoot, "README.md"), "utf8"),
     ).resolves.toBe("# archive\n");
     expect(workflowPath).toContain("WORKFLOW.md");
+  });
+
+  it("fails clearly when the generated report schema is stale and leaves the archive unchanged", async () => {
+    const sourceRoot = await createTempDir("symphony-factory-runs-stale-");
+    const archiveRoot = await createTempDir("symphony-factory-runs-archive-");
+    tempRoots.push(sourceRoot, archiveRoot);
+
+    await writeReportWorkflow(sourceRoot);
+    const workspaceRoot = deriveWorkspaceRoot(sourceRoot);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await initializeGitRepo(sourceRoot);
+    await checkoutGitBranch(sourceRoot, "symphony/44");
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T10:25:30.123Z",
+    });
+    await downgradeIssueReportSchemaVersion(
+      generated.outputPaths.reportJsonFile,
+    );
+    await commitAllFiles(sourceRoot, "seed stale report publish inputs");
+
+    await initializeGitRepo(archiveRoot);
+    await fs.writeFile(
+      path.join(archiveRoot, "README.md"),
+      "# archive\n",
+      "utf8",
+    );
+
+    await expect(
+      publishIssueToFactoryRuns({
+        workspaceRoot,
+        sourceRoot,
+        archiveRoot,
+        issueNumber: 44,
+      }),
+    ).rejects.toThrowError(
+      `Generated issue report JSON at ${generated.outputPaths.reportJsonFile} uses schema version 1, but this build expects ${ISSUE_REPORT_SCHEMA_VERSION.toString()}; run 'symphony-report issue --issue 44' first to regenerate it.`,
+    );
+
+    await expect(
+      fs.stat(path.join(archiveRoot, "symphony-ts", "issues", "44")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.readFile(path.join(archiveRoot, "README.md"), "utf8"),
+    ).resolves.toBe("# archive\n");
   });
 
   it("cleans up empty archive directories when publication fails after staging starts", async () => {

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -43,15 +43,18 @@ describe("report CLI", () => {
       return true;
     }) as typeof process.stdout.write);
 
-    await runReportCli([
-      "node",
-      "symphony-report",
-      "issue",
-      "--issue",
-      "44",
-      "--workflow",
-      workflowPath,
-    ]);
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
 
     const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
     await expect(
@@ -70,15 +73,18 @@ describe("report CLI", () => {
     const workspaceRoot = deriveWorkspaceRoot(tempDir);
     await seedFailedIssueArtifacts(workspaceRoot, 44);
 
-    await runReportCli([
-      "node",
-      "symphony-report",
-      "issue",
-      "--issue",
-      "44",
-      "--workflow",
-      workflowPath,
-    ]);
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
 
     const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
     const reportJson = await fs.readFile(
@@ -150,15 +156,18 @@ describe("report CLI", () => {
     const workspaceRoot = deriveWorkspaceRoot(tempDir);
     await seedSessionAnchoredPartialArtifacts(workspaceRoot, 44);
 
-    await runReportCli([
-      "node",
-      "symphony-report",
-      "issue",
-      "--issue",
-      "44",
-      "--workflow",
-      workflowPath,
-    ]);
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
 
     const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
     const reportMd = await fs.readFile(
@@ -236,15 +245,18 @@ Prompt body
       await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
 
       await expect(
-        runReportCli([
-          "node",
-          "symphony-report",
-          "issue",
-          "--issue",
-          "44",
-          "--workflow",
-          workflowPath,
-        ]),
+        runReportCli(
+          [
+            "node",
+            "symphony-report",
+            "issue",
+            "--issue",
+            "44",
+            "--workflow",
+            workflowPath,
+          ],
+          { issueEnrichers: [] },
+        ),
       ).resolves.toBeUndefined();
     } finally {
       if (previousApiKey === undefined) {

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -2,12 +2,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runReportCli } from "../../src/cli/report.js";
+import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
 import { createTempDir } from "../support/git.js";
 import {
+  deriveCodexSessionsRoot,
   deriveWorkspaceRoot,
   seedFailedIssueArtifacts,
   seedSessionAnchoredPartialArtifacts,
   seedSuccessfulIssueArtifacts,
+  writeCodexSessionLog,
   writeReportWorkflow,
 } from "../support/issue-report-fixtures.js";
 
@@ -90,6 +93,54 @@ describe("report CLI", () => {
     expect(reportJson).toContain('"outcome": "failed"');
     expect(reportMd).toContain("## Token Usage");
     expect(reportMd).toContain("Status: unavailable");
+  });
+
+  it("writes optional Codex-enriched token usage when a matching JSONL log is available", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-codex-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: path.join(workspaceRoot, "issue-44"),
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-issue-44.jsonl",
+      totalTokens: 3210,
+      finalSummary: "- Enriched the report from a matched Codex JSONL session.",
+    });
+
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      {
+        issueEnrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+      },
+    );
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
+    const reportJson = await fs.readFile(
+      path.join(reportDir, "report.json"),
+      "utf8",
+    );
+    const reportMd = await fs.readFile(
+      path.join(reportDir, "report.md"),
+      "utf8",
+    );
+    expect(reportJson).toContain('"status": "complete"');
+    expect(reportJson).toContain('"totalTokens": 3210');
+    expect(reportJson).toContain("matched Codex JSONL session");
+    expect(reportMd).toContain("Status: complete");
+    expect(reportMd).toContain("Final summary:");
   });
 
   it("generates a partial report when session artifacts still anchor the issue", async () => {

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -610,3 +610,48 @@ export async function writeCodexSessionLog(options: {
   );
   return filePath;
 }
+
+export async function downgradeIssueReportSchemaVersion(
+  reportJsonFile: string,
+): Promise<void> {
+  const parsedReport = JSON.parse(
+    await fs.readFile(reportJsonFile, "utf8"),
+  ) as {
+    readonly tokenUsage?: {
+      readonly sessions?: readonly Record<string, unknown>[];
+    };
+  } & Record<string, unknown>;
+  const sessions = parsedReport.tokenUsage?.sessions ?? [];
+  const [firstSession, ...remainingSessions] = sessions;
+  const staleFirstSession =
+    firstSession === undefined
+      ? undefined
+      : (({
+          status: _status,
+          notes: _notes,
+          ...session
+        }: Record<string, unknown>) => session)(firstSession);
+
+  await fs.writeFile(
+    reportJsonFile,
+    `${JSON.stringify(
+      {
+        ...parsedReport,
+        version: 1,
+        tokenUsage:
+          parsedReport.tokenUsage === undefined
+            ? undefined
+            : {
+                ...parsedReport.tokenUsage,
+                sessions:
+                  staleFirstSession === undefined
+                    ? sessions
+                    : [staleFirstSession, ...remainingSessions],
+              },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -504,11 +504,21 @@ export async function writeCodexSessionLog(options: {
   readonly workspacePath: string;
   readonly branch: string;
   readonly fileName: string;
+  readonly metaTimestamp?: string | null | undefined;
   readonly inputTokens?: number | undefined;
   readonly cachedInputTokens?: number | undefined;
   readonly outputTokens?: number | undefined;
   readonly reasoningOutputTokens?: number | undefined;
   readonly totalTokens?: number | undefined;
+  readonly tokenEvents?:
+    | readonly {
+        readonly inputTokens?: number | undefined;
+        readonly cachedInputTokens?: number | undefined;
+        readonly outputTokens?: number | undefined;
+        readonly reasoningOutputTokens?: number | undefined;
+        readonly totalTokens?: number | undefined;
+      }[]
+    | undefined;
   readonly finalSummary?: string | undefined;
   readonly malformed?: boolean | undefined;
 }): Promise<string> {
@@ -527,13 +537,26 @@ export async function writeCodexSessionLog(options: {
     return filePath;
   }
 
+  const metaTimestamp =
+    options.metaTimestamp === undefined
+      ? options.startedAt
+      : options.metaTimestamp;
+  const tokenEvents = options.tokenEvents ?? [
+    {
+      inputTokens: options.inputTokens ?? 2000,
+      cachedInputTokens: options.cachedInputTokens ?? 500,
+      outputTokens: options.outputTokens ?? 250,
+      reasoningOutputTokens: options.reasoningOutputTokens ?? 100,
+      totalTokens: options.totalTokens ?? 2750,
+    },
+  ];
   const lines = [
     {
-      timestamp: options.startedAt,
+      ...(metaTimestamp === null ? {} : { timestamp: metaTimestamp }),
       type: "session_meta",
       payload: {
         id: options.fileName.replace(/\.jsonl$/u, ""),
-        timestamp: options.startedAt,
+        ...(metaTimestamp === null ? {} : { timestamp: metaTimestamp }),
         cwd: options.workspacePath,
         originator: "codex_cli_rs",
         cli_version: "0.71.0",
@@ -546,22 +569,22 @@ export async function writeCodexSessionLog(options: {
         },
       },
     },
-    {
+    ...tokenEvents.map((event) => ({
       timestamp: options.startedAt,
       type: "event_msg",
       payload: {
         type: "token_count",
         info: {
           total_token_usage: {
-            input_tokens: options.inputTokens ?? 2000,
-            cached_input_tokens: options.cachedInputTokens ?? 500,
-            output_tokens: options.outputTokens ?? 250,
-            reasoning_output_tokens: options.reasoningOutputTokens ?? 100,
-            total_tokens: options.totalTokens ?? 2750,
+            input_tokens: event.inputTokens ?? 2000,
+            cached_input_tokens: event.cachedInputTokens ?? 500,
+            output_tokens: event.outputTokens ?? 250,
+            reasoning_output_tokens: event.reasoningOutputTokens ?? 100,
+            total_tokens: event.totalTokens ?? 2750,
           },
         },
       },
-    },
+    })),
     {
       timestamp: options.startedAt,
       type: "response_item",

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -421,6 +421,78 @@ export async function seedSessionAnchoredPartialArtifacts(
   });
 }
 
+export async function seedLateUnfinishedSessionArtifacts(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<void> {
+  const paths = deriveIssueArtifactPaths(workspaceRoot, issueNumber);
+  const sessionId = `issue-${issueNumber.toString()}-session-1`;
+
+  await fs.mkdir(paths.attemptsDir, { recursive: true });
+  await fs.mkdir(paths.sessionsDir, { recursive: true });
+  await fs.mkdir(paths.logsDir, { recursive: true });
+
+  await writeJsonFile(path.join(paths.attemptsDir, "1.json"), {
+    version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+    issueNumber,
+    attemptNumber: 1,
+    branch: `symphony/${issueNumber.toString()}`,
+    startedAt: "2026-03-09T22:00:00.000Z",
+    finishedAt: null,
+    outcome: "attempt-failed",
+    summary: "Observed from an unfinished late-start session snapshot",
+    sessionId,
+    runnerPid: 7474,
+    pullRequest: null,
+    review: null,
+    checks: null,
+  });
+
+  await writeJsonFile(
+    path.join(paths.sessionsDir, `${encodeURIComponent(sessionId)}.json`),
+    {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 1,
+      sessionId,
+      provider: "codex",
+      model: "gpt-5.4",
+      startedAt: "2026-03-09T22:00:00.000Z",
+      finishedAt: null,
+      workspacePath: path.join(
+        workspaceRoot,
+        `issue-${issueNumber.toString()}`,
+      ),
+      branch: `symphony/${issueNumber.toString()}`,
+      logPointers: [
+        {
+          name: "runner.log",
+          location: path.join(paths.logsDir, "runner.log"),
+          archiveLocation: null,
+        },
+      ],
+    },
+  );
+
+  await writeJsonFile(paths.logPointersFile, {
+    version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+    issueNumber,
+    sessions: {
+      [sessionId]: {
+        sessionId,
+        pointers: [
+          {
+            name: "runner.log",
+            location: path.join(paths.logsDir, "runner.log"),
+            archiveLocation: null,
+          },
+        ],
+        archiveLocation: null,
+      },
+    },
+  });
+}
+
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -424,9 +424,13 @@ export async function seedSessionAnchoredPartialArtifacts(
 export async function seedLateUnfinishedSessionArtifacts(
   workspaceRoot: string,
   issueNumber: number,
+  options?: {
+    readonly startedAt?: string | undefined;
+  },
 ): Promise<void> {
   const paths = deriveIssueArtifactPaths(workspaceRoot, issueNumber);
   const sessionId = `issue-${issueNumber.toString()}-session-1`;
+  const startedAt = options?.startedAt ?? "2026-03-09T22:00:00.000Z";
 
   await fs.mkdir(paths.attemptsDir, { recursive: true });
   await fs.mkdir(paths.sessionsDir, { recursive: true });
@@ -437,7 +441,7 @@ export async function seedLateUnfinishedSessionArtifacts(
     issueNumber,
     attemptNumber: 1,
     branch: `symphony/${issueNumber.toString()}`,
-    startedAt: "2026-03-09T22:00:00.000Z",
+    startedAt,
     finishedAt: null,
     outcome: "attempt-failed",
     summary: "Observed from an unfinished late-start session snapshot",
@@ -457,7 +461,7 @@ export async function seedLateUnfinishedSessionArtifacts(
       sessionId,
       provider: "codex",
       model: "gpt-5.4",
-      startedAt: "2026-03-09T22:00:00.000Z",
+      startedAt,
       finishedAt: null,
       workspacePath: path.join(
         workspaceRoot,

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -51,6 +51,10 @@ export function deriveWorkspaceRoot(rootDir: string): string {
   return path.join(rootDir, ".tmp", "workspaces");
 }
 
+export function deriveCodexSessionsRoot(rootDir: string): string {
+  return path.join(rootDir, ".codex", "sessions");
+}
+
 export async function seedSuccessfulIssueArtifacts(
   workspaceRoot: string,
   issueNumber: number,
@@ -420,4 +424,94 @@ export async function seedSessionAnchoredPartialArtifacts(
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export async function writeCodexSessionLog(options: {
+  readonly sessionsRoot: string;
+  readonly startedAt: string;
+  readonly workspacePath: string;
+  readonly branch: string;
+  readonly fileName: string;
+  readonly inputTokens?: number | undefined;
+  readonly cachedInputTokens?: number | undefined;
+  readonly outputTokens?: number | undefined;
+  readonly reasoningOutputTokens?: number | undefined;
+  readonly totalTokens?: number | undefined;
+  readonly finalSummary?: string | undefined;
+  readonly malformed?: boolean | undefined;
+}): Promise<string> {
+  const date = new Date(options.startedAt);
+  const dayRoot = path.join(
+    options.sessionsRoot,
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  );
+  const filePath = path.join(dayRoot, options.fileName);
+  await fs.mkdir(dayRoot, { recursive: true });
+
+  if (options.malformed === true) {
+    await fs.writeFile(filePath, "{not-json}\n", "utf8");
+    return filePath;
+  }
+
+  const lines = [
+    {
+      timestamp: options.startedAt,
+      type: "session_meta",
+      payload: {
+        id: options.fileName.replace(/\.jsonl$/u, ""),
+        timestamp: options.startedAt,
+        cwd: options.workspacePath,
+        originator: "codex_cli_rs",
+        cli_version: "0.71.0",
+        source: "cli",
+        model_provider: "openai",
+        git: {
+          commit_hash: "abc123def456",
+          branch: options.branch,
+          repository_url: "git@github.com:sociotechnica-org/symphony-ts.git",
+        },
+      },
+    },
+    {
+      timestamp: options.startedAt,
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: {
+            input_tokens: options.inputTokens ?? 2000,
+            cached_input_tokens: options.cachedInputTokens ?? 500,
+            output_tokens: options.outputTokens ?? 250,
+            reasoning_output_tokens: options.reasoningOutputTokens ?? 100,
+            total_tokens: options.totalTokens ?? 2750,
+          },
+        },
+      },
+    },
+    {
+      timestamp: options.startedAt,
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text:
+              options.finalSummary ??
+              "- Added optional runner-log enrichment and preserved provider-neutral report output.",
+          },
+        ],
+      },
+    },
+  ];
+
+  await fs.writeFile(
+    filePath,
+    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+  return filePath;
 }

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -6,6 +6,7 @@ import { createTempDir } from "../support/git.js";
 import {
   deriveCodexSessionsRoot,
   deriveWorkspaceRoot,
+  seedLateUnfinishedSessionArtifacts,
   seedSuccessfulIssueArtifacts,
   writeCodexSessionLog,
 } from "../support/issue-report-fixtures.js";
@@ -138,6 +139,39 @@ describe("issue report enrichment", () => {
     expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
     expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
       "A runner log file in the matching time window could not be parsed, so enrichment was skipped.",
+    );
+  });
+
+  it("finds a matching Codex log in the next UTC day when the canonical session has no finish time", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-next-day-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedLateUnfinishedSessionArtifacts(workspaceRoot, 44);
+
+    const logPath = await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-10T01:30:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-10T01-30-00-next-day.jsonl",
+      totalTokens: 1440,
+      finalSummary:
+        "- Continued the late-night Codex session into the next UTC day.",
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-10T02:00:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(1440);
+    expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
+      logPath,
+    );
+    expect(generated.report.tokenUsage.sessions[0]?.finalSummary).toBe(
+      "- Continued the late-night Codex session into the next UTC day.",
     );
   });
 });

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -1,5 +1,16 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+import {
+  ISSUE_ARTIFACT_SCHEMA_VERSION,
+  deriveIssueArtifactPaths,
+} from "../../src/observability/issue-artifacts.js";
+import type { IssueArtifactSessionSnapshot } from "../../src/observability/issue-artifacts.js";
+import type {
+  IssueReportDocument,
+  LoadedIssueArtifacts,
+} from "../../src/observability/issue-report.js";
 import { generateIssueReport } from "../../src/observability/issue-report.js";
 import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
 import { createTempDir } from "../support/git.js";
@@ -235,6 +246,102 @@ describe("issue report enrichment", () => {
     expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
       "At least one runner log file in the matching time window could not be parsed; enrichment used the only readable match.",
     );
+  });
+
+  it("keeps earlier session enrichments when a later session hits a filesystem error", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-fs-error-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    const issueNumber = 44;
+    const issueRoot = path.join(
+      workspaceRoot,
+      `issue-${issueNumber.toString()}`,
+    );
+
+    const readableSession: IssueArtifactSessionSnapshot = {
+      version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+      issueNumber,
+      attemptNumber: 1,
+      sessionId: "issue-44-session-1",
+      provider: "codex",
+      model: "gpt-5.4",
+      startedAt: "2026-03-09T10:05:00.000Z",
+      finishedAt: "2026-03-09T10:10:00.000Z",
+      workspacePath: issueRoot,
+      branch: "symphony/44",
+      logPointers: [],
+    };
+    const failingSession: IssueArtifactSessionSnapshot = {
+      ...readableSession,
+      sessionId: "issue-44-session-2",
+      startedAt: "2026-03-12T11:05:00.000Z",
+      finishedAt: "2026-03-12T11:10:00.000Z",
+    };
+    const loaded: LoadedIssueArtifacts = {
+      issueNumber,
+      paths: deriveIssueArtifactPaths(workspaceRoot, issueNumber),
+      issue: null,
+      events: [],
+      hasEventsFile: false,
+      attempts: [],
+      sessions: [readableSession, failingSession],
+      logPointers: null,
+    };
+
+    const logPath = await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: readableSession.startedAt ?? "2026-03-09T10:05:00.000Z",
+      workspacePath: issueRoot,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-readable.jsonl",
+      totalTokens: 2750,
+    });
+
+    const blockedDayRoot = path.join(sessionsRoot, "2026", "03", "12");
+    const blockedDayRootResolved = path.resolve(blockedDayRoot);
+    const originalReaddir = fs.readdir.bind(fs);
+    const readdirSpy = vi
+      .spyOn(fs, "readdir")
+      .mockImplementation(async (filePath, options) => {
+        if (path.resolve(String(filePath)) === blockedDayRootResolved) {
+          const error = new Error("permission denied") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        return originalReaddir(filePath, options);
+      });
+
+    try {
+      const enrichment = await new CodexIssueReportEnricher({
+        sessionsRoot,
+      }).enrich({
+        workspaceRoot,
+        loaded,
+        report: {} as IssueReportDocument,
+      });
+
+      expect(enrichment.sessions).toHaveLength(2);
+      expect(enrichment.sessions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionId: readableSession.sessionId,
+            tokenUsage: expect.objectContaining({
+              totalTokens: 2750,
+            }),
+            sourceArtifacts: [logPath],
+          }),
+          expect.objectContaining({
+            sessionId: failingSession.sessionId,
+            notes: [
+              "Runner log enrichment failed for this session and was skipped: permission denied",
+            ],
+          }),
+        ]),
+      );
+    } finally {
+      readdirSpy.mockRestore();
+    }
   });
 
   it("does not match a Codex log with no parseable session timestamp", async () => {

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateIssueReport } from "../../src/observability/issue-report.js";
+import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
+import { createTempDir } from "../support/git.js";
+import {
+  deriveCodexSessionsRoot,
+  deriveWorkspaceRoot,
+  seedSuccessfulIssueArtifacts,
+  writeCodexSessionLog,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("issue report enrichment", () => {
+  it("merges matched Codex JSONL token usage and final summary into the report", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-enriched-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const logPath = await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-issue-44.jsonl",
+      inputTokens: 2000,
+      cachedInputTokens: 500,
+      outputTokens: 250,
+      reasoningOutputTokens: 100,
+      totalTokens: 2750,
+      finalSummary:
+        "- Added optional runner-log enrichment and preserved provider-neutral report output.",
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:00:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(2750);
+    expect(generated.report.tokenUsage.explanation).toContain(
+      "token totals for all 1 session(s)",
+    );
+    expect(generated.report.tokenUsage.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
+        status: "complete",
+        inputTokens: 2000,
+        cachedInputTokens: 500,
+        outputTokens: 250,
+        reasoningOutputTokens: 100,
+        totalTokens: 2750,
+        originator: "codex_cli_rs",
+        sessionSource: "cli",
+        cliVersion: "0.71.0",
+        modelProvider: "openai",
+        gitBranch: "symphony/44",
+        gitCommit: "abc123def456",
+        finalSummary:
+          "- Added optional runner-log enrichment and preserved provider-neutral report output.",
+      }),
+    ]);
+    expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
+      logPath,
+    );
+    expect(generated.markdown).toContain("Final summary:");
+    expect(generated.markdown).toContain("Token detail:");
+  });
+
+  it("keeps report generation successful when multiple Codex logs match the same session", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-ambiguous-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-a.jsonl",
+    });
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:06:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-06-00-b.jsonl",
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:05:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("unavailable");
+    expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
+    expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
+      "Multiple runner log files matched this session, so enrichment was skipped to avoid guessing.",
+    );
+  });
+
+  it("keeps report generation successful when a matching-window Codex log is malformed", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-malformed-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-malformed.jsonl",
+      malformed: true,
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:10:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("unavailable");
+    expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
+    expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
+      "A runner log file in the matching time window could not be parsed, so enrichment was skipped.",
+    );
+  });
+});

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -40,8 +40,10 @@ describe("issue report enrichment", () => {
       outputTokens: 250,
       reasoningOutputTokens: 100,
       totalTokens: 2750,
-      finalSummary:
-        "- Added optional runner-log enrichment and preserved provider-neutral report output.",
+      finalSummary: [
+        "- Added optional runner-log enrichment.",
+        "- Preserved provider-neutral report output.",
+      ].join("\n"),
     });
 
     const generated = await generateIssueReport(workspaceRoot, 44, {
@@ -69,14 +71,22 @@ describe("issue report enrichment", () => {
         modelProvider: "openai",
         gitBranch: "symphony/44",
         gitCommit: "abc123def456",
-        finalSummary:
-          "- Added optional runner-log enrichment and preserved provider-neutral report output.",
+        finalSummary: [
+          "- Added optional runner-log enrichment.",
+          "- Preserved provider-neutral report output.",
+        ].join("\n"),
       }),
     ]);
     expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
       logPath,
     );
     expect(generated.markdown).toContain("Final summary:");
+    expect(generated.markdown).toContain(
+      "    - Added optional runner-log enrichment.",
+    );
+    expect(generated.markdown).toContain(
+      "    - Preserved provider-neutral report output.",
+    );
     expect(generated.markdown).toContain("Token detail:");
   });
 
@@ -188,6 +198,42 @@ describe("issue report enrichment", () => {
     expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
     expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
       "A runner log file in the matching time window could not be parsed, so enrichment was skipped.",
+    );
+  });
+
+  it("keeps a parse-failure note when one readable Codex log still matches", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-partial-parse-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-readable.jsonl",
+      totalTokens: 2750,
+    });
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:06:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-06-00-malformed.jsonl",
+      malformed: true,
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:10:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(2750);
+    expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
+      "At least one runner log file in the matching time window could not be parsed; enrichment used the only readable match.",
     );
   });
 

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -80,6 +80,55 @@ describe("issue report enrichment", () => {
     expect(generated.markdown).toContain("Token detail:");
   });
 
+  it("uses the latest cumulative Codex token_count snapshot when a log records multiple events", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-multi-token-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-multi-token.jsonl",
+      tokenEvents: [
+        {
+          inputTokens: 1200,
+          cachedInputTokens: 200,
+          outputTokens: 150,
+          reasoningOutputTokens: 50,
+          totalTokens: 1600,
+        },
+        {
+          inputTokens: 2000,
+          cachedInputTokens: 500,
+          outputTokens: 250,
+          reasoningOutputTokens: 100,
+          totalTokens: 2750,
+        },
+      ],
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:00:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(2750);
+    expect(generated.report.tokenUsage.sessions[0]).toEqual(
+      expect.objectContaining({
+        inputTokens: 2000,
+        cachedInputTokens: 500,
+        outputTokens: 250,
+        reasoningOutputTokens: 100,
+        totalTokens: 2750,
+      }),
+    );
+  });
+
   it("keeps report generation successful when multiple Codex logs match the same session", async () => {
     const tempDir = await createTempDir("symphony-issue-report-ambiguous-");
     tempRoots.push(tempDir);
@@ -139,6 +188,34 @@ describe("issue report enrichment", () => {
     expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
     expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
       "A runner log file in the matching time window could not be parsed, so enrichment was skipped.",
+    );
+  });
+
+  it("does not match a Codex log with no parseable session timestamp", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-no-timestamp-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      metaTimestamp: null,
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-no-timestamp.jsonl",
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:10:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("unavailable");
+    expect(generated.report.tokenUsage.sessions[0]?.totalTokens).toBeNull();
+    expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
+      "No matching runner log file was found for this session.",
     );
   });
 

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -297,4 +297,41 @@ describe("issue report enrichment", () => {
       "- Continued the late-night Codex session into the next UTC day.",
     );
   });
+
+  it("finds a next-day Codex log when only the unfinished-session post-window crosses UTC midnight", async () => {
+    const tempDir = await createTempDir(
+      "symphony-issue-report-next-day-post-window-",
+    );
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedLateUnfinishedSessionArtifacts(workspaceRoot, 44, {
+      startedAt: "2026-03-09T19:45:00.000Z",
+    });
+
+    const logPath = await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-10T00:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-10T00-05-00-post-window.jsonl",
+      totalTokens: 900,
+      finalSummary:
+        "- Crossed midnight during the unfinished-session match margin.",
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-10T00:10:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(900);
+    expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
+      logPath,
+    );
+    expect(generated.report.tokenUsage.sessions[0]?.finalSummary).toBe(
+      "- Crossed midnight during the unfinished-session match margin.",
+    );
+  });
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  ISSUE_REPORT_SCHEMA_VERSION,
   generateIssueReport,
   readIssueReport,
   writeIssueReport,
@@ -12,6 +13,7 @@ import {
 } from "../../src/observability/issue-artifacts.js";
 import { createTempDir } from "../support/git.js";
 import {
+  downgradeIssueReportSchemaVersion,
   deriveWorkspaceRoot,
   seedSessionAnchoredPartialArtifacts,
   seedSuccessfulIssueArtifacts,
@@ -301,6 +303,23 @@ describe("issue report generation", () => {
 
     await expect(readIssueReport(workspaceRoot, 44)).rejects.toThrowError(
       `No generated issue report JSON found for issue #44 at ${path.join(generated.outputPaths.issueRoot, "report.json")}; run 'symphony-report issue --issue 44' first.`,
+    );
+  });
+
+  it("rejects stored generated reports from older schema versions with a regeneration error", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-read-stale-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T14:10:00.000Z",
+    });
+    await downgradeIssueReportSchemaVersion(
+      generated.outputPaths.reportJsonFile,
+    );
+
+    await expect(readIssueReport(workspaceRoot, 44)).rejects.toThrowError(
+      `Generated issue report JSON at ${generated.outputPaths.reportJsonFile} uses schema version 1, but this build expects ${ISSUE_REPORT_SCHEMA_VERSION.toString()}; run 'symphony-report issue --issue 44' first to regenerate it.`,
     );
   });
 });

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -284,4 +284,23 @@ describe("issue report generation", () => {
       );
     },
   );
+
+  it("prefers the JSON-missing error when both generated report files are absent", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-read-both-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+    const generated = await writeIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T14:05:00.000Z",
+    });
+
+    await Promise.all([
+      fs.rm(path.join(generated.outputPaths.issueRoot, "report.json")),
+      fs.rm(path.join(generated.outputPaths.issueRoot, "report.md")),
+    ]);
+
+    await expect(readIssueReport(workspaceRoot, 44)).rejects.toThrowError(
+      `No generated issue report JSON found for issue #44 at ${path.join(generated.outputPaths.issueRoot, "report.json")}; run 'symphony-report issue --issue 44' first.`,
+    );
+  });
 });

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -82,6 +82,17 @@ describe("LocalRunner", () => {
     });
   });
 
+  it("does not treat the next CLI flag as a Codex model name", () => {
+    expect(
+      describeLocalRunnerBackend(
+        "codex exec -m --dangerously-bypass-approvals-and-sandbox -C . -",
+      ),
+    ).toEqual({
+      provider: "codex",
+      model: null,
+    });
+  });
+
   it("handles a closed stdin pipe without crashing the process", async () => {
     const runner = new LocalRunner(
       {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { RunSession } from "../../src/domain/run.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
+import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
 import { LocalRunner } from "../../src/runner/local.js";
 import { waitForExit } from "../support/process.js";
 
@@ -69,6 +70,15 @@ describe("LocalRunner", () => {
       provider: "local-runner",
       model: null,
       logPointers: [],
+    });
+  });
+
+  it("treats backslashes as literal characters inside single-quoted arguments", () => {
+    expect(
+      describeLocalRunnerBackend("codex exec -m 'gpt\\\\5.4\\\\reasoning'"),
+    ).toEqual({
+      provider: "codex",
+      model: "gpt\\\\5.4\\\\reasoning",
     });
   });
 

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -38,7 +38,8 @@ describe("LocalRunner", () => {
   it("describes Codex-backed sessions with provider and model metadata", () => {
     const runner = new LocalRunner(
       {
-        command: "codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -",
+        command:
+          "codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -",
         promptTransport: "stdin",
         timeoutMs: 5_000,
         env: {},

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -35,6 +35,42 @@ function createSession(): RunSession {
 }
 
 describe("LocalRunner", () => {
+  it("describes Codex-backed sessions with provider and model metadata", () => {
+    const runner = new LocalRunner(
+      {
+        command: "codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -",
+        promptTransport: "stdin",
+        timeoutMs: 5_000,
+        env: {},
+      },
+      new JsonLogger(),
+    );
+
+    expect(runner.describeSession(createSession())).toEqual({
+      provider: "codex",
+      model: "gpt-5.4",
+      logPointers: [],
+    });
+  });
+
+  it("keeps unknown commands on the local-runner fallback path", () => {
+    const runner = new LocalRunner(
+      {
+        command: "tests/fixtures/fake-agent-success.sh",
+        promptTransport: "stdin",
+        timeoutMs: 5_000,
+        env: {},
+      },
+      new JsonLogger(),
+    );
+
+    expect(runner.describeSession(createSession())).toEqual({
+      provider: "local-runner",
+      model: null,
+      logPointers: [],
+    });
+  });
+
   it("handles a closed stdin pipe without crashing the process", async () => {
     const runner = new LocalRunner(
       {


### PR DESCRIPTION
## Summary
- add a provider-neutral issue report enrichment seam in observability
- add a Codex JSONL enricher plus local-runner Codex provider/model detection
- keep report generation optional and partial-safe when runner logs are missing, malformed, or ambiguous

Closes #46

Plan: docs/plans/046-runner-log-report-enrichment/plan.md
