### PR TITLE
Phase 3.1: provider-neutral runner contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 **What makes symphony-ts different:**
 
 - **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
-- **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) and pluggable workers (local Codex today, remote workers planned). Swap any layer without touching the others.
+- **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) and a provider-neutral runner contract with a local Codex adapter today, remote workers planned. Swap any layer without touching the others.
 - **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear) instead of a separate control plane. Today's bootstrap runtime is designed for one local factory instance; broader multi-instance coordination is planned.
 - **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
 - **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,10 +89,12 @@ This layer owns filesystem preparation, not tracker policy.
 Responsible for:
 
 - launching coding agents
-- reporting execution events and final results
+- reporting provider-neutral execution events and final results
 - timeout and cancellation behavior
 
-The runner should not own prompt construction or tracker mutations.
+The runner should not own prompt construction or tracker mutations. Codex is the
+current local adapter behind that contract, not a shape the orchestrator should
+depend on.
 
 ### Orchestrator
 

--- a/docs/plans/089-provider-neutral-runner-contract/plan.md
+++ b/docs/plans/089-provider-neutral-runner-contract/plan.md
@@ -1,0 +1,243 @@
+# Issue 89 Plan: Provider-Neutral Runner Contract And Codex Adapter Boundary
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Define a provider-neutral internal runner contract and refactor the existing local Codex path behind that contract, while keeping prompt rendering, tracker writes, and orchestration policy outside the runner adapter.
+
+## Scope
+
+- define a stable runner service contract, event model, and final result model in `src/runner/`
+- separate provider-neutral runner domain types from the Codex-specific local implementation details
+- adapt the current local runner implementation so Codex remains the working backend through the new contract
+- keep the orchestrator dependent on the runner interface rather than a Codex-shaped execution path
+- add contract-focused tests that prove the runner shape is provider-neutral and that the Codex adapter honors the contract
+- update docs where the contract surface or execution-layer responsibility needs to be explicit
+
+## Non-goals
+
+- `WORKFLOW.md` runner-selection UX or provider configuration redesign
+- Claude Code integration from `#91`
+- arbitrary generic command execution as a first-class multi-provider abstraction
+- remote/background runner providers from `#15`
+- tracker policy, tracker transport, or tracker normalization changes
+- changing continuation-turn policy, retry budgets, or handoff lifecycle semantics introduced in `#99`
+
+## Current Gaps
+
+- `src/runner/service.ts` already exposes a live-session shape, but it is still effectively expressed in terms of the local Codex path rather than a deliberate provider-neutral contract
+- `src/runner/local.ts` and `src/runner/local-live-session.ts` mix the stable runner interface with Codex-specific session discovery and resume assumptions
+- the orchestrator currently depends on the runner contract, but the available contract tests are named and structured around the local runner rather than a backend-neutral runner capability surface
+- runner events are limited to spawn notifications; that is enough for current artifact persistence, but the contract does not yet clearly distinguish provider-neutral lifecycle events from backend-specific session metadata
+- current tests prove Codex behavior, but they do not clearly lock in what a non-Codex backend would be allowed to implement without orchestration changes
+
+## Decision Notes
+
+- This slice should preserve the existing orchestrator behavior. The main deliverable is a cleaner execution-layer seam, not new worker behavior.
+- The current `Runner`, `LiveRunnerSession`, and `RunnerSessionDescription` types are close to the target seam. The work here is to formalize them as the stable contract and push Codex-specific mechanics behind an adapter boundary.
+- The contract should model explicit run lifecycle facts the orchestrator already needs today:
+  - spawn notification for local process ownership
+  - provider/model/session metadata for observability
+  - final per-turn result with stdout/stderr, timestamps, exit code, and session description
+- The contract should not force every provider to mimic Codex session discovery. Backends without reusable conversations should still be valid implementations if they can report the same normalized result shape.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: issue scope, contract goals, and the decision that runner choice stays in the execution layer
+  - does not belong: Codex subprocess arguments or orchestrator retry behavior
+- Configuration Layer
+  - belongs: unchanged typed runner-related config already resolved under `agent`
+  - does not belong: backend selection UX or new provider config in this slice
+- Coordination Layer
+  - belongs: consuming the runner interface and remaining ignorant of Codex-specific implementation details
+  - does not belong: session discovery, resume command building, or backend-specific command parsing
+- Execution Layer
+  - belongs: the runner contract, event/result model, live-session lifecycle, local runner implementation, and Codex adapter boundary
+  - does not belong: tracker writes, prompt rendering policy, or lifecycle handoff decisions
+- Integration Layer
+  - belongs: untouched in this slice; tracker adapters remain the integration boundary for issue state
+  - does not belong: any runner-provider details
+- Observability Layer
+  - belongs: consuming normalized runner events/session descriptions for status and issue artifacts
+  - does not belong: inferring backend semantics from raw subprocess output
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/run.ts`
+  - refine provider-neutral runner event/result types if needed
+- `src/runner/service.ts`
+  - define the stable runner contract and normalized event/result/session shapes
+- `src/runner/`
+  - split provider-neutral contract helpers from the local Codex-backed implementation details
+- `src/orchestrator/service.ts`
+  - narrow any remaining assumptions so it consumes the runner interface only
+- `tests/unit/`
+  - add runner contract tests plus focused Codex-adapter tests
+- docs
+  - document the execution-layer seam if the current docs imply a Codex-shaped runner
+
+### Does not belong in this issue
+
+- `src/config/` UX changes for selecting among providers
+- tracker transport, normalization, or handoff policy changes
+- follow-up / retry state machine redesign
+- remote runner protocol work
+- introducing a second real provider implementation
+
+## Layering Notes
+
+- `config/workflow`
+  - keeps producing agent config
+  - does not learn provider-specific runner behavior in this slice
+- `tracker`
+  - remains the only layer that writes tracker state
+  - does not receive runner-provider metadata beyond existing normalized lifecycle inputs
+- `workspace`
+  - keeps preparing filesystem state for runs
+  - does not own runner-provider selection or backend session handling
+- `runner`
+  - owns launching agents, reporting normalized execution events, and backend-session details behind a stable interface
+  - does not render prompts, inspect tracker handoff state, or mutate tracker state
+- `orchestrator`
+  - owns dispatch/retry/handoff policy while depending only on the runner contract
+  - does not parse Codex-specific output or build provider-specific commands
+- `observability`
+  - records normalized runner facts
+  - does not deduce execution semantics from backend-specific raw logs
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR by limiting the seam to the execution layer:
+
+1. formalize a provider-neutral runner contract and supporting types
+2. move Codex/local implementation details behind that contract
+3. update orchestrator/tests/docs to consume the contract cleanly
+
+This stays reviewable because it does not combine:
+
+- runner contract extraction with tracker changes
+- runner contract extraction with workflow UX changes
+- runner contract extraction with retry/policy redesign
+- runner contract extraction with adding a second provider
+
+Follow-up slices can add provider selection (`#90`) or another backend implementation (`#91`) against the contract from this PR.
+
+## Runner Session State Model
+
+This issue does not change orchestration retry or handoff state, so a new orchestrator runtime state machine is not required. The stateful surface introduced or clarified here is the runner session lifecycle.
+
+### States
+
+- `idle`
+  - runner instance exists but no run has started
+- `starting`
+  - backend process/session for a turn is being launched
+- `running`
+  - a turn is active and provider-neutral lifecycle events may be emitted
+- `completed`
+  - a turn finished with a normalized result
+- `failed`
+  - the launch or turn failed with a runner error
+- `closed`
+  - no more turns will be executed for this live session
+
+### Allowed transitions
+
+- `idle -> starting`
+- `starting -> running`
+- `starting -> failed`
+- `running -> completed`
+- `running -> failed`
+- `completed -> starting`
+  - for another turn in a live session
+- `completed -> closed`
+- `failed -> closed`
+
+### Contract rules
+
+- spawn notifications are optional in timing but, when emitted, must describe the concrete launched process for the current turn
+- session metadata is normalized as `provider`, `model`, `backendSessionId`, `latestTurnNumber`, and log pointers
+- backends may report `backendSessionId: null` when they do not support reusable conversations
+- the runner contract must not require the orchestrator to know whether turn reuse is implemented by `resume`, a daemon, or a fresh process
+
+## Failure-Class Matrix
+
+| Observed condition                                                            | Local facts available                          | Normalized runner facts available                          | Expected decision                                                                              |
+| ----------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Runner cannot start the provider process                                      | workspace path, command config                 | launch failure / thrown runner error                       | existing orchestrator failure path; no tracker-policy change                                   |
+| Turn exits non-zero                                                           | run session, turn number                       | normalized `RunResult` with exit code and captured output  | existing orchestrator failure/reconciliation path                                              |
+| Turn succeeds on a provider without reusable session ids                      | provider known, backend has no session concept | `backendSessionId: null`, successful result                | contract remains valid; orchestrator continues to rely only on normalized turn result          |
+| Codex continuation turn is requested before a backend session id is available | prior turn metadata, provider `codex`          | runner error                                               | fail at the adapter boundary rather than leaking Codex-specific recovery into the orchestrator |
+| Spawn event persistence callback fails                                        | child pid known, callback threw                | runner error after cleanup attempt                         | existing orchestrator failure path with child cleanup preserved                                |
+| Provider-specific session discovery fails after successful Codex turn         | stdout/stderr, timestamps, workspace metadata  | adapter cannot supply required Codex continuation metadata | treat as adapter failure; do not silently cold-start or mutate orchestrator policy             |
+
+## Storage / Persistence Contract
+
+- no new durable tracker state is introduced in this slice
+- existing issue-artifact and status persistence continues to consume normalized spawn/session metadata through the runner contract
+- if runner-domain types move, the persisted artifact shape should remain backward-compatible for the currently recorded fields (`provider`, `model`, `backendSessionId`, `latestTurnNumber`, and log pointers)
+
+## Observability Requirements
+
+- keep a normalized spawn event contract for issue artifacts and watchdog state
+- keep `RunnerSessionDescription` explicit enough for status/reporting surfaces without parsing provider-specific output in observability code
+- document that `backendSessionId` is provider-neutral optional metadata rather than a Codex-only orchestrator requirement
+- preserve existing log-pointer behavior for Codex session enrichment
+
+## Implementation Steps
+
+1. Refine `src/runner/service.ts` and any supporting run-domain types so the contract explicitly separates:
+   - normalized runner lifecycle events
+   - normalized per-turn results
+   - normalized session description metadata
+2. Extract or rename local/Codex-specific pieces so the provider-neutral contract lives independently from the local backend implementation.
+3. Update `src/runner/local.ts` and `src/runner/local-live-session.ts` to implement the contract strictly through the adapter boundary.
+4. Narrow `src/orchestrator/service.ts` call sites if any Codex-shaped assumptions remain, without changing orchestration policy.
+5. Add or restructure unit tests to include:
+   - provider-neutral contract tests against a simple fake runner
+   - Codex/local adapter tests that prove session metadata, spawn events, continuation-session behavior, and failure handling
+6. Update README or architecture/docs text if needed so the runner layer is described as provider-neutral and Codex is described as one adapter.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- runner contract accepts a backend with no reusable session id and still yields a valid normalized result/session description
+- runner contract emits spawn metadata without forcing a Codex-specific event type
+- local Codex-backed runner reports provider/model metadata through the normalized session description
+- local Codex-backed live session captures backend session id after the first successful turn and reuses it on continuation turns
+- local runner surfaces adapter failures when Codex session discovery or resume prerequisites fail
+- orchestrator test uses only the runner interface and does not depend on local/Codex concrete types
+
+### Integration / end-to-end coverage
+
+- keep existing local runner/orchestrator tests passing through the refactored contract
+- if a broader e2e fixture already exercises the local Codex path through the orchestrator, keep it green without adding new tracker behavior
+
+### Acceptance scenarios
+
+1. A one-shot run still launches through the provider-neutral runner interface and completes with the same observable result shape.
+2. A multi-turn Codex run still reuses the same backend session through the adapter while the orchestrator consumes only normalized runner facts.
+3. A hypothetical non-Codex backend fake can satisfy the contract without implementing Codex session discovery or resume behavior.
+4. Existing issue artifacts/status handling still record spawn/session metadata without depending on Codex-specific parsing in orchestration code.
+
+## Exit Criteria
+
+- the orchestrator depends only on a stable runner interface
+- the local Codex path works through that interface without policy regression
+- runner events/results are explicit and provider-neutral in shape
+- tests cover both the contract surface and the Codex adapter boundary
+- docs describe the runner as an execution-layer seam rather than a Codex-shaped path
+
+## Deferred To Later Issues Or PRs
+
+- provider-selection config and factory wiring from `#90`
+- Claude Code adapter implementation from `#91`
+- remote/background runner contracts from `#15`
+- any broader command-runner generalization beyond what this issue needs

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -14,20 +14,7 @@ export interface RunSession {
   readonly attempt: RunAttempt;
 }
 
