### PR TITLE
Add multi-issue campaign digest reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Generate a per-issue report from local artifacts:
 pnpm tsx bin/symphony-report.ts issue --issue 44
 ```
 
+Generate a campaign digest from existing per-issue reports:
+
+```bash
+pnpm tsx bin/symphony-report.ts campaign --issues 32,43,44
+pnpm tsx bin/symphony-report.ts campaign --from 2026-03-01 --to 2026-03-07
+```
+
 When available, the report command also applies optional built-in runner-log
 enrichment. Today that means Codex JSONL sessions under `~/.codex/sessions/`.
 Missing, malformed, or ambiguous runner logs do not block report generation;
@@ -88,6 +95,18 @@ session logs into:
 
 If publication fails, the local artifacts under `.var/factory/...` and
 `.var/reports/...` remain the source of truth.
+
+Campaign digests stay detached from archive publication and are generated only
+from existing issue reports. They are written under:
+
+```text
+.var/reports/campaigns/<campaign-id>/
+  summary.md
+  timeline.md
+  github-activity.md
+  token-usage.md
+  learnings.md
+```
 
 ## How It Works
 

--- a/docs/plans/047-generate-multi-issue-campaign-digests/plan.md
+++ b/docs/plans/047-generate-multi-issue-campaign-digests/plan.md
@@ -1,0 +1,345 @@
+# Issue 47 Plan: Generate Multi-Issue Campaign Digests
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Add a detached campaign-reporting path to `bin/symphony-report.ts` that reads a selected set of existing per-issue reports, aggregates them into one campaign digest for an explicit issue list or a date window, and writes stable campaign markdown outputs under `.var/reports/campaigns/<campaign-id>/` without embedding campaign generation into the factory runtime or archive-publication flow.
+
+## Scope
+
+This slice covers:
+
+1. a provider-neutral campaign digest input model rooted in existing generated issue reports from `#44` and optional read-only references back to canonical local artifacts when the issue report already points to them
+2. a standalone reporting CLI subcommand with command shapes:
+   - `pnpm tsx bin/symphony-report.ts campaign --issues 32,43,44`
+   - `pnpm tsx bin/symphony-report.ts campaign --from 2026-03-01 --to 2026-03-07`
+3. selection logic for explicit issue lists and inclusive date-window filtering over locally generated issue reports
+4. stable campaign outputs under `.var/reports/campaigns/<campaign-id>/`:
+   - `summary.md`
+   - `timeline.md`
+   - `github-activity.md`
+   - `token-usage.md`
+   - `learnings.md`
+5. aggregation logic that rolls up issue outcomes, major lifecycle events, PR/check/review facts, token/cost availability, and cross-issue conclusions from the structured issue-report pipeline
+6. tests and docs that prove issue-level reporting and campaign-level reporting remain separate responsibilities
+
+## Non-goals
+
+This slice does not include:
+
+1. changing the per-issue artifact or report schema from `#43`, `#44`, or `#46`
+2. auto-generating missing per-issue reports as part of `campaign`; this command should consume existing generated issue reports and fail clearly when required inputs are missing
+3. publishing campaign digests to `factory-runs` or coupling them to the issue-report publication path from `#45`
+4. embedding campaign digest generation into `symphony run`, orchestrator retries, or any runtime handoff path
+5. adding tracker-provider-specific report composition rules at the campaign layer
+6. adding workflow-frontmatter config for campaign rendering or selection defaults
+7. inventing a new coordination concept such as campaign state, campaign ownership, or campaign retries
+
+## Current Gaps
+
+After `#44`, `#45`, and `#46`, `symphony-ts` can generate and publish one issue report at a time, but there is no campaign-level digest surface:
+
+1. operators cannot summarize several issues or one factory period from the structured reporting pipeline
+2. the reporting CLI has no command for aggregating report sets by issue list or time window
+3. there is no stable campaign output directory contract under `.var/reports/campaigns/`
+4. the useful sections from the first factory-run writeup still require bespoke manual assembly instead of deterministic report aggregation
+5. token usage, review churn, and recurring failure modes remain visible only one issue at a time
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer: owns the stable campaign section set, selection semantics, partial-data rules, and the rule that campaign digests consume existing report artifacts rather than operator memory. This issue does not add tracker or orchestration policy.
+- Configuration Layer: limited to detached CLI argument parsing and path resolution for the campaign command. This issue should not add `WORKFLOW.md` schema or runtime configuration knobs.
+- Coordination Layer: untouched. The orchestrator must not gain campaign state, campaign scheduling, or campaign side effects.
+- Execution Layer: untouched. Workspace and runner behavior must not change to satisfy campaign rendering.
+- Integration Layer: touched only through existing issue-report facts that already normalize tracker/provider detail. This issue should not add direct tracker API reads or provider-specific aggregation logic.
+- Observability Layer: owns campaign input loading, selection, aggregation, markdown rendering, output-path helpers, and the detached CLI/service surface.
+
+## Architecture Boundaries
+
+### Observability
+
+Belongs here:
+
+1. typed campaign digest input/output models built from stored issue reports
+2. report-set selection helpers for explicit issue numbers and date windows
+3. deterministic campaign-id derivation and output paths under `.var/reports/campaigns/`
+4. campaign aggregation for summary, timeline, GitHub activity, token usage, and learnings
+5. markdown renderers for the five required campaign files
+6. explicit partial/unavailable notes when the selected issue reports contain gaps
+
+Does not belong here:
+
+1. tracker API reads
+2. publication-to-archive logic
+3. orchestration retries, leases, or campaign runtime state
+4. ad hoc memory-only conclusions that are not grounded in selected issue reports
+
+### CLI / Config
+
+Belongs here:
+
+1. parsing `campaign --issues ...` and `campaign --from ... --to ...`
+2. resolving the repo root and workspace root from `WORKFLOW.md`
+3. printing campaign generation results and output locations
+
+Does not belong here:
+
+1. aggregation logic inline in option parsing
+2. hidden behavior that mutates issue reports or generates archive publications
+
+### Integration
+
+Belongs here:
+
+1. nothing new beyond the existing issue-report contracts already consumed by observability
+
+Does not belong here:
+
+1. direct tracker transport reads for campaign generation
+2. provider-specific token aggregation logic that bypasses issue reports
+
+### Coordination / Execution
+
+Belongs here:
+
+1. nothing new in this slice
+
+Does not belong here:
+
+1. campaign selection policy
+2. campaign generation triggers
+3. campaign retry or cleanup logic
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR because it stays on one detached read-side seam:
+
+1. extend the existing reporting CLI with one `campaign` subcommand
+2. add campaign-specific loaders, aggregators, and markdown renderers under `src/observability/`
+3. add focused unit and integration coverage using existing issue-report fixtures plus generated per-issue reports
+4. update docs for the new command and output location
+
+This PR deliberately defers:
+
+1. archive publication of campaign digests
+2. campaign JSON artifacts or other new durable machine-readable publication formats unless a later issue needs them explicitly
+3. runtime-loop integration or automatic campaign generation after factory runs
+4. re-deriving campaign facts from raw tracker payloads or operator-authored notes
+
+The seam is reviewable because it adds one new consumer of existing issue reports and keeps coordination, tracker integration, and archive publication untouched.
+
+## Campaign Digest Input Model
+
+The campaign digest core input should be an explicit selected set of stored issue reports:
+
+1. load `report.json` through the existing stored-report reader so schema-version checks stay centralized
+2. treat each loaded issue report as the canonical normalized unit for campaign aggregation
+3. preserve references back to report artifact paths and raw artifact paths already embedded in each issue report for evidence and traceability
+4. do not aggregate directly from ad hoc issue comments, operator notes, or raw runner logs
+
+### Selection modes
+
+Exactly one selection mode should be used per command invocation:
+
+1. explicit issue list: `--issues 32,43,44`
+2. date window: `--from YYYY-MM-DD --to YYYY-MM-DD`
+
+### Date-window policy
+
+For time-window selection, use report facts rather than ad hoc filesystem mtime:
+
+1. prefer the issue report operational window derived from `summary.startedAt` and `summary.endedAt`
+2. when one bound is unavailable, fall back to the available bound
+3. when both operational bounds are unavailable, fall back to `generatedAt`
+4. include a report when its derived issue window overlaps the inclusive requested window
+5. if no reports match, fail clearly instead of generating empty campaign files
+
+This keeps selection deterministic while staying grounded in structured report data.
+
+## Campaign Output Contract
+
+Write campaign digests to:
+
+```text
+.var/reports/campaigns/<campaign-id>/
+  summary.md
+  timeline.md
+  github-activity.md
+  token-usage.md
+  learnings.md
+```
+
+### Campaign ID
+
+Derive a stable, filesystem-safe campaign id from the selection mode:
+
+1. explicit issue selection should preserve the selected issue numbers in sorted order
+2. date-window selection should preserve the requested `from` and `to` dates
+3. if needed for legibility or collision avoidance, append a short deterministic suffix derived from the selected issue set
+
+The campaign id is an observability output identifier, not a new runtime entity.
+
+### `summary.md`
+
+Should include:
+
+1. campaign id and selection summary
+2. issue count
+3. outcome counts such as succeeded, failed, partial, and unknown
+4. attempt and PR totals when derivable
+5. a concise overall outcome statement
+6. notable conclusions grounded in the selected issue reports
+
+### `timeline.md`
+
+Should include:
+
+1. one ordered merged timeline across the selected issue reports
+2. issue numbers/titles attached to each entry
+3. stable event ordering with explicit notes when issue timelines were partial
+4. enough detail to show major transitions such as claim, plan review, runner start, PR open, review feedback, retry, success, or failure
+
+### `github-activity.md`
+
+Should include:
+
+1. aggregate PR count and per-issue PR references
+2. review-round totals and actionable-review totals when present
+3. pending/failing check patterns across the selected reports
+4. merge/close availability notes when per-issue reports lacked those facts
+5. a concise cross-issue GitHub activity summary
+
+### `token-usage.md`
+
+Should include:
+
+1. an aggregate campaign token/cost status of `unavailable`, `partial`, `estimated`, or `complete`
+2. total tokens and cost only when the selected issue reports support those totals
+3. issue-level and session-level availability notes where needed
+4. explicit accounting of how many selected reports were complete, partial, or unavailable for token usage
+
+### `learnings.md`
+
+Should include:
+
+1. cross-issue conclusions grounded in repeated evidence across the selected reports
+2. recurring failure modes
+3. recurring review or CI friction when present
+4. concrete changes to make, phrased as evidence-backed follow-up guidance rather than speculative narrative
+5. explicit gaps where the selected reports do not justify a stronger conclusion
+
+## State Model / Failure Matrix
+
+This issue does not change long-running orchestration, retries, continuations, reconciliation, leases, or handoff states, so an orchestrator runtime state machine is not required.
+
+The campaign generator still needs an explicit read-side failure matrix:
+
+| Observed condition                                                            | Local facts available                                                      | Expected behavior                                                                            |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Explicit issue list where every requested issue has a current stored report   | generated `report.json` and `report.md` for each issue                     | generate all campaign markdown files successfully                                            |
+| Explicit issue list where one or more requested issues lack generated reports | some requested report directories missing                                  | fail clearly and instruct the operator to generate the missing issue reports first           |
+| Stored report exists but uses an older schema version                         | stale `report.json`                                                        | fail clearly and instruct the operator to regenerate that issue report first                 |
+| Date-window selection matches a non-empty set of reports                      | report metadata and summary timestamps                                     | generate campaign files from the selected set                                                |
+| Date-window selection matches no reports                                      | report directories exist but none overlap the requested window             | fail clearly instead of writing an empty campaign digest                                     |
+| Selected reports contain partial timeline or GitHub data                      | mixed complete and partial issue reports                                   | generate the campaign digest with explicit partial notes in affected sections                |
+| Selected reports contain mixed token-usage statuses                           | issue reports with `complete`, `partial`, and `unavailable` token sections | aggregate only supported totals and surface a campaign-level partial/unavailable explanation |
+| Campaign output directory does not exist yet                                  | readable issue reports only                                                | create `.var/reports/campaigns/<campaign-id>/` and write all required files                  |
+| One campaign output file write fails                                          | in-memory aggregated campaign facts                                        | fail loudly; do not silently claim success                                                   |
+
+## Storage / Persistence Contract
+
+This issue adds a detached generated-output contract under `.var/reports/campaigns/`; it does not create new canonical runtime state.
+
+Contract rules:
+
+1. stored per-issue reports remain the canonical campaign inputs
+2. campaign markdown outputs are derived artifacts and can be regenerated
+3. writing a campaign digest must not mutate any per-issue report or raw issue artifact
+4. campaign generation should use atomic writes for each output file, consistent with the existing reporting path
+5. a rerun with the same selection may rewrite the same campaign directory deterministically
+
+## Observability Requirements
+
+1. each campaign file must remain readable even when some selected issue reports are partial
+2. section-level notes must distinguish between unavailable source facts and actual observed outcomes
+3. the command output should tell the operator which campaign id was generated and where the files were written
+4. campaign learnings must remain traceable to the selected issue reports rather than unstated operator judgment
+
+## Implementation Steps
+
+1. Extend `src/cli/report.ts` so `parseReportArgs()` and `runReportCli()` support a new `campaign` command while preserving the existing `issue` and `publish` flows.
+2. Add campaign path helpers and report-set discovery/loading helpers under `src/observability/` that reuse the stored issue-report reader and schema validation.
+3. Implement selection helpers for explicit issue lists and inclusive date-window filtering over stored issue reports.
+4. Implement a typed in-memory campaign digest model that aggregates:
+   - overall outcome counts and notable conclusions
+   - merged timeline entries across issues
+   - PR/review/check activity across the selected reports
+   - campaign-level token totals and availability
+   - evidence-backed cross-issue learnings and gaps
+5. Implement deterministic markdown renderers for `summary.md`, `timeline.md`, `github-activity.md`, `token-usage.md`, and `learnings.md`.
+6. Implement a campaign writer that creates `.var/reports/campaigns/<campaign-id>/` and writes the required files atomically.
+7. Add unit tests for CLI argument parsing, selection logic, aggregation rules, campaign-id derivation, and markdown rendering.
+8. Add integration tests that:
+   - generate multiple issue reports from fixtures
+   - run `symphony-report campaign --issues ...`
+   - run `symphony-report campaign --from ... --to ...`
+   - verify the required output files and partial-data behavior
+9. Update `README.md` with campaign command examples and output locations.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. parses `campaign --issues 32,43,44` into a validated issue-number selection
+2. parses `campaign --from 2026-03-01 --to 2026-03-07` into a validated inclusive date-window selection
+3. rejects invalid combinations such as mixing `--issues` with `--from` or omitting one date bound
+4. derives stable campaign ids for explicit issue sets and date-window selections
+5. selects reports by overlapping issue-window facts and falls back to `generatedAt` only when necessary
+6. aggregates mixed issue outcomes, PR counts, review rounds, and token-usage statuses correctly
+7. renders all five campaign markdown files with explicit partial/unavailable notes when needed
+
+### Integration
+
+1. `symphony-report campaign --issues 32,43,44` generates the five required files from existing generated issue reports
+2. `symphony-report campaign --from 2026-03-01 --to 2026-03-07` selects the expected locally generated issue reports and generates the same stable file set
+3. missing or stale issue reports fail clearly with a regeneration instruction instead of silently skipping them
+4. mixed complete and partial issue reports still generate a campaign digest with explicit section notes
+
+### End-to-End
+
+1. a realistic local reporting flow can generate several per-issue reports first, then produce one campaign digest whose sections mirror the useful summary/timeline/GitHub/token/learnings concepts from the first factory-run writeup
+
+## Acceptance Scenarios
+
+1. The CLI can generate a campaign digest from an explicit issue list.
+2. The CLI can generate a campaign digest from an inclusive date window over existing issue reports.
+3. The campaign digest always writes `summary.md`, `timeline.md`, `github-activity.md`, `token-usage.md`, and `learnings.md`.
+4. Campaign aggregation stays provider-neutral at the core and remains detached from tracker transport, archive publication, and runtime coordination.
+5. Issue-level reporting and campaign-level reporting remain clearly separated: per-issue reports are inputs, and campaign digests are a higher-level derived output.
+
+## Exit Criteria
+
+1. `symphony-report` exposes a working `campaign` subcommand with explicit issue-list and date-window selection
+2. campaign digests are generated entirely from structured local reporting artifacts
+3. the required five campaign markdown files are written under `.var/reports/campaigns/<campaign-id>/`
+4. mixed data availability is handled explicitly rather than hidden
+5. tests cover both selection modes and representative partial-data paths
+6. docs describe the detached campaign-reporting workflow
+
+## Deferred To Later Issues Or PRs
+
+1. publishing campaign digests to `factory-runs`
+2. automatic backfill or scheduled campaign generation
+3. campaign JSON or other archive-oriented machine-readable contracts
+4. richer campaign slicing such as wave identifiers, label-based cohorts, or tracker-native queries
+5. cross-repo or multi-factory campaign aggregation
+
+## Decision Notes
+
+1. This plan intentionally treats existing generated issue reports as the campaign system of record to keep the campaign layer provider-neutral and detached from raw tracker transport.
+2. The command should fail on missing or stale per-issue reports rather than silently regenerating them because implicit regeneration would blur issue-level and campaign-level responsibilities and broaden the review surface.

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import { loadWorkflowWorkspaceRoot } from "../config/workflow.js";
 import { publishIssueToFactoryRuns } from "../integration/factory-runs.js";
 import { createDefaultIssueReportEnrichers } from "../runner/codex-report-enricher.js";
