### PR TITLE
Follow up merged report enrichment review comments

### DIFF
--- a/src/domain/error-format.ts
+++ b/src/domain/error-format.ts
@@ -1,0 +1,3 @@
+export function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/domain/number-coerce.ts
+++ b/src/domain/number-coerce.ts
@@ -1,0 +1,3 @@
+export function asFiniteNumber(value: unknown): number | null {
+  return Number.isFinite(value) ? (value as number) : null;
+}

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -1,3 +1,4 @@
+import { formatErrorMessage } from "../domain/error-format.js";
 import type {
   IssueReportDocument,
   IssueReportTokenUsage,
@@ -294,8 +295,4 @@ function hasRunnerEnrichmentSourceArtifacts(
 
 function uniqueStrings(values: readonly string[]): readonly string[] {
   return [...new Set(values)];
-}
-
-function formatErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { formatErrorMessage } from "../domain/error-format.js";
 import type { IssueArtifactSessionSnapshot } from "../observability/issue-artifacts.js";
 import type {
   IssueReportEnricher,
@@ -417,9 +418,5 @@ function asString(value: unknown): string | null {
 }
 
 function asNumber(value: unknown): number | null {
-  return typeof value === "number" ? value : null;
-}
-
-function formatErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return typeof value === "number" && !Number.isNaN(value) ? value : null;
 }

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -279,11 +279,11 @@ function parseTokenCount(
     return null;
   }
   return {
-    inputTokens: asNumber(total["input_tokens"]),
-    cachedInputTokens: asNumber(total["cached_input_tokens"]),
-    outputTokens: asNumber(total["output_tokens"]),
-    reasoningOutputTokens: asNumber(total["reasoning_output_tokens"]),
-    totalTokens: asNumber(total["total_tokens"]),
+    inputTokens: asFiniteNumber(total["input_tokens"]),
+    cachedInputTokens: asFiniteNumber(total["cached_input_tokens"]),
+    outputTokens: asFiniteNumber(total["output_tokens"]),
+    reasoningOutputTokens: asFiniteNumber(total["reasoning_output_tokens"]),
+    totalTokens: asFiniteNumber(total["total_tokens"]),
   };
 }
 
@@ -417,6 +417,6 @@ function asString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function asNumber(value: unknown): number | null {
+export function asFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && !Number.isNaN(value) ? value : null;
 }

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -418,5 +418,5 @@ function asString(value: unknown): string | null {
 }
 
 export function asFiniteNumber(value: unknown): number | null {
-  return typeof value === "number" && !Number.isNaN(value) ? value : null;
+  return Number.isFinite(value) ? (value as number) : null;
 }

--- a/src/runner/codex-report-enricher.ts
+++ b/src/runner/codex-report-enricher.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { formatErrorMessage } from "../domain/error-format.js";
+import { asFiniteNumber } from "../domain/number-coerce.js";
 import type { IssueArtifactSessionSnapshot } from "../observability/issue-artifacts.js";
 import type {
   IssueReportEnricher,
@@ -415,8 +416,4 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function asString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
-}
-
-export function asFiniteNumber(value: unknown): number | null {
-  return Number.isFinite(value) ? (value as number) : null;
 }

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -626,15 +626,10 @@ export async function downgradeIssueReportSchemaVersion(
     };
   } & Record<string, unknown>;
   const sessions = parsedReport.tokenUsage?.sessions ?? [];