-export interface RunSpawnEvent {
-  readonly pid: number;
-  readonly spawnedAt: string;
-}
-
 export interface RunTurn {
   readonly prompt: string;
   readonly turnNumber: number;
-}
-
-export interface RunResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly startedAt: string;
-  readonly finishedAt: string;
 }

--- a/src/orchestrator/issue-lease.ts
+++ b/src/orchestrator/issue-lease.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { RunSession, RunSpawnEvent } from "../domain/run.js";
+import type { RunSession } from "../domain/run.js";
 import type { Logger } from "../observability/logger.js";
+import type { RunnerSpawnedEvent } from "../runner/service.js";
 
 function isStaleLeaseError(code: string | undefined): boolean {
   return code === "ENOENT" || code === "ENOTDIR" || code === "ESRCH";
@@ -119,7 +120,7 @@ export class LocalIssueLeaseManager {
     );
   }
 
-  recordRunnerSpawn(lockDir: string, event: RunSpawnEvent): void {
+  recordRunnerSpawn(lockDir: string, event: RunnerSpawnedEvent): void {
     const record = this.#readRecordSync(lockDir);
     if (record === null) {
       return;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -701,19 +701,28 @@ export class BootstrapOrchestrator implements Orchestrator {
     lockDir: string,
     signal: AbortSignal,
   ): Promise<RunnerTurnResult> {
+    const runnerEventHandlers: {
+      [Kind in RunnerEvent["kind"]]: (
+        event: Extract<RunnerEvent, { kind: Kind }>,
+      ) => void;
+    } = {
+      spawned: (event): void => {
+        this.#recordRunnerSpawn(
+          {
+            runSession: session,
+            description:
+              liveRunnerSession?.describe() ??
+              this.#runner.describeSession(session),
+            latestTurnNumber: turn.turnNumber,
+          },
+          lockDir,
+          event,
+          turn.turnNumber,
+        );
+      },
+    };
     const onEvent = (event: RunnerEvent): void => {
-      this.#recordRunnerSpawn(
-        {
-          runSession: session,
-          description:
-            liveRunnerSession?.describe() ??
-            this.#runner.describeSession(session),
-          latestTurnNumber: turn.turnNumber,
-        },
-        lockDir,
-        event,
-        turn.turnNumber,
-      );
+      runnerEventHandlers[event.kind](event);
     };
     if (liveRunnerSession !== undefined) {
       return await liveRunnerSession.runTurn(turn, {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -3,7 +3,7 @@ import { OrchestratorError, RunnerAbortedError } from "../domain/errors.js";
 import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RetryState } from "../domain/retry.js";
-import type { RunSpawnEvent, RunSession, RunTurn } from "../domain/run.js";
+import type { RunSession, RunTurn } from "../domain/run.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -33,7 +33,9 @@ import {
 } from "../observability/status.js";
 import type {
   LiveRunnerSession,
+  RunnerEvent,
   Runner,
+  RunnerSpawnedEvent,
   RunnerTurnResult,
 } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
@@ -699,7 +701,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     lockDir: string,
     signal: AbortSignal,
   ): Promise<RunnerTurnResult> {
-    const onSpawn = (event: RunSpawnEvent): void => {
+    const onEvent = (event: RunnerEvent): void => {
       this.#recordRunnerSpawn(
         {
           runSession: session,
@@ -716,7 +718,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     if (liveRunnerSession !== undefined) {
       return await liveRunnerSession.runTurn(turn, {
         signal,
-        onSpawn,
+        onEvent,
       });
     }
     const result = await this.#runner.run(
@@ -726,7 +728,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       },
       {
         signal,
-        onSpawn,
+        onEvent,
       },
     );
     return {
@@ -1505,7 +1507,7 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   #createRunnerSpawnObservation(
     session: RunSessionArtifactsState,
-    event: RunSpawnEvent,
+    event: RunnerSpawnedEvent,
     turnNumber: number,
   ): IssueArtifactObservation {
     const sessionArtifacts = this.#createSessionObservationArtifacts(session);
@@ -1815,7 +1817,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   #recordRunnerSpawn(
     session: RunSessionArtifactsState,
     lockDir: string,
-    event: RunSpawnEvent,
+    event: RunnerSpawnedEvent,
     turnNumber: number,
   ): void {
     const issueNumber = session.runSession.issue.number;
@@ -1834,7 +1836,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber,
       at: event.spawnedAt,
     });
-    // The runner onSpawn callback is synchronous; snapshot persistence is optional.
+    // The runner event callback is synchronous; snapshot persistence is optional.
     void this.#persistStatusSnapshot();
     void this.#recordIssueArtifact(
       this.#createRunnerSpawnObservation(session, event, turnNumber),

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -722,6 +722,9 @@ export class BootstrapOrchestrator implements Orchestrator {
       },
     };
     const onEvent = (event: RunnerEvent): void => {
+      // If `RunnerEvent` grows beyond spawn notifications, keep the dispatch
+      // map explicit and add a cast at this call site to preserve the
+      // correlation between `event.kind` and the handler parameter type.
       runnerEventHandlers[event.kind](event);
     };
     if (liveRunnerSession !== undefined) {

--- a/src/runner/codex-resume-command.ts
+++ b/src/runner/codex-resume-command.ts
@@ -53,6 +53,8 @@ export function buildCodexResumeCommand(
  * `codex exec resume`. Unknown flags are dropped conservatively:
  * - known switches are forwarded unchanged
  * - known value-consuming flags are forwarded as flag/value pairs
+ * - exec-only flags such as `-C` are dropped as flag/value pairs because the
+ *   resumed command already runs in the prepared workspace
  * - unknown flags consume their following token as a pair when it looks like a
  *   value-bearing argument, so continuation command reconstruction cannot leak
  *   a stray value token into the resumed command
@@ -76,7 +78,6 @@ function filterCodexResumeArgs(args: readonly string[]): {
       continue;
     }
     if (
-      token === "-C" ||
       token === "-c" ||
       token === "--config" ||
       token === "--enable" ||
@@ -91,6 +92,16 @@ function filterCodexResumeArgs(args: readonly string[]): {
       const value = args[index + 1];
       if (value !== undefined && value !== "-" && !value.startsWith("-")) {
         filteredArgs.push(token, value);
+        index += 1;
+      } else {
+        droppedArgs.push(token);
+      }
+      continue;
+    }
+    if (token === "-C") {
+      const value = args[index + 1];
+      if (value !== undefined && value !== "-" && !value.startsWith("-")) {
+        droppedArgs.push(token, value);
         index += 1;
       } else {
         droppedArgs.push(token);

--- a/src/runner/local-execution.ts
+++ b/src/runner/local-execution.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { RunnerAbortedError, RunnerError } from "../domain/errors.js";
-import type { RunResult, RunSession } from "../domain/run.js";
+import type { RunSession } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import type { RunnerRunOptions } from "./service.js";
+import type { RunnerExecutionResult, RunnerRunOptions } from "./service.js";
 
 export interface LocalCommandExecutionOptions {
   readonly command: string;
@@ -21,7 +21,7 @@ export async function executeLocalRunnerCommand(
   logger: Logger,
   config: AgentConfig,
   execution: LocalCommandExecutionOptions,
-): Promise<RunResult> {
+): Promise<RunnerExecutionResult> {
   const startedAt = new Date().toISOString();
   // Multi-turn runs keep per-turn prompt files distinct; older one-shot runs
   // used `.symphony-prompt.md`.
@@ -45,7 +45,7 @@ export async function executeLocalRunnerCommand(
     turnNumber: execution.turnNumber,
   });
 
-  return await new Promise<RunResult>((resolve, reject) => {
+  return await new Promise<RunnerExecutionResult>((resolve, reject) => {
     const child = spawn("bash", ["-lc", command], {
       cwd: execution.session.workspace.path,
       env: {
@@ -123,7 +123,8 @@ export async function executeLocalRunnerCommand(
     if (child.pid !== undefined) {
       try {
         spawnNotificationPromise = Promise.resolve(
-          execution.options?.onSpawn?.({
+          execution.options?.onEvent?.({
+            kind: "spawned",
             pid: child.pid,
             spawnedAt: new Date().toISOString(),
           }),

--- a/src/runner/local-live-session.ts
+++ b/src/runner/local-live-session.ts
@@ -1,5 +1,5 @@
 import { RunnerError } from "../domain/errors.js";
-import type { RunResult, RunSession, RunTurn } from "../domain/run.js";
+import type { RunSession, RunTurn } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { buildCodexResumeCommand } from "./codex-resume-command.js";
@@ -11,6 +11,7 @@ import {
 import { describeLocalRunnerSession } from "./local-session-description.js";
 import type {
   LiveRunnerSession,
+  RunnerExecutionResult,
   RunnerRunOptions,
   RunnerSessionDescription,
   RunnerTurnResult,
@@ -25,7 +26,7 @@ export class LocalRunnerSession implements LiveRunnerSession {
     logger: Logger,
     config: AgentConfig,
     execution: LocalCommandExecutionOptions,
-  ) => Promise<RunResult>;
+  ) => Promise<RunnerExecutionResult>;
   #loggedDroppedResumeArgs = false;
   #backendSessionId: string | null = null;
   #latestTurnNumber: number | null = null;
@@ -38,7 +39,7 @@ export class LocalRunnerSession implements LiveRunnerSession {
       logger: Logger,
       config: AgentConfig,
       execution: LocalCommandExecutionOptions,
-    ) => Promise<RunResult> = executeLocalRunnerCommand,
+    ) => Promise<RunnerExecutionResult> = executeLocalRunnerCommand,
   ) {
     this.#config = config;
     this.#logger = logger;

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -1,4 +1,4 @@
-import type { RunResult, RunSession } from "../domain/run.js";
+import type { RunSession } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { executeLocalRunnerCommand } from "./local-execution.js";
@@ -6,6 +6,7 @@ import { LocalRunnerSession } from "./local-live-session.js";
 import { describeLocalRunnerSession } from "./local-session-description.js";
 import type {
   Runner,
+  RunnerExecutionResult,
   RunnerRunOptions,
   RunnerSessionDescription,
 } from "./service.js";
@@ -41,7 +42,7 @@ export class LocalRunner implements Runner {
   async run(
     session: RunSession,
     options?: RunnerRunOptions,
-  ): Promise<RunResult> {
+  ): Promise<RunnerExecutionResult> {
     return await LocalRunner.executeCommand(this.#logger, this.#config, {
       command: this.#config.command,
       prompt: session.prompt,
@@ -54,7 +55,7 @@ export class LocalRunner implements Runner {
 
   static async executeCommand(
     ...args: Parameters<typeof executeLocalRunnerCommand>
-  ): Promise<RunResult> {
+  ): Promise<RunnerExecutionResult> {
     return await executeLocalRunnerCommand(...args);
   }
 }

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,9 +1,20 @@
-import type {
-  RunResult,
-  RunSession,
-  RunSpawnEvent,
-  RunTurn,
-} from "../domain/run.js";
+import type { RunSession, RunTurn } from "../domain/run.js";
+
+export interface RunnerExecutionResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+}
+
+export interface RunnerSpawnedEvent {
+  readonly kind: "spawned";
+  readonly pid: number;
+  readonly spawnedAt: string;
+}
+
+export type RunnerEvent = RunnerSpawnedEvent;
 export interface RunnerLogPointer {
   readonly name: string;
   readonly location: string | null;
@@ -24,10 +35,10 @@ export interface RunnerSessionDescriber {
 
 export interface RunnerRunOptions {
   readonly signal?: AbortSignal;
-  readonly onSpawn?: (event: RunSpawnEvent) => void | Promise<void>;
+  readonly onEvent?: (event: RunnerEvent) => void | Promise<void>;
 }
 
-export interface RunnerTurnResult extends RunResult {
+export interface RunnerTurnResult extends RunnerExecutionResult {
   readonly session: RunnerSessionDescription;
 }
 
@@ -37,6 +48,9 @@ export interface LiveRunnerSession {
 }
 
 export interface Runner extends RunnerSessionDescriber {
-  run(session: RunSession, options?: RunnerRunOptions): Promise<RunResult>;
+  run(
+    session: RunSession,
+    options?: RunnerRunOptions,
+  ): Promise<RunnerExecutionResult>;
   startSession?(session: RunSession): Promise<LiveRunnerSession>;
 }

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -15,6 +15,7 @@ export interface RunnerSpawnedEvent {
 }
 
 export type RunnerEvent = RunnerSpawnedEvent;
+
 export interface RunnerLogPointer {
   readonly name: string;
   readonly location: string | null;

--- a/tests/unit/issue-lease.test.ts
+++ b/tests/unit/issue-lease.test.ts
@@ -62,6 +62,7 @@ describe("LocalIssueLeaseManager", () => {
 
       await manager.recordRun(lockDir!, createSession(21, tempRoot));
       manager.recordRunnerSpawn(lockDir!, {
+        kind: "spawned",
         pid: process.pid,
         spawnedAt: new Date().toISOString(),
       });

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -544,9 +544,13 @@ describe("LocalRunner", () => {
       expect(warn).toHaveBeenCalledWith(
         "Dropped unsupported Codex continuation arguments while building resume command",
         expect.objectContaining({
-          droppedArgs: ["--profile", "strict"],
+          droppedArgs: ["--profile", "strict", "-C", "."],
         }),
       );
+      expect(
+        (executeSpy.mock.calls[1]?.[2] as { command: string } | undefined)
+          ?.command,
+      ).not.toContain(" -C ");
     } finally {
       executeSpy.mockRestore();
       homedirSpy.mockRestore();
@@ -617,7 +621,7 @@ describe("LocalRunner", () => {
       expect(warn).toHaveBeenCalledWith(
         "Dropped unsupported Codex continuation arguments while building resume command",
         expect.objectContaining({
-          droppedArgs: ["--profile", "--model"],
+          droppedArgs: ["--profile", "--model", "-C", "."],
         }),
       );
     } finally {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { RunSession, RunSpawnEvent } from "../../src/domain/run.js";
+import type { RunSession } from "../../src/domain/run.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
 import { LocalRunner } from "../../src/runner/local.js";
+import type { RunnerSpawnedEvent } from "../../src/runner/service.js";
 import { waitForExit } from "../support/process.js";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -177,7 +178,8 @@ describe("LocalRunner", () => {
 
     const run = runner.run(session, {
       signal: abortController.signal,
-      onSpawn(event) {
+      onEvent(event) {
+        expect(event.kind).toBe("spawned");
         spawnedPid = event.pid;
         abortController.abort();
       },
@@ -203,7 +205,7 @@ describe("LocalRunner", () => {
     let spawnedPid = -1;
 
     const run = runner.run(session, {
-      onSpawn: async (event: RunSpawnEvent) => {
+      onEvent: async (event: RunnerSpawnedEvent) => {
         spawnedPid = event.pid;
         throw new Error("persist failed");
       },

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import type { HandoffLifecycle } from "../../src/domain/handoff.js";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
-import type { RunResult, RunSession } from "../../src/domain/run.js";
+import type { RunSession } from "../../src/domain/run.js";
 import type { PreparedWorkspace } from "../../src/domain/workspace.js";
 import type {
   PromptBuilder,
@@ -27,6 +27,7 @@ import type { Logger } from "../../src/observability/logger.js";
 import type {
   LiveRunnerSession,
   Runner,
+  RunnerExecutionResult,
   RunnerTurnResult,
 } from "../../src/runner/service.js";
 import type { Tracker } from "../../src/tracker/service.js";
@@ -384,7 +385,7 @@ class ConcurrencyRunner implements Runner {
     return createRunnerSessionDescription();
   }
 
-  async run(session: RunSession): Promise<RunResult> {
+  async run(session: RunSession): Promise<RunnerExecutionResult> {
     this.startedIssues.push(session.issue.number);
     this.#active += 1;
     this.maxActive = Math.max(this.maxActive, this.#active);
@@ -413,7 +414,7 @@ class RecordingRunner implements Runner {
     return createRunnerSessionDescription();
   }
 
-  async run(session: RunSession): Promise<RunResult> {
+  async run(session: RunSession): Promise<RunnerExecutionResult> {
     this.sessionIds.push(session.id);
     this.attempts.push(session.attempt.sequence);
     this.prompts.push(session.prompt);
@@ -439,7 +440,7 @@ class SecondTurnFailingLiveRunner implements Runner {
     return createRunnerSessionDescription();
   }
 
-  async run(): Promise<RunResult> {
+  async run(): Promise<RunnerExecutionResult> {
     throw new Error("runner.run should not be called");
   }
 
@@ -479,7 +480,7 @@ class RecordingLiveSessionRunner implements Runner {
     return createRunnerSessionDescription();
   }
 
-  async run(): Promise<RunResult> {
+  async run(): Promise<RunnerExecutionResult> {
     throw new Error("runner.run should not be called");
   }
 
@@ -581,7 +582,7 @@ class BlockingRecordingRunner implements Runner {
     await this.issueStarted.get(issueNumber)?.promise;
   }
 
-  async run(session: RunSession): Promise<RunResult> {
+  async run(session: RunSession): Promise<RunnerExecutionResult> {
     this.startedIssues.push(session.issue.number);
     this.issueStarted.get(session.issue.number)?.resolve();
     await this.#finish.promise;
@@ -741,7 +742,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           runnerCalls += 1;
           throw new Error("runner should not be called");
         },
@@ -781,7 +782,7 @@ describe("BootstrapOrchestrator", () => {
           describeSession() {
             return createRunnerSessionDescription();
           },
-          async run(): Promise<RunResult> {
+          async run(): Promise<RunnerExecutionResult> {
             runnerCalls += 1;
             throw new Error("runner should not be called");
           },
@@ -963,7 +964,7 @@ describe("BootstrapOrchestrator", () => {
           describeSession() {
             return createRunnerSessionDescription();
           },
-          async run(): Promise<RunResult> {
+          async run(): Promise<RunnerExecutionResult> {
             runnerCalls += 1;
             throw new Error("runner should not be called");
           },
@@ -1184,7 +1185,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           throw new Error("runner should not be called");
         },
       },
@@ -1276,7 +1277,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           runnerCalls += 1;
           throw new Error("runner should not be called");
         },
@@ -1504,7 +1505,7 @@ describe("BootstrapOrchestrator", () => {
       describeSession() {
         return createRunnerSessionDescription();
       },
-      async run(session): Promise<RunResult> {
+      async run(session): Promise<RunnerExecutionResult> {
         runnerCalls.push(session.attempt.sequence);
         const timestamp = new Date().toISOString();
         return {
@@ -1570,9 +1571,10 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(_session, options): Promise<RunResult> {
+        async run(_session, options): Promise<RunnerExecutionResult> {
           const timestamp = "2026-03-09T16:30:00.000Z";
-          await options?.onSpawn?.({
+          await options?.onEvent?.({
+            kind: "spawned",
             pid: runnerPid,
             spawnedAt: timestamp,
           });
@@ -1649,8 +1651,9 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(_session, options): Promise<RunResult> {
-          await options?.onSpawn?.({
+        async run(_session, options): Promise<RunnerExecutionResult> {
+          await options?.onEvent?.({
+            kind: "spawned",
             pid: runnerPid,
             spawnedAt: "2026-03-09T16:35:00.000Z",
           });
@@ -2020,7 +2023,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           const timestamp = "2026-03-09T16:45:00.000Z";
           return {
             exitCode: 17,
@@ -2071,7 +2074,7 @@ describe("BootstrapOrchestrator", () => {
           describeSessionCalls += 1;
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           const timestamp = "2026-03-09T17:00:00.000Z";
           return {
             exitCode: 0,
@@ -2143,7 +2146,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(): Promise<RunResult> {
+        async run(): Promise<RunnerExecutionResult> {
           const timestamp = new Date().toISOString();
           return {
             exitCode: 17,
@@ -2193,7 +2196,7 @@ describe("BootstrapOrchestrator", () => {
         describeSession() {
           return createRunnerSessionDescription();
         },
-        async run(session): Promise<RunResult> {
+        async run(session): Promise<RunnerExecutionResult> {
           runnerCalls.push(session.attempt.sequence);
           const timestamp = new Date().toISOString();
           return {
@@ -2253,19 +2256,21 @@ describe("BootstrapOrchestrator", () => {
           describeSession() {
             return createRunnerSessionDescription();
           },
-          async run(_session, options): Promise<RunResult> {
+          async run(_session, options): Promise<RunnerExecutionResult> {
             started.resolve();
-            return await new Promise<RunResult>((_resolve, reject) => {
-              options?.signal?.addEventListener(
-                "abort",
-                () => {
-                  reject(
-                    new RunnerAbortedError("Runner cancelled by shutdown"),
-                  );
-                },
-                { once: true },
-              );
-            });
+            return await new Promise<RunnerExecutionResult>(
+              (_resolve, reject) => {
+                options?.signal?.addEventListener(
+                  "abort",
+                  () => {
+                    reject(
+                      new RunnerAbortedError("Runner cancelled by shutdown"),
+                    );
+                  },
+                  { once: true },
+                );
+              },
+            );
           },
         },
         new NullLogger(),
@@ -2363,7 +2368,7 @@ describe("BootstrapOrchestrator watchdog", () => {
       async run(_session, options) {
         runStarted.resolve();
         // Simulate a runner that stalls indefinitely until aborted
-        return new Promise<RunResult>((resolve, reject) => {
+        return new Promise<RunnerExecutionResult>((resolve, reject) => {
           const handleAbort = (): void => {
             runAborted = true;
             reject(new RunnerAbortedError("Aborted"));
@@ -2434,7 +2439,7 @@ describe("BootstrapOrchestrator watchdog", () => {
         return createRunnerSessionDescription();
       },
       async run(_session, options) {
-        return new Promise<RunResult>((resolve, reject) => {
+        return new Promise<RunnerExecutionResult>((resolve, reject) => {
           const handleAbort = (): void => {
             abortCount += 1;
             reject(new RunnerAbortedError("Aborted"));
@@ -2518,7 +2523,7 @@ describe("BootstrapOrchestrator watchdog", () => {
         return createRunnerSessionDescription();
       },
       async run(_session, options) {
-        return new Promise<RunResult>((_resolve, reject) => {
+        return new Promise<RunnerExecutionResult>((_resolve, reject) => {
           const handleAbort = (): void => {
             abortCount += 1;
             void readFactoryStatusSnapshot(deriveStatusFilePath(tmpDir))

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -153,14 +153,17 @@ describe("runner contract", () => {
     const events: RunnerEvent[] = [];
     expect(startSession).toBeDefined();
     const liveSession = await startSession!(createSession());
-    const result = await liveSession.runTurn({
-      prompt: "Continuation prompt",
-      turnNumber: 2,
-    }, {
-      onEvent(event) {
-        events.push(event);
+    const result = await liveSession.runTurn(
+      {
+        prompt: "Continuation prompt",
+        turnNumber: 2,
       },
-    });
+      {
+        onEvent(event) {
+          events.push(event);
+        },
+      },
+    );
 
     expect(events).toEqual([
       {

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { RunSession, RunTurn } from "../../src/domain/run.js";
+import type {
+  LiveRunnerSession,
+  Runner,
+  RunnerEvent,
+  RunnerExecutionResult,
+  RunnerRunOptions,
+  RunnerTurnResult,
+} from "../../src/runner/service.js";
+
+function createSession(): RunSession {
+  return {
+    id: "sociotechnica-org/symphony-ts#89/attempt-1",
+    issue: {
+      id: "89",
+      identifier: "sociotechnica-org/symphony-ts#89",
+      number: 89,
+      title: "Provider-neutral runner contract",
+      description: "",
+      labels: [],
+      state: "open",
+      url: "https://example.test/issues/89",
+      createdAt: "2026-03-12T10:00:00.000Z",
+      updatedAt: "2026-03-12T10:00:00.000Z",
+    },
+    workspace: {
+      key: "sociotechnica-org_symphony-ts_89",
+      path: "/tmp/symphony-89",
+      branchName: "symphony/89",
+      createdNow: false,
+    },
+    prompt: "Initial prompt",
+    startedAt: "2026-03-12T10:00:00.000Z",
+    attempt: {
+      sequence: 1,
+    },
+  };
+}
+
+class FakeProviderLiveSession implements LiveRunnerSession {
+  #latestTurnNumber: number | null = null;
+
+  describe() {
+    return {
+      provider: "fake-provider",
+      model: "fake-model",
+      backendSessionId: null,
+      latestTurnNumber: this.#latestTurnNumber,
+      logPointers: [
+        {
+          name: "stdout",
+          location: "/tmp/fake-provider.stdout.log",
+          archiveLocation: null,
+        },
+      ],
+    } as const;
+  }
+
+  async runTurn(turn: RunTurn): Promise<RunnerTurnResult> {
+    this.#latestTurnNumber = turn.turnNumber;
+    return {
+      exitCode: 0,
+      stdout: `completed turn ${turn.turnNumber.toString()}`,
+      stderr: "",
+      startedAt: "2026-03-12T10:00:00.000Z",
+      finishedAt: "2026-03-12T10:00:01.000Z",
+      session: this.describe(),
+    };
+  }
+}
+
+class FakeProviderRunner implements Runner {
+  describeSession(_session: RunSession) {
+    return {
+      provider: "fake-provider",
+      model: "fake-model",
+      backendSessionId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    } as const;
+  }
+
+  async run(
+    session: RunSession,
+    options?: RunnerRunOptions,
+  ): Promise<RunnerExecutionResult> {
+    await options?.onEvent?.({
+      kind: "spawned",
+      pid: 4242,
+      spawnedAt: session.startedAt,
+    });
+    return {
+      exitCode: 0,
+      stdout: "completed",
+      stderr: "",
+      startedAt: session.startedAt,
+      finishedAt: "2026-03-12T10:00:01.000Z",
+    };
+  }
+
+  async startSession(_session: RunSession): Promise<LiveRunnerSession> {
+    return new FakeProviderLiveSession();
+  }
+}
+
+describe("runner contract", () => {
+  it("accepts a provider without reusable backend session ids", async () => {
+    const runner = new FakeProviderRunner();
+    const session = createSession();
+    const events: RunnerEvent[] = [];
+
+    const result = await runner.run(session, {
+      onEvent(event) {
+        events.push(event);
+      },
+    });
+
+    expect(runner.describeSession(session)).toEqual({
+      provider: "fake-provider",
+      model: "fake-model",
+      backendSessionId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    });
+    expect(events).toEqual([
+      {
+        kind: "spawned",
+        pid: 4242,
+        spawnedAt: "2026-03-12T10:00:00.000Z",
+      },
+    ]);
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: "completed",
+      stderr: "",
+      startedAt: "2026-03-12T10:00:00.000Z",
+      finishedAt: "2026-03-12T10:00:01.000Z",
+    });
+  });
+
+  it("supports live sessions without Codex-specific resume state", async () => {
+    const runner = new FakeProviderRunner();
+    const liveSession = await runner.startSession!(createSession());
+    const result = await liveSession.runTurn({
+      prompt: "Continuation prompt",
+      turnNumber: 2,
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: "completed turn 2",
+      stderr: "",
+      startedAt: "2026-03-12T10:00:00.000Z",
+      finishedAt: "2026-03-12T10:00:01.000Z",
+      session: {
+        provider: "fake-provider",
+        model: "fake-model",
+        backendSessionId: null,
+        latestTurnNumber: 2,
+        logPointers: [
+          {
+            name: "stdout",
+            location: "/tmp/fake-provider.stdout.log",
+            archiveLocation: null,
+          },
+        ],
+      },
+    });
+  });
+});

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -141,7 +141,9 @@ describe("runner contract", () => {
 
   it("supports live sessions without Codex-specific resume state", async () => {
     const runner = new FakeProviderRunner();
-    const liveSession = await runner.startSession!(createSession());
+    const startSession = runner.startSession;
+    expect(startSession).toBeDefined();
+    const liveSession = await startSession!(createSession());
     const result = await liveSession.runTurn({
       prompt: "Continuation prompt",
       turnNumber: 2,

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -57,8 +57,16 @@ class FakeProviderLiveSession implements LiveRunnerSession {
     } as const;
   }
 
-  async runTurn(turn: RunTurn): Promise<RunnerTurnResult> {
+  async runTurn(
+    turn: RunTurn,
+    options?: RunnerRunOptions,
+  ): Promise<RunnerTurnResult> {
     this.#latestTurnNumber = turn.turnNumber;
+    await options?.onEvent?.({
+      kind: "spawned",
+      pid: 31337,
+      spawnedAt: "2026-03-12T10:00:00.000Z",
+    });
     return {
       exitCode: 0,
       stdout: `completed turn ${turn.turnNumber.toString()}`,
@@ -142,13 +150,25 @@ describe("runner contract", () => {
   it("supports live sessions without Codex-specific resume state", async () => {
     const runner = new FakeProviderRunner();
     const startSession = runner.startSession;
+    const events: RunnerEvent[] = [];
     expect(startSession).toBeDefined();
     const liveSession = await startSession!(createSession());
     const result = await liveSession.runTurn({
       prompt: "Continuation prompt",
       turnNumber: 2,
+    }, {
+      onEvent(event) {
+        events.push(event);
+      },
     });
 
+    expect(events).toEqual([
+      {
+        kind: "spawned",
+        pid: 31337,
+        spawnedAt: "2026-03-12T10:00:00.000Z",
+      },
+    ]);
     expect(result).toEqual({
       exitCode: 0,
       stdout: "completed turn 2",


### PR DESCRIPTION
## Summary\n- move runner execution event/result types into the runner contract so the orchestrator depends on provider-neutral runner interfaces\n- keep the local Codex-backed runner behind that contract while preserving existing continuation and spawn-observability behavior\n- add provider-neutral contract coverage with a fake backend plus updated local runner/orchestrator tests and docs\n\n## Testing\n- pnpm typecheck\n- pnpm lint\n- pnpm format:check\n- pnpm test\n\nCloses #89\nPlan: docs/plans/089-provider-neutral-runner-contract/plan.md