+import {
+  writeCampaignDigest,
+  type CampaignSelection,
+} from "../observability/campaign-report.js";
 import { writeIssueReport } from "../observability/issue-report.js";
 import type { IssueReportEnricher } from "../observability/issue-report-enrichment.js";
 
@@ -16,16 +20,30 @@ export type ReportCliArgs =
       readonly issueNumber: number;
       readonly workflowPath: string;
       readonly archiveRoot: string;
+    }
+  | {
+      readonly command: "campaign";
+      readonly workflowPath: string;
+      readonly selection: CampaignSelection;
     };
 
 export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   const args = argv.slice(2);
   const command = args[0];
 
-  if (command !== "issue" && command !== "publish") {
+  if (command !== "issue" && command !== "publish" && command !== "campaign") {
     throw new Error(
-      "Usage: symphony-report <issue|publish> --issue <number> [--workflow <path>] [--archive-root <path>]",
+      "Usage: symphony-report <issue|publish|campaign> [--issue <number>] [--issues <a,b,c> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>] [--workflow <path>] [--archive-root <path>]",
     );
+  }
+
+  const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
+  if (command === "campaign") {
+    return {
+      command: "campaign",
+      workflowPath: path.resolve(process.cwd(), workflowPath),
+      selection: parseCampaignSelection(args),
+    };
   }
 
   const issueValue = readOptionValue(args, "--issue");
@@ -37,7 +55,6 @@ export function parseReportArgs(argv: readonly string[]): ReportCliArgs {
   }
   const issueNumber = Number.parseInt(issueValue, 10);
 
-  const workflowPath = readOptionValue(args, "--workflow") ?? "WORKFLOW.md";
   if (command === "issue") {
     return {
       command: "issue",
@@ -76,6 +93,13 @@ export async function runReportCli(
     );
     return;
   }
+  if (args.command === "campaign") {
+    const generated = await writeCampaignDigest(workspaceRoot, args.selection);
+    process.stdout.write(
+      `Generated campaign digest ${generated.digest.campaignId}\nsummary.md: ${generated.outputPaths.summaryFile}\ntimeline.md: ${generated.outputPaths.timelineFile}\ngithub-activity.md: ${generated.outputPaths.githubActivityFile}\ntoken-usage.md: ${generated.outputPaths.tokenUsageFile}\nlearnings.md: ${generated.outputPaths.learningsFile}\n`,
+    );
+    return;
+  }
 
   const published = await publishIssueToFactoryRuns({
     workspaceRoot,
@@ -98,4 +122,65 @@ function readOptionValue(args: readonly string[], flag: string): string | null {
     throw new Error(`Missing value for ${flag}`);
   }
   return value;
+}
+
+function parseCampaignSelection(args: readonly string[]): CampaignSelection {
+  const issuesValue = readOptionValue(args, "--issues");
+  const from = readOptionValue(args, "--from");
+  const to = readOptionValue(args, "--to");
+
+  if (issuesValue !== null && (from !== null || to !== null)) {
+    throw new Error(
+      "Campaign selection must use either --issues or --from/--to, not both",
+    );
+  }
+
+  if (issuesValue !== null) {
+    const issueNumbers = issuesValue
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    if (issueNumbers.length === 0) {
+      throw new Error("Missing required --issues <a,b,c> option");
+    }
+    for (const issueValue of issueNumbers) {
+      if (!/^[1-9]\d*$/u.test(issueValue)) {
+        throw new Error(`Invalid issue number in --issues: ${issueValue}`);
+      }
+    }
+    return {
+      kind: "issues",
+      issueNumbers: issueNumbers
+        .map((issueValue) => Number.parseInt(issueValue, 10))
+        .sort((left, right) => left - right),
+    };
+  }
+
+  if (from === null && to === null) {
+    throw new Error(
+      "Campaign generation requires either --issues <a,b,c> or --from <YYYY-MM-DD> --to <YYYY-MM-DD>",
+    );
+  }
+  if (from === null || to === null) {
+    throw new Error(
+      "Campaign date-window selection requires both --from and --to",
+    );
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(from)) {
+    throw new Error(`Invalid campaign from date: ${from}`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(to)) {
+    throw new Error(`Invalid campaign to date: ${to}`);
+  }
+  if (from > to) {
+    throw new Error(
+      `Campaign date window must satisfy --from <= --to; received ${from} > ${to}`,
+    );
+  }
+
+  return {
+    kind: "date-window",
+    from,
+    to,
+  };
 }

--- a/src/observability/campaign-report-format.ts
+++ b/src/observability/campaign-report-format.ts
@@ -1,0 +1,12 @@
+export function renderCampaignIssueLabel(
+  issueNumber: number,
+  title: string | null,
+): string {
+  return title === null
+    ? `#${issueNumber.toString()}`
+    : `#${issueNumber.toString()} ${title}`;
+}
+
+export function renderCampaignNameList(values: readonly string[]): string {
+  return values.length === 0 ? "none" : values.join(", ");
+}

--- a/src/observability/campaign-report-markdown.ts
+++ b/src/observability/campaign-report-markdown.ts
@@ -1,0 +1,314 @@
+import type {
+  CampaignCheckPattern,
+  CampaignDigest,
+  CampaignLearningCluster,
+  CampaignSelection,
+} from "./campaign-report.js";
+
+export function renderCampaignSummaryMarkdown(digest: CampaignDigest): string {
+  const lines: string[] = [];
+
+  lines.push(`# Campaign Summary: ${digest.campaignId}`);
+  lines.push("");
+  lines.push(`- Generated at: ${digest.generatedAt}`);
+  lines.push(`- Selection: ${renderSelection(digest.selection)}`);
+  lines.push(`- Issue count: ${digest.summary.issueCount.toString()}`);
+  lines.push(
+    `- Outcome counts: succeeded ${digest.summary.outcomeCounts.succeeded.toString()}, failed ${digest.summary.outcomeCounts.failed.toString()}, partial ${digest.summary.outcomeCounts.partial.toString()}, unknown ${digest.summary.outcomeCounts.unknown.toString()}`,
+  );
+  lines.push(`- Attempts: ${digest.summary.attemptCount.toString()}`);
+  lines.push(`- Pull requests: ${digest.summary.pullRequestCount.toString()}`);
+  lines.push("");
+
+  lines.push("## Overall Outcome");
+  lines.push(digest.summary.overallOutcome);
+  lines.push("");
+
+  lines.push("## Notable Conclusions");
+  if (digest.summary.notableConclusions.length === 0) {
+    lines.push("- None recorded.");
+  } else {
+    for (const conclusion of digest.summary.notableConclusions) {
+      lines.push(`- ${conclusion}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Issue Breakdown");
+  for (const issue of digest.summary.issues) {
+    lines.push(
+      `- ${renderIssueLabel(issue.issueNumber, issue.title)} | outcome ${issue.classifiedOutcome} | report ${issue.reportStatus} | attempts ${issue.attemptCount.toString()} | PRs ${issue.pullRequestCount.toString()} | started ${renderValue(issue.startedAt)} | ended ${renderValue(issue.endedAt)}`,
+    );
+    lines.push(`  - Conclusion: ${issue.overallConclusion}`);
+    lines.push(`  - report.json: ${issue.reportJsonFile}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function renderCampaignTimelineMarkdown(digest: CampaignDigest): string {
+  const lines: string[] = [];
+  const partialIssues = digest.reports
+    .filter((report) => report.report.summary.status !== "complete")
+    .map((report) =>
+      renderIssueLabel(
+        report.report.summary.issueNumber,
+        report.report.summary.title,
+      ),
+    );
+
+  lines.push(`# Campaign Timeline: ${digest.campaignId}`);
+  lines.push("");
+  lines.push(`- Generated at: ${digest.generatedAt}`);
+  lines.push(`- Selection: ${renderSelection(digest.selection)}`);
+  lines.push(`- Timeline entries: ${digest.timeline.length.toString()}`);
+  lines.push(
+    `- Partial issue timelines: ${partialIssues.length === 0 ? "None" : partialIssues.join(", ")}`,
+  );
+  lines.push("");
+
+  lines.push("## Events");
+  if (digest.timeline.length === 0) {
+    lines.push("- Unavailable: No campaign timeline entries were available.");
+  } else {
+    for (const entry of digest.timeline) {
+      lines.push(
+        `- ${renderValue(entry.at)} | ${renderIssueLabel(entry.issueNumber, entry.issueTitle)} | ${entry.title} | ${entry.summary}`,
+      );
+      if (entry.attemptNumber !== null) {
+        lines.push(`  - Attempt: ${entry.attemptNumber.toString()}`);
+      }
+      if (entry.sessionId !== null) {
+        lines.push(`  - Session: ${entry.sessionId}`);
+      }
+      for (const detail of entry.details) {
+        lines.push(`  - ${detail}`);
+      }
+      lines.push(`  - Source report: ${entry.sourceReport}`);
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function renderCampaignGitHubActivityMarkdown(
+  digest: CampaignDigest,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# Campaign GitHub Activity: ${digest.campaignId}`);
+  lines.push("");
+  lines.push(`- Generated at: ${digest.generatedAt}`);
+  lines.push(`- Selection: ${renderSelection(digest.selection)}`);
+  lines.push(`- Status: ${digest.githubActivity.status}`);
+  lines.push(`- Summary: ${digest.githubActivity.summary}`);
+  lines.push(
+    `- Pull requests observed: ${digest.githubActivity.pullRequests.length.toString()}`,
+  );
+  lines.push(
+    `- Review feedback rounds: ${digest.githubActivity.reviewFeedbackRounds.toString()}`,
+  );
+  lines.push(
+    `- Actionable review count: ${renderNumber(digest.githubActivity.actionableReviewCount)}`,
+  );
+  lines.push(
+    `- Unresolved thread count: ${renderNumber(digest.githubActivity.unresolvedThreadCount)}`,
+  );
+  lines.push(
+    `- Pending checks: ${renderPatternList(digest.githubActivity.pendingChecks)}`,
+  );
+  lines.push(
+    `- Failing checks: ${renderPatternList(digest.githubActivity.failingChecks)}`,
+  );
+  lines.push(`- Merge timing: ${digest.githubActivity.mergeAvailabilityNote}`);
+  lines.push(`- Close timing: ${digest.githubActivity.closeAvailabilityNote}`);
+  for (const note of digest.githubActivity.notes) {
+    lines.push(`- Note: ${note}`);
+  }
+  lines.push("");
+
+  lines.push("## Pull Requests");
+  if (digest.githubActivity.pullRequests.length === 0) {
+    lines.push("- None observed.");
+  } else {
+    for (const pullRequest of digest.githubActivity.pullRequests) {
+      lines.push(
+        `- ${renderIssueLabel(pullRequest.issueNumber, pullRequest.issueTitle)} | PR #${pullRequest.number.toString()} | ${pullRequest.url}`,
+      );
+      lines.push(
+        `  - Attempts: ${pullRequest.attemptNumbers.length === 0 ? "Unavailable" : pullRequest.attemptNumbers.join(", ")}`,
+      );
+      lines.push(
+        `  - First observed: ${renderValue(pullRequest.firstObservedAt)}`,
+      );
+      lines.push(
+        `  - Latest commit: ${renderValue(pullRequest.latestCommitAt)}`,
+      );
+      lines.push(
+        `  - Review rounds: ${pullRequest.reviewFeedbackRounds.toString()}`,
+      );
+      lines.push(
+        `  - Actionable reviews: ${renderNumber(pullRequest.actionableReviewCount)}`,
+      );
+      lines.push(
+        `  - Unresolved threads: ${renderNumber(pullRequest.unresolvedThreadCount)}`,
+      );
+      lines.push(
+        `  - Pending checks: ${renderNameList(pullRequest.pendingChecks)}`,
+      );
+      lines.push(
+        `  - Failing checks: ${renderNameList(pullRequest.failingChecks)}`,
+      );
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function renderCampaignTokenUsageMarkdown(
+  digest: CampaignDigest,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# Campaign Token Usage: ${digest.campaignId}`);
+  lines.push("");
+  lines.push(`- Generated at: ${digest.generatedAt}`);
+  lines.push(`- Selection: ${renderSelection(digest.selection)}`);
+  lines.push(`- Aggregate status: ${digest.tokenUsage.status}`);
+  lines.push(`- Explanation: ${digest.tokenUsage.explanation}`);
+  lines.push(`- Total tokens: ${renderNumber(digest.tokenUsage.totalTokens)}`);
+  lines.push(
+    `- Estimated cost (USD): ${renderCurrency(digest.tokenUsage.costUsd)}`,
+  );
+  lines.push(
+    `- Status counts: complete ${digest.tokenUsage.issueCounts.complete.toString()}, estimated ${digest.tokenUsage.issueCounts.estimated.toString()}, partial ${digest.tokenUsage.issueCounts.partial.toString()}, unavailable ${digest.tokenUsage.issueCounts.unavailable.toString()}`,
+  );
+  lines.push(
+    `- Observed token subtotal: ${renderNumber(digest.tokenUsage.observedTokenSubtotal)}`,
+  );
+  lines.push(
+    `- Observed cost subtotal (USD): ${renderCurrency(digest.tokenUsage.observedCostSubtotal)}`,
+  );
+  for (const note of digest.tokenUsage.notes) {
+    lines.push(`- Note: ${note}`);
+  }
+  lines.push("");
+
+  lines.push("## Issue Coverage");
+  for (const issue of digest.tokenUsage.issues) {
+    lines.push(
+      `- ${renderIssueLabel(issue.issueNumber, issue.title)} | status ${issue.status} | sessions ${issue.sessionCount.toString()} | total tokens ${renderNumber(issue.totalTokens)} | cost ${renderCurrency(issue.costUsd)}`,
+    );
+    for (const note of issue.notes) {
+      lines.push(`  - Note: ${note}`);
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function renderCampaignLearningsMarkdown(
+  digest: CampaignDigest,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# Campaign Learnings: ${digest.campaignId}`);
+  lines.push("");
+  lines.push(`- Generated at: ${digest.generatedAt}`);
+  lines.push(`- Selection: ${renderSelection(digest.selection)}`);
+  lines.push("");
+
+  lines.push("## Cross-Issue Conclusions");
+  renderLearningClusters(lines, digest.learnings.crossIssueConclusions);
+  lines.push("");
+
+  lines.push("## Recurring Failure Modes");
+  renderLearningClusters(lines, digest.learnings.recurringFailureModes);
+  lines.push("");
+
+  lines.push("## Changes To Make");
+  if (digest.learnings.changesToMake.length === 0) {
+    lines.push("- None recorded.");
+  } else {
+    for (const change of digest.learnings.changesToMake) {
+      lines.push(`- ${change}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Gaps");
+  if (digest.learnings.gaps.length === 0) {
+    lines.push("- None recorded.");
+  } else {
+    for (const gap of digest.learnings.gaps) {
+      lines.push(`- ${gap}`);
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function renderLearningClusters(
+  lines: string[],
+  clusters: readonly CampaignLearningCluster[],
+): void {
+  if (clusters.length === 0) {
+    lines.push("- None recorded.");
+    return;
+  }
+
+  for (const cluster of clusters) {
+    lines.push(`- ${cluster.title}: ${cluster.summary}`);
+    lines.push(
+      `  - Issues: ${cluster.issueNumbers.length === 0 ? "Unavailable" : cluster.issueNumbers.map((issueNumber) => `#${issueNumber.toString()}`).join(", ")}`,
+    );
+    for (const evidence of cluster.evidence) {
+      lines.push(`  - ${evidence}`);
+    }
+  }
+}
+
+function renderSelection(selection: CampaignSelection): string {
+  if (selection.kind === "issues") {
+    return selection.issueNumbers
+      .map((issueNumber) => `#${issueNumber.toString()}`)
+      .join(", ");
+  }
+  return `${selection.from} to ${selection.to}`;
+}
+
+function renderIssueLabel(issueNumber: number, title: string | null): string {
+  return title === null
+    ? `#${issueNumber.toString()}`
+    : `#${issueNumber.toString()} ${title}`;
+}
+
+function renderPatternList(patterns: readonly CampaignCheckPattern[]): string {
+  if (patterns.length === 0) {
+    return "None";
+  }
+  return patterns
+    .map((pattern) => `${pattern.name} (${pattern.count.toString()})`)
+    .join(", ");
+}
+
+function renderNameList(values: readonly string[]): string {
+  return values.length === 0 ? "None" : values.join(", ");
+}
+
+function renderValue(value: string | null): string {
+  return value === null ? "Unavailable" : value;
+}
+
+function renderNumber(value: number | null): string {
+  return value === null ? "Unavailable" : value.toString();
+}
+
+function renderCurrency(value: number | null): string {
+  return value === null ? "Unavailable" : value.toFixed(2);
+}

--- a/src/observability/campaign-report-markdown.ts
+++ b/src/observability/campaign-report-markdown.ts
@@ -4,6 +4,10 @@ import type {
   CampaignLearningCluster,
   CampaignSelection,
 } from "./campaign-report.js";
+import {
+  renderCampaignIssueLabel,
+  renderCampaignNameList,
+} from "./campaign-report-format.js";
 
 export function renderCampaignSummaryMarkdown(digest: CampaignDigest): string {
   const lines: string[] = [];
@@ -283,9 +287,7 @@ function renderSelection(selection: CampaignSelection): string {
 }
 
 function renderIssueLabel(issueNumber: number, title: string | null): string {
-  return title === null
-    ? `#${issueNumber.toString()}`
-    : `#${issueNumber.toString()} ${title}`;
+  return renderCampaignIssueLabel(issueNumber, title);
 }
 
 function renderPatternList(patterns: readonly CampaignCheckPattern[]): string {
@@ -298,7 +300,7 @@ function renderPatternList(patterns: readonly CampaignCheckPattern[]): string {
 }
 
 function renderNameList(values: readonly string[]): string {
-  return values.length === 0 ? "None" : values.join(", ");
+  return renderCampaignNameList(values);
 }
 
 function renderValue(value: string | null): string {

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -21,6 +21,10 @@ import {
   renderCampaignTimelineMarkdown,
   renderCampaignTokenUsageMarkdown,
 } from "./campaign-report-markdown.js";
+import {
+  renderCampaignIssueLabel,
+  renderCampaignNameList,
+} from "./campaign-report-format.js";
 
 export type CampaignSelection =
   | {
@@ -1073,9 +1077,7 @@ function deriveCampaignTokenStatus(
   if (
     statuses.every((status) => status === "complete" || status === "estimated")
   ) {
-    return statuses.some((status) => status === "estimated")
-      ? "estimated"
-      : "complete";
+    return "estimated";
   }
   if (statuses.every((status) => status === "unavailable")) {
     return "unavailable";
@@ -1155,9 +1157,7 @@ function dedupeNumbers(values: readonly number[]): readonly number[] {
 }
 
 function renderIssueLabel(issueNumber: number, title: string | null): string {
-  return title === null
-    ? `#${issueNumber.toString()}`
-    : `#${issueNumber.toString()} ${title}`;
+  return renderCampaignIssueLabel(issueNumber, title);
 }
 
 function renderPatternSummary(
@@ -1172,7 +1172,7 @@ function renderPatternSummary(
 }
 
 function renderNameList(values: readonly string[]): string {
-  return values.length === 0 ? "none" : values.join(", ");
+  return renderCampaignNameList(values);
 }
 
 function compareNumbersAscending(left: number, right: number): number {

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -918,9 +918,7 @@ function buildOverallCampaignOutcome(
   if (outcomeCounts.unknown > 0) {
     qualifiers.push(`${outcomeCounts.unknown.toString()} remained unknown`);
   }
-  return qualifiers.length === 0
-    ? lead
-    : `${lead} ${qualifiers.join(", ")}.`;
+  return qualifiers.length === 0 ? lead : `${lead} ${qualifiers.join(", ")}.`;
 }
 
 function buildGitHubSummary(

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -507,13 +507,15 @@ function buildCampaignGitHubActivity(
     .map((pullRequest) => pullRequest.unresolvedThreadCount)
     .filter((value): value is number => value !== null);
   const actionableReviewCount =
-    actionableReviewValues.length === pullRequests.length
-      ? actionableReviewValues.reduce((sum, value) => sum + value, 0)
-      : null;
+    pullRequests.length === 0 ||
+    actionableReviewValues.length !== pullRequests.length
+      ? null
+      : actionableReviewValues.reduce((sum, value) => sum + value, 0);
   const unresolvedThreadCount =
-    unresolvedThreadValues.length === pullRequests.length
-      ? unresolvedThreadValues.reduce((sum, value) => sum + value, 0)
-      : null;
+    pullRequests.length === 0 ||
+    unresolvedThreadValues.length !== pullRequests.length
+      ? null
+      : unresolvedThreadValues.reduce((sum, value) => sum + value, 0);
   const pendingChecks = countNamedPatterns(
     pullRequests.flatMap((pullRequest) => pullRequest.pendingChecks),
   );
@@ -927,7 +929,13 @@ function buildOverallCampaignOutcome(
   if (outcomeCounts.unknown > 0) {
     parts.push(`${outcomeCounts.unknown.toString()} remained unknown`);
   }
-  return parts.join(" ");
+  const firstPart = parts[0];
+  if (firstPart === undefined) {
+    return "No issue reports were selected.";
+  }
+  return parts.length === 1
+    ? firstPart
+    : `${firstPart} ${parts.slice(1).join(", ")}.`;
 }
 
 function buildGitHubSummary(

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -440,7 +440,7 @@ function buildCampaignTimeline(
   const entries = reports.flatMap((storedReport) => {
     const issueNumber = storedReport.report.summary.issueNumber;
     const issueTitle = storedReport.report.summary.title;
-    const timelineEntries = storedReport.report.timeline.map((entry) => ({
+    return storedReport.report.timeline.map((entry) => ({
       at: entry.at,
       issueNumber,
       issueTitle,
@@ -452,24 +452,6 @@ function buildCampaignTimeline(
       details: entry.details,
       sourceReport: storedReport.outputPaths.reportJsonFile,
     }));
-    const operatorEntries =
-      storedReport.report.operatorInterventions.entries.map((entry) => ({
-        at: entry.at,
-        issueNumber,
-        issueTitle,
-        kind: `operator-${entry.kind}`,
-        title:
-          entry.kind === "approved"
-            ? "Plan review approved"
-            : "Plan review waived",
-        summary: entry.summary,
-        attemptNumber: null,
-        sessionId: null,
-        details: entry.details,
-        sourceReport: storedReport.outputPaths.reportJsonFile,
-      }));
-
-    return [...timelineEntries, ...operatorEntries];
   });
 
   return entries.sort(compareCampaignTimelineEntries);
@@ -522,6 +504,10 @@ function buildCampaignGitHubActivity(
   const failingChecks = countNamedPatterns(
     pullRequests.flatMap((pullRequest) => pullRequest.failingChecks),
   );
+  const unavailableReportCount = reports.filter(
+    (storedReport) =>
+      storedReport.report.githubActivity.status === "unavailable",
+  ).length;
   const partialReportCount = reports.filter(
     (storedReport) => storedReport.report.githubActivity.status !== "complete",
   ).length;
@@ -548,7 +534,11 @@ function buildCampaignGitHubActivity(
 
   return {
     status:
-      partialReportCount === 0 && reports.length > 0 ? "complete" : "partial",
+      reports.length === 0 || unavailableReportCount === reports.length
+        ? "unavailable"
+        : partialReportCount === 0
+          ? "complete"
+          : "partial",
     summary: buildGitHubSummary(
       pullRequests.length,
       reviewFeedbackRounds,
@@ -917,25 +907,20 @@ function buildOverallCampaignOutcome(
     return `All ${issueCount.toString()} selected issues completed successfully.`;
   }
 
-  const parts = [
-    `Completed ${outcomeCounts.succeeded.toString()} of ${issueCount.toString()} selected issues.`,
-  ];
+  const lead = `Completed ${outcomeCounts.succeeded.toString()} of ${issueCount.toString()} selected issues.`;
+  const qualifiers: string[] = [];
   if (outcomeCounts.failed > 0) {
-    parts.push(`${outcomeCounts.failed.toString()} failed`);
+    qualifiers.push(`${outcomeCounts.failed.toString()} failed`);
   }
   if (outcomeCounts.partial > 0) {
-    parts.push(`${outcomeCounts.partial.toString()} remained partial`);
+    qualifiers.push(`${outcomeCounts.partial.toString()} remained partial`);
   }
   if (outcomeCounts.unknown > 0) {
-    parts.push(`${outcomeCounts.unknown.toString()} remained unknown`);
+    qualifiers.push(`${outcomeCounts.unknown.toString()} remained unknown`);
   }
-  const firstPart = parts[0];
-  if (firstPart === undefined) {
-    return "No issue reports were selected.";
-  }
-  return parts.length === 1
-    ? firstPart
-    : `${firstPart} ${parts.slice(1).join(", ")}.`;
+  return qualifiers.length === 0
+    ? lead
+    : `${lead} ${qualifiers.join(", ")}.`;
 }
 
 function buildGitHubSummary(

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -1,0 +1,1180 @@
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
+import { writeTextFileAtomic } from "./atomic-file.js";
+import { deriveFactoryRuntimeRoot } from "./issue-artifacts.js";
+import type {
+  IssueReportAvailability,
+  IssueReportDocument,
+  IssueReportTokenUsageStatus,
+  StoredIssueReportDocument,
+} from "./issue-report.js";
+import {
+  deriveIssueReportsRoot,
+  readIssueReportDocument,
+} from "./issue-report.js";
+import {
+  renderCampaignGitHubActivityMarkdown,
+  renderCampaignLearningsMarkdown,
+  renderCampaignSummaryMarkdown,
+  renderCampaignTimelineMarkdown,
+  renderCampaignTokenUsageMarkdown,
+} from "./campaign-report-markdown.js";
+
+export type CampaignSelection =
+  | {
+      readonly kind: "issues";
+      readonly issueNumbers: readonly number[];
+    }
+  | {
+      readonly kind: "date-window";
+      readonly from: string;
+      readonly to: string;
+    };
+
+export type CampaignIssueOutcome =
+  | "succeeded"
+  | "failed"
+  | "partial"
+  | "unknown";
+
+export interface CampaignReportPaths {
+  readonly campaignRoot: string;
+  readonly summaryFile: string;
+  readonly timelineFile: string;
+  readonly githubActivityFile: string;
+  readonly tokenUsageFile: string;
+  readonly learningsFile: string;
+}
+
+export interface CampaignSummaryIssue {
+  readonly issueNumber: number;
+  readonly title: string | null;
+  readonly classifiedOutcome: CampaignIssueOutcome;
+  readonly reportStatus: IssueReportAvailability;
+  readonly startedAt: string | null;
+  readonly endedAt: string | null;
+  readonly attemptCount: number;
+  readonly pullRequestCount: number;
+  readonly overallConclusion: string;
+  readonly reportJsonFile: string;
+}
+
+export interface CampaignSummarySection {
+  readonly issueCount: number;
+  readonly outcomeCounts: Readonly<Record<CampaignIssueOutcome, number>>;
+  readonly attemptCount: number;
+  readonly pullRequestCount: number;
+  readonly overallOutcome: string;
+  readonly notableConclusions: readonly string[];
+  readonly issues: readonly CampaignSummaryIssue[];
+}
+
+export interface CampaignTimelineEntry {
+  readonly at: string | null;
+  readonly issueNumber: number;
+  readonly issueTitle: string | null;
+  readonly kind: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly attemptNumber: number | null;
+  readonly sessionId: string | null;
+  readonly details: readonly string[];
+  readonly sourceReport: string;
+}
+
+export interface CampaignCheckPattern {
+  readonly name: string;
+  readonly count: number;
+}
+
+export interface CampaignPullRequestActivity {
+  readonly issueNumber: number;
+  readonly issueTitle: string | null;
+  readonly number: number;
+  readonly url: string;
+  readonly attemptNumbers: readonly number[];
+  readonly firstObservedAt: string | null;
+  readonly latestCommitAt: string | null;
+  readonly reviewFeedbackRounds: number;
+  readonly actionableReviewCount: number | null;
+  readonly unresolvedThreadCount: number | null;
+  readonly pendingChecks: readonly string[];
+  readonly failingChecks: readonly string[];
+}
+
+export interface CampaignGitHubActivity {
+  readonly status: IssueReportAvailability;
+  readonly summary: string;
+  readonly pullRequests: readonly CampaignPullRequestActivity[];
+  readonly reviewFeedbackRounds: number;
+  readonly actionableReviewCount: number | null;
+  readonly unresolvedThreadCount: number | null;
+  readonly pendingChecks: readonly CampaignCheckPattern[];
+  readonly failingChecks: readonly CampaignCheckPattern[];
+  readonly mergeAvailabilityNote: string;
+  readonly closeAvailabilityNote: string;
+  readonly notes: readonly string[];
+}
+
+export interface CampaignTokenUsageIssue {
+  readonly issueNumber: number;
+  readonly title: string | null;
+  readonly status: IssueReportTokenUsageStatus;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+  readonly sessionCount: number;
+  readonly notes: readonly string[];
+}
+
+export interface CampaignTokenUsage {
+  readonly status: IssueReportTokenUsageStatus;
+  readonly explanation: string;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+  readonly observedTokenSubtotal: number | null;
+  readonly observedCostSubtotal: number | null;
+  readonly issueCounts: Readonly<Record<IssueReportTokenUsageStatus, number>>;
+  readonly issues: readonly CampaignTokenUsageIssue[];
+  readonly notes: readonly string[];
+}
+
+export interface CampaignLearningCluster {
+  readonly title: string;
+  readonly summary: string;
+  readonly issueNumbers: readonly number[];
+  readonly evidence: readonly string[];
+}
+
+export interface CampaignLearnings {
+  readonly crossIssueConclusions: readonly CampaignLearningCluster[];
+  readonly recurringFailureModes: readonly CampaignLearningCluster[];
+  readonly changesToMake: readonly string[];
+  readonly gaps: readonly string[];
+}
+
+export interface CampaignDigest {
+  readonly generatedAt: string;
+  readonly campaignId: string;
+  readonly selection: CampaignSelection;
+  readonly reports: readonly StoredIssueReportDocument[];
+  readonly summary: CampaignSummarySection;
+  readonly timeline: readonly CampaignTimelineEntry[];
+  readonly githubActivity: CampaignGitHubActivity;
+  readonly tokenUsage: CampaignTokenUsage;
+  readonly learnings: CampaignLearnings;
+}
+
+export interface CampaignMarkdownFiles {
+  readonly summary: string;
+  readonly timeline: string;
+  readonly githubActivity: string;
+  readonly tokenUsage: string;
+  readonly learnings: string;
+}
+
+export interface GeneratedCampaignDigest {
+  readonly digest: CampaignDigest;
+  readonly markdown: CampaignMarkdownFiles;
+  readonly outputPaths: CampaignReportPaths;
+}
+
+export function deriveCampaignReportsRoot(workspaceRoot: string): string {
+  return path.join(
+    path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
+    "reports",
+    "campaigns",
+  );
+}
+
+export function deriveCampaignId(selection: CampaignSelection): string {
+  if (selection.kind === "issues") {
+    return `issues-${normalizeIssueNumbers(selection.issueNumbers).join("-")}`;
+  }
+  return `window-${selection.from}-to-${selection.to}`;
+}
+
+export function deriveCampaignReportPaths(
+  workspaceRoot: string,
+  campaignId: string,
+): CampaignReportPaths {
+  const campaignRoot = path.join(
+    deriveCampaignReportsRoot(workspaceRoot),
+    campaignId,
+  );
+  return {
+    campaignRoot,
+    summaryFile: path.join(campaignRoot, "summary.md"),
+    timelineFile: path.join(campaignRoot, "timeline.md"),
+    githubActivityFile: path.join(campaignRoot, "github-activity.md"),
+    tokenUsageFile: path.join(campaignRoot, "token-usage.md"),
+    learningsFile: path.join(campaignRoot, "learnings.md"),
+  };
+}
+
+export async function generateCampaignDigest(
+  workspaceRoot: string,
+  selection: CampaignSelection,
+  options?: {
+    readonly generatedAt?: string | undefined;
+  },
+): Promise<GeneratedCampaignDigest> {
+  const normalizedSelection = normalizeCampaignSelection(selection);
+  const reports = await loadCampaignIssueReports(
+    workspaceRoot,
+    normalizedSelection,
+  );
+  const digest = buildCampaignDigest(
+    normalizedSelection,
+    reports,
+    options?.generatedAt ?? new Date().toISOString(),
+  );
+  const outputPaths = deriveCampaignReportPaths(
+    workspaceRoot,
+    digest.campaignId,
+  );
+  const markdown = {
+    summary: renderCampaignSummaryMarkdown(digest),
+    timeline: renderCampaignTimelineMarkdown(digest),
+    githubActivity: renderCampaignGitHubActivityMarkdown(digest),
+    tokenUsage: renderCampaignTokenUsageMarkdown(digest),
+    learnings: renderCampaignLearningsMarkdown(digest),
+  };
+
+  return {
+    digest,
+    markdown,
+    outputPaths,
+  };
+}
+
+export async function writeCampaignDigest(
+  workspaceRoot: string,
+  selection: CampaignSelection,
+  options?: {
+    readonly generatedAt?: string | undefined;
+  },
+): Promise<GeneratedCampaignDigest> {
+  const generated = await generateCampaignDigest(
+    workspaceRoot,
+    selection,
+    options,
+  );
+  await Promise.all([
+    writeTextFileAtomic(
+      generated.outputPaths.summaryFile,
+      generated.markdown.summary,
+      {
+        tempPrefix: ".campaign-report",
+      },
+    ),
+    writeTextFileAtomic(
+      generated.outputPaths.timelineFile,
+      generated.markdown.timeline,
+      {
+        tempPrefix: ".campaign-report",
+      },
+    ),
+    writeTextFileAtomic(
+      generated.outputPaths.githubActivityFile,
+      generated.markdown.githubActivity,
+      {
+        tempPrefix: ".campaign-report",
+      },
+    ),
+    writeTextFileAtomic(
+      generated.outputPaths.tokenUsageFile,
+      generated.markdown.tokenUsage,
+      {
+        tempPrefix: ".campaign-report",
+      },
+    ),
+    writeTextFileAtomic(
+      generated.outputPaths.learningsFile,
+      generated.markdown.learnings,
+      {
+        tempPrefix: ".campaign-report",
+      },
+    ),
+  ]);
+  return generated;
+}
+
+export async function loadCampaignIssueReports(
+  workspaceRoot: string,
+  selection: CampaignSelection,
+): Promise<readonly StoredIssueReportDocument[]> {
+  if (selection.kind === "issues") {
+    const issueNumbers = normalizeIssueNumbers(selection.issueNumbers);
+    return Promise.all(
+      issueNumbers.map((issueNumber) =>
+        readIssueReportDocument(workspaceRoot, issueNumber),
+      ),
+    );
+  }
+
+  const issueNumbers = await listStoredIssueReportNumbers(workspaceRoot);
+  if (issueNumbers.length === 0) {
+    throw new ObservabilityError(
+      `No generated issue reports were found under ${deriveIssueReportsRoot(workspaceRoot)}; run 'symphony-report issue --issue <number>' first.`,
+    );
+  }
+
+  const reports = await Promise.all(
+    issueNumbers.map((issueNumber) =>
+      readIssueReportDocument(workspaceRoot, issueNumber),
+    ),
+  );
+  const selectedReports = reports.filter((report) =>
+    matchesCampaignDateWindow(report.report, selection),
+  );
+
+  if (selectedReports.length === 0) {
+    throw new ObservabilityError(
+      `No generated issue reports overlapped ${selection.from} to ${selection.to} under ${deriveIssueReportsRoot(workspaceRoot)}; generate or regenerate the relevant issue reports first.`,
+    );
+  }
+
+  return selectedReports.sort(compareStoredReportsByIssueNumber);
+}
+
+export function buildCampaignDigest(
+  selection: CampaignSelection,
+  reports: readonly StoredIssueReportDocument[],
+  generatedAt: string,
+): CampaignDigest {
+  const normalizedSelection = normalizeCampaignSelection(selection);
+  const orderedReports = [...reports].sort(compareStoredReportsByIssueNumber);
+  const summary = buildCampaignSummary(orderedReports);
+  const timeline = buildCampaignTimeline(orderedReports);
+  const githubActivity = buildCampaignGitHubActivity(orderedReports);
+  const tokenUsage = buildCampaignTokenUsage(orderedReports);
+  const learnings = buildCampaignLearnings(
+    orderedReports,
+    summary,
+    githubActivity,
+    tokenUsage,
+  );
+
+  return {
+    generatedAt,
+    campaignId: deriveCampaignId(normalizedSelection),
+    selection: normalizedSelection,
+    reports: orderedReports,
+    summary,
+    timeline,
+    githubActivity,
+    tokenUsage,
+    learnings,
+  };
+}
+
+export function matchesCampaignDateWindow(
+  report: IssueReportDocument,
+  selection: Extract<CampaignSelection, { kind: "date-window" }>,
+): boolean {
+  const reportWindow = deriveReportWindow(report);
+  const requestedStart = parseDateWindowBoundary(selection.from, "start");
+  const requestedEnd = parseDateWindowBoundary(selection.to, "end");
+  return (
+    reportWindow.start <= requestedEnd && reportWindow.end >= requestedStart
+  );
+}
+
+function buildCampaignSummary(
+  reports: readonly StoredIssueReportDocument[],
+): CampaignSummarySection {
+  const outcomeCounts: Record<CampaignIssueOutcome, number> = {
+    succeeded: 0,
+    failed: 0,
+    partial: 0,
+    unknown: 0,
+  };
+
+  const issues = reports.map((storedReport) => {
+    const classifiedOutcome = classifyCampaignIssueOutcome(storedReport.report);
+    outcomeCounts[classifiedOutcome] += 1;
+    return {
+      issueNumber: storedReport.report.summary.issueNumber,
+      title: storedReport.report.summary.title,
+      classifiedOutcome,
+      reportStatus: storedReport.report.summary.status,
+      startedAt: storedReport.report.summary.startedAt,
+      endedAt: storedReport.report.summary.endedAt,
+      attemptCount: storedReport.report.summary.attemptCount,
+      pullRequestCount: storedReport.report.summary.pullRequestCount,
+      overallConclusion: storedReport.report.summary.overallConclusion,
+      reportJsonFile: storedReport.outputPaths.reportJsonFile,
+    };
+  });
+
+  const attemptCount = issues.reduce(
+    (sum, issue) => sum + issue.attemptCount,
+    0,
+  );
+  const pullRequestCount = issues.reduce(
+    (sum, issue) => sum + issue.pullRequestCount,
+    0,
+  );
+  const notableConclusions = buildNotableConclusions(reports, outcomeCounts);
+
+  return {
+    issueCount: issues.length,
+    outcomeCounts,
+    attemptCount,
+    pullRequestCount,
+    overallOutcome: buildOverallCampaignOutcome(issues.length, outcomeCounts),
+    notableConclusions,
+    issues,
+  };
+}
+
+function buildCampaignTimeline(
+  reports: readonly StoredIssueReportDocument[],
+): readonly CampaignTimelineEntry[] {
+  const entries = reports.flatMap((storedReport) => {
+    const issueNumber = storedReport.report.summary.issueNumber;
+    const issueTitle = storedReport.report.summary.title;
+    const timelineEntries = storedReport.report.timeline.map((entry) => ({
+      at: entry.at,
+      issueNumber,
+      issueTitle,
+      kind: entry.kind,
+      title: entry.title,
+      summary: entry.summary,
+      attemptNumber: entry.attemptNumber,
+      sessionId: entry.sessionId,
+      details: entry.details,
+      sourceReport: storedReport.outputPaths.reportJsonFile,
+    }));
+    const operatorEntries =
+      storedReport.report.operatorInterventions.entries.map((entry) => ({
+        at: entry.at,
+        issueNumber,
+        issueTitle,
+        kind: `operator-${entry.kind}`,
+        title:
+          entry.kind === "approved"
+            ? "Plan review approved"
+            : "Plan review waived",
+        summary: entry.summary,
+        attemptNumber: null,
+        sessionId: null,
+        details: entry.details,
+        sourceReport: storedReport.outputPaths.reportJsonFile,
+      }));
+
+    return [...timelineEntries, ...operatorEntries];
+  });
+
+  return entries.sort(compareCampaignTimelineEntries);
+}
+
+function buildCampaignGitHubActivity(
+  reports: readonly StoredIssueReportDocument[],
+): CampaignGitHubActivity {
+  const pullRequests = reports.flatMap((storedReport) =>
+    storedReport.report.githubActivity.pullRequests.map((pullRequest) => ({
+      issueNumber: storedReport.report.summary.issueNumber,
+      issueTitle: storedReport.report.summary.title,
+      number: pullRequest.number,
+      url: pullRequest.url,
+      attemptNumbers: pullRequest.attemptNumbers,
+      firstObservedAt: pullRequest.firstObservedAt,
+      latestCommitAt: pullRequest.latestCommitAt,
+      reviewFeedbackRounds: pullRequest.reviewFeedbackRounds,
+      actionableReviewCount: pullRequest.actionableReviewCount,
+      unresolvedThreadCount: pullRequest.unresolvedThreadCount,
+      pendingChecks: pullRequest.pendingChecks,
+      failingChecks: pullRequest.failingChecks,
+    })),
+  );
+
+  const reviewFeedbackRounds = reports.reduce(
+    (sum, storedReport) =>
+      sum + storedReport.report.githubActivity.reviewFeedbackRounds,
+    0,
+  );
+  const actionableReviewValues = pullRequests
+    .map((pullRequest) => pullRequest.actionableReviewCount)
+    .filter((value): value is number => value !== null);
+  const unresolvedThreadValues = pullRequests
+    .map((pullRequest) => pullRequest.unresolvedThreadCount)
+    .filter((value): value is number => value !== null);
+  const actionableReviewCount =
+    actionableReviewValues.length === pullRequests.length
+      ? actionableReviewValues.reduce((sum, value) => sum + value, 0)
+      : null;
+  const unresolvedThreadCount =
+    unresolvedThreadValues.length === pullRequests.length
+      ? unresolvedThreadValues.reduce((sum, value) => sum + value, 0)
+      : null;
+  const pendingChecks = countNamedPatterns(
+    pullRequests.flatMap((pullRequest) => pullRequest.pendingChecks),
+  );
+  const failingChecks = countNamedPatterns(
+    pullRequests.flatMap((pullRequest) => pullRequest.failingChecks),
+  );
+  const partialReportCount = reports.filter(
+    (storedReport) => storedReport.report.githubActivity.status !== "complete",
+  ).length;
+  const notes = dedupeStrings([
+    partialReportCount === 0
+      ? ""
+      : `${partialReportCount.toString()} selected issue reports contained partial GitHub activity facts.`,
+    pullRequests.length === 0
+      ? "No pull requests were observed in the selected issue reports."
+      : "",
+    pendingChecks.length === 0
+      ? ""
+      : `Pending checks were observed for ${pullRequests.filter((pullRequest) => pullRequest.pendingChecks.length > 0).length.toString()} pull requests.`,
+    failingChecks.length === 0
+      ? ""
+      : `Failing checks were observed for ${pullRequests.filter((pullRequest) => pullRequest.failingChecks.length > 0).length.toString()} pull requests.`,
+  ]);
+  const mergeAvailabilityCount = reports.filter(
+    (storedReport) => storedReport.report.githubActivity.mergedAt !== null,
+  ).length;
+  const closeAvailabilityCount = reports.filter(
+    (storedReport) => storedReport.report.githubActivity.closedAt !== null,
+  ).length;
+
+  return {
+    status:
+      partialReportCount === 0 && reports.length > 0 ? "complete" : "partial",
+    summary: buildGitHubSummary(
+      pullRequests.length,
+      reviewFeedbackRounds,
+      pendingChecks,
+      failingChecks,
+    ),
+    pullRequests,
+    reviewFeedbackRounds,
+    actionableReviewCount,
+    unresolvedThreadCount,
+    pendingChecks,
+    failingChecks,
+    mergeAvailabilityNote:
+      mergeAvailabilityCount === reports.length
+        ? "Merge timing was available for all selected issue reports."
+        : `Merge timing was unavailable for ${(reports.length - mergeAvailabilityCount).toString()} of ${reports.length.toString()} selected issue reports.`,
+    closeAvailabilityNote:
+      closeAvailabilityCount === reports.length
+        ? "Issue close timing was available for all selected issue reports."
+        : `Issue close timing was unavailable for ${(reports.length - closeAvailabilityCount).toString()} of ${reports.length.toString()} selected issue reports.`,
+    notes,
+  };
+}
+
+function buildCampaignTokenUsage(
+  reports: readonly StoredIssueReportDocument[],
+): CampaignTokenUsage {
+  const issueCounts: Record<IssueReportTokenUsageStatus, number> = {
+    unavailable: 0,
+    partial: 0,
+    estimated: 0,
+    complete: 0,
+  };
+  const issues = reports.map((storedReport) => {
+    const issueTokenUsage = storedReport.report.tokenUsage;
+    issueCounts[issueTokenUsage.status] += 1;
+    return {
+      issueNumber: storedReport.report.summary.issueNumber,
+      title: storedReport.report.summary.title,
+      status: issueTokenUsage.status,
+      totalTokens: issueTokenUsage.totalTokens,
+      costUsd: issueTokenUsage.costUsd,
+      sessionCount: issueTokenUsage.sessions.length,
+      notes: issueTokenUsage.notes,
+    };
+  });
+
+  const status = deriveCampaignTokenStatus(issues.map((issue) => issue.status));
+  const totalTokens = issues.every((issue) => issue.totalTokens !== null)
+    ? issues.reduce((sum, issue) => sum + (issue.totalTokens ?? 0), 0)
+    : null;
+  const costUsd = issues.every((issue) => issue.costUsd !== null)
+    ? issues.reduce((sum, issue) => sum + (issue.costUsd ?? 0), 0)
+    : null;
+  const observedTokenIssues = issues.filter(
+    (issue) => issue.totalTokens !== null,
+  );
+  const observedCostIssues = issues.filter((issue) => issue.costUsd !== null);
+  const observedTokenSubtotal =
+    observedTokenIssues.length === 0
+      ? null
+      : observedTokenIssues.reduce(
+          (sum, issue) => sum + (issue.totalTokens ?? 0),
+          0,
+        );
+  const observedCostSubtotal =
+    observedCostIssues.length === 0
+      ? null
+      : observedCostIssues.reduce(
+          (sum, issue) => sum + (issue.costUsd ?? 0),
+          0,
+        );
+  const explanation = buildCampaignTokenExplanation(
+    issues.length,
+    issueCounts,
+    status,
+  );
+  const notes = dedupeStrings([
+    observedTokenIssues.length === issues.length
+      ? ""
+      : `${observedTokenIssues.length.toString()} of ${issues.length.toString()} selected issue reports supplied token totals.`,
+    observedCostIssues.length === issues.length
+      ? ""
+      : `${observedCostIssues.length.toString()} of ${issues.length.toString()} selected issue reports supplied cost totals.`,
+  ]);
+
+  return {
+    status,
+    explanation,
+    totalTokens,
+    costUsd,
+    observedTokenSubtotal,
+    observedCostSubtotal,
+    issueCounts,
+    issues,
+    notes,
+  };
+}
+
+function buildCampaignLearnings(
+  reports: readonly StoredIssueReportDocument[],
+  summary: CampaignSummarySection,
+  githubActivity: CampaignGitHubActivity,
+  tokenUsage: CampaignTokenUsage,
+): CampaignLearnings {
+  const crossIssueConclusions = buildCrossIssueConclusions(
+    reports,
+    summary,
+    githubActivity,
+    tokenUsage,
+  );
+  const recurringFailureModes = buildRecurringFailureModes(
+    reports,
+    summary,
+    githubActivity,
+    tokenUsage,
+  );
+  const changesToMake = dedupeStrings([
+    tokenUsage.status === "complete"
+      ? ""
+      : `Expand token-usage capture or enrichment; campaign token coverage was ${tokenUsage.status} across ${summary.issueCount.toString()} issue reports.`,
+    reports.every(
+      (storedReport) => storedReport.report.githubActivity.mergedAt === null,
+    )
+      ? "Record merge timing in canonical local artifacts so campaign digests can distinguish shipped work from PR-open state."
+      : "",
+    reports.every(
+      (storedReport) => storedReport.report.githubActivity.closedAt === null,
+    )
+      ? "Record exact issue-close timing in canonical local artifacts so campaign windows can compare tracker closure against report completion."
+      : "",
+    summary.outcomeCounts.partial > 0
+      ? `Preserve fuller canonical event ledgers for partial issues; ${summary.outcomeCounts.partial.toString()} selected reports remained partial or in-flight.`
+      : "",
+    githubActivity.failingChecks.length > 0
+      ? `Stabilize recurring failing checks: ${renderPatternSummary(githubActivity.failingChecks)}.`
+      : "",
+  ]);
+  const gaps = dedupeStrings([
+    crossIssueConclusions.length === 0
+      ? "No repeated issue-level learning titles appeared across the selected reports."
+      : "",
+    reports.some(
+      (storedReport) => storedReport.report.summary.status !== "complete",
+    )
+      ? "Some selected reports were partial, so the campaign digest may undercount lifecycle events."
+      : "",
+    tokenUsage.status === "unavailable"
+      ? "No selected report supplied campaign-usable token totals."
+      : "",
+  ]);
+
+  return {
+    crossIssueConclusions,
+    recurringFailureModes,
+    changesToMake,
+    gaps,
+  };
+}
+
+function buildCrossIssueConclusions(
+  reports: readonly StoredIssueReportDocument[],
+  summary: CampaignSummarySection,
+  githubActivity: CampaignGitHubActivity,
+  tokenUsage: CampaignTokenUsage,
+): readonly CampaignLearningCluster[] {
+  const observationClusters = collectObservationClusters(reports).filter(
+    (cluster) => cluster.issueNumbers.length > 1,
+  );
+  const derivedClusters: CampaignLearningCluster[] = [
+    {
+      title: "Campaign delivery outcomes",
+      summary: summary.overallOutcome,
+      issueNumbers: summary.issues.map((issue) => issue.issueNumber),
+      evidence: summary.issues.map(
+        (issue) =>
+          `${renderIssueLabel(issue.issueNumber, issue.title)}: ${issue.overallConclusion}`,
+      ),
+    },
+  ];
+
+  if (
+    githubActivity.reviewFeedbackRounds > 0 ||
+    githubActivity.pullRequests.length > 0
+  ) {
+    derivedClusters.push({
+      title: "GitHub activity patterns",
+      summary: githubActivity.summary,
+      issueNumbers: dedupeNumbers(
+        githubActivity.pullRequests.map(
+          (pullRequest) => pullRequest.issueNumber,
+        ),
+      ),
+      evidence: githubActivity.pullRequests.map(
+        (pullRequest) =>
+          `${renderIssueLabel(pullRequest.issueNumber, pullRequest.issueTitle)}: PR #${pullRequest.number.toString()} recorded ${pullRequest.reviewFeedbackRounds.toString()} review rounds, pending checks ${renderNameList(pullRequest.pendingChecks)}, failing checks ${renderNameList(pullRequest.failingChecks)}.`,
+      ),
+    });
+  }
+
+  if (tokenUsage.status !== "complete") {
+    derivedClusters.push({
+      title: "Token coverage limits",
+      summary: tokenUsage.explanation,
+      issueNumbers: tokenUsage.issues.map((issue) => issue.issueNumber),
+      evidence: tokenUsage.issues.map(
+        (issue) =>
+          `${renderIssueLabel(issue.issueNumber, issue.title)}: token status ${issue.status}.`,
+      ),
+    });
+  }
+
+  return [...observationClusters, ...derivedClusters].map(
+    normalizeLearningCluster,
+  );
+}
+
+function buildRecurringFailureModes(
+  reports: readonly StoredIssueReportDocument[],
+  summary: CampaignSummarySection,
+  githubActivity: CampaignGitHubActivity,
+  tokenUsage: CampaignTokenUsage,
+): readonly CampaignLearningCluster[] {
+  const clusters: CampaignLearningCluster[] = [];
+  const failedIssues = summary.issues.filter(
+    (issue) => issue.classifiedOutcome === "failed",
+  );
+  if (failedIssues.length > 0) {
+    clusters.push({
+      title: "Failed issues",
+      summary: `${failedIssues.length.toString()} selected issues ended in a failed terminal outcome.`,
+      issueNumbers: failedIssues.map((issue) => issue.issueNumber),
+      evidence: failedIssues.map(
+        (issue) =>
+          `${renderIssueLabel(issue.issueNumber, issue.title)}: ${issue.overallConclusion}`,
+      ),
+    });
+  }
+
+  const partialIssues = summary.issues.filter(
+    (issue) => issue.classifiedOutcome === "partial",
+  );
+  if (partialIssues.length > 0) {
+    clusters.push({
+      title: "Partial or unresolved issues",
+      summary: `${partialIssues.length.toString()} selected issues remained partial or non-terminal in their stored issue reports.`,
+      issueNumbers: partialIssues.map((issue) => issue.issueNumber),
+      evidence: partialIssues.map(
+        (issue) =>
+          `${renderIssueLabel(issue.issueNumber, issue.title)}: ${issue.overallConclusion}`,
+      ),
+    });
+  }
+
+  if (githubActivity.failingChecks.length > 0) {
+    clusters.push({
+      title: "Failing check patterns",
+      summary: `Recurring failing checks were recorded: ${renderPatternSummary(githubActivity.failingChecks)}.`,
+      issueNumbers: dedupeNumbers(
+        githubActivity.pullRequests
+          .filter((pullRequest) => pullRequest.failingChecks.length > 0)
+          .map((pullRequest) => pullRequest.issueNumber),
+      ),
+      evidence: githubActivity.pullRequests
+        .filter((pullRequest) => pullRequest.failingChecks.length > 0)
+        .map(
+          (pullRequest) =>
+            `${renderIssueLabel(pullRequest.issueNumber, pullRequest.issueTitle)}: PR #${pullRequest.number.toString()} failed ${renderNameList(pullRequest.failingChecks)}.`,
+        ),
+    });
+  }
+
+  if (
+    tokenUsage.issueCounts.unavailable > 0 ||
+    tokenUsage.issueCounts.partial > 0
+  ) {
+    clusters.push({
+      title: "Token-usage blind spots",
+      summary: `${(tokenUsage.issueCounts.unavailable + tokenUsage.issueCounts.partial).toString()} selected issue reports did not provide complete token accounting.`,
+      issueNumbers: tokenUsage.issues
+        .filter(
+          (issue) =>
+            issue.status === "unavailable" || issue.status === "partial",
+        )
+        .map((issue) => issue.issueNumber),
+      evidence: tokenUsage.issues
+        .filter(
+          (issue) =>
+            issue.status === "unavailable" || issue.status === "partial",
+        )
+        .map(
+          (issue) =>
+            `${renderIssueLabel(issue.issueNumber, issue.title)}: token status ${issue.status}.`,
+        ),
+    });
+  }
+
+  return clusters.map(normalizeLearningCluster);
+}
+
+function collectObservationClusters(
+  reports: readonly StoredIssueReportDocument[],
+): readonly CampaignLearningCluster[] {
+  const clusters = new Map<
+    string,
+    {
+      title: string;
+      summary: string;
+      issueNumbers: Set<number>;
+      evidence: string[];
+    }
+  >();
+
+  for (const storedReport of reports) {
+    for (const observation of storedReport.report.learnings.observations) {
+      const key = observation.title.trim().toLowerCase();
+      const existing = clusters.get(key) ?? {
+        title: observation.title,
+        summary: observation.summary,
+        issueNumbers: new Set<number>(),
+        evidence: [],
+      };
+      existing.issueNumbers.add(storedReport.report.summary.issueNumber);
+      existing.evidence.push(
+        `${renderIssueLabel(storedReport.report.summary.issueNumber, storedReport.report.summary.title)}: ${observation.evidence.join(" ") || observation.summary}`,
+      );
+      clusters.set(key, existing);
+    }
+  }
+
+  return [...clusters.values()].map((cluster) => ({
+    title: cluster.title,
+    summary: cluster.summary,
+    issueNumbers: [...cluster.issueNumbers].sort(compareNumbersAscending),
+    evidence: dedupeStrings(cluster.evidence),
+  }));
+}
+
+function buildNotableConclusions(
+  reports: readonly StoredIssueReportDocument[],
+  outcomeCounts: Readonly<Record<CampaignIssueOutcome, number>>,
+): readonly string[] {
+  const conclusions = [
+    outcomeCounts.failed === 0
+      ? ""
+      : `${outcomeCounts.failed.toString()} selected issues ended in failure and should be reviewed for retry or follow-up patterns.`,
+    outcomeCounts.partial === 0
+      ? ""
+      : `${outcomeCounts.partial.toString()} selected issues remained partial or non-terminal in their stored reports.`,
+    `${reports.filter((storedReport) => storedReport.report.operatorInterventions.entries.length > 0).length.toString()} selected issues recorded explicit operator plan-review interventions.`,
+    `${reports.reduce((sum, storedReport) => sum + storedReport.report.githubActivity.reviewFeedbackRounds, 0).toString()} review-feedback rounds were recorded across the selected issue reports.`,
+    `${reports.filter((storedReport) => storedReport.report.tokenUsage.status === "complete").length.toString()} of ${reports.length.toString()} selected issue reports provided complete token totals.`,
+  ];
+
+  return dedupeStrings(conclusions);
+}
+
+function buildOverallCampaignOutcome(
+  issueCount: number,
+  outcomeCounts: Readonly<Record<CampaignIssueOutcome, number>>,
+): string {
+  if (issueCount === 0) {
+    return "No issue reports were selected.";
+  }
+  if (outcomeCounts.succeeded === issueCount) {
+    return `All ${issueCount.toString()} selected issues completed successfully.`;
+  }
+
+  const parts = [
+    `Completed ${outcomeCounts.succeeded.toString()} of ${issueCount.toString()} selected issues.`,
+  ];
+  if (outcomeCounts.failed > 0) {
+    parts.push(`${outcomeCounts.failed.toString()} failed`);
+  }
+  if (outcomeCounts.partial > 0) {
+    parts.push(`${outcomeCounts.partial.toString()} remained partial`);
+  }
+  if (outcomeCounts.unknown > 0) {
+    parts.push(`${outcomeCounts.unknown.toString()} remained unknown`);
+  }
+  return parts.join(" ");
+}
+
+function buildGitHubSummary(
+  pullRequestCount: number,
+  reviewFeedbackRounds: number,
+  pendingChecks: readonly CampaignCheckPattern[],
+  failingChecks: readonly CampaignCheckPattern[],
+): string {
+  const parts = [
+    `${pullRequestCount.toString()} pull requests were observed`,
+    `${reviewFeedbackRounds.toString()} review-feedback rounds were recorded`,
+  ];
+  if (pendingChecks.length > 0) {
+    parts.push(
+      `pending checks included ${renderPatternSummary(pendingChecks)}`,
+    );
+  }
+  if (failingChecks.length > 0) {
+    parts.push(
+      `failing checks included ${renderPatternSummary(failingChecks)}`,
+    );
+  }
+  return `${parts.join("; ")}.`;
+}
+
+function buildCampaignTokenExplanation(
+  issueCount: number,
+  issueCounts: Readonly<Record<IssueReportTokenUsageStatus, number>>,
+  status: IssueReportTokenUsageStatus,
+): string {
+  if (status === "complete") {
+    return `All ${issueCount.toString()} selected issue reports supplied complete token totals.`;
+  }
+  if (status === "estimated") {
+    return `All ${issueCount.toString()} selected issue reports supplied token totals, but at least one total remained estimated.`;
+  }
+  if (status === "unavailable") {
+    return `None of the ${issueCount.toString()} selected issue reports supplied campaign-usable token totals.`;
+  }
+  return `${issueCounts.complete.toString()} complete, ${issueCounts.estimated.toString()} estimated, ${issueCounts.partial.toString()} partial, and ${issueCounts.unavailable.toString()} unavailable token-usage reports were selected.`;
+}
+
+function normalizeCampaignSelection(
+  selection: CampaignSelection,
+): CampaignSelection {
+  if (selection.kind === "issues") {
+    return {
+      kind: "issues",
+      issueNumbers: normalizeIssueNumbers(selection.issueNumbers),
+    };
+  }
+  return selection;
+}
+
+function normalizeIssueNumbers(
+  issueNumbers: readonly number[],
+): readonly number[] {
+  const uniqueNumbers = new Set<number>();
+  for (const issueNumber of issueNumbers) {
+    uniqueNumbers.add(issueNumber);
+  }
+  return [...uniqueNumbers].sort(compareNumbersAscending);
+}
+
+async function listStoredIssueReportNumbers(
+  workspaceRoot: string,
+): Promise<readonly number[]> {
+  const reportsRoot = deriveIssueReportsRoot(workspaceRoot);
+  const entries = await fs
+    .readdir(reportsRoot, {
+      withFileTypes: true,
+    })
+    .catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [] as Dirent[];
+      }
+      throw error;
+    });
+
+  return entries
+    .filter((entry) => entry.isDirectory() && /^[1-9]\d*$/u.test(entry.name))
+    .map((entry) => Number.parseInt(entry.name, 10))
+    .sort(compareNumbersAscending);
+}
+
+function deriveReportWindow(report: IssueReportDocument): {
+  readonly start: number;
+  readonly end: number;
+} {
+  const startedAt = parseTimestamp(report.summary.startedAt);
+  const endedAt = parseTimestamp(report.summary.endedAt);
+  const generatedAt = parseTimestamp(report.generatedAt);
+  const start = startedAt ?? endedAt ?? generatedAt;
+  const end = endedAt ?? startedAt ?? generatedAt;
+
+  if (start === null || end === null) {
+    throw new ObservabilityError(
+      `Issue report #${report.summary.issueNumber.toString()} did not contain a usable reporting window.`,
+    );
+  }
+
+  return start <= end ? { start, end } : { start: end, end: start };
+}
+
+function parseDateWindowBoundary(
+  value: string,
+  boundary: "start" | "end",
+): number {
+  const timestamp = Date.parse(
+    `${value}T${boundary === "start" ? "00:00:00.000" : "23:59:59.999"}Z`,
+  );
+  if (Number.isNaN(timestamp)) {
+    throw new ObservabilityError(`Invalid campaign date boundary: ${value}`);
+  }
+  return timestamp;
+}
+
+function parseTimestamp(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function classifyCampaignIssueOutcome(
+  report: IssueReportDocument,
+): CampaignIssueOutcome {
+  if (report.summary.outcome === "succeeded") {
+    return "succeeded";
+  }
+  if (report.summary.outcome === "failed") {
+    return "failed";
+  }
+  if (report.summary.outcome === "unknown") {
+    return "unknown";
+  }
+  return "partial";
+}
+
+function deriveCampaignTokenStatus(
+  statuses: readonly IssueReportTokenUsageStatus[],
+): IssueReportTokenUsageStatus {
+  if (statuses.every((status) => status === "complete")) {
+    return "complete";
+  }
+  if (
+    statuses.every((status) => status === "complete" || status === "estimated")
+  ) {
+    return statuses.some((status) => status === "estimated")
+      ? "estimated"
+      : "complete";
+  }
+  if (statuses.every((status) => status === "unavailable")) {
+    return "unavailable";
+  }
+  return "partial";
+}
+
+function countNamedPatterns(
+  values: readonly string[],
+): readonly CampaignCheckPattern[] {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((left, right) =>
+      right.count === left.count
+        ? left.name.localeCompare(right.name)
+        : right.count - left.count,
+    );
+}
+
+function compareStoredReportsByIssueNumber(
+  left: StoredIssueReportDocument,
+  right: StoredIssueReportDocument,
+): number {
+  return compareNumbersAscending(
+    left.report.summary.issueNumber,
+    right.report.summary.issueNumber,
+  );
+}
+
+function compareCampaignTimelineEntries(
+  left: CampaignTimelineEntry,
+  right: CampaignTimelineEntry,
+): number {
+  const leftAt =
+    left.at === null ? Number.POSITIVE_INFINITY : Date.parse(left.at);
+  const rightAt =
+    right.at === null ? Number.POSITIVE_INFINITY : Date.parse(right.at);
+  if (leftAt !== rightAt) {
+    return leftAt - rightAt;
+  }
+  if (left.issueNumber !== right.issueNumber) {
+    return compareNumbersAscending(left.issueNumber, right.issueNumber);
+  }
+  return left.title.localeCompare(right.title);
+}
+
+function normalizeLearningCluster(
+  cluster: CampaignLearningCluster,
+): CampaignLearningCluster {
+  return {
+    title: cluster.title,
+    summary: cluster.summary,
+    issueNumbers: dedupeNumbers(cluster.issueNumbers),
+    evidence: dedupeStrings(cluster.evidence),
+  };
+}
+
+function dedupeStrings(values: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const value of values) {
+    if (value.length === 0 || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    deduped.push(value);
+  }
+  return deduped;
+}
+
+function dedupeNumbers(values: readonly number[]): readonly number[] {
+  return [...new Set(values)].sort(compareNumbersAscending);
+}
+
+function renderIssueLabel(issueNumber: number, title: string | null): string {
+  return title === null
+    ? `#${issueNumber.toString()}`
+    : `#${issueNumber.toString()} ${title}`;
+}
+
+function renderPatternSummary(
+  patterns: readonly CampaignCheckPattern[],
+): string {
+  if (patterns.length === 0) {
+    return "none";
+  }
+  return patterns
+    .map((pattern) => `${pattern.name} (${pattern.count.toString()})`)
+    .join(", ");
+}
+
+function renderNameList(values: readonly string[]): string {
+  return values.length === 0 ? "none" : values.join(", ");
+}
+
+function compareNumbersAscending(left: number, right: number): number {
+  return left - right;
+}

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -677,8 +677,11 @@ function buildCampaignLearnings(
       ? `Stabilize recurring failing checks: ${renderPatternSummary(githubActivity.failingChecks)}.`
       : "",
   ]);
+  const repeatedObservationCount = collectObservationClusters(reports).filter(
+    (cluster) => cluster.issueNumbers.length > 1,
+  ).length;
   const gaps = dedupeStrings([
-    crossIssueConclusions.length === 0
+    repeatedObservationCount === 0
       ? "No repeated issue-level learning titles appeared across the selected reports."
       : "",
     reports.some(

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -43,6 +43,12 @@ export interface StoredIssueReport {
   readonly outputPaths: IssueReportPaths;
 }
 
+export interface StoredIssueReportDocument {
+  readonly report: IssueReportDocument;
+  readonly rawReportJson: string;
+  readonly outputPaths: IssueReportPaths;
+}
+
 export interface IssueReportSummary {
   readonly status: IssueReportAvailability;
   readonly issueNumber: number;
@@ -213,7 +219,7 @@ export interface GeneratedIssueReport {
   readonly outputPaths: IssueReportPaths;
 }
 
-function deriveIssueReportsRoot(workspaceRoot: string): string {
+export function deriveIssueReportsRoot(workspaceRoot: string): string {
   return path.join(
     path.dirname(deriveFactoryRuntimeRoot(workspaceRoot)),
     "reports",
@@ -289,34 +295,16 @@ export async function writeIssueReport(
   return generated;
 }
 
-export async function readIssueReport(
+export async function readIssueReportDocument(
   workspaceRoot: string,
   issueNumber: number,
-): Promise<StoredIssueReport> {
+): Promise<StoredIssueReportDocument> {
   const outputPaths = deriveIssueReportPaths(workspaceRoot, issueNumber);
-  const [rawReportJsonResult, rawReportMarkdownResult] =
-    await Promise.allSettled([
-      readRequiredIssueReportFile(
-        outputPaths.reportJsonFile,
-        issueNumber,
-        "JSON",
-      ),
-      readRequiredIssueReportFile(
-        outputPaths.reportMarkdownFile,
-        issueNumber,
-        "markdown",
-      ),
-    ]);
-
-  if (rawReportJsonResult.status === "rejected") {
-    throw rawReportJsonResult.reason;
-  }
-  if (rawReportMarkdownResult.status === "rejected") {
-    throw rawReportMarkdownResult.reason;
-  }
-
-  const rawReportJson = rawReportJsonResult.value;
-  const rawReportMarkdown = rawReportMarkdownResult.value;
+  const rawReportJson = await readRequiredIssueReportFile(
+    outputPaths.reportJsonFile,
+    issueNumber,
+    "JSON",
+  );
 
   let parsedReport: unknown;
   try {
@@ -338,8 +326,39 @@ export async function readIssueReport(
   return {
     report,
     rawReportJson,
-    rawReportMarkdown,
     outputPaths,
+  };
+}
+
+export async function readIssueReport(
+  workspaceRoot: string,
+  issueNumber: number,
+): Promise<StoredIssueReport> {
+  const [storedDocumentResult, rawReportMarkdownResult] =
+    await Promise.allSettled([
+      readIssueReportDocument(workspaceRoot, issueNumber),
+      readRequiredIssueReportFile(
+        deriveIssueReportPaths(workspaceRoot, issueNumber).reportMarkdownFile,
+        issueNumber,
+        "markdown",
+      ),
+    ]);
+
+  if (storedDocumentResult.status === "rejected") {
+    throw storedDocumentResult.reason;
+  }
+  if (rawReportMarkdownResult.status === "rejected") {
+    throw rawReportMarkdownResult.reason;
+  }
+
+  const storedDocument = storedDocumentResult.value;
+  const rawReportMarkdown = rawReportMarkdownResult.value;
+
+  return {
+    report: storedDocument.report,
+    rawReportJson: storedDocument.rawReportJson,
+    rawReportMarkdown,
+    outputPaths: storedDocument.outputPaths,
   };
 }
 

--- a/tests/integration/campaign-report-cli.test.ts
+++ b/tests/integration/campaign-report-cli.test.ts
@@ -1,0 +1,334 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runReportCli } from "../../src/cli/report.js";
+import { CodexIssueReportEnricher } from "../../src/runner/codex-report-enricher.js";
+import { createTempDir } from "../support/git.js";
+import {
+  deriveCodexSessionsRoot,
+  deriveWorkspaceRoot,
+  downgradeIssueReportSchemaVersion,
+  seedFailedIssueArtifacts,
+  seedLateUnfinishedSessionArtifacts,
+  seedSessionAnchoredPartialArtifacts,
+  seedSuccessfulIssueArtifacts,
+  writeCodexSessionLog,
+  writeReportWorkflow,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("campaign report CLI", () => {
+  it("generates the campaign digest files for an explicit issue list", async () => {
+    const tempDir = await createTempDir("symphony-campaign-cli-issues-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 32, {
+      claimedAt: "2026-03-02T09:00:00.000Z",
+      planReadyAt: "2026-03-02T09:05:00.000Z",
+      attemptStartedAt: "2026-03-02T09:10:00.000Z",
+      prOpenedAt: "2026-03-02T09:25:00.000Z",
+      latestCommitAt: "2026-03-02T09:24:00.000Z",
+      succeededAt: "2026-03-02T10:00:00.000Z",
+      finalCommitAt: "2026-03-02T09:58:00.000Z",
+    });
+    await seedFailedIssueArtifacts(workspaceRoot, 43, {
+      attemptStartedAt: "2026-03-05T12:00:00.000Z",
+      retryScheduledAt: "2026-03-05T12:06:00.000Z",
+      failedAt: "2026-03-05T12:20:00.000Z",
+    });
+    await seedSessionAnchoredPartialArtifacts(workspaceRoot, 44);
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-02T09:10:00.000Z",
+      workspacePath: path.join(workspaceRoot, "issue-32"),
+      branch: "symphony/32",
+      fileName: "campaign-issue-32.jsonl",
+      totalTokens: 3210,
+      finalSummary: "- Added campaign digest coverage.",
+    });
+
+    const enrichers = [new CodexIssueReportEnricher({ sessionsRoot })];
+    for (const issueNumber of [32, 43, 44]) {
+      await runReportCli(
+        [
+          "node",
+          "symphony-report",
+          "issue",
+          "--issue",
+          issueNumber.toString(),
+          "--workflow",
+          workflowPath,
+        ],
+        { issueEnrichers: enrichers },
+      );
+    }
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "campaign",
+      "--issues",
+      "32,43,44",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const campaignDir = path.join(
+      tempDir,
+      ".var",
+      "reports",
+      "campaigns",
+      "issues-32-43-44",
+    );
+    await expect(
+      fs.readFile(path.join(campaignDir, "summary.md"), "utf8"),
+    ).resolves.toContain("Issue count: 3");
+    await expect(
+      fs.readFile(path.join(campaignDir, "timeline.md"), "utf8"),
+    ).resolves.toContain("#43 Generate per-issue reports from local artifacts");
+    await expect(
+      fs.readFile(path.join(campaignDir, "github-activity.md"), "utf8"),
+    ).resolves.toContain("Pull requests observed");
+    await expect(
+      fs.readFile(path.join(campaignDir, "token-usage.md"), "utf8"),
+    ).resolves.toContain("Aggregate status: partial");
+    await expect(
+      fs.readFile(path.join(campaignDir, "learnings.md"), "utf8"),
+    ).resolves.toContain("## Cross-Issue Conclusions");
+    expect(stdout.join("")).toContain(
+      "Generated campaign digest issues-32-43-44",
+    );
+  });
+
+  it("selects generated issue reports by date window", async () => {
+    const tempDir = await createTempDir("symphony-campaign-cli-window-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 32, {
+      claimedAt: "2026-03-02T09:00:00.000Z",
+      planReadyAt: "2026-03-02T09:05:00.000Z",
+      attemptStartedAt: "2026-03-02T09:10:00.000Z",
+      prOpenedAt: "2026-03-02T09:25:00.000Z",
+      latestCommitAt: "2026-03-02T09:24:00.000Z",
+      succeededAt: "2026-03-02T10:00:00.000Z",
+      finalCommitAt: "2026-03-02T09:58:00.000Z",
+    });
+    await seedFailedIssueArtifacts(workspaceRoot, 43, {
+      attemptStartedAt: "2026-03-06T12:00:00.000Z",
+      retryScheduledAt: "2026-03-06T12:06:00.000Z",
+      failedAt: "2026-03-06T12:20:00.000Z",
+    });
+    await seedLateUnfinishedSessionArtifacts(workspaceRoot, 44, {
+      startedAt: "2026-03-09T22:00:00.000Z",
+    });
+
+    for (const issueNumber of [32, 43, 44]) {
+      await runReportCli(
+        [
+          "node",
+          "symphony-report",
+          "issue",
+          "--issue",
+          issueNumber.toString(),
+          "--workflow",
+          workflowPath,
+        ],
+        { issueEnrichers: [] },
+      );
+    }
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "campaign",
+      "--from",
+      "2026-03-01",
+      "--to",
+      "2026-03-07",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    const summary = await fs.readFile(
+      path.join(
+        tempDir,
+        ".var",
+        "reports",
+        "campaigns",
+        "window-2026-03-01-to-2026-03-07",
+        "summary.md",
+      ),
+      "utf8",
+    );
+    expect(summary).toContain("Issue count: 2");
+    expect(summary).toContain(
+      "#32 Generate per-issue reports from local artifacts",
+    );
+    expect(summary).toContain(
+      "#43 Generate per-issue reports from local artifacts",
+    );
+    expect(summary).not.toContain(
+      "#44 Generate per-issue reports from local artifacts",
+    );
+  });
+
+  it("fails clearly when a requested issue report is missing", async () => {
+    const tempDir = await createTempDir("symphony-campaign-cli-missing-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 32);
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "32",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
+
+    await expect(
+      runReportCli([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--issues",
+        "32,43",
+        "--workflow",
+        workflowPath,
+      ]),
+    ).rejects.toThrowError(
+      /No generated issue report JSON found for issue #43/,
+    );
+  });
+
+  it("fails clearly when a selected issue report uses a stale schema", async () => {
+    const tempDir = await createTempDir("symphony-campaign-cli-stale-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
+    await downgradeIssueReportSchemaVersion(
+      path.join(tempDir, ".var", "reports", "issues", "44", "report.json"),
+    );
+
+    await expect(
+      runReportCli([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--issues",
+        "44",
+        "--workflow",
+        workflowPath,
+      ]),
+    ).rejects.toThrowError(/uses schema version 1/);
+  });
+
+  it("keeps explicit partial-data notes in the generated campaign digest", async () => {
+    const tempDir = await createTempDir("symphony-campaign-cli-partial-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 32);
+    await seedSessionAnchoredPartialArtifacts(workspaceRoot, 44);
+
+    for (const issueNumber of [32, 44]) {
+      await runReportCli(
+        [
+          "node",
+          "symphony-report",
+          "issue",
+          "--issue",
+          issueNumber.toString(),
+          "--workflow",
+          workflowPath,
+        ],
+        { issueEnrichers: [] },
+      );
+    }
+
+    await runReportCli([
+      "node",
+      "symphony-report",
+      "campaign",
+      "--issues",
+      "32,44",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    await expect(
+      fs.readFile(
+        path.join(
+          tempDir,
+          ".var",
+          "reports",
+          "campaigns",
+          "issues-32-44",
+          "timeline.md",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("Partial issue timelines: #44");
+    await expect(
+      fs.readFile(
+        path.join(
+          tempDir,
+          ".var",
+          "reports",
+          "campaigns",
+          "issues-32-44",
+          "learnings.md",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain(
+      "Some selected reports were partial, so the campaign digest may undercount lifecycle events.",
+    );
+  });
+});

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -58,12 +58,29 @@ export function deriveCodexSessionsRoot(rootDir: string): string {
 export async function seedSuccessfulIssueArtifacts(
   workspaceRoot: string,
   issueNumber: number,
+  options?: {
+    readonly claimedAt?: string | undefined;
+    readonly planReadyAt?: string | undefined;
+    readonly attemptStartedAt?: string | undefined;
+    readonly prOpenedAt?: string | undefined;
+    readonly latestCommitAt?: string | undefined;
+    readonly succeededAt?: string | undefined;
+    readonly finalCommitAt?: string | undefined;
+  },
 ): Promise<void> {
   const store = new LocalIssueArtifactStore(workspaceRoot);
   const issueIdentifier = `sociotechnica-org/symphony-ts#${issueNumber.toString()}`;
   const issueUrl = `https://github.com/sociotechnica-org/symphony-ts/issues/${issueNumber.toString()}`;
   const branch = `symphony/${issueNumber.toString()}`;
   const sessionId = `${issueIdentifier}/attempt-1/session-1`;
+  const claimedAt = options?.claimedAt ?? "2026-03-09T10:00:00.000Z";
+  const planReadyAt = options?.planReadyAt ?? "2026-03-09T10:02:00.000Z";
+  const attemptStartedAt =
+    options?.attemptStartedAt ?? "2026-03-09T10:05:00.000Z";
+  const prOpenedAt = options?.prOpenedAt ?? "2026-03-09T10:10:00.000Z";
+  const latestCommitAt = options?.latestCommitAt ?? "2026-03-09T10:09:30.000Z";
+  const succeededAt = options?.succeededAt ?? "2026-03-09T10:20:00.000Z";
+  const finalCommitAt = options?.finalCommitAt ?? "2026-03-09T10:19:00.000Z";
 
   await store.recordObservation({
     issue: {
@@ -75,7 +92,7 @@ export async function seedSuccessfulIssueArtifacts(
       branch,
       currentOutcome: "claimed",
       currentSummary: `Claimed ${issueIdentifier}`,
-      observedAt: "2026-03-09T10:00:00.000Z",
+      observedAt: claimedAt,
       latestAttemptNumber: 1,
     },
     events: [
@@ -83,7 +100,7 @@ export async function seedSuccessfulIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "claimed",
         issueNumber,
-        observedAt: "2026-03-09T10:00:00.000Z",
+        observedAt: claimedAt,
         attemptNumber: 1,
         sessionId: null,
         details: {
@@ -94,7 +111,7 @@ export async function seedSuccessfulIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "plan-ready",
         issueNumber,
-        observedAt: "2026-03-09T10:02:00.000Z",
+        observedAt: planReadyAt,
         attemptNumber: 1,
         sessionId: null,
         details: {
@@ -115,7 +132,7 @@ export async function seedSuccessfulIssueArtifacts(
       branch,
       currentOutcome: "awaiting-review",
       currentSummary: "PR opened and awaiting checks",
-      observedAt: "2026-03-09T10:10:00.000Z",
+      observedAt: prOpenedAt,
       latestAttemptNumber: 1,
       latestSessionId: sessionId,
     },
@@ -124,8 +141,8 @@ export async function seedSuccessfulIssueArtifacts(
       issueNumber,
       attemptNumber: 1,
       branch,
-      startedAt: "2026-03-09T10:05:00.000Z",
-      finishedAt: "2026-03-09T10:10:00.000Z",
+      startedAt: attemptStartedAt,
+      finishedAt: prOpenedAt,
       outcome: "awaiting-review",
       summary: "PR opened and awaiting checks",
       sessionId,
@@ -133,7 +150,7 @@ export async function seedSuccessfulIssueArtifacts(
       pullRequest: {
         number: 144,
         url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
-        latestCommitAt: "2026-03-09T10:09:30.000Z",
+        latestCommitAt,
       },
       review: {
         actionableCount: 0,
@@ -151,8 +168,8 @@ export async function seedSuccessfulIssueArtifacts(
       sessionId,
       provider: "codex",
       model: "gpt-5.4",
-      startedAt: "2026-03-09T10:05:00.000Z",
-      finishedAt: "2026-03-09T10:10:00.000Z",
+      startedAt: attemptStartedAt,
+      finishedAt: prOpenedAt,
       workspacePath: path.join(
         workspaceRoot,
         `issue-${issueNumber.toString()}`,
@@ -182,7 +199,7 @@ export async function seedSuccessfulIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "runner-spawned",
         issueNumber,
-        observedAt: "2026-03-09T10:05:00.000Z",
+        observedAt: attemptStartedAt,
         attemptNumber: 1,
         sessionId,
         details: {
@@ -193,7 +210,7 @@ export async function seedSuccessfulIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "pr-opened",
         issueNumber,
-        observedAt: "2026-03-09T10:10:00.000Z",
+        observedAt: prOpenedAt,
         attemptNumber: 1,
         sessionId,
         details: {
@@ -202,7 +219,7 @@ export async function seedSuccessfulIssueArtifacts(
           pullRequest: {
             number: 144,
             url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
-            latestCommitAt: "2026-03-09T10:09:30.000Z",
+            latestCommitAt,
           },
           review: {
             actionableCount: 0,
@@ -227,7 +244,7 @@ export async function seedSuccessfulIssueArtifacts(
       branch,
       currentOutcome: "succeeded",
       currentSummary: "Issue completed successfully",
-      observedAt: "2026-03-09T10:20:00.000Z",
+      observedAt: succeededAt,
       latestAttemptNumber: 1,
       latestSessionId: sessionId,
     },
@@ -236,7 +253,7 @@ export async function seedSuccessfulIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "succeeded",
         issueNumber,
-        observedAt: "2026-03-09T10:20:00.000Z",
+        observedAt: succeededAt,
         attemptNumber: 1,
         sessionId,
         details: {
@@ -244,7 +261,7 @@ export async function seedSuccessfulIssueArtifacts(
           pullRequest: {
             number: 144,
             url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",
-            latestCommitAt: "2026-03-09T10:19:00.000Z",
+            latestCommitAt: finalCommitAt,
           },
           review: {
             actionableCount: 0,
@@ -263,12 +280,22 @@ export async function seedSuccessfulIssueArtifacts(
 export async function seedFailedIssueArtifacts(
   workspaceRoot: string,
   issueNumber: number,
+  options?: {
+    readonly retryScheduledAt?: string | undefined;
+    readonly attemptStartedAt?: string | undefined;
+    readonly failedAt?: string | undefined;
+  },
 ): Promise<void> {
   const store = new LocalIssueArtifactStore(workspaceRoot);
   const issueIdentifier = `sociotechnica-org/symphony-ts#${issueNumber.toString()}`;
   const issueUrl = `https://github.com/sociotechnica-org/symphony-ts/issues/${issueNumber.toString()}`;
   const branch = `symphony/${issueNumber.toString()}`;
   const sessionId = `${issueIdentifier}/attempt-2/session-1`;
+  const retryScheduledAt =
+    options?.retryScheduledAt ?? "2026-03-09T11:00:00.000Z";
+  const attemptStartedAt =
+    options?.attemptStartedAt ?? "2026-03-09T10:55:00.000Z";
+  const failedAt = options?.failedAt ?? "2026-03-09T11:10:00.000Z";
 
   await store.recordObservation({
     issue: {
@@ -280,7 +307,7 @@ export async function seedFailedIssueArtifacts(
       branch,
       currentOutcome: "retry-scheduled",
       currentSummary: "Retry scheduled after missing PR",
-      observedAt: "2026-03-09T11:00:00.000Z",
+      observedAt: retryScheduledAt,
       latestAttemptNumber: 2,
       latestSessionId: sessionId,
     },
@@ -289,8 +316,8 @@ export async function seedFailedIssueArtifacts(
       issueNumber,
       attemptNumber: 2,
       branch,
-      startedAt: "2026-03-09T10:55:00.000Z",
-      finishedAt: "2026-03-09T11:00:00.000Z",
+      startedAt: attemptStartedAt,
+      finishedAt: retryScheduledAt,
       outcome: "attempt-failed",
       summary: "No open pull request found",
       sessionId,
@@ -306,8 +333,8 @@ export async function seedFailedIssueArtifacts(
       sessionId,
       provider: "codex",
       model: "gpt-5.4",
-      startedAt: "2026-03-09T10:55:00.000Z",
-      finishedAt: "2026-03-09T11:00:00.000Z",
+      startedAt: attemptStartedAt,
+      finishedAt: retryScheduledAt,
       workspacePath: path.join(
         workspaceRoot,
         `issue-${issueNumber.toString()}`,
@@ -325,7 +352,7 @@ export async function seedFailedIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "retry-scheduled",
         issueNumber,
-        observedAt: "2026-03-09T11:00:00.000Z",
+        observedAt: retryScheduledAt,
         attemptNumber: 2,
         sessionId,
         details: {
@@ -337,7 +364,7 @@ export async function seedFailedIssueArtifacts(
         version: ISSUE_ARTIFACT_SCHEMA_VERSION,
         kind: "failed",
         issueNumber,
-        observedAt: "2026-03-09T11:10:00.000Z",
+        observedAt: failedAt,
         attemptNumber: 2,
         sessionId,
         details: {

--- a/tests/unit/campaign-report.test.ts
+++ b/tests/unit/campaign-report.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCampaignDigest,
+  deriveCampaignId,
+  matchesCampaignDateWindow,
+} from "../../src/observability/campaign-report.js";
+import {
+  renderCampaignGitHubActivityMarkdown,
+  renderCampaignLearningsMarkdown,
+  renderCampaignSummaryMarkdown,
+  renderCampaignTimelineMarkdown,
+  renderCampaignTokenUsageMarkdown,
+} from "../../src/observability/campaign-report-markdown.js";
+import {
+  ISSUE_REPORT_SCHEMA_VERSION,
+  type IssueReportDocument,
+  type StoredIssueReportDocument,
+} from "../../src/observability/issue-report.js";
+
+describe("campaign report", () => {
+  it("derives stable campaign ids", () => {
+    expect(
+      deriveCampaignId({
+        kind: "issues",
+        issueNumbers: [44, 32, 43, 44],
+      }),
+    ).toBe("issues-32-43-44");
+    expect(
+      deriveCampaignId({
+        kind: "date-window",
+        from: "2026-03-01",
+        to: "2026-03-07",
+      }),
+    ).toBe("window-2026-03-01-to-2026-03-07");
+  });
+
+  it("matches date windows using report bounds and generatedAt fallback", () => {
+    const bounded = buildStoredIssueReport({
+      issueNumber: 32,
+      summary: {
+        startedAt: "2026-03-03T10:00:00.000Z",
+        endedAt: "2026-03-05T18:00:00.000Z",
+      },
+      generatedAt: "2026-03-06T10:00:00.000Z",
+    });
+    const generatedOnly = buildStoredIssueReport({
+      issueNumber: 43,
+      generatedAt: "2026-03-09T12:00:00.000Z",
+      summary: {
+        startedAt: null,
+        endedAt: null,
+      },
+    });
+
+    expect(
+      matchesCampaignDateWindow(bounded.report, {
+        kind: "date-window",
+        from: "2026-03-01",
+        to: "2026-03-04",
+      }),
+    ).toBe(true);
+    expect(
+      matchesCampaignDateWindow(generatedOnly.report, {
+        kind: "date-window",
+        from: "2026-03-01",
+        to: "2026-03-07",
+      }),
+    ).toBe(false);
+    expect(
+      matchesCampaignDateWindow(generatedOnly.report, {
+        kind: "date-window",
+        from: "2026-03-09",
+        to: "2026-03-09",
+      }),
+    ).toBe(true);
+  });
+
+  it("aggregates mixed issue outcomes, github activity, and token availability", () => {
+    const digest = buildCampaignDigest(
+      {
+        kind: "issues",
+        issueNumbers: [44, 32, 43],
+      },
+      [
+        buildStoredIssueReport({
+          issueNumber: 32,
+          title: "Issue 32",
+          summary: {
+            outcome: "succeeded",
+            attemptCount: 1,
+            pullRequestCount: 1,
+            overallConclusion: "Completed cleanly.",
+          },
+          githubActivity: {
+            pullRequests: [
+              {
+                number: 132,
+                url: "https://example.test/pr/132",
+                attemptNumbers: [1],
+                firstObservedAt: "2026-03-03T10:10:00.000Z",
+                latestCommitAt: "2026-03-03T11:00:00.000Z",
+                reviewFeedbackRounds: 1,
+                actionableReviewCount: 1,
+                unresolvedThreadCount: 0,
+                pendingChecks: ["CI"],
+                failingChecks: [],
+              },
+            ],
+            reviewFeedbackRounds: 1,
+          },
+          tokenUsage: {
+            status: "complete",
+            totalTokens: 3200,
+          },
+          learnings: {
+            observations: [
+              {
+                title: "Review loop stayed small",
+                summary: "One feedback round was enough.",
+                evidence: ["PR #132 cleared after one review round."],
+              },
+            ],
+          },
+        }),
+        buildStoredIssueReport({
+          issueNumber: 43,
+          title: "Issue 43",
+          summary: {
+            outcome: "failed",
+            overallConclusion: "Failed after retries were exhausted.",
+          },
+          githubActivity: {
+            reviewFeedbackRounds: 0,
+          },
+          tokenUsage: {
+            status: "unavailable",
+          },
+        }),
+        buildStoredIssueReport({
+          issueNumber: 44,
+          title: "Issue 44",
+          summary: {
+            status: "partial",
+            outcome: "awaiting-review",
+            overallConclusion: "PR opened but local facts remained partial.",
+          },
+          githubActivity: {
+            pullRequests: [
+              {
+                number: 144,
+                url: "https://example.test/pr/144",
+                attemptNumbers: [1],
+                firstObservedAt: "2026-03-04T14:10:00.000Z",
+                latestCommitAt: "2026-03-04T15:00:00.000Z",
+                reviewFeedbackRounds: 0,
+                actionableReviewCount: 0,
+                unresolvedThreadCount: 0,
+                pendingChecks: [],
+                failingChecks: ["lint"],
+              },
+            ],
+          },
+          tokenUsage: {
+            status: "estimated",
+            totalTokens: 1200,
+          },
+        }),
+      ],
+      "2026-03-11T12:00:00.000Z",
+    );
+
+    expect(digest.summary.outcomeCounts).toEqual({
+      succeeded: 1,
+      failed: 1,
+      partial: 1,
+      unknown: 0,
+    });
+    expect(digest.githubActivity.pullRequests).toHaveLength(2);
+    expect(digest.githubActivity.pendingChecks).toEqual([
+      { name: "CI", count: 1 },
+    ]);
+    expect(digest.githubActivity.failingChecks).toEqual([
+      { name: "lint", count: 1 },
+    ]);
+    expect(digest.tokenUsage.status).toBe("partial");
+    expect(digest.tokenUsage.totalTokens).toBeNull();
+    expect(digest.tokenUsage.observedTokenSubtotal).toBe(4400);
+    expect(digest.learnings.changesToMake).toContain(
+      "Expand token-usage capture or enrichment; campaign token coverage was partial across 3 issue reports.",
+    );
+  });
+
+  it("renders all five markdown outputs with stable headings", () => {
+    const digest = buildCampaignDigest(
+      {
+        kind: "issues",
+        issueNumbers: [32, 44],
+      },
+      [
+        buildStoredIssueReport({
+          issueNumber: 32,
+          title: "Issue 32",
+          summary: {
+            outcome: "succeeded",
+          },
+          tokenUsage: {
+            status: "complete",
+            totalTokens: 2200,
+          },
+        }),
+        buildStoredIssueReport({
+          issueNumber: 44,
+          title: "Issue 44",
+          summary: {
+            status: "partial",
+            outcome: "awaiting-review",
+            overallConclusion: "Awaiting review with partial timeline facts.",
+          },
+          tokenUsage: {
+            status: "unavailable",
+          },
+        }),
+      ],
+      "2026-03-11T12:00:00.000Z",
+    );
+
+    expect(renderCampaignSummaryMarkdown(digest)).toContain(
+      "# Campaign Summary: issues-32-44",
+    );
+    expect(renderCampaignTimelineMarkdown(digest)).toContain(
+      "# Campaign Timeline: issues-32-44",
+    );
+    expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
+      "# Campaign GitHub Activity: issues-32-44",
+    );
+    expect(renderCampaignTokenUsageMarkdown(digest)).toContain(
+      "Aggregate status: partial",
+    );
+    expect(renderCampaignLearningsMarkdown(digest)).toContain(
+      "## Changes To Make",
+    );
+  });
+});
+
+function buildStoredIssueReport(options: {
+  readonly issueNumber: number;
+  readonly title?: string | undefined;
+  readonly generatedAt?: string | undefined;
+  readonly summary?: {
+    readonly status?: "complete" | "partial" | "unavailable" | undefined;
+    readonly outcome?:
+      | "claimed"
+      | "running"
+      | "attempt-failed"
+      | "awaiting-plan-review"
+      | "awaiting-review"
+      | "needs-follow-up"
+      | "retry-scheduled"
+      | "succeeded"
+      | "failed"
+      | "unknown"
+      | undefined;
+    readonly startedAt?: string | null | undefined;
+    readonly endedAt?: string | null | undefined;
+    readonly attemptCount?: number | undefined;
+    readonly pullRequestCount?: number | undefined;
+    readonly overallConclusion?: string | undefined;
+  };
+  readonly timeline?: IssueReportDocument["timeline"] | undefined;
+  readonly githubActivity?: {
+    readonly pullRequests?:
+      | IssueReportDocument["githubActivity"]["pullRequests"]
+      | undefined;
+    readonly reviewFeedbackRounds?: number | undefined;
+  };
+  readonly tokenUsage?: {
+    readonly status?:
+      | "unavailable"
+      | "partial"
+      | "estimated"
+      | "complete"
+      | undefined;
+    readonly totalTokens?: number | null | undefined;
+    readonly costUsd?: number | null | undefined;
+  };
+  readonly learnings?: {
+    readonly observations?:
+      | IssueReportDocument["learnings"]["observations"]
+      | undefined;
+  };
+}): StoredIssueReportDocument {
+  const issueNumber = options.issueNumber;
+  const title = options.title ?? `Issue ${issueNumber.toString()}`;
+  const timeline = options.timeline ?? [
+    {
+      kind: "claimed",
+      at: options.summary?.startedAt ?? "2026-03-03T10:00:00.000Z",
+      title: "Issue claimed",
+      summary: "Claimed for work",
+      attemptNumber: 1,
+      sessionId: null,
+      details: [],
+    },
+  ];
+  const report: IssueReportDocument = {
+    version: ISSUE_REPORT_SCHEMA_VERSION,
+    generatedAt: options.generatedAt ?? "2026-03-05T12:00:00.000Z",
+    summary: {
+      status: options.summary?.status ?? "complete",
+      issueNumber,
+      issueIdentifier: `sociotechnica-org/symphony-ts#${issueNumber.toString()}`,
+      repo: "sociotechnica-org/symphony-ts",
+      title,
+      issueUrl: `https://example.test/issues/${issueNumber.toString()}`,
+      branch: `symphony/${issueNumber.toString()}`,
+      outcome: options.summary?.outcome ?? "succeeded",
+      startedAt:
+        options.summary?.startedAt === undefined
+          ? "2026-03-03T10:00:00.000Z"
+          : options.summary.startedAt,
+      endedAt:
+        options.summary?.endedAt === undefined
+          ? "2026-03-03T12:00:00.000Z"
+          : options.summary.endedAt,
+      attemptCount: options.summary?.attemptCount ?? 1,
+      pullRequestCount: options.summary?.pullRequestCount ?? 0,
+      overallConclusion:
+        options.summary?.overallConclusion ?? "Completed successfully.",
+      notes: [],
+    },
+    timeline,
+    githubActivity: {
+      status: "partial",
+      issueStateTransitionsStatus: "unavailable",
+      issueStateTransitionsNote:
+        "Canonical local artifacts do not record issue state transitions.",
+      pullRequests: options.githubActivity?.pullRequests ?? [],
+      reviewFeedbackRounds: options.githubActivity?.reviewFeedbackRounds ?? 0,
+      reviewLoopSummary: "No review activity recorded.",
+      mergedAt: null,
+      mergeNote: "Merge timing unavailable.",
+      closedAt: null,
+      closeNote: "Close timing unavailable.",
+      notes: [],
+    },
+    tokenUsage: {
+      status: options.tokenUsage?.status ?? "unavailable",
+      explanation: "Synthetic token usage for unit tests.",
+      totalTokens: options.tokenUsage?.totalTokens ?? null,
+      costUsd: options.tokenUsage?.costUsd ?? null,
+      sessions: [],
+      attempts: [],
+      agents: [],
+      rawArtifacts: [],
+      notes: [],
+    },
+    learnings: {
+      status: "partial",
+      observations: options.learnings?.observations ?? [],
+      gaps: [],
+    },
+    artifacts: {
+      rawIssueRoot: `/tmp/issues/${issueNumber.toString()}`,
+      issueFile: `/tmp/issues/${issueNumber.toString()}/issue.json`,
+      eventsFile: `/tmp/issues/${issueNumber.toString()}/events.jsonl`,
+      attemptFiles: [],
+      sessionFiles: [],
+      logPointersFile: null,
+      missingArtifacts: [],
+      generatedReportJson: `/tmp/reports/issues/${issueNumber.toString()}/report.json`,
+      generatedReportMarkdown: `/tmp/reports/issues/${issueNumber.toString()}/report.md`,
+    },
+    operatorInterventions: {
+      status: "complete",
+      summary: "No operator intervention required.",
+      entries: [],
+      note: "None.",
+    },
+  };
+
+  return {
+    report,
+    rawReportJson: JSON.stringify(report),
+    outputPaths: {
+      issueRoot: `/tmp/reports/issues/${issueNumber.toString()}`,
+      reportJsonFile: `/tmp/reports/issues/${issueNumber.toString()}/report.json`,
+      reportMarkdownFile: `/tmp/reports/issues/${issueNumber.toString()}/report.md`,
+    },
+  };
+}

--- a/tests/unit/campaign-report.test.ts
+++ b/tests/unit/campaign-report.test.ts
@@ -175,6 +175,9 @@ describe("campaign report", () => {
       partial: 1,
       unknown: 0,
     });
+    expect(digest.summary.overallOutcome).toBe(
+      "Completed 1 of 3 selected issues. 1 failed, 1 remained partial.",
+    );
     expect(digest.githubActivity.pullRequests).toHaveLength(2);
     expect(digest.githubActivity.pendingChecks).toEqual([
       { name: "CI", count: 1 },
@@ -187,6 +190,39 @@ describe("campaign report", () => {
     expect(digest.tokenUsage.observedTokenSubtotal).toBe(4400);
     expect(digest.learnings.changesToMake).toContain(
       "Expand token-usage capture or enrichment; campaign token coverage was partial across 3 issue reports.",
+    );
+  });
+
+  it("treats aggregate review counts as unavailable when no pull requests were observed", () => {
+    const digest = buildCampaignDigest(
+      {
+        kind: "issues",
+        issueNumbers: [43],
+      },
+      [
+        buildStoredIssueReport({
+          issueNumber: 43,
+          title: "Issue 43",
+          summary: {
+            outcome: "failed",
+            overallConclusion: "Failed before opening a PR.",
+          },
+          githubActivity: {
+            reviewFeedbackRounds: 0,
+          },
+        }),
+      ],
+      "2026-03-11T12:00:00.000Z",
+    );
+
+    expect(digest.githubActivity.pullRequests).toHaveLength(0);
+    expect(digest.githubActivity.actionableReviewCount).toBeNull();
+    expect(digest.githubActivity.unresolvedThreadCount).toBeNull();
+    expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
+      "- Actionable review count: Unavailable",
+    );
+    expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
+      "- Unresolved thread count: Unavailable",
     );
   });
 

--- a/tests/unit/report-cli.test.ts
+++ b/tests/unit/report-cli.test.ts
@@ -28,6 +28,47 @@ describe("parseReportArgs", () => {
     });
   });
 
+  it("parses the campaign command for an explicit issue list", () => {
+    expect(
+      parseReportArgs([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--issues",
+        "44,32,43",
+      ]),
+    ).toEqual({
+      command: "campaign",
+      workflowPath: expect.stringContaining("WORKFLOW.md"),
+      selection: {
+        kind: "issues",
+        issueNumbers: [32, 43, 44],
+      },
+    });
+  });
+
+  it("parses the campaign command for a date window", () => {
+    expect(
+      parseReportArgs([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--from",
+        "2026-03-01",
+        "--to",
+        "2026-03-07",
+      ]),
+    ).toEqual({
+      command: "campaign",
+      workflowPath: expect.stringContaining("WORKFLOW.md"),
+      selection: {
+        kind: "date-window",
+        from: "2026-03-01",
+        to: "2026-03-07",
+      },
+    });
+  });
+
   it("requires a valid issue number", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "issue", "--issue", "abc"]),
@@ -50,7 +91,7 @@ describe("parseReportArgs", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "status"]),
     ).toThrowError(
-      "Usage: symphony-report <issue|publish> --issue <number> [--workflow <path>] [--archive-root <path>]",
+      "Usage: symphony-report <issue|publish|campaign> [--issue <number>] [--issues <a,b,c> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>] [--workflow <path>] [--archive-root <path>]",
     );
   });
 
@@ -58,5 +99,39 @@ describe("parseReportArgs", () => {
     expect(() =>
       parseReportArgs(["node", "symphony-report", "publish", "--issue", "44"]),
     ).toThrowError("Missing required --archive-root <path> option");
+  });
+
+  it("rejects invalid campaign selection combinations", () => {
+    expect(() =>
+      parseReportArgs([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--issues",
+        "44,45",
+        "--from",
+        "2026-03-01",
+        "--to",
+        "2026-03-07",
+      ]),
+    ).toThrowError(
+      "Campaign selection must use either --issues or --from/--to, not both",
+    );
+    expect(() =>
+      parseReportArgs(["node", "symphony-report", "campaign"]),
+    ).toThrowError(
+      "Campaign generation requires either --issues <a,b,c> or --from <YYYY-MM-DD> --to <YYYY-MM-DD>",
+    );
+    expect(() =>
+      parseReportArgs([
+        "node",
+        "symphony-report",
+        "campaign",
+        "--from",
+        "2026-03-07",
+      ]),
+    ).toThrowError(
+      "Campaign date-window selection requires both --from and --to",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a detached \ command for explicit issue lists and inclusive date windows
- aggregate existing issue reports into stable campaign summary, timeline, GitHub activity, token usage, and learnings markdown outputs
- cover the new reporting path with unit and integration tests and document the command in the README

Closes #47
