### PR TITLE
Require explicit tracker repo configuration to prevent accidental use

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ pnpm install
 
 Your target repo needs three labels: `symphony:ready`, `symphony:running`, `symphony:failed`.
 
-Edit `WORKFLOW.md` to point `tracker.repo` and `workspace.repo_url` at your own repository (the checked-in default targets `sociotechnica-org/symphony-ts`). See [Configuration](#configuration) for all available fields.
+**Before running**, set `tracker.repo` in `WORKFLOW.md` to the GitHub repository you want Symphony to work against (e.g. `your-org/your-repo`). The checked-in default is blank — Symphony will refuse to start without it. You can also set the `SYMPHONY_REPO` environment variable instead:
+
+```bash
+export SYMPHONY_REPO=your-org/your-repo
+```
+
+See [Configuration](#configuration) for all available fields.
 
 Run one poll cycle:
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,7 +1,7 @@
 ---
 tracker:
   kind: github-bootstrap
-  repo: sociotechnica-org/symphony-ts
+  repo: # REQUIRED: set to your-org/your-repo
   api_url: https://api.github.com
   ready_label: symphony:ready
   running_label: symphony:running

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -60,12 +60,16 @@ function requireString(value: unknown, field: string): string {
 }
 
 function requireGitHubRepo(value: unknown): string {
-  if (value !== undefined && typeof value !== "string") {
+  if (value !== undefined && value !== null && typeof value !== "string") {
     throw new ConfigError(
       `tracker.repo must be a non-empty string, got ${JSON.stringify(value)}`,
     );
   }
-  if (value === undefined || value.trim() === "") {
+  if (
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
     throw new ConfigError(
       "tracker.repo is not set; provide it in WORKFLOW.md or set the SYMPHONY_REPO environment variable",
     );


### PR DESCRIPTION
## Summary

Removed the hardcoded `sociotechnica-org/symphony-ts` repository from the distributed WORKFLOW.md so cloned repos don't accidentally start polling issues from the main repository. Cloned factories now refuse to start until explicitly configured with their own tracker repository.

## Changes

- **WORKFLOW.md**: Removed the hardcoded repo value; now requires explicit configuration
- **README.md**: Made setup instructions prominent and explicit about setting `tracker.repo` before running
- **src/config/workflow.ts**: Updated `requireGitHubRepo()` to handle null values (from YAML comments) and provide the clear error message

The existing validation and error messaging already existed; this change removes the problematic default and clarifies the startup requirement.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>