-  const [firstSession, ...remainingSessions] = sessions;
-  const staleFirstSession =
-    firstSession === undefined
-      ? undefined
-      : (({
-          status: _status,
-          notes: _notes,
-          ...session
-        }: Record<string, unknown>) => session)(firstSession);
+  const staleSessions = sessions.map(
+    ({ status: _status, notes: _notes, ...session }: Record<string, unknown>) =>
+      session,
+  );
 
   await fs.writeFile(
     reportJsonFile,
@@ -647,10 +642,7 @@ export async function downgradeIssueReportSchemaVersion(
             ? undefined
             : {
                 ...parsedReport.tokenUsage,
-                sessions:
-                  staleFirstSession === undefined
-                    ? sessions
-                    : [staleFirstSession, ...remainingSessions],
+                sessions: staleSessions,
               },
       },
       null,

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -155,6 +155,8 @@ describe("issue report enrichment", () => {
 
   it("treats NaN as unavailable in Codex numeric coercion", () => {
     expect(asFiniteNumber(Number.NaN)).toBeNull();
+    expect(asFiniteNumber(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(asFiniteNumber(Number.NEGATIVE_INFINITY)).toBeNull();
     expect(asFiniteNumber(2750)).toBe(2750);
     expect(asFiniteNumber(null)).toBeNull();
   });

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -12,10 +12,8 @@ import type {
   LoadedIssueArtifacts,
 } from "../../src/observability/issue-report.js";
 import { generateIssueReport } from "../../src/observability/issue-report.js";
-import {
-  asFiniteNumber,
-  CodexIssueReportEnricher,
-} from "../../src/runner/codex-report-enricher.js";
+import { asFiniteNumber } from "../../src/domain/number-coerce.js";
+import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
 import { createTempDir } from "../support/git.js";
 import {
   deriveCodexSessionsRoot,

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -12,7 +12,10 @@ import type {
   LoadedIssueArtifacts,
 } from "../../src/observability/issue-report.js";
 import { generateIssueReport } from "../../src/observability/issue-report.js";
-import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
+import {
+  asFiniteNumber,
+  CodexIssueReportEnricher,
+} from "../../src/runner/codex-report-enricher.js";
 import { createTempDir } from "../support/git.js";
 import {
   deriveCodexSessionsRoot,
@@ -150,47 +153,10 @@ describe("issue report enrichment", () => {
     );
   });
 
-  it("treats NaN token values in Codex logs as unavailable instead of complete totals", async () => {
-    const tempDir = await createTempDir("symphony-issue-report-nan-token-");
-    tempRoots.push(tempDir);
-    const workspaceRoot = deriveWorkspaceRoot(tempDir);
-    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
-    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
-
-    await writeCodexSessionLog({
-      sessionsRoot,
-      startedAt: "2026-03-09T10:05:00.000Z",
-      workspacePath: `${workspaceRoot}/issue-44`,
-      branch: "symphony/44",
-      fileName: "rollout-2026-03-09T10-05-00-nan-token.jsonl",
-      tokenEvents: [
-        {
-          inputTokens: Number.NaN,
-          cachedInputTokens: 500,
-          outputTokens: 250,
-          reasoningOutputTokens: 100,
-          totalTokens: Number.NaN,
-        },
-      ],
-    });
-
-    const generated = await generateIssueReport(workspaceRoot, 44, {
-      generatedAt: "2026-03-09T13:00:00.000Z",
-      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
-    });
-
-    expect(generated.report.tokenUsage.status).toBe("partial");
-    expect(generated.report.tokenUsage.totalTokens).toBeNull();
-    expect(generated.report.tokenUsage.sessions[0]).toEqual(
-      expect.objectContaining({
-        inputTokens: null,
-        cachedInputTokens: 500,
-        outputTokens: 250,
-        reasoningOutputTokens: 100,
-        totalTokens: null,
-        status: "partial",
-      }),
-    );
+  it("treats NaN as unavailable in Codex numeric coercion", () => {
+    expect(asFiniteNumber(Number.NaN)).toBeNull();
+    expect(asFiniteNumber(2750)).toBe(2750);
+    expect(asFiniteNumber(null)).toBeNull();
   });
 
   it("keeps report generation successful when multiple Codex logs match the same session", async () => {

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -150,6 +150,49 @@ describe("issue report enrichment", () => {
     );
   });
 
+  it("treats NaN token values in Codex logs as unavailable instead of complete totals", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-nan-token-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-nan-token.jsonl",
+      tokenEvents: [
+        {
+          inputTokens: Number.NaN,
+          cachedInputTokens: 500,
+          outputTokens: 250,
+          reasoningOutputTokens: 100,
+          totalTokens: Number.NaN,
+        },
+      ],
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:00:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("partial");
+    expect(generated.report.tokenUsage.totalTokens).toBeNull();
+    expect(generated.report.tokenUsage.sessions[0]).toEqual(
+      expect.objectContaining({
+        inputTokens: null,
+        cachedInputTokens: 500,
+        outputTokens: 250,
+        reasoningOutputTokens: 100,
+        totalTokens: null,
+        status: "partial",
+      }),
+    );
+  });
+
   it("keeps report generation successful when multiple Codex logs match the same session", async () => {
     const tempDir = await createTempDir("symphony-issue-report-ambiguous-");
     tempRoots.push(tempDir);

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -203,6 +203,55 @@ describe("issue report generation", () => {
     ]);
   });
 
+  it("downgrades every stored token-usage session when rewriting a report to schema v1", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-downgrade-");
+    tempRoots.push(tempDir);
+    const reportJsonFile = path.join(tempDir, "report.json");
+
+    await fs.writeFile(
+      reportJsonFile,
+      `${JSON.stringify(
+        {
+          version: ISSUE_REPORT_SCHEMA_VERSION,
+          tokenUsage: {
+            sessions: [
+              {
+                sessionId: "session-1",
+                status: "complete",
+                notes: ["note-1"],
+              },
+              {
+                sessionId: "session-2",
+                status: "partial",
+                notes: ["note-2"],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await downgradeIssueReportSchemaVersion(reportJsonFile);
+
+    const downgraded = JSON.parse(
+      await fs.readFile(reportJsonFile, "utf8"),
+    ) as {
+      readonly version: number;
+      readonly tokenUsage: {
+        readonly sessions: readonly Record<string, unknown>[];
+      };
+    };
+
+    expect(downgraded.version).toBe(1);
+    expect(downgraded.tokenUsage.sessions).toEqual([
+      { sessionId: "session-1" },
+      { sessionId: "session-2" },
+    ]);
+  });
+
   it.each(["approved", "waived"] as const)(
     "does not keep awaiting plan review after a %s handoff event",
     async (decisionKind) => {


### PR DESCRIPTION
## Summary
- guard Codex token parsing against `NaN` values so enrichment cannot silently produce in-memory `NaN` totals
- extract the duplicated `formatErrorMessage()` helper into a shared domain utility
- make the stale-schema downgrade fixture strip v2-only fields from every session and add regression coverage

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- codex review --base origin/main

Follow-up to #46 after merged PR #84 left bot review comments open.