### PR TITLE
Remove codex review requirement from repo policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Implementation work is not complete when the code compiles locally. It is comple
 
 1. plan exists,
 2. implementation is complete,
-3. a local self-review pass has been run when a reliable review tool is available, and any findings have been fixed,
+3. a local self-review pass has been run (skipped only when no local review tool is available and that is noted), and any findings have been fixed,
 4. formatting, lint, typecheck, and all tests are passing,
 5. a PR is created,
 6. PR CI is watched until it passes,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Implementation work is not complete when the code compiles locally. It is comple
 
 1. plan exists,
 2. implementation is complete,
-3. `codex review --base origin/main` has been run and all self-review findings have been fixed,
+3. a local self-review pass has been run when a reliable review tool is available, and any findings have been fixed,
 4. formatting, lint, typecheck, and all tests are passing,
 5. a PR is created,
 6. PR CI is watched until it passes,

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -72,7 +72,7 @@ Rules:
 12. Do not begin substantial implementation until the plan is explicitly `approved` by a human or explicitly `waived` by issue or operator instructions that say not to wait for human feedback.
 13. If plan approval is explicitly waived, record that in your issue/PR notes and continue directly from plan into implementation.
 14. Implement the issue completely, including docs and tests required by the repo process.
-15. Run `codex review --base origin/main` on your changes and fix the findings before opening a PR.
+15. Run a local self-review pass when a reliable review tool is available, and fix the findings before opening a PR.
 16. Run the relevant local checks before finishing.
 17. Open a pull request against `main` in `{{ config.tracker.repo }}` and reference the issue in the PR body.
 18. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -72,7 +72,7 @@ Rules:
 12. Do not begin substantial implementation until the plan is explicitly `approved` by a human or explicitly `waived` by issue or operator instructions that say not to wait for human feedback.
 13. If plan approval is explicitly waived, record that in your issue/PR notes and continue directly from plan into implementation.
 14. Implement the issue completely, including docs and tests required by the repo process.
-15. Run a local self-review pass when a reliable review tool is available, and fix the findings before opening a PR.
+15. Run a local self-review pass when a reliable review tool is available, and fix the findings before opening a PR. If no reliable tool is available, note that in the PR.
 16. Run the relevant local checks before finishing.
 17. Open a pull request against `main` in `{{ config.tracker.repo }}` and reference the issue in the PR body.
 18. If the PR already exists, continue on the same branch and address CI or review feedback instead of opening a new PR.


### PR DESCRIPTION
## Summary
- remove the hard `codex review --base origin/main` requirement from `AGENTS.md`
- remove the same hard requirement from `WORKFLOW.md`
- keep the self-review expectation, but make it tool-agnostic and contingent on a reliable local review tool being available

## Notes
- this PR intentionally updates the live repo policy only
- historical plan documents still mention `codex review`; those are plan-of-record artifacts and are left untouched in this cleanup

## Validation
- docs-only change; no code/test changes
