### PR TITLE
Tighten operator merge gate for bot reviews

### DIFF
--- a/docs/plans/098-status-tui/plan.md
+++ b/docs/plans/098-status-tui/plan.md
@@ -1,0 +1,260 @@
+# Plan: Status TUI for the Factory (#98)
+
+Status: draft
+
+## Summary
+
+Port the Elixir `StatusDashboard` GenServer to TypeScript as a `StatusDashboard`
+class in `src/observability/tui.ts`. The TUI is a pull-based terminal renderer that
+periodically calls `Orchestrator.snapshot()` and writes a full-screen ANSI display
+showing running agents, the backoff queue, token throughput, and poll state.
+
+Spec: `.context/attachments/TUI_SPEC.md`
+Reference: `../symphony/elixir/lib/symphony_elixir/status_dashboard.ex`
+
+## Scope
+
+- Add `ObservabilityConfig` to workflow domain and config loader
+- Add `onUpdate` callback to runner interface; implement line-by-line JSON event
+  streaming in `LocalRunner`
+- Add `RunningEntry` state to orchestrator (per-issue Codex state: tokens, turns,
+  last event)
+- Add `snapshot()` method to `BootstrapOrchestrator`
+- Add `notifyUpdate()` calls at all state-change points in the orchestrator
+- Implement `StatusDashboard` with tick loop, push-refresh, rate-limited rendering,
+  TPS calculation, event humanizer, and ANSI formatter
+- Wire TUI startup into the `run` CLI command
+
+## Non-goals
+
+- Web/HTTP dashboard
+- PubSub infrastructure
+- Remote runner support
+- Sparkline graph (defer to follow-up; internal use only)
+
+## Symphony Abstraction Layer Mapping
+
+| Layer         | Work in this PR                                          |
+|---------------|----------------------------------------------------------|
+| Configuration | Add `observability` section to `ResolvedConfig`          |
+| Integration   | Add `onUpdate` hook to Runner; parse Codex stdout events |
+| Coordination  | Add `RunningEntry` map, `snapshot()`, polling flags      |
+| Execution     | No changes                                               |
+| Observability | New `StatusDashboard` (TUI renderer)                     |
+
+## Current Gaps
+
+The following are missing from the TypeScript factory and must be added:
+
+1. **Runner `onUpdate` hook** — `LocalRunner` collects stdout as a buffer. It needs
+   to stream line-by-line and try to parse each line as a JSON Codex event, calling
+   `onUpdate` per event. This is the TS equivalent of Elixir's
+   `codex_message_handler` / `:codex_worker_update` pattern.
+
+2. **`RunningEntry` state** — `OrchestratorState` has `runningIssueNumbers:
+   Set<number>` but no per-issue Codex state. Needs a `runningEntries: Map<number,
+   RunningEntry>` with `sessionId`, `turnCount`, `codexTotalTokens`, `lastCodexEvent`,
+   `lastCodexMessage`, `codexAppServerPid`.
+
+3. **Orchestrator `snapshot()` method** — no equivalent exists in TypeScript.
+
+4. **Aggregate `codexTotals`** — `{inputTokens, outputTokens, totalTokens,
+   secondsRunning}` accumulated across all running agents, reset on poll cycle.
+
+5. **`rateLimits` state** — extracted from Codex update events; not tracked yet.
+
+6. **Polling state flags** — `checkingNow: boolean` and `nextPollInMs: number`
+   not currently exposed.
+
+7. **`ObservabilityConfig` in workflow config** — `ResolvedConfig` has no
+   `observability` section (`dashboardEnabled`, `refreshMs`, `renderIntervalMs`).
+
+## Architecture Boundaries
+
+```
+LocalRunner
+  └── onUpdate(event) ──────────────────────────────────┐
+                                                        ▼
+BootstrapOrchestrator                          OrchestratorState
+  ├── runningEntries: Map<id, RunningEntry>    (RunningEntry per issue)
+  ├── codexTotals: CodexTotals
+  ├── rateLimits: RateLimits | null
+  ├── pollingState: PollingState
+  ├── snapshot(): TuiSnapshot | "unavailable"
+  └── notifyUpdate() ──────────────────────────────────┐
+                                                       ▼
+                                             StatusDashboard
+                                               └── renders to stdout (ANSI)
+```
+
+- The TUI reads orchestrator state but never mutates it.
+- The orchestrator snapshot is synchronous in Elixir (GenServer.call); in TS it is
+  a direct method call on the same object (synchronous, no timeout needed).
+- The TUI runs as a `setInterval`-based tick loop in the same Node.js process,
+  started after the orchestrator is created.
+
+## Implementation Steps
+
+### Step 1 — Config: Add `ObservabilityConfig`
+
+`src/domain/workflow.ts`:
+```ts
+export interface ObservabilityConfig {
+  readonly dashboardEnabled: boolean;
+  readonly refreshMs: number;
+  readonly renderIntervalMs: number;
+}
+
+// Add to ResolvedConfig:
+readonly observability: ObservabilityConfig;
+```
+
+`src/config/workflow.ts`: parse `observability:` YAML section with defaults
+(dashboardEnabled=true, refreshMs=1000, renderIntervalMs=16).
+
+### Step 2 — Runner: Add `onUpdate` callback and `RunUpdateEvent`
+
+`src/domain/run.ts`:
+```ts
+export interface RunUpdateEvent {
+  readonly event: string;         // event type from Codex JSON
+  readonly payload: unknown;      // raw parsed JSON message
+  readonly timestamp: string;
+}
+```
+
+`src/runner/service.ts`:
+```ts
+export interface RunnerRunOptions {
+  readonly signal?: AbortSignal;
+  readonly onSpawn?: (event: RunSpawnEvent) => void | Promise<void>;
+  readonly onUpdate?: (event: RunUpdateEvent) => void;  // NEW
+}
+```
+
+`src/runner/local.ts`: Replace `stdout += chunk.toString()` with a line buffer.
+On each newline, attempt `JSON.parse`. If successful, call `onUpdate` with the
+parsed event. Also accumulate raw stdout for `RunResult` as before.
+
+### Step 3 — Orchestrator: `RunningEntry` and state extensions
+
+New file `src/orchestrator/running-entry.ts`:
+```ts
+export interface RunningEntry {
+  readonly issueNumber: number;
+  readonly identifier: string;
+  readonly startedAt: Date;
+  readonly retryAttempt: number;
+  sessionId: string | null;
+  turnCount: number;
+  codexInputTokens: number;
+  codexOutputTokens: number;
+  codexTotalTokens: number;
+  codexLastReportedInputTokens: number;
+  codexLastReportedOutputTokens: number;
+  codexLastReportedTotalTokens: number;
+  codexAppServerPid: number | null;
+  lastCodexEvent: string | null;
+  lastCodexMessage: unknown | null;
+  lastCodexTimestamp: string | null;
+}
+```
+
+`src/orchestrator/state.ts`:
+- Add `runningEntries: Map<number, RunningEntry>`
+- Add `codexTotals: CodexTotals` (aggregated tokens + secondsRunning)
+- Add `rateLimits: RateLimits | null`
+- Add `pollingState: PollingState` (checkingNow, nextPollAtMs, intervalMs)
+
+### Step 4 — Orchestrator: `snapshot()` and `notifyUpdate()`
+
+`src/orchestrator/service.ts`:
+- Add `snapshot(): TuiSnapshot | "unavailable"` — returns running entries,
+  retries, codexTotals, rateLimits, pollingState
+- Add `notifyUpdate(dashboard: StatusDashboard | null): void` — calls
+  `dashboard.refresh()` if set
+- Call `notifyUpdate` at: poll tick start, poll tick end, agent spawn, agent exit,
+  `onUpdate` events, retry scheduling
+
+### Step 5 — TUI: `StatusDashboard`
+
+New file `src/observability/tui.ts`:
+
+State:
+- `refreshMs`, `enabled`, `renderIntervalMs` (from config + overrides)
+- `renderFn: (content: string) => void` (injectable for tests)
+- `tokenSamples: Array<[timestampMs, totalTokens]>` (rolling 5s TPS window)
+- `lastTpsSecond: number | null`, `lastTpsValue: number`
+- `lastRenderedContent: string | null`, `lastRenderedAtMs: number | null`
+- `pendingContent: string | null`, `flushTimerRef: NodeJS.Timeout | null`
+- `lastSnapshotFingerprint: string | null`
+
+Public API:
+- `start(): void` — schedule first tick
+- `stop(): void` — clear timers, render offline frame
+- `refresh(): void` — push-triggered re-render (rate-limited)
+- `renderOfflineStatus(): void` — render final offline frame on shutdown
+
+Internal:
+- `tick()` — re-read config, maybe render, schedule next tick
+- `maybeRender()` — snapshot → format → rate-limit → output
+- `renderNow(content: string)` — write ANSI to terminal
+- `formatSnapshot(snapshot)` — full formatter (see Section 5 of spec)
+- `formatRunningRows(running, terminalCols)` — table rows
+- `formatRetryRows(retrying)` — backoff queue rows
+- `humanizeEvent(message)` — event taxonomy (Section 7 of spec)
+- `rollingTps(samples, nowMs, currentTokens)` — Section 6.1
+- `throttledTps(samples, nowMs, currentTokens, lastSecond, lastValue)` — Section 6.2
+
+ANSI helpers:
+- Inline constants: `RED`, `GREEN`, `YELLOW`, `BLUE`, `MAGENTA`, `CYAN`, `GRAY`,
+  `BOLD`, `DIM`, `RESET` using raw escape codes from spec Section 8.
+- No external terminal library.
+
+### Step 6 — CLI: Wire TUI startup
+
+`src/cli/index.ts`: After creating the orchestrator, create `StatusDashboard` with
+the orchestrator's `snapshot` bound as the data source. Pass the dashboard to the
+orchestrator so it can call `notifyUpdate`. Call `dashboard.stop()` on shutdown.
+
+## Tests
+
+Unit tests (`tests/unit/tui.test.ts`):
+- `formatSnapshot` with sample data → expected ANSI string (use `renderFn` capture)
+- `humanizeEvent` for each event type in taxonomy
+- `rollingTps` edge cases (empty, single sample, window prune)
+- `throttledTps` — same-second caching
+- Snapshot fingerprinting — no re-render on identical data
+- Content deduplication — no IO on identical formatted string
+- Flush timer throttling — pending content flushed after `renderIntervalMs`
+- Offline frame renders "app_status=offline"
+
+Integration tests (`tests/integration/tui.test.ts`):
+- TUI started with a fake orchestrator stub, ticks once, captures rendered output
+- Push refresh (`refresh()`) triggers immediate render, respects rate limit
+- TUI disabled when `dashboardEnabled: false`
+
+## Acceptance Criteria
+
+- `pnpm typecheck` passes
+- `pnpm lint` passes
+- `pnpm test` passes (including new unit + integration tests)
+- Factory runs with TUI enabled show the box-drawing frame with running agents table
+  and backoff queue on the terminal
+- Factory runs with TUI disabled (or in test mode via `enabled: false`) produce no
+  terminal output from the TUI
+- `stop()` renders an offline frame
+
+## Exit Criteria
+
+- All tests pass
+- PR opened against `main`
+- CI green
+
+## Deferred
+
+- Sparkline graph (Section 6.3) — visual nicety, not required for operator utility
+- Web dashboard / PubSub (Section 2.3 broadcast path) — separate issue
+- Remote runner TUI integration — local only for now
+- Project URL and Dashboard URL header lines — depend on tracker config shape;
+  render as "n/a" initially

--- a/docs/plans/098-status-tui/plan.md
+++ b/docs/plans/098-status-tui/plan.md
@@ -35,7 +35,7 @@ Reference: `../symphony/elixir/lib/symphony_elixir/status_dashboard.ex`
 ## Symphony Abstraction Layer Mapping
 
 | Layer         | Work in this PR                                          |
-|---------------|----------------------------------------------------------|
+| ------------- | -------------------------------------------------------- |
 | Configuration | Add `observability` section to `ResolvedConfig`          |
 | Integration   | Add `onUpdate` hook to Runner; parse Codex stdout events |
 | Coordination  | Add `RunningEntry` map, `snapshot()`, polling flags      |
@@ -52,14 +52,14 @@ The following are missing from the TypeScript factory and must be added:
    `codex_message_handler` / `:codex_worker_update` pattern.
 
 2. **`RunningEntry` state** — `OrchestratorState` has `runningIssueNumbers:
-   Set<number>` but no per-issue Codex state. Needs a `runningEntries: Map<number,
-   RunningEntry>` with `sessionId`, `turnCount`, `codexTotalTokens`, `lastCodexEvent`,
+Set<number>` but no per-issue Codex state. Needs a `runningEntries: Map<number,
+RunningEntry>` with `sessionId`, `turnCount`, `codexTotalTokens`, `lastCodexEvent`,
    `lastCodexMessage`, `codexAppServerPid`.
 
 3. **Orchestrator `snapshot()` method** — no equivalent exists in TypeScript.
 
 4. **Aggregate `codexTotals`** — `{inputTokens, outputTokens, totalTokens,
-   secondsRunning}` accumulated across all running agents, reset on poll cycle.
+secondsRunning}` accumulated across all running agents, reset on poll cycle.
 
 5. **`rateLimits` state** — extracted from Codex update events; not tracked yet.
 
@@ -98,6 +98,7 @@ BootstrapOrchestrator                          OrchestratorState
 ### Step 1 — Config: Add `ObservabilityConfig`
 
 `src/domain/workflow.ts`:
+
 ```ts
 export interface ObservabilityConfig {
   readonly dashboardEnabled: boolean;
@@ -115,20 +116,22 @@ readonly observability: ObservabilityConfig;
 ### Step 2 — Runner: Add `onUpdate` callback and `RunUpdateEvent`
 
 `src/domain/run.ts`:
+
 ```ts
 export interface RunUpdateEvent {
-  readonly event: string;         // event type from Codex JSON
-  readonly payload: unknown;      // raw parsed JSON message
+  readonly event: string; // event type from Codex JSON
+  readonly payload: unknown; // raw parsed JSON message
   readonly timestamp: string;
 }
 ```
 
 `src/runner/service.ts`:
+
 ```ts
 export interface RunnerRunOptions {
   readonly signal?: AbortSignal;
   readonly onSpawn?: (event: RunSpawnEvent) => void | Promise<void>;
-  readonly onUpdate?: (event: RunUpdateEvent) => void;  // NEW
+  readonly onUpdate?: (event: RunUpdateEvent) => void; // NEW
 }
 ```
 
@@ -139,6 +142,7 @@ parsed event. Also accumulate raw stdout for `RunResult` as before.
 ### Step 3 — Orchestrator: `RunningEntry` and state extensions
 
 New file `src/orchestrator/running-entry.ts`:
+
 ```ts
 export interface RunningEntry {
   readonly issueNumber: number;
@@ -161,6 +165,7 @@ export interface RunningEntry {
 ```
 
 `src/orchestrator/state.ts`:
+
 - Add `runningEntries: Map<number, RunningEntry>`
 - Add `codexTotals: CodexTotals` (aggregated tokens + secondsRunning)
 - Add `rateLimits: RateLimits | null`
@@ -169,6 +174,7 @@ export interface RunningEntry {
 ### Step 4 — Orchestrator: `snapshot()` and `notifyUpdate()`
 
 `src/orchestrator/service.ts`:
+
 - Add `snapshot(): TuiSnapshot | "unavailable"` — returns running entries,
   retries, codexTotals, rateLimits, pollingState
 - Add `notifyUpdate(dashboard: StatusDashboard | null): void` — calls
@@ -181,6 +187,7 @@ export interface RunningEntry {
 New file `src/observability/tui.ts`:
 
 State:
+
 - `refreshMs`, `enabled`, `renderIntervalMs` (from config + overrides)
 - `renderFn: (content: string) => void` (injectable for tests)
 - `tokenSamples: Array<[timestampMs, totalTokens]>` (rolling 5s TPS window)
@@ -190,12 +197,14 @@ State:
 - `lastSnapshotFingerprint: string | null`
 
 Public API:
+
 - `start(): void` — schedule first tick
 - `stop(): void` — clear timers, render offline frame
 - `refresh(): void` — push-triggered re-render (rate-limited)
 - `renderOfflineStatus(): void` — render final offline frame on shutdown
 
 Internal:
+
 - `tick()` — re-read config, maybe render, schedule next tick
 - `maybeRender()` — snapshot → format → rate-limit → output
 - `renderNow(content: string)` — write ANSI to terminal
@@ -207,6 +216,7 @@ Internal:
 - `throttledTps(samples, nowMs, currentTokens, lastSecond, lastValue)` — Section 6.2
 
 ANSI helpers:
+
 - Inline constants: `RED`, `GREEN`, `YELLOW`, `BLUE`, `MAGENTA`, `CYAN`, `GRAY`,
   `BOLD`, `DIM`, `RESET` using raw escape codes from spec Section 8.
 - No external terminal library.
@@ -220,6 +230,7 @@ orchestrator so it can call `notifyUpdate`. Call `dashboard.stop()` on shutdown.
 ## Tests
 
 Unit tests (`tests/unit/tui.test.ts`):
+
 - `formatSnapshot` with sample data → expected ANSI string (use `renderFn` capture)
 - `humanizeEvent` for each event type in taxonomy
 - `rollingTps` edge cases (empty, single sample, window prune)
@@ -230,6 +241,7 @@ Unit tests (`tests/unit/tui.test.ts`):
 - Offline frame renders "app_status=offline"
 
 Integration tests (`tests/integration/tui.test.ts`):
+
 - TUI started with a fake orchestrator stub, ticks once, captures rendered output
 - Push refresh (`refresh()`) triggers immediate render, respects rate limit
 - TUI disabled when `dashboardEnabled: false`

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -12,6 +12,7 @@ Use this skill when acting as the operator for the local Symphony factory.
 - Observe the live factory, not just the repository.
 - Repair broken or stalled execution.
 - Drive PRs through CI and automated review to a mergeable state.
+- Handle `plan-ready` issues: review plans, request changes when needed, and approve when ready.
 - Keep GitHub as a thin queue and rely on Symphony's own polling and concurrency.
 - Maintain a persistent local operator notebook in `.ralph/operator-scratchpad.md`.
 
@@ -22,7 +23,12 @@ Use this skill when acting as the operator for the local Symphony factory.
 3. Check the live Symphony worker process and determine whether it is healthy, progressing, stuck, crashed, or misconfigured.
 4. If the factory is unhealthy, fix the concrete problem and restart it.
 5. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-6. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+6. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
+   - `Plan review: approved`
+   - `Plan review: changes-requested`
+   - `Plan review: waived`
+7. After posting a review decision, verify the factory acknowledges it and transitions correctly.
+8. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
 
@@ -33,6 +39,10 @@ Use this skill when acting as the operator for the local Symphony factory.
 - Use an isolated checkout when fixing PR branches so local operator-only modifications do not leak into tracked work.
 - The factory owns PR follow-up by default. If a fresh actionable review batch lands and the factory does not pick it up, debug the miss as a factory/runtime problem before taking over the branch manually.
 - Do not silently replace the worker on an active PR just because the next fix is obvious. Operator PR intervention is for stalled or broken factory behavior, not the normal path.
+- Treat plan review as a required operator checkpoint:
+  - if the plan is sound, post `Plan review: approved`,
+  - if revisions are needed, post `Plan review: changes-requested` with concrete guidance,
+  - if explicitly bypassing review, post `Plan review: waived` and record why.
 
 ## Factory Fix Rule
 
@@ -51,6 +61,7 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 
 - Do not merge while required CI is red or while actionable review comments remain.
 - Greptile and Bugbot comments count as review feedback.
+- Do not treat "all threads resolved" as sufficient by itself. Before merging, also check for top-level bot review comments or review summaries that still contain unaddressed actionable feedback.
 - Low-severity cleanup comments can be answered instead of fixed only when the tradeoff is explicit and defensible.
 
 ## Learned Heuristics

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -114,8 +114,8 @@ export async function runCli(argv: readonly string[]): Promise<void> {
       "--i-understand-that-this-will-be-running-without-the-usual-guardrails",
     )
   ) {
-    const B = "\x1b[1;31m";
-    const R = "\x1b[0m";
+    const B = process.stdout.isTTY ? "\x1b[1;31m" : "";
+    const R = process.stdout.isTTY ? "\x1b[0m" : "";
     process.stdout.write(
       [
         `${B}╭──────────────────────────────────────────────────────────────╮${R}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -119,12 +119,13 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     process.stdout.write(
       [
         `${B}╭──────────────────────────────────────────────────────────────╮${R}`,
-        `${B}│  ⚠  Symphony is about to run agents on your behalf            │${R}`,
-        `${B}│                                                                │${R}`,
-        `${B}│  To confirm you understand and wish to proceed, re-run with:  │${R}`,
-        `${B}│                                                                │${R}`,
-        `${B}│    --i-understand-that-this-will-be-running-without-the-      │${R}`,
-        `${B}│    usual-guardrails                                            │${R}`,
+        `${B}│  Symphony is about to run agents on your behalf.             │${R}`,
+        `${B}│                                                              │${R}`,
+        `${B}│  To confirm you understand and wish to proceed,              │${R}`,
+        `${B}│  re-run with the flag:                                       │${R}`,
+        `${B}│                                                              │${R}`,
+        `${B}│    --i-understand-that-this-will-be-running-                 │${R}`,
+        `${B}│    without-the-usual-guardrails                              │${R}`,
         `${B}╰──────────────────────────────────────────────────────────────╯${R}`,
       ].join("\n") + "\n",
     );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,8 +158,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   dashboard.start();
 
   if (args.once) {
-    await orchestrator.runOnce();
-    dashboard.stop();
+    try {
+      await orchestrator.runOnce();
+    } finally {
+      dashboard.stop();
+    }
     return;
   }
 
@@ -170,8 +173,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   };
   process.on("SIGINT", stopDashboard);
   process.on("SIGTERM", stopDashboard);
-  await orchestrator.runLoop(abortController.signal);
-  dashboard.stop();
+  try {
+    await orchestrator.runLoop(abortController.signal);
+  } finally {
+    dashboard.stop();
+  }
 }
 
 async function resolveStatusFilePath(workflowPath: string): Promise<string> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import {
   renderFactoryStatusSnapshot,
 } from "../observability/status.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
+import { StatusDashboard } from "../observability/tui.js";
 import { LocalRunner } from "../runner/local.js";
 import { createTracker } from "../tracker/factory.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
@@ -127,15 +128,28 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     logger,
   );
 
+  const dashboard = new StatusDashboard(
+    () => orchestrator.snapshot(),
+    () => workflow.config.observability,
+  );
+  orchestrator.setDashboardNotify(() => dashboard.refresh());
+  dashboard.start();
+
   if (args.once) {
     await orchestrator.runOnce();
+    dashboard.stop();
     return;
   }
 
   const abortController = new AbortController();
-  process.on("SIGINT", () => abortController.abort());
-  process.on("SIGTERM", () => abortController.abort());
+  const stopDashboard = (): void => {
+    dashboard.stop();
+    abortController.abort();
+  };
+  process.on("SIGINT", stopDashboard);
+  process.on("SIGTERM", stopDashboard);
   await orchestrator.runLoop(abortController.signal);
+  dashboard.stop();
 }
 
 async function resolveStatusFilePath(workflowPath: string): Promise<string> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -109,6 +109,28 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     return;
   }
 
+  if (
+    !argv.includes(
+      "--i-understand-that-this-will-be-running-without-the-usual-guardrails",
+    )
+  ) {
+    const B = "\x1b[1;31m";
+    const R = "\x1b[0m";
+    process.stdout.write(
+      [
+        `${B}╭──────────────────────────────────────────────────────────────╮${R}`,
+        `${B}│  ⚠  Symphony is about to run agents on your behalf            │${R}`,
+        `${B}│                                                                │${R}`,
+        `${B}│  To confirm you understand and wish to proceed, re-run with:  │${R}`,
+        `${B}│                                                                │${R}`,
+        `${B}│    --i-understand-that-this-will-be-running-without-the-      │${R}`,
+        `${B}│    usual-guardrails                                            │${R}`,
+        `${B}╰──────────────────────────────────────────────────────────────╯${R}`,
+      ].join("\n") + "\n",
+    );
+    process.exit(1);
+  }
+
   const logger = new JsonLogger();
   const workflow = await loadWorkflow(args.workflowPath);
   const promptBuilder = createPromptBuilder(workflow);

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -298,7 +298,9 @@ function resolveObservabilityConfig(
     dashboardEnabled:
       dashboardEnabled === undefined ? true : Boolean(dashboardEnabled),
     refreshMs:
-      refreshMs === undefined ? 1000 : requireNumber(refreshMs, "observability.refresh_ms"),
+      refreshMs === undefined
+        ? 1000
+        : requireNumber(refreshMs, "observability.refresh_ms"),
     renderIntervalMs:
       renderIntervalMs === undefined
         ? 16
@@ -312,7 +314,10 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   const workspace = coerceOptionalObject(raw.workspace, "workspace");
   const hooks = coerceOptionalObject(raw.hooks, "hooks");
   const agent = coerceOptionalObject(raw.agent, "agent");
-  const observabilityRaw = coerceOptionalObject(raw.observability, "observability");
+  const observabilityRaw = coerceOptionalObject(
+    raw.observability,
+    "observability",
+  );
 
   // Apply SYMPHONY_REPO env override (github-bootstrap only; ignored by other tracker kinds)
   const rawRepoEnv = process.env["SYMPHONY_REPO"];

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -296,7 +296,11 @@ function resolveObservabilityConfig(
   const renderIntervalMs = raw["render_interval_ms"];
   return {
     dashboardEnabled:
-      dashboardEnabled === undefined ? true : Boolean(dashboardEnabled),
+      dashboardEnabled === undefined
+        ? true
+        : dashboardEnabled === false || dashboardEnabled === "false"
+          ? false
+          : Boolean(dashboardEnabled),
     refreshMs:
       refreshMs === undefined
         ? 1000

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -7,6 +7,7 @@ import type { HandoffLifecycle } from "../domain/handoff.js";
 import type {
   GitHubBootstrapTrackerConfig,
   LinearTrackerConfig,
+  ObservabilityConfig,
   PromptBuilder,
   ResolvedConfig,
   TrackerConfig,
@@ -19,6 +20,7 @@ interface RawWorkflow {
   readonly workspace?: Record<string, unknown>;
   readonly hooks?: Record<string, unknown>;
   readonly agent?: Record<string, unknown>;
+  readonly observability?: Record<string, unknown>;
 }
 
 const liquid = new Liquid({
@@ -286,12 +288,31 @@ function resolveRepoUrl(
   return requireString(explicitRepoUrl, "workspace.repo_url");
 }
 
+function resolveObservabilityConfig(
+  raw: Readonly<Record<string, unknown>>,
+): ObservabilityConfig {
+  const dashboardEnabled = raw["dashboard_enabled"];
+  const refreshMs = raw["refresh_ms"];
+  const renderIntervalMs = raw["render_interval_ms"];
+  return {
+    dashboardEnabled:
+      dashboardEnabled === undefined ? true : Boolean(dashboardEnabled),
+    refreshMs:
+      refreshMs === undefined ? 1000 : requireNumber(refreshMs, "observability.refresh_ms"),
+    renderIntervalMs:
+      renderIntervalMs === undefined
+        ? 16
+        : requireNumber(renderIntervalMs, "observability.render_interval_ms"),
+  };
+}
+
 function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   const tracker = coerceOptionalObject(raw.tracker, "tracker");
   const polling = coerceOptionalObject(raw.polling, "polling");
   const workspace = coerceOptionalObject(raw.workspace, "workspace");
   const hooks = coerceOptionalObject(raw.hooks, "hooks");
   const agent = coerceOptionalObject(raw.agent, "agent");
+  const observabilityRaw = coerceOptionalObject(raw.observability, "observability");
 
   // Apply SYMPHONY_REPO env override (github-bootstrap only; ignored by other tracker kinds)
   const rawRepoEnv = process.env["SYMPHONY_REPO"];
@@ -391,6 +412,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         ...(repo !== undefined ? { GITHUB_REPO: repo } : {}),
       },
     },
+    observability: resolveObservabilityConfig(observabilityRaw),
   };
 
   if (!["stdin", "file"].includes(resolved.agent.promptTransport)) {

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -26,3 +26,9 @@ export interface RunResult {
   readonly startedAt: string;
   readonly finishedAt: string;
 }
+
+export interface RunUpdateEvent {
+  readonly event: string;
+  readonly payload: unknown;
+  readonly timestamp: string;
+}

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -62,6 +62,12 @@ export interface AgentConfig {
   readonly env: Readonly<Record<string, string>>;
 }
 
+export interface ObservabilityConfig {
+  readonly dashboardEnabled: boolean;
+  readonly refreshMs: number;
+  readonly renderIntervalMs: number;
+}
+
 export interface ResolvedConfig {
   readonly workflowPath: string;
   readonly tracker: TrackerConfig;
@@ -69,6 +75,7 @@ export interface ResolvedConfig {
   readonly workspace: WorkspaceConfig;
   readonly hooks: HooksConfig;
   readonly agent: AgentConfig;
+  readonly observability: ObservabilityConfig;
 }
 
 export interface WorkflowDefinition {

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -1,0 +1,1119 @@
+/**
+ * StatusDashboard — terminal status TUI for the Symphony factory.
+ *
+ * Pull-based: polls orchestrator.snapshot() on a configurable tick interval.
+ * Push-aware: accepts refresh() calls from the orchestrator on state changes.
+ * Rate-limited: throttles renders to at most once per renderIntervalMs.
+ * Observability-only: never mutates orchestrator state.
+ */
+
+import type { ObservabilityConfig } from "../domain/workflow.js";
+import type { TuiSnapshot } from "../orchestrator/service.js";
+
+// ─── ANSI constants ────────────────────────────────────────────────────────
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RED = "\x1b[31m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const BLUE = "\x1b[34m";
+const MAGENTA = "\x1b[35m";
+const CYAN = "\x1b[36m";
+const GRAY = "\x1b[90m";
+
+function colorize(text: string, code: string): string {
+  return `${code}${text}${RESET}`;
+}
+
+// ─── Column widths ──────────────────────────────────────────────────────────
+
+const ID_WIDTH = 8;
+const STAGE_WIDTH = 14;
+const PID_WIDTH = 8;
+const AGE_WIDTH = 12;
+const TOKENS_WIDTH = 10;
+const SESSION_WIDTH = 14;
+const EVENT_MIN_WIDTH = 12;
+const ROW_CHROME_WIDTH = 10;
+const DEFAULT_TERMINAL_COLUMNS = 115;
+const THROUGHPUT_WINDOW_MS = 5_000;
+const MINIMUM_IDLE_RERENDER_MS = 1_000;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type TokenSample = readonly [timestampMs: number, totalTokens: number];
+
+interface DashboardState {
+  refreshMs: number;
+  enabled: boolean;
+  renderIntervalMs: number;
+  renderFn: (content: string) => void;
+  tokenSamples: TokenSample[];
+  lastTpsSecond: number | null;
+  lastTpsValue: number;
+  lastRenderedContent: string | null;
+  lastRenderedAtMs: number | null;
+  pendingContent: string | null;
+  flushTimerRef: NodeJS.Timeout | null;
+  lastSnapshotFingerprint: string | null;
+  tickTimer: NodeJS.Timeout | null;
+}
+
+// ─── Public interface ────────────────────────────────────────────────────────
+
+export interface StatusDashboardOptions {
+  readonly enabled?: boolean;
+  readonly refreshMs?: number;
+  readonly renderIntervalMs?: number;
+  readonly renderFn?: (content: string) => void;
+}
+
+export class StatusDashboard {
+  readonly #getSnapshot: () => TuiSnapshot;
+  readonly #getConfig: () => ObservabilityConfig;
+  readonly #state: DashboardState;
+
+  constructor(
+    getSnapshot: () => TuiSnapshot,
+    getConfig: () => ObservabilityConfig,
+    options?: StatusDashboardOptions,
+  ) {
+    this.#getSnapshot = getSnapshot;
+    this.#getConfig = getConfig;
+
+    const config = getConfig();
+    const enabled = options?.enabled ?? (config.dashboardEnabled && isTerminalEnabled());
+
+    this.#state = {
+      refreshMs: options?.refreshMs ?? config.refreshMs,
+      enabled,
+      renderIntervalMs: options?.renderIntervalMs ?? config.renderIntervalMs,
+      renderFn: options?.renderFn ?? renderToTerminal,
+      tokenSamples: [],
+      lastTpsSecond: null,
+      lastTpsValue: 0,
+      lastRenderedContent: null,
+      lastRenderedAtMs: null,
+      pendingContent: null,
+      flushTimerRef: null,
+      lastSnapshotFingerprint: null,
+      tickTimer: null,
+    };
+  }
+
+  start(): void {
+    if (!this.#state.enabled) return;
+    this.#scheduleTick();
+  }
+
+  stop(): void {
+    if (this.#state.tickTimer !== null) {
+      clearTimeout(this.#state.tickTimer);
+      this.#state.tickTimer = null;
+    }
+    if (this.#state.flushTimerRef !== null) {
+      clearTimeout(this.#state.flushTimerRef);
+      this.#state.flushTimerRef = null;
+    }
+    this.renderOfflineStatus();
+  }
+
+  refresh(): void {
+    if (!this.#state.enabled) return;
+    this.#refreshRuntimeConfig();
+    this.#maybeRender();
+  }
+
+  renderOfflineStatus(): void {
+    const content = [
+      colorize("╭─ SYMPHONY STATUS", BOLD),
+      colorize("│ app_status=offline", RED),
+      "╰─",
+    ].join("\n");
+    try {
+      this.#state.renderFn(content);
+    } catch {
+      // best-effort
+    }
+  }
+
+  // ─── Tick loop ────────────────────────────────────────────────────────────
+
+  #scheduleTick(): void {
+    this.#state.tickTimer = setTimeout(() => {
+      this.#onTick();
+    }, this.#state.refreshMs);
+  }
+
+  #onTick(): void {
+    if (!this.#state.enabled) return;
+    this.#refreshRuntimeConfig();
+    this.#maybeRender();
+    this.#scheduleTick();
+  }
+
+  #refreshRuntimeConfig(): void {
+    const config = this.#getConfig();
+    this.#state.refreshMs = config.refreshMs;
+    this.#state.renderIntervalMs = config.renderIntervalMs;
+    this.#state.enabled = config.dashboardEnabled && isTerminalEnabled();
+  }
+
+  // ─── Render pipeline ─────────────────────────────────────────────────────
+
+  #maybeRender(): void {
+    const nowMs = Date.now();
+    let snapshot: TuiSnapshot | null = null;
+    try {
+      snapshot = this.#getSnapshot();
+    } catch {
+      // snapshot unavailable
+    }
+
+    const currentTokens = snapshot?.codexTotals.totalTokens ?? 0;
+
+    // Update token samples
+    if (snapshot !== null) {
+      this.#state.tokenSamples = updateTokenSamples(this.#state.tokenSamples, nowMs, currentTokens);
+    } else {
+      this.#state.tokenSamples = pruneTokenSamples(this.#state.tokenSamples, nowMs);
+    }
+
+    // Throttled TPS
+    const { second: tpsSecond, tps } = throttledTps(
+      this.#state.lastTpsSecond,
+      this.#state.lastTpsValue,
+      nowMs,
+      this.#state.tokenSamples,
+      currentTokens,
+    );
+    this.#state.lastTpsSecond = tpsSecond;
+    this.#state.lastTpsValue = tps;
+
+    // Snapshot fingerprinting
+    const fingerprint = snapshot !== null ? JSON.stringify(snapshot) : null;
+    const snapshotChanged = fingerprint !== this.#state.lastSnapshotFingerprint;
+    const periodicDue = isPeriodicRerenderDue(this.#state.lastRenderedAtMs, nowMs);
+
+    if (!snapshotChanged && !periodicDue) return;
+
+    if (snapshotChanged) {
+      this.#state.lastSnapshotFingerprint = fingerprint;
+    }
+
+    const content = formatSnapshotContent(snapshot, tps);
+    this.#maybeEnqueueRender(content, nowMs);
+  }
+
+  #maybeEnqueueRender(content: string, nowMs: number): void {
+    if (content === this.#state.lastRenderedContent) return;
+
+    if (isRenderNow(this.#state.lastRenderedAtMs, this.#state.renderIntervalMs)) {
+      this.#renderContent(content, nowMs);
+    } else {
+      this.#scheduleFlushRender(content, nowMs);
+    }
+  }
+
+  #scheduleFlushRender(content: string, nowMs: number): void {
+    this.#state.pendingContent = content;
+    if (this.#state.flushTimerRef !== null) return;
+
+    const delayMs = flushDelayMs(this.#state.lastRenderedAtMs, this.#state.renderIntervalMs, nowMs);
+    this.#state.flushTimerRef = setTimeout(() => {
+      this.#onFlushRender();
+    }, delayMs);
+  }
+
+  #onFlushRender(): void {
+    this.#state.flushTimerRef = null;
+    const content = this.#state.pendingContent;
+    this.#state.pendingContent = null;
+    if (content !== null) {
+      this.#renderContent(content, Date.now());
+    }
+  }
+
+  #renderContent(content: string, nowMs: number): void {
+    try {
+      this.#state.renderFn(content);
+      this.#state.lastRenderedContent = content;
+      this.#state.lastRenderedAtMs = nowMs;
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+// ─── Terminal output ──────────────────────────────────────────────────────
+
+function renderToTerminal(content: string): void {
+  process.stdout.write(`\x1b[H\x1b[2J${content}\n`);
+}
+
+function isTerminalEnabled(): boolean {
+  return process.env["NODE_ENV"] !== "test";
+}
+
+// ─── Snapshot formatter ───────────────────────────────────────────────────
+
+export function formatSnapshotContent(
+  snapshot: TuiSnapshot | null,
+  tps: number,
+  terminalColumnsOverride?: number,
+): string {
+  if (snapshot === null) {
+    return [
+      colorize("╭─ SYMPHONY STATUS", BOLD),
+      colorize("│ Orchestrator snapshot unavailable", RED),
+      colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
+      formatRefreshLine(null),
+      "╰─",
+    ]
+      .flat()
+      .join("\n");
+  }
+
+  const { running, retrying, codexTotals, rateLimits, polling } = snapshot;
+  const eventWidth = runningEventWidth(terminalColumnsOverride);
+  const runningRows = formatRunningRows(running, eventWidth);
+  const runningToBackoffSpacer = running.length > 0 ? ["│"] : [];
+  const backoffRows = formatRetryRows(retrying);
+
+  return [
+    colorize("╭─ SYMPHONY STATUS", BOLD),
+    colorize("│ Agents: ", BOLD) +
+      colorize(String(running.length), GREEN) +
+      colorize("/", GRAY) +
+      colorize("n/a", GRAY),
+    colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
+    colorize("│ Runtime: ", BOLD) + colorize(formatRuntimeSeconds(codexTotals.secondsRunning), MAGENTA),
+    colorize("│ Tokens: ", BOLD) +
+      colorize(`in ${formatCount(codexTotals.inputTokens)}`, YELLOW) +
+      colorize(" | ", GRAY) +
+      colorize(`out ${formatCount(codexTotals.outputTokens)}`, YELLOW) +
+      colorize(" | ", GRAY) +
+      colorize(`total ${formatCount(codexTotals.totalTokens)}`, YELLOW),
+    colorize("│ Rate Limits: ", BOLD) + formatRateLimits(rateLimits),
+    formatRefreshLine(polling),
+    colorize("├─ Running", BOLD),
+    "│",
+    runningTableHeaderRow(eventWidth),
+    runningTableSeparatorRow(eventWidth),
+    ...runningRows,
+    ...runningToBackoffSpacer,
+    colorize("├─ Backoff queue", BOLD),
+    "│",
+    ...backoffRows,
+    "╰─",
+  ]
+    .flat()
+    .join("\n");
+}
+
+// ─── Header helpers ───────────────────────────────────────────────────────
+
+function formatRefreshLine(polling: TuiSnapshot["polling"] | null): string {
+  if (polling === null || polling === undefined) {
+    return colorize("│ Next refresh: ", BOLD) + colorize("n/a", GRAY);
+  }
+  if (polling.checkingNow) {
+    return colorize("│ Next refresh: ", BOLD) + colorize("checking now…", CYAN);
+  }
+  const dueInMs = Math.max(0, polling.nextPollAtMs - Date.now());
+  const seconds = Math.ceil(dueInMs / 1000);
+  return colorize("│ Next refresh: ", BOLD) + colorize(`${String(seconds)}s`, CYAN);
+}
+
+function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
+  if (rateLimits === null || rateLimits === undefined) {
+    return colorize("unavailable", GRAY);
+  }
+  const { limitId, primary, secondary, credits } = rateLimits;
+  const idPart = colorize(limitId ?? "unknown", YELLOW);
+  const primaryPart = colorize(`primary ${formatRateLimitBucket(primary)}`, CYAN);
+  const secondaryPart = colorize(`secondary ${formatRateLimitBucket(secondary)}`, CYAN);
+  const creditsPart = colorize(credits ?? "credits n/a", GREEN);
+  return (
+    idPart +
+    colorize(" | ", GRAY) +
+    primaryPart +
+    colorize(" | ", GRAY) +
+    secondaryPart +
+    colorize(" | ", GRAY) +
+    creditsPart
+  );
+}
+
+function formatRateLimitBucket(
+  bucket: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null,
+): string {
+  if (bucket === null || bucket === undefined) return "n/a";
+  const resetSecs = Math.ceil(bucket.resetInMs / 1000);
+  return `${formatCount(bucket.used)}/${formatCount(bucket.limit)} reset ${String(resetSecs)}s`;
+}
+
+// ─── Running table ────────────────────────────────────────────────────────
+
+function runningTableHeaderRow(eventWidth: number): string {
+  const header = [
+    formatCell("ID", ID_WIDTH),
+    formatCell("STAGE", STAGE_WIDTH),
+    formatCell("PID", PID_WIDTH),
+    formatCell("AGE / TURN", AGE_WIDTH),
+    formatCell("TOKENS", TOKENS_WIDTH),
+    formatCell("SESSION", SESSION_WIDTH),
+    formatCell("EVENT", eventWidth),
+  ].join(" ");
+  return "│   " + colorize(header, GRAY);
+}
+
+function runningTableSeparatorRow(eventWidth: number): string {
+  const width =
+    ID_WIDTH +
+    STAGE_WIDTH +
+    PID_WIDTH +
+    AGE_WIDTH +
+    TOKENS_WIDTH +
+    SESSION_WIDTH +
+    eventWidth +
+    6;
+  return "│   " + colorize("─".repeat(width), GRAY);
+}
+
+function formatRunningRows(
+  running: TuiSnapshot["running"],
+  eventWidth: number,
+): string[] {
+  if (running.length === 0) {
+    return ["│  " + colorize("No active agents", GRAY), "│"];
+  }
+  return running.map((entry) => formatRunningRow(entry, eventWidth));
+}
+
+function formatRunningRow(
+  entry: TuiSnapshot["running"][number],
+  eventWidth: number,
+): string {
+  const runtimeSecs = Math.floor((Date.now() - entry.startedAt.getTime()) / 1000);
+  const issue = formatCell(entry.identifier, ID_WIDTH);
+  const stage = formatCell("working", STAGE_WIDTH);
+  const pid = formatCell(entry.codexAppServerPid !== null ? String(entry.codexAppServerPid) : "n/a", PID_WIDTH);
+  const age = formatCell(formatRuntimeAndTurns(runtimeSecs, entry.turnCount), AGE_WIDTH);
+  const tokens = formatCell(formatCount(entry.codexTotalTokens), TOKENS_WIDTH, "right");
+  const session = formatCell(compactSessionId(entry.sessionId), SESSION_WIDTH);
+  const eventLabel = formatCell(humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent), eventWidth);
+
+  const statusColor = statusDotColor(entry.lastCodexEvent);
+
+  return (
+    "│ " +
+    colorize("●", statusColor) +
+    " " +
+    colorize(issue, CYAN) +
+    " " +
+    colorize(stage, statusColor) +
+    " " +
+    colorize(pid, YELLOW) +
+    " " +
+    colorize(age, MAGENTA) +
+    " " +
+    colorize(tokens, YELLOW) +
+    " " +
+    colorize(session, CYAN) +
+    " " +
+    colorize(eventLabel, statusColor)
+  );
+}
+
+function statusDotColor(event: string | null): string {
+  if (event === null || event === "none") return RED;
+  if (event === "codex/event/token_count") return YELLOW;
+  if (event === "codex/event/task_started") return GREEN;
+  if (event === "turn_completed") return MAGENTA;
+  return BLUE;
+}
+
+// ─── Backoff queue ────────────────────────────────────────────────────────
+
+function formatRetryRows(retrying: TuiSnapshot["retrying"]): string[] {
+  if (retrying.length === 0) {
+    return ["│  " + colorize("No queued retries", GRAY)];
+  }
+  return retrying.map((entry) => {
+    const dueStr = formatDueIn(entry.dueInMs);
+    const errorPart =
+      entry.lastError.trim() !== ""
+        ? " " + colorize(`error=${sanitizeRetryError(entry.lastError)}`, DIM)
+        : "";
+    return (
+      "│  " +
+      colorize("↻", YELLOW) +
+      " " +
+      colorize(entry.identifier, RED) +
+      " " +
+      colorize(`attempt=${String(entry.nextAttempt)}`, YELLOW) +
+      colorize(" in ", DIM) +
+      colorize(dueStr, CYAN) +
+      errorPart
+    );
+  });
+}
+
+function formatDueIn(ms: number): string {
+  const secs = Math.floor(ms / 1000);
+  const millis = ms % 1000;
+  return `${String(secs)}.${String(millis).padStart(3, "0")}s`;
+}
+
+function sanitizeRetryError(error: string): string {
+  const cleaned = error
+    .replace(/\r\n/g, " ")
+    .replace(/\r/g, " ")
+    .replace(/\n/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return truncate(cleaned, 96);
+}
+
+// ─── TPS calculation ──────────────────────────────────────────────────────
+
+export function rollingTps(
+  samples: readonly TokenSample[],
+  nowMs: number,
+  currentTokens: number,
+): number {
+  const updated: TokenSample[] = [[nowMs, currentTokens], ...samples];
+  const pruned = pruneTokenSamples(updated, nowMs);
+
+  if (pruned.length < 2) return 0;
+
+  const oldest = pruned[pruned.length - 1]!;
+  const [oldestMs, oldestTokens] = oldest;
+  const elapsedMs = nowMs - oldestMs;
+  const deltaTokens = Math.max(0, currentTokens - oldestTokens);
+
+  if (elapsedMs <= 0) return 0;
+  return deltaTokens / (elapsedMs / 1000);
+}
+
+export function throttledTps(
+  lastSecond: number | null,
+  lastValue: number,
+  nowMs: number,
+  samples: readonly TokenSample[],
+  currentTokens: number,
+): { second: number; tps: number } {
+  const second = Math.floor(nowMs / 1000);
+  if (lastSecond !== null && lastSecond === second) {
+    return { second, tps: lastValue };
+  }
+  return { second, tps: rollingTps(samples, nowMs, currentTokens) };
+}
+
+function updateTokenSamples(
+  samples: TokenSample[],
+  nowMs: number,
+  totalTokens: number,
+): TokenSample[] {
+  return pruneTokenSamples([[nowMs, totalTokens], ...samples], nowMs);
+}
+
+function pruneTokenSamples(samples: readonly TokenSample[], nowMs: number): TokenSample[] {
+  const minTs = nowMs - THROUGHPUT_WINDOW_MS;
+  return samples.filter(([ts]) => ts >= minTs) as TokenSample[];
+}
+
+// ─── Render timing helpers ────────────────────────────────────────────────
+
+function isPeriodicRerenderDue(lastRenderedAtMs: number | null, nowMs: number): boolean {
+  if (lastRenderedAtMs === null) return true;
+  return nowMs - lastRenderedAtMs >= MINIMUM_IDLE_RERENDER_MS;
+}
+
+function isRenderNow(lastRenderedAtMs: number | null, renderIntervalMs: number): boolean {
+  if (lastRenderedAtMs === null) return true;
+  return Date.now() - lastRenderedAtMs >= renderIntervalMs;
+}
+
+function flushDelayMs(
+  lastRenderedAtMs: number | null,
+  renderIntervalMs: number,
+  nowMs: number,
+): number {
+  if (lastRenderedAtMs === null) return 1;
+  const remaining = renderIntervalMs - (nowMs - lastRenderedAtMs);
+  return Math.max(1, remaining);
+}
+
+// ─── Formatting helpers ───────────────────────────────────────────────────
+
+function formatTps(value: number): string {
+  return formatCount(Math.floor(value));
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function formatRuntimeSeconds(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins)}m ${String(secs)}s`;
+}
+
+function formatRuntimeAndTurns(seconds: number, turnCount: number): string {
+  if (turnCount > 0) {
+    return `${formatRuntimeSeconds(seconds)} / ${String(turnCount)}`;
+  }
+  return formatRuntimeSeconds(seconds);
+}
+
+function formatCell(value: string, width: number, align: "left" | "right" = "left"): string {
+  const cleaned = value.replace(/\n/g, " ").replace(/\s+/g, " ").trim();
+  const truncated = truncatePlain(cleaned, width);
+  return align === "right"
+    ? truncated.padStart(width)
+    : truncated.padEnd(width);
+}
+
+function truncatePlain(value: string, width: number): string {
+  if (value.length <= width) return value;
+  return value.slice(0, width - 3) + "...";
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max) + "...";
+}
+
+function compactSessionId(sessionId: string | null): string {
+  if (sessionId === null || sessionId === undefined) return "n/a";
+  if (sessionId.length > 10) {
+    return sessionId.slice(0, 4) + "..." + sessionId.slice(-6);
+  }
+  return sessionId;
+}
+
+function runningEventWidth(terminalColumnsOverride?: number): number {
+  const cols = terminalColumnsOverride ?? terminalColumns();
+  const fixedWidth =
+    ID_WIDTH + STAGE_WIDTH + PID_WIDTH + AGE_WIDTH + TOKENS_WIDTH + SESSION_WIDTH;
+  return Math.max(EVENT_MIN_WIDTH, cols - fixedWidth - ROW_CHROME_WIDTH);
+}
+
+function terminalColumns(): number {
+  const envCols = process.env["COLUMNS"];
+  if (envCols !== undefined) {
+    const parsed = parseInt(envCols.trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  // Node.js stdout columns
+  const cols = process.stdout.columns;
+  if (typeof cols === "number" && cols > 0) return cols;
+  return DEFAULT_TERMINAL_COLUMNS;
+}
+
+// ─── Event humanizer ─────────────────────────────────────────────────────
+
+export function humanizeEvent(
+  message: unknown,
+  eventType: string | null,
+): string {
+  if (message === null || message === undefined) return "no codex message yet";
+  const payload = unwrapPayload(message);
+  const byEvent = eventType !== null ? humanizeByEvent(eventType, message, payload) : null;
+  return truncate(byEvent ?? humanizePayload(payload), 140);
+}
+
+function unwrapPayload(message: unknown): unknown {
+  if (message === null || typeof message !== "object" || Array.isArray(message)) {
+    return message;
+  }
+  const obj = message as Record<string, unknown>;
+  if (typeof getKey(obj, "method") === "string") return message;
+  if (typeof getKey(obj, "session_id") === "string") return message;
+  if (typeof getKey(obj, "reason") === "string") return message;
+  return getKey(obj, "payload") ?? message;
+}
+
+function humanizeByEvent(event: string, message: unknown, payload: unknown): string | null {
+  // Wrapper events
+  if (event.startsWith("codex/event/")) {
+    return humanizeWrapperEvent(event.slice("codex/event/".length), payload);
+  }
+  // Legacy event atoms
+  switch (event) {
+    case "session_started": {
+      const sessionId = getMapKey(payload, ["session_id", "sessionId"]);
+      return typeof sessionId === "string"
+        ? `session started (${sessionId})`
+        : "session started";
+    }
+    case "turn_input_required":
+      return "turn blocked: waiting for user input";
+    case "turn_ended_with_error":
+      return `turn ended with error: ${formatReason(message)}`;
+    case "startup_failed":
+      return `startup failed: ${formatReason(message)}`;
+    case "turn_failed":
+      return humanizeMethod("turn/failed", payload) ?? "turn failed";
+    case "turn_cancelled":
+      return "turn cancelled";
+    case "malformed":
+      return "malformed JSON event from codex";
+    default:
+      return null;
+  }
+}
+
+function humanizeWrapperEvent(suffix: string, payload: unknown): string {
+  switch (suffix) {
+    case "task_started": return "task started";
+    case "user_message": return "user message received";
+    case "mcp_startup_complete": return "mcp startup complete";
+    case "exec_command_output_delta": return "command output streaming";
+    case "mcp_tool_call_begin": return "mcp tool call started";
+    case "mcp_tool_call_end": return "mcp tool call completed";
+    case "agent_reasoning_section_break": return "reasoning section break";
+    case "turn_diff": return "turn diff updated";
+    case "agent_message_delta": return humanizeStreamingEvent("agent message streaming", payload);
+    case "agent_message_content_delta": return humanizeStreamingEvent("agent message content streaming", payload);
+    case "agent_reasoning_delta": return humanizeStreamingEvent("reasoning streaming", payload);
+    case "reasoning_content_delta": return humanizeStreamingEvent("reasoning content streaming", payload);
+    case "agent_reasoning": return humanizeReasoningUpdate(payload);
+    case "exec_command_begin": return humanizeExecCommandBegin(payload);
+    case "exec_command_end": return humanizeExecCommandEnd(payload);
+    case "token_count": {
+      const usage = extractFirstPath(payload, TOKEN_USAGE_PATHS);
+      const usageText = formatUsageCounts(usage);
+      return usageText !== null ? `token count update (${usageText})` : "token count update";
+    }
+    case "mcp_startup_update": {
+      const server =
+        mapPath(payload, ["params", "msg", "server"]) ?? "mcp";
+      const state =
+        mapPath(payload, ["params", "msg", "status", "state"]) ?? "updated";
+      return `mcp startup: ${String(server)} ${String(state)}`;
+    }
+    case "item_started": {
+      const t = wrapperPayloadType(payload);
+      if (t === "token_count") return humanizeWrapperEvent("token_count", payload);
+      return typeof t === "string" ? `item started (${humanizeItemType(t)})` : "item started";
+    }
+    case "item_completed": {
+      const t = wrapperPayloadType(payload);
+      if (t === "token_count") return humanizeWrapperEvent("token_count", payload);
+      return typeof t === "string" ? `item completed (${humanizeItemType(t)})` : "item completed";
+    }
+    default: {
+      const msgType = mapPath(payload, ["params", "msg", "type"]);
+      return typeof msgType === "string" ? `${suffix} (${msgType})` : suffix;
+    }
+  }
+}
+
+function humanizePayload(payload: unknown): string {
+  if (typeof payload === "string") {
+    return sanitize(payload);
+  }
+  if (payload === null || payload === undefined) {
+    return "no codex message yet";
+  }
+  if (typeof payload === "object" && !Array.isArray(payload)) {
+    const method = getKey(payload as Record<string, unknown>, "method");
+    if (typeof method === "string") {
+      return humanizeMethod(method, payload) ?? method;
+    }
+    const sessionId = getKey(payload as Record<string, unknown>, "session_id");
+    if (typeof sessionId === "string") {
+      return `session started (${sessionId})`;
+    }
+  }
+  return sanitize(JSON.stringify(payload).slice(0, 80));
+}
+
+function humanizeMethod(method: string, payload: unknown): string | null {
+  switch (method) {
+    case "thread/started": {
+      const threadId = mapPath(payload, ["params", "thread", "id"]);
+      return typeof threadId === "string"
+        ? `thread started (${threadId})`
+        : "thread started";
+    }
+    case "turn/started": {
+      const turnId = mapPath(payload, ["params", "turn", "id"]);
+      return typeof turnId === "string"
+        ? `turn started (${turnId})`
+        : "turn started";
+    }
+    case "turn/completed": {
+      const status =
+        mapPath(payload, ["params", "turn", "status"]) ?? "completed";
+      const usage =
+        mapPath(payload, ["params", "usage"]) ??
+        mapPath(payload, ["params", "tokenUsage"]) ??
+        getMapKey(payload, ["usage"]);
+      const usageText = formatUsageCounts(usage);
+      const suffix = usageText !== null ? ` (${usageText})` : "";
+      return `turn completed (${String(status)})${suffix}`;
+    }
+    case "turn/failed": {
+      const errMsg = mapPath(payload, ["params", "error", "message"]);
+      return typeof errMsg === "string" ? `turn failed: ${errMsg}` : "turn failed";
+    }
+    case "turn/cancelled":
+      return "turn cancelled";
+    case "turn/diff/updated": {
+      const diff = mapPath(payload, ["params", "diff"]);
+      if (typeof diff === "string" && diff !== "") {
+        const lines = diff.split("\n").filter((l) => l.trim() !== "").length;
+        return `turn diff updated (${String(lines)} lines)`;
+      }
+      return "turn diff updated";
+    }
+    case "turn/plan/updated": {
+      const plan =
+        mapPath(payload, ["params", "plan"]) ??
+        mapPath(payload, ["params", "steps"]) ??
+        mapPath(payload, ["params", "items"]);
+      return Array.isArray(plan)
+        ? `plan updated (${String(plan.length)} steps)`
+        : "plan updated";
+    }
+    case "thread/tokenUsage/updated": {
+      const usage =
+        mapPath(payload, ["params", "tokenUsage", "total"]) ??
+        getMapKey(payload, ["usage"]);
+      const text = formatUsageCounts(usage);
+      return text !== null
+        ? `thread token usage updated (${text})`
+        : "thread token usage updated";
+    }
+    case "item/started":
+      return humanizeItemLifecycle("started", payload);
+    case "item/completed":
+      return humanizeItemLifecycle("completed", payload);
+    case "item/agentMessage/delta":
+      return humanizeStreamingEvent("agent message streaming", payload);
+    case "item/plan/delta":
+      return humanizeStreamingEvent("plan streaming", payload);
+    case "item/reasoning/summaryTextDelta":
+      return humanizeStreamingEvent("reasoning summary streaming", payload);
+    case "item/reasoning/summaryPartAdded":
+      return humanizeStreamingEvent("reasoning summary section added", payload);
+    case "item/reasoning/textDelta":
+      return humanizeStreamingEvent("reasoning text streaming", payload);
+    case "item/commandExecution/outputDelta":
+      return humanizeStreamingEvent("command output streaming", payload);
+    case "item/fileChange/outputDelta":
+      return humanizeStreamingEvent("file change output streaming", payload);
+    case "item/commandExecution/requestApproval": {
+      const cmd = extractCommand(payload);
+      return typeof cmd === "string"
+        ? `command approval requested (${cmd})`
+        : "command approval requested";
+    }
+    case "item/fileChange/requestApproval": {
+      const count = mapPath(payload, ["params", "fileChangeCount"]) ??
+        mapPath(payload, ["params", "changeCount"]);
+      return typeof count === "number" && count > 0
+        ? `file change approval requested (${String(count)} files)`
+        : "file change approval requested";
+    }
+    case "item/tool/requestUserInput":
+    case "tool/requestUserInput": {
+      const q =
+        mapPath(payload, ["params", "question"]) ??
+        mapPath(payload, ["params", "prompt"]);
+      return typeof q === "string" && q.trim() !== ""
+        ? `tool requires user input: ${inlineText(q)}`
+        : "tool requires user input";
+    }
+    case "item/tool/call": {
+      const tool =
+        mapPath(payload, ["params", "tool"]) ??
+        mapPath(payload, ["params", "name"]);
+      return typeof tool === "string" && tool.trim() !== ""
+        ? `dynamic tool call requested (${tool.trim()})`
+        : "dynamic tool call requested";
+    }
+    case "account/updated": {
+      const auth = mapPath(payload, ["params", "authMode"]) ?? "unknown";
+      return `account updated (auth ${String(auth)})`;
+    }
+    case "account/rateLimits/updated":
+      return "rate limits updated";
+    case "account/chatgptAuthTokens/refresh":
+      return "account auth token refresh requested";
+    default: {
+      if (method.startsWith("codex/event/")) {
+        return humanizeWrapperEvent(method.slice("codex/event/".length), payload);
+      }
+      const msgType = mapPath(payload, ["params", "msg", "type"]);
+      return typeof msgType === "string" ? `${method} (${msgType})` : method;
+    }
+  }
+}
+
+function humanizeItemLifecycle(state: string, payload: unknown): string {
+  const item =
+    (mapPath(payload, ["params", "item"]) as Record<string, unknown> | null) ??
+    {};
+  const itemType = humanizeItemType(
+    typeof getMapKey(item, ["type"]) === "string"
+      ? (getMapKey(item, ["type"]) as string)
+      : null,
+  );
+  const itemStatus = getMapKey(item, ["status"]);
+  const itemId = getMapKey(item, ["id"]);
+  const details: string[] = [];
+  if (typeof itemId === "string" && itemId.length > 0) {
+    details.push(itemId.length > 12 ? itemId.slice(0, 12) : itemId);
+  }
+  if (typeof itemStatus === "string" && itemStatus.trim() !== "") {
+    details.push(humanizeStatus(itemStatus));
+  }
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `item ${state}: ${itemType}${suffix}`;
+}
+
+function humanizeItemType(type: string | null): string {
+  if (type === null || type === undefined) return "item";
+  return type
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .replace(/\//g, " ")
+    .toLowerCase()
+    .trim();
+}
+
+function humanizeStatus(status: string): string {
+  return status.replace(/_/g, " ").replace(/-/g, " ").toLowerCase().trim();
+}
+
+function humanizeStreamingEvent(label: string, payload: unknown): string {
+  const preview = extractDeltaPreview(payload);
+  return preview !== null ? `${label}: ${preview}` : label;
+}
+
+function humanizeReasoningUpdate(payload: unknown): string {
+  const focus = extractReasoningFocus(payload);
+  return focus !== null ? `reasoning update: ${focus}` : "reasoning update";
+}
+
+function humanizeExecCommandBegin(payload: unknown): string {
+  const command = extractCommand(payload);
+  return typeof command === "string" ? command : "command started";
+}
+
+function humanizeExecCommandEnd(payload: unknown): string {
+  const exitCode =
+    mapPath(payload, ["params", "msg", "exit_code"]) ??
+    mapPath(payload, ["params", "msg", "exitCode"]);
+  return typeof exitCode === "number"
+    ? `command completed (exit ${String(exitCode)})`
+    : "command completed";
+}
+
+function extractCommand(payload: unknown): string | null {
+  const parsedCmd = mapPath(payload, ["params", "parsedCmd"]);
+  const raw =
+    parsedCmd ??
+    mapPath(payload, ["params", "msg", "command"]) ??
+    mapPath(payload, ["params", "command"]) ??
+    mapPath(payload, ["params", "cmd"]) ??
+    mapPath(payload, ["params", "argv"]) ??
+    mapPath(payload, ["params", "args"]);
+  return normalizeCommand(raw);
+}
+
+function normalizeCommand(cmd: unknown): string | null {
+  if (typeof cmd === "string") return inlineText(cmd);
+  if (Array.isArray(cmd) && cmd.every((c) => typeof c === "string")) {
+    return inlineText((cmd as string[]).join(" "));
+  }
+  if (cmd !== null && typeof cmd === "object") {
+    const obj = cmd as Record<string, unknown>;
+    const binary = getMapKey(obj, ["parsedCmd", "command", "cmd"]);
+    const args = getMapKey(obj, ["args", "argv"]);
+    if (typeof binary === "string" && Array.isArray(args)) {
+      return normalizeCommand([binary, ...(args as string[])]);
+    }
+    return normalizeCommand(binary ?? args);
+  }
+  return null;
+}
+
+function extractDeltaPreview(payload: unknown): string | null {
+  const delta = extractFirstPath(payload, DELTA_PATHS);
+  if (typeof delta === "string") {
+    const trimmed = delta.trim();
+    return trimmed !== "" ? inlineText(trimmed) : null;
+  }
+  return null;
+}
+
+function extractReasoningFocus(payload: unknown): string | null {
+  const value = extractFirstPath(payload, REASONING_FOCUS_PATHS);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed !== "" ? inlineText(trimmed) : null;
+  }
+  return null;
+}
+
+function formatUsageCounts(usage: unknown): string | null {
+  if (usage === null || typeof usage !== "object" || Array.isArray(usage)) {
+    return null;
+  }
+  const obj = usage as Record<string, unknown>;
+  const input = parseInteger(
+    getMapKey(obj, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]),
+  );
+  const output = parseInteger(
+    getMapKey(obj, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]),
+  );
+  const total = parseInteger(
+    getMapKey(obj, ["total_tokens", "totalTokens", "total"]),
+  );
+  const parts: string[] = [];
+  if (input !== null) parts.push(`in ${formatCount(input)}`);
+  if (output !== null) parts.push(`out ${formatCount(output)}`);
+  if (total !== null) parts.push(`total ${formatCount(total)}`);
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+function formatReason(message: unknown): string {
+  if (message !== null && typeof message === "object") {
+    const reason = getMapKey(message as Record<string, unknown>, ["reason"]);
+    if (reason !== null && reason !== undefined) {
+      return formatErrorValue(reason);
+    }
+    return sanitize(JSON.stringify(message).slice(0, 80));
+  }
+  return formatErrorValue(message);
+}
+
+function formatErrorValue(error: unknown): string {
+  if (error !== null && typeof error === "object") {
+    const msg = (error as Record<string, unknown>)["message"];
+    if (typeof msg === "string") return msg;
+  }
+  return sanitize(String(error).slice(0, 80));
+}
+
+function wrapperPayloadType(payload: unknown): unknown {
+  return (
+    mapPath(payload, ["params", "msg", "payload", "type"]) ?? undefined
+  );
+}
+
+function inlineText(text: string): string {
+  return truncate(text.replace(/\n/g, " ").replace(/\s+/g, " ").trim(), 80);
+}
+
+function sanitize(value: string): string {
+  return value
+    .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
+    .replace(/\x1b./g, "")
+    .replace(/[\x00-\x1f\x7f]/g, "")
+    .replace(/\n/g, " ")
+    .trim();
+}
+
+function parseInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string") {
+    const parsed = parseInt(value.trim(), 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+// ─── Map helpers ─────────────────────────────────────────────────────────
+
+function getKey(obj: Record<string, unknown>, key: string): unknown {
+  if (Object.hasOwn(obj, key)) return obj[key];
+  // camelCase fallback
+  const camel = key.replace(/_([a-z])/g, (_, c: string) => (c as string).toUpperCase());
+  if (camel !== key && Object.hasOwn(obj, camel)) return obj[camel];
+  // snake_case fallback
+  const snake = key.replace(/([A-Z])/g, "_$1").toLowerCase();
+  if (snake !== key && Object.hasOwn(obj, snake)) return obj[snake];
+  return undefined;
+}
+
+function getMapKey(obj: unknown, keys: string[]): unknown {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) return undefined;
+  const record = obj as Record<string, unknown>;
+  for (const key of keys) {
+    const val = getKey(record, key);
+    if (val !== undefined && val !== null) return val;
+  }
+  return undefined;
+}
+
+function mapPath(obj: unknown, path: string[]): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (current === null || current === undefined || typeof current !== "object" || Array.isArray(current)) {
+      return undefined;
+    }
+    current = getKey(current as Record<string, unknown>, key);
+  }
+  return current;
+}
+
+function extractFirstPath(payload: unknown, paths: readonly (readonly string[])[]): unknown {
+  for (const path of paths) {
+    const val = mapPath(payload, path as string[]);
+    if (val !== null && val !== undefined) return val;
+  }
+  return undefined;
+}
+
+// ─── Path constants ───────────────────────────────────────────────────────
+
+const TOKEN_USAGE_PATHS = [
+  ["params", "msg", "payload", "info", "total_token_usage"],
+  ["params", "msg", "info", "total_token_usage"],
+  ["params", "tokenUsage", "total"],
+] as const;
+
+const DELTA_PATHS = [
+  ["params", "delta"],
+  ["params", "msg", "delta"],
+  ["params", "textDelta"],
+  ["params", "msg", "textDelta"],
+  ["params", "outputDelta"],
+  ["params", "msg", "outputDelta"],
+  ["params", "text"],
+  ["params", "msg", "text"],
+  ["params", "summaryText"],
+  ["params", "msg", "summaryText"],
+  ["params", "msg", "content"],
+  ["params", "msg", "payload", "delta"],
+  ["params", "msg", "payload", "textDelta"],
+  ["params", "msg", "payload", "outputDelta"],
+  ["params", "msg", "payload", "text"],
+  ["params", "msg", "payload", "summaryText"],
+  ["params", "msg", "payload", "content"],
+] as const;
+
+const REASONING_FOCUS_PATHS = [
+  ["params", "reason"],
+  ["params", "summaryText"],
+  ["params", "summary"],
+  ["params", "text"],
+  ["params", "msg", "reason"],
+  ["params", "msg", "summaryText"],
+  ["params", "msg", "summary"],
+  ["params", "msg", "text"],
+  ["params", "msg", "payload", "reason"],
+  ["params", "msg", "payload", "summaryText"],
+  ["params", "msg", "payload", "summary"],
+  ["params", "msg", "payload", "text"],
+] as const;

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -491,7 +491,7 @@ function formatRetryRows(retrying: TuiSnapshot["retrying"]): string[] {
   return retrying.map((entry) => {
     const dueStr = formatDueIn(entry.dueInMs);
     const errorPart =
-      entry.lastError.trim() !== ""
+      entry.lastError !== null && entry.lastError.trim() !== ""
         ? " " + colorize(`error=${sanitizeRetryError(entry.lastError)}`, DIM)
         : "";
     return (

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -383,7 +383,7 @@ export function formatSnapshotContent(
 // ─── Header helpers ───────────────────────────────────────────────────────
 
 function formatRefreshLine(polling: TuiSnapshot["polling"] | null): string {
-  if (polling === null || polling === undefined) {
+  if (polling === null) {
     return colorize("│ Next refresh: ", BOLD) + colorize("n/a", GRAY);
   }
   if (polling.checkingNow) {
@@ -397,7 +397,7 @@ function formatRefreshLine(polling: TuiSnapshot["polling"] | null): string {
 }
 
 function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
-  if (rateLimits === null || rateLimits === undefined) {
+  if (rateLimits === null) {
     return colorize("unavailable", GRAY);
   }
   const { limitId, primary, secondary, credits } = rateLimits;
@@ -429,7 +429,7 @@ function formatRateLimitBucket(
     readonly resetInMs: number;
   } | null,
 ): string {
-  if (bucket === null || bucket === undefined) return "n/a";
+  if (bucket === null) return "n/a";
   const resetSecs = Math.ceil(bucket.resetInMs / 1000);
   return `${formatCount(bucket.used)}/${formatCount(bucket.limit)} reset ${String(resetSecs)}s`;
 }
@@ -755,7 +755,7 @@ function truncate(value: string, max: number): string {
 }
 
 function compactSessionId(sessionId: string | null): string {
-  if (sessionId === null || sessionId === undefined) return "n/a";
+  if (sessionId === null) return "n/a";
   if (sessionId.length > 10) {
     return sessionId.slice(0, 4) + "..." + sessionId.slice(-6);
   }
@@ -1088,7 +1088,7 @@ function humanizeItemLifecycle(state: string, payload: unknown): string {
 }
 
 function humanizeItemType(type: string | null): string {
-  if (type === null || type === undefined) return "item";
+  if (type === null) return "item";
   return type
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/_/g, " ")

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -526,7 +526,7 @@ function statusDotColor(event: string | null): string {
   if (event === null || event === "none") return RED;
   if (event === "codex/event/token_count") return YELLOW;
   if (event === "codex/event/task_started") return GREEN;
-  if (event === "turn_completed") return MAGENTA;
+  if (event === "turn/completed") return MAGENTA;
   return BLUE;
 }
 
@@ -719,8 +719,9 @@ function formatCount(value: number): string {
 }
 
 function formatRuntimeSeconds(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
+  const total = Math.floor(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
   return `${String(mins)}m ${String(secs)}s`;
 }
 

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -294,18 +294,31 @@ export function formatSnapshotContent(
       .join("\n");
   }
 
-  const { running, retrying, codexTotals, rateLimits, polling } = snapshot;
+  const {
+    running,
+    retrying,
+    codexTotals,
+    rateLimits,
+    polling,
+    maxConcurrentRuns,
+    projectUrl,
+  } = snapshot;
   const eventWidth = runningEventWidth(terminalColumnsOverride);
   const runningRows = formatRunningRows(running, eventWidth);
   const runningToBackoffSpacer = running.length > 0 ? ["│"] : [];
   const backoffRows = formatRetryRows(retrying);
+
+  const projectLine =
+    projectUrl !== null
+      ? [colorize("│ Project: ", BOLD) + colorize(projectUrl, CYAN)]
+      : [];
 
   return [
     colorize("╭─ SYMPHONY STATUS", BOLD),
     colorize("│ Agents: ", BOLD) +
       colorize(String(running.length), GREEN) +
       colorize("/", GRAY) +
-      colorize("n/a", GRAY),
+      colorize(String(maxConcurrentRuns), GRAY),
     colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
     colorize("│ Runtime: ", BOLD) +
       colorize(formatRuntimeSeconds(codexTotals.secondsRunning), MAGENTA),
@@ -316,6 +329,7 @@ export function formatSnapshotContent(
       colorize(" | ", GRAY) +
       colorize(`total ${formatCount(codexTotals.totalTokens)}`, YELLOW),
     colorize("│ Rate Limits: ", BOLD) + formatRateLimits(rateLimits),
+    ...projectLine,
     formatRefreshLine(polling),
     colorize("├─ Running", BOLD),
     "│",
@@ -432,7 +446,7 @@ function formatRunningRow(
     (Date.now() - entry.startedAt.getTime()) / 1000,
   );
   const issue = formatCell(entry.identifier, ID_WIDTH);
-  const stage = formatCell("working", STAGE_WIDTH);
+  const stage = formatCell(entry.issueState, STAGE_WIDTH);
   const pid = formatCell(
     entry.codexAppServerPid !== null ? String(entry.codexAppServerPid) : "n/a",
     PID_WIDTH,

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -84,7 +84,8 @@ export class StatusDashboard {
     this.#getConfig = getConfig;
 
     const config = getConfig();
-    const enabled = options?.enabled ?? (config.dashboardEnabled && isTerminalEnabled());
+    const enabled =
+      options?.enabled ?? (config.dashboardEnabled && isTerminalEnabled());
 
     this.#state = {
       refreshMs: options?.refreshMs ?? config.refreshMs,
@@ -176,9 +177,16 @@ export class StatusDashboard {
 
     // Update token samples
     if (snapshot !== null) {
-      this.#state.tokenSamples = updateTokenSamples(this.#state.tokenSamples, nowMs, currentTokens);
+      this.#state.tokenSamples = updateTokenSamples(
+        this.#state.tokenSamples,
+        nowMs,
+        currentTokens,
+      );
     } else {
-      this.#state.tokenSamples = pruneTokenSamples(this.#state.tokenSamples, nowMs);
+      this.#state.tokenSamples = pruneTokenSamples(
+        this.#state.tokenSamples,
+        nowMs,
+      );
     }
 
     // Throttled TPS
@@ -195,7 +203,10 @@ export class StatusDashboard {
     // Snapshot fingerprinting
     const fingerprint = snapshot !== null ? JSON.stringify(snapshot) : null;
     const snapshotChanged = fingerprint !== this.#state.lastSnapshotFingerprint;
-    const periodicDue = isPeriodicRerenderDue(this.#state.lastRenderedAtMs, nowMs);
+    const periodicDue = isPeriodicRerenderDue(
+      this.#state.lastRenderedAtMs,
+      nowMs,
+    );
 
     if (!snapshotChanged && !periodicDue) return;
 
@@ -210,7 +221,9 @@ export class StatusDashboard {
   #maybeEnqueueRender(content: string, nowMs: number): void {
     if (content === this.#state.lastRenderedContent) return;
 
-    if (isRenderNow(this.#state.lastRenderedAtMs, this.#state.renderIntervalMs)) {
+    if (
+      isRenderNow(this.#state.lastRenderedAtMs, this.#state.renderIntervalMs)
+    ) {
       this.#renderContent(content, nowMs);
     } else {
       this.#scheduleFlushRender(content, nowMs);
@@ -221,7 +234,11 @@ export class StatusDashboard {
     this.#state.pendingContent = content;
     if (this.#state.flushTimerRef !== null) return;
 
-    const delayMs = flushDelayMs(this.#state.lastRenderedAtMs, this.#state.renderIntervalMs, nowMs);
+    const delayMs = flushDelayMs(
+      this.#state.lastRenderedAtMs,
+      this.#state.renderIntervalMs,
+      nowMs,
+    );
     this.#state.flushTimerRef = setTimeout(() => {
       this.#onFlushRender();
     }, delayMs);
@@ -268,7 +285,8 @@ export function formatSnapshotContent(
     return [
       colorize("╭─ SYMPHONY STATUS", BOLD),
       colorize("│ Orchestrator snapshot unavailable", RED),
-      colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
+      colorize("│ Throughput: ", BOLD) +
+        colorize(`${formatTps(tps)} tps`, CYAN),
       formatRefreshLine(null),
       "╰─",
     ]
@@ -289,7 +307,8 @@ export function formatSnapshotContent(
       colorize("/", GRAY) +
       colorize("n/a", GRAY),
     colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
-    colorize("│ Runtime: ", BOLD) + colorize(formatRuntimeSeconds(codexTotals.secondsRunning), MAGENTA),
+    colorize("│ Runtime: ", BOLD) +
+      colorize(formatRuntimeSeconds(codexTotals.secondsRunning), MAGENTA),
     colorize("│ Tokens: ", BOLD) +
       colorize(`in ${formatCount(codexTotals.inputTokens)}`, YELLOW) +
       colorize(" | ", GRAY) +
@@ -324,7 +343,9 @@ function formatRefreshLine(polling: TuiSnapshot["polling"] | null): string {
   }
   const dueInMs = Math.max(0, polling.nextPollAtMs - Date.now());
   const seconds = Math.ceil(dueInMs / 1000);
-  return colorize("│ Next refresh: ", BOLD) + colorize(`${String(seconds)}s`, CYAN);
+  return (
+    colorize("│ Next refresh: ", BOLD) + colorize(`${String(seconds)}s`, CYAN)
+  );
 }
 
 function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
@@ -333,8 +354,14 @@ function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
   }
   const { limitId, primary, secondary, credits } = rateLimits;
   const idPart = colorize(limitId ?? "unknown", YELLOW);
-  const primaryPart = colorize(`primary ${formatRateLimitBucket(primary)}`, CYAN);
-  const secondaryPart = colorize(`secondary ${formatRateLimitBucket(secondary)}`, CYAN);
+  const primaryPart = colorize(
+    `primary ${formatRateLimitBucket(primary)}`,
+    CYAN,
+  );
+  const secondaryPart = colorize(
+    `secondary ${formatRateLimitBucket(secondary)}`,
+    CYAN,
+  );
   const creditsPart = colorize(credits ?? "credits n/a", GREEN);
   return (
     idPart +
@@ -348,7 +375,11 @@ function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
 }
 
 function formatRateLimitBucket(
-  bucket: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null,
+  bucket: {
+    readonly used: number;
+    readonly limit: number;
+    readonly resetInMs: number;
+  } | null,
 ): string {
   if (bucket === null || bucket === undefined) return "n/a";
   const resetSecs = Math.ceil(bucket.resetInMs / 1000);
@@ -397,14 +428,29 @@ function formatRunningRow(
   entry: TuiSnapshot["running"][number],
   eventWidth: number,
 ): string {
-  const runtimeSecs = Math.floor((Date.now() - entry.startedAt.getTime()) / 1000);
+  const runtimeSecs = Math.floor(
+    (Date.now() - entry.startedAt.getTime()) / 1000,
+  );
   const issue = formatCell(entry.identifier, ID_WIDTH);
   const stage = formatCell("working", STAGE_WIDTH);
-  const pid = formatCell(entry.codexAppServerPid !== null ? String(entry.codexAppServerPid) : "n/a", PID_WIDTH);
-  const age = formatCell(formatRuntimeAndTurns(runtimeSecs, entry.turnCount), AGE_WIDTH);
-  const tokens = formatCell(formatCount(entry.codexTotalTokens), TOKENS_WIDTH, "right");
+  const pid = formatCell(
+    entry.codexAppServerPid !== null ? String(entry.codexAppServerPid) : "n/a",
+    PID_WIDTH,
+  );
+  const age = formatCell(
+    formatRuntimeAndTurns(runtimeSecs, entry.turnCount),
+    AGE_WIDTH,
+  );
+  const tokens = formatCell(
+    formatCount(entry.codexTotalTokens),
+    TOKENS_WIDTH,
+    "right",
+  );
   const session = formatCell(compactSessionId(entry.sessionId), SESSION_WIDTH);
-  const eventLabel = formatCell(humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent), eventWidth);
+  const eventLabel = formatCell(
+    humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent),
+    eventWidth,
+  );
 
   const statusColor = statusDotColor(entry.lastCodexEvent);
 
@@ -521,19 +567,28 @@ function updateTokenSamples(
   return pruneTokenSamples([[nowMs, totalTokens], ...samples], nowMs);
 }
 
-function pruneTokenSamples(samples: readonly TokenSample[], nowMs: number): TokenSample[] {
+function pruneTokenSamples(
+  samples: readonly TokenSample[],
+  nowMs: number,
+): TokenSample[] {
   const minTs = nowMs - THROUGHPUT_WINDOW_MS;
   return samples.filter(([ts]) => ts >= minTs) as TokenSample[];
 }
 
 // ─── Render timing helpers ────────────────────────────────────────────────
 
-function isPeriodicRerenderDue(lastRenderedAtMs: number | null, nowMs: number): boolean {
+function isPeriodicRerenderDue(
+  lastRenderedAtMs: number | null,
+  nowMs: number,
+): boolean {
   if (lastRenderedAtMs === null) return true;
   return nowMs - lastRenderedAtMs >= MINIMUM_IDLE_RERENDER_MS;
 }
 
-function isRenderNow(lastRenderedAtMs: number | null, renderIntervalMs: number): boolean {
+function isRenderNow(
+  lastRenderedAtMs: number | null,
+  renderIntervalMs: number,
+): boolean {
   if (lastRenderedAtMs === null) return true;
   return Date.now() - lastRenderedAtMs >= renderIntervalMs;
 }
@@ -571,7 +626,11 @@ function formatRuntimeAndTurns(seconds: number, turnCount: number): string {
   return formatRuntimeSeconds(seconds);
 }
 
-function formatCell(value: string, width: number, align: "left" | "right" = "left"): string {
+function formatCell(
+  value: string,
+  width: number,
+  align: "left" | "right" = "left",
+): string {
   const cleaned = value.replace(/\n/g, " ").replace(/\s+/g, " ").trim();
   const truncated = truncatePlain(cleaned, width);
   return align === "right"
@@ -600,7 +659,12 @@ function compactSessionId(sessionId: string | null): string {
 function runningEventWidth(terminalColumnsOverride?: number): number {
   const cols = terminalColumnsOverride ?? terminalColumns();
   const fixedWidth =
-    ID_WIDTH + STAGE_WIDTH + PID_WIDTH + AGE_WIDTH + TOKENS_WIDTH + SESSION_WIDTH;
+    ID_WIDTH +
+    STAGE_WIDTH +
+    PID_WIDTH +
+    AGE_WIDTH +
+    TOKENS_WIDTH +
+    SESSION_WIDTH;
   return Math.max(EVENT_MIN_WIDTH, cols - fixedWidth - ROW_CHROME_WIDTH);
 }
 
@@ -624,12 +688,17 @@ export function humanizeEvent(
 ): string {
   if (message === null || message === undefined) return "no codex message yet";
   const payload = unwrapPayload(message);
-  const byEvent = eventType !== null ? humanizeByEvent(eventType, message, payload) : null;
+  const byEvent =
+    eventType !== null ? humanizeByEvent(eventType, message, payload) : null;
   return truncate(byEvent ?? humanizePayload(payload), 140);
 }
 
 function unwrapPayload(message: unknown): unknown {
-  if (message === null || typeof message !== "object" || Array.isArray(message)) {
+  if (
+    message === null ||
+    typeof message !== "object" ||
+    Array.isArray(message)
+  ) {
     return message;
   }
   const obj = message as Record<string, unknown>;
@@ -639,7 +708,11 @@ function unwrapPayload(message: unknown): unknown {
   return getKey(obj, "payload") ?? message;
 }
 
-function humanizeByEvent(event: string, message: unknown, payload: unknown): string | null {
+function humanizeByEvent(
+  event: string,
+  message: unknown,
+  payload: unknown,
+): string | null {
   // Wrapper events
   if (event.startsWith("codex/event/")) {
     return humanizeWrapperEvent(event.slice("codex/event/".length), payload);
@@ -671,42 +744,64 @@ function humanizeByEvent(event: string, message: unknown, payload: unknown): str
 
 function humanizeWrapperEvent(suffix: string, payload: unknown): string {
   switch (suffix) {
-    case "task_started": return "task started";
-    case "user_message": return "user message received";
-    case "mcp_startup_complete": return "mcp startup complete";
-    case "exec_command_output_delta": return "command output streaming";
-    case "mcp_tool_call_begin": return "mcp tool call started";
-    case "mcp_tool_call_end": return "mcp tool call completed";
-    case "agent_reasoning_section_break": return "reasoning section break";
-    case "turn_diff": return "turn diff updated";
-    case "agent_message_delta": return humanizeStreamingEvent("agent message streaming", payload);
-    case "agent_message_content_delta": return humanizeStreamingEvent("agent message content streaming", payload);
-    case "agent_reasoning_delta": return humanizeStreamingEvent("reasoning streaming", payload);
-    case "reasoning_content_delta": return humanizeStreamingEvent("reasoning content streaming", payload);
-    case "agent_reasoning": return humanizeReasoningUpdate(payload);
-    case "exec_command_begin": return humanizeExecCommandBegin(payload);
-    case "exec_command_end": return humanizeExecCommandEnd(payload);
+    case "task_started":
+      return "task started";
+    case "user_message":
+      return "user message received";
+    case "mcp_startup_complete":
+      return "mcp startup complete";
+    case "exec_command_output_delta":
+      return "command output streaming";
+    case "mcp_tool_call_begin":
+      return "mcp tool call started";
+    case "mcp_tool_call_end":
+      return "mcp tool call completed";
+    case "agent_reasoning_section_break":
+      return "reasoning section break";
+    case "turn_diff":
+      return "turn diff updated";
+    case "agent_message_delta":
+      return humanizeStreamingEvent("agent message streaming", payload);
+    case "agent_message_content_delta":
+      return humanizeStreamingEvent("agent message content streaming", payload);
+    case "agent_reasoning_delta":
+      return humanizeStreamingEvent("reasoning streaming", payload);
+    case "reasoning_content_delta":
+      return humanizeStreamingEvent("reasoning content streaming", payload);
+    case "agent_reasoning":
+      return humanizeReasoningUpdate(payload);
+    case "exec_command_begin":
+      return humanizeExecCommandBegin(payload);
+    case "exec_command_end":
+      return humanizeExecCommandEnd(payload);
     case "token_count": {
       const usage = extractFirstPath(payload, TOKEN_USAGE_PATHS);
       const usageText = formatUsageCounts(usage);
-      return usageText !== null ? `token count update (${usageText})` : "token count update";
+      return usageText !== null
+        ? `token count update (${usageText})`
+        : "token count update";
     }
     case "mcp_startup_update": {
-      const server =
-        mapPath(payload, ["params", "msg", "server"]) ?? "mcp";
+      const server = mapPath(payload, ["params", "msg", "server"]) ?? "mcp";
       const state =
         mapPath(payload, ["params", "msg", "status", "state"]) ?? "updated";
       return `mcp startup: ${String(server)} ${String(state)}`;
     }
     case "item_started": {
       const t = wrapperPayloadType(payload);
-      if (t === "token_count") return humanizeWrapperEvent("token_count", payload);
-      return typeof t === "string" ? `item started (${humanizeItemType(t)})` : "item started";
+      if (t === "token_count")
+        return humanizeWrapperEvent("token_count", payload);
+      return typeof t === "string"
+        ? `item started (${humanizeItemType(t)})`
+        : "item started";
     }
     case "item_completed": {
       const t = wrapperPayloadType(payload);
-      if (t === "token_count") return humanizeWrapperEvent("token_count", payload);
-      return typeof t === "string" ? `item completed (${humanizeItemType(t)})` : "item completed";
+      if (t === "token_count")
+        return humanizeWrapperEvent("token_count", payload);
+      return typeof t === "string"
+        ? `item completed (${humanizeItemType(t)})`
+        : "item completed";
     }
     default: {
       const msgType = mapPath(payload, ["params", "msg", "type"]);
@@ -762,7 +857,9 @@ function humanizeMethod(method: string, payload: unknown): string | null {
     }
     case "turn/failed": {
       const errMsg = mapPath(payload, ["params", "error", "message"]);
-      return typeof errMsg === "string" ? `turn failed: ${errMsg}` : "turn failed";
+      return typeof errMsg === "string"
+        ? `turn failed: ${errMsg}`
+        : "turn failed";
     }
     case "turn/cancelled":
       return "turn cancelled";
@@ -817,7 +914,8 @@ function humanizeMethod(method: string, payload: unknown): string | null {
         : "command approval requested";
     }
     case "item/fileChange/requestApproval": {
-      const count = mapPath(payload, ["params", "fileChangeCount"]) ??
+      const count =
+        mapPath(payload, ["params", "fileChangeCount"]) ??
         mapPath(payload, ["params", "changeCount"]);
       return typeof count === "number" && count > 0
         ? `file change approval requested (${String(count)} files)`
@@ -850,7 +948,10 @@ function humanizeMethod(method: string, payload: unknown): string | null {
       return "account auth token refresh requested";
     default: {
       if (method.startsWith("codex/event/")) {
-        return humanizeWrapperEvent(method.slice("codex/event/".length), payload);
+        return humanizeWrapperEvent(
+          method.slice("codex/event/".length),
+          payload,
+        );
       }
       const msgType = mapPath(payload, ["params", "msg", "type"]);
       return typeof msgType === "string" ? `${method} (${msgType})` : method;
@@ -971,10 +1072,20 @@ function formatUsageCounts(usage: unknown): string | null {
   }
   const obj = usage as Record<string, unknown>;
   const input = parseInteger(
-    getMapKey(obj, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]),
+    getMapKey(obj, [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+    ]),
   );
   const output = parseInteger(
-    getMapKey(obj, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]),
+    getMapKey(obj, [
+      "output_tokens",
+      "outputTokens",
+      "completion_tokens",
+      "completionTokens",
+    ]),
   );
   const total = parseInteger(
     getMapKey(obj, ["total_tokens", "totalTokens", "total"]),
@@ -1006,9 +1117,7 @@ function formatErrorValue(error: unknown): string {
 }
 
 function wrapperPayloadType(payload: unknown): unknown {
-  return (
-    mapPath(payload, ["params", "msg", "payload", "type"]) ?? undefined
-  );
+  return mapPath(payload, ["params", "msg", "payload", "type"]) ?? undefined;
 }
 
 function inlineText(text: string): string {
@@ -1038,7 +1147,9 @@ function parseInteger(value: unknown): number | null {
 function getKey(obj: Record<string, unknown>, key: string): unknown {
   if (Object.hasOwn(obj, key)) return obj[key];
   // camelCase fallback
-  const camel = key.replace(/_([a-z])/g, (_, c: string) => (c as string).toUpperCase());
+  const camel = key.replace(/_([a-z])/g, (_, c: string) =>
+    (c as string).toUpperCase(),
+  );
   if (camel !== key && Object.hasOwn(obj, camel)) return obj[camel];
   // snake_case fallback
   const snake = key.replace(/([A-Z])/g, "_$1").toLowerCase();
@@ -1047,7 +1158,8 @@ function getKey(obj: Record<string, unknown>, key: string): unknown {
 }
 
 function getMapKey(obj: unknown, keys: string[]): unknown {
-  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) return undefined;
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj))
+    return undefined;
   const record = obj as Record<string, unknown>;
   for (const key of keys) {
     const val = getKey(record, key);
@@ -1059,7 +1171,12 @@ function getMapKey(obj: unknown, keys: string[]): unknown {
 function mapPath(obj: unknown, path: string[]): unknown {
   let current: unknown = obj;
   for (const key of path) {
-    if (current === null || current === undefined || typeof current !== "object" || Array.isArray(current)) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object" ||
+      Array.isArray(current)
+    ) {
       return undefined;
     }
     current = getKey(current as Record<string, unknown>, key);
@@ -1067,7 +1184,10 @@ function mapPath(obj: unknown, path: string[]): unknown {
   return current;
 }
 
-function extractFirstPath(payload: unknown, paths: readonly (readonly string[])[]): unknown {
+function extractFirstPath(
+  payload: unknown,
+  paths: readonly (readonly string[])[],
+): unknown {
   for (const path of paths) {
     const val = mapPath(payload, path as string[]);
     if (val !== null && val !== undefined) return val;

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -40,6 +40,9 @@ const ROW_CHROME_WIDTH = 10;
 const DEFAULT_TERMINAL_COLUMNS = 115;
 const THROUGHPUT_WINDOW_MS = 5_000;
 const MINIMUM_IDLE_RERENDER_MS = 1_000;
+const SPARKLINE_WINDOW_MS = 600_000; // 10 minutes
+const SPARKLINE_BUCKETS = 24;
+const SPARKLINE_CHARS = "▁▂▃▄▅▆▇█";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -51,6 +54,7 @@ interface DashboardState {
   renderIntervalMs: number;
   renderFn: (content: string) => void;
   tokenSamples: TokenSample[];
+  sparklineSamples: TokenSample[];
   lastTpsSecond: number | null;
   lastTpsValue: number;
   lastRenderedContent: string | null;
@@ -93,6 +97,7 @@ export class StatusDashboard {
       renderIntervalMs: options?.renderIntervalMs ?? config.renderIntervalMs,
       renderFn: options?.renderFn ?? renderToTerminal,
       tokenSamples: [],
+      sparklineSamples: [],
       lastTpsSecond: null,
       lastTpsValue: 0,
       lastRenderedContent: null,
@@ -175,7 +180,7 @@ export class StatusDashboard {
 
     const currentTokens = snapshot?.codexTotals.totalTokens ?? 0;
 
-    // Update token samples
+    // Update token samples (5-second TPS window)
     if (snapshot !== null) {
       this.#state.tokenSamples = updateTokenSamples(
         this.#state.tokenSamples,
@@ -185,6 +190,20 @@ export class StatusDashboard {
     } else {
       this.#state.tokenSamples = pruneTokenSamples(
         this.#state.tokenSamples,
+        nowMs,
+      );
+    }
+
+    // Update sparkline samples (10-minute window)
+    if (snapshot !== null) {
+      this.#state.sparklineSamples = updateSparklineSamples(
+        this.#state.sparklineSamples,
+        nowMs,
+        currentTokens,
+      );
+    } else {
+      this.#state.sparklineSamples = pruneSparklineSamples(
+        this.#state.sparklineSamples,
         nowMs,
       );
     }
@@ -214,7 +233,8 @@ export class StatusDashboard {
       this.#state.lastSnapshotFingerprint = fingerprint;
     }
 
-    const content = formatSnapshotContent(snapshot, tps);
+    const sparkline = tpsSparkline(this.#state.sparklineSamples, nowMs);
+    const content = formatSnapshotContent(snapshot, tps, undefined, sparkline);
     this.#maybeEnqueueRender(content, nowMs);
   }
 
@@ -280,13 +300,17 @@ export function formatSnapshotContent(
   snapshot: TuiSnapshot | null,
   tps: number,
   terminalColumnsOverride?: number,
+  sparkline?: string,
 ): string {
+  const sparklineSuffix =
+    sparkline !== undefined && sparkline !== "" ? ` ${sparkline}` : "";
   if (snapshot === null) {
     return [
       colorize("╭─ SYMPHONY STATUS", BOLD),
       colorize("│ Orchestrator snapshot unavailable", RED),
       colorize("│ Throughput: ", BOLD) +
-        colorize(`${formatTps(tps)} tps`, CYAN),
+        colorize(`${formatTps(tps)} tps`, CYAN) +
+        sparklineSuffix,
       formatRefreshLine(null),
       "╰─",
     ]
@@ -319,7 +343,9 @@ export function formatSnapshotContent(
       colorize(String(running.length), GREEN) +
       colorize("/", GRAY) +
       colorize(String(maxConcurrentRuns), GRAY),
-    colorize("│ Throughput: ", BOLD) + colorize(`${formatTps(tps)} tps`, CYAN),
+    colorize("│ Throughput: ", BOLD) +
+      colorize(`${formatTps(tps)} tps`, CYAN) +
+      sparklineSuffix,
     colorize("│ Runtime: ", BOLD) +
       colorize(formatRuntimeSeconds(codexTotals.secondsRunning), MAGENTA),
     colorize("│ Tokens: ", BOLD) +
@@ -587,6 +613,63 @@ function pruneTokenSamples(
 ): TokenSample[] {
   const minTs = nowMs - THROUGHPUT_WINDOW_MS;
   return samples.filter(([ts]) => ts >= minTs) as TokenSample[];
+}
+
+function updateSparklineSamples(
+  samples: TokenSample[],
+  nowMs: number,
+  totalTokens: number,
+): TokenSample[] {
+  return pruneSparklineSamples([[nowMs, totalTokens], ...samples], nowMs);
+}
+
+function pruneSparklineSamples(
+  samples: readonly TokenSample[],
+  nowMs: number,
+): TokenSample[] {
+  const minTs = nowMs - SPARKLINE_WINDOW_MS;
+  return samples.filter(([ts]) => ts >= minTs) as TokenSample[];
+}
+
+export function tpsSparkline(
+  samples: readonly TokenSample[],
+  nowMs: number,
+): string {
+  if (samples.length < 2) return "";
+
+  const bucketMs = SPARKLINE_WINDOW_MS / SPARKLINE_BUCKETS;
+  const windowStart = nowMs - SPARKLINE_WINDOW_MS;
+  const bucketTps: number[] = new Array(SPARKLINE_BUCKETS).fill(0) as number[];
+
+  const sorted = [...samples].sort((a, b) => a[0] - b[0]);
+
+  for (let i = 1; i < sorted.length; i++) {
+    const [prevMs, prevTokens] = sorted[i - 1]!;
+    const [curMs, curTokens] = sorted[i]!;
+    const elapsedMs = curMs - prevMs;
+    if (elapsedMs <= 0) continue;
+
+    const deltaTokens = Math.max(0, curTokens - prevTokens);
+    const pairTps = deltaTokens / (elapsedMs / 1000);
+
+    const midMs = (prevMs + curMs) / 2;
+    const bucketIndex = Math.floor((midMs - windowStart) / bucketMs);
+    if (bucketIndex >= 0 && bucketIndex < SPARKLINE_BUCKETS) {
+      bucketTps[bucketIndex] = Math.max(bucketTps[bucketIndex]!, pairTps);
+    }
+  }
+
+  const maxTps = Math.max(...bucketTps);
+  if (maxTps === 0) return "";
+
+  const levels = SPARKLINE_CHARS.length;
+  return bucketTps
+    .map((v) => {
+      if (v === 0) return " ";
+      const idx = Math.min(levels - 1, Math.floor((v / maxTps) * levels));
+      return SPARKLINE_CHARS[idx] ?? SPARKLINE_CHARS[levels - 1]!;
+    })
+    .join("");
 }
 
 // ─── Render timing helpers ────────────────────────────────────────────────

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -78,6 +78,8 @@ export class StatusDashboard {
   readonly #getSnapshot: () => TuiSnapshot;
   readonly #getConfig: () => ObservabilityConfig;
   readonly #state: DashboardState;
+  readonly #explicitEnabled: boolean | undefined;
+  #stopped = false;
 
   constructor(
     getSnapshot: () => TuiSnapshot,
@@ -86,10 +88,11 @@ export class StatusDashboard {
   ) {
     this.#getSnapshot = getSnapshot;
     this.#getConfig = getConfig;
+    this.#explicitEnabled = options?.enabled;
 
     const config = getConfig();
     const enabled =
-      options?.enabled ?? (config.dashboardEnabled && isTerminalEnabled());
+      this.#explicitEnabled ?? (config.dashboardEnabled && isTerminalEnabled());
 
     this.#state = {
       refreshMs: options?.refreshMs ?? config.refreshMs,
@@ -115,6 +118,8 @@ export class StatusDashboard {
   }
 
   stop(): void {
+    if (this.#stopped) return;
+    this.#stopped = true;
     if (this.#state.tickTimer !== null) {
       clearTimeout(this.#state.tickTimer);
       this.#state.tickTimer = null;
@@ -123,7 +128,9 @@ export class StatusDashboard {
       clearTimeout(this.#state.flushTimerRef);
       this.#state.flushTimerRef = null;
     }
-    this.renderOfflineStatus();
+    if (this.#state.enabled) {
+      this.renderOfflineStatus();
+    }
   }
 
   refresh(): void {
@@ -164,7 +171,8 @@ export class StatusDashboard {
     const config = this.#getConfig();
     this.#state.refreshMs = config.refreshMs;
     this.#state.renderIntervalMs = config.renderIntervalMs;
-    this.#state.enabled = config.dashboardEnabled && isTerminalEnabled();
+    this.#state.enabled =
+      this.#explicitEnabled ?? (config.dashboardEnabled && isTerminalEnabled());
   }
 
   // ─── Render pipeline ─────────────────────────────────────────────────────
@@ -291,7 +299,7 @@ function renderToTerminal(content: string): void {
 }
 
 function isTerminalEnabled(): boolean {
-  return process.env["NODE_ENV"] !== "test";
+  return process.env["NODE_ENV"] !== "test" && process.stdout.isTTY === true;
 }
 
 // ─── Snapshot formatter ───────────────────────────────────────────────────

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -134,7 +134,7 @@ export class StatusDashboard {
   }
 
   refresh(): void {
-    if (!this.#state.enabled) return;
+    if (this.#stopped || !this.#state.enabled) return;
     this.#refreshRuntimeConfig();
     this.#maybeRender();
   }
@@ -161,8 +161,10 @@ export class StatusDashboard {
   }
 
   #onTick(): void {
-    if (!this.#state.enabled) return;
+    if (this.#stopped || !this.#state.enabled) return;
     this.#refreshRuntimeConfig();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!this.#state.enabled) return;
     this.#maybeRender();
     this.#scheduleTick();
   }

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -79,6 +79,8 @@ export class StatusDashboard {
   readonly #getConfig: () => ObservabilityConfig;
   readonly #state: DashboardState;
   readonly #explicitEnabled: boolean | undefined;
+  readonly #explicitRefreshMs: number | undefined;
+  readonly #explicitRenderIntervalMs: number | undefined;
   #stopped = false;
 
   constructor(
@@ -89,6 +91,8 @@ export class StatusDashboard {
     this.#getSnapshot = getSnapshot;
     this.#getConfig = getConfig;
     this.#explicitEnabled = options?.enabled;
+    this.#explicitRefreshMs = options?.refreshMs;
+    this.#explicitRenderIntervalMs = options?.renderIntervalMs;
 
     const config = getConfig();
     const enabled =
@@ -171,8 +175,9 @@ export class StatusDashboard {
 
   #refreshRuntimeConfig(): void {
     const config = this.#getConfig();
-    this.#state.refreshMs = config.refreshMs;
-    this.#state.renderIntervalMs = config.renderIntervalMs;
+    this.#state.refreshMs = this.#explicitRefreshMs ?? config.refreshMs;
+    this.#state.renderIntervalMs =
+      this.#explicitRenderIntervalMs ?? config.renderIntervalMs;
     this.#state.enabled =
       this.#explicitEnabled ?? (config.dashboardEnabled && isTerminalEnabled());
   }

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -16,7 +16,7 @@ export interface RunningEntry {
   codexLastReportedTotalTokens: number;
   codexAppServerPid: number | null;
   lastCodexEvent: string | null;
-  lastCodexMessage: unknown | null;
+  lastCodexMessage: unknown;
   lastCodexTimestamp: string | null;
 }
 

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -1,0 +1,205 @@
+import type { RunUpdateEvent } from "../domain/run.js";
+
+export interface RunningEntry {
+  readonly issueNumber: number;
+  readonly identifier: string;
+  readonly startedAt: Date;
+  readonly retryAttempt: number;
+  sessionId: string | null;
+  turnCount: number;
+  codexInputTokens: number;
+  codexOutputTokens: number;
+  codexTotalTokens: number;
+  codexLastReportedInputTokens: number;
+  codexLastReportedOutputTokens: number;
+  codexLastReportedTotalTokens: number;
+  codexAppServerPid: number | null;
+  lastCodexEvent: string | null;
+  lastCodexMessage: unknown | null;
+  lastCodexTimestamp: string | null;
+}
+
+export function createRunningEntry(
+  issueNumber: number,
+  identifier: string,
+  retryAttempt: number,
+): RunningEntry {
+  return {
+    issueNumber,
+    identifier,
+    startedAt: new Date(),
+    retryAttempt,
+    sessionId: null,
+    turnCount: 0,
+    codexInputTokens: 0,
+    codexOutputTokens: 0,
+    codexTotalTokens: 0,
+    codexLastReportedInputTokens: 0,
+    codexLastReportedOutputTokens: 0,
+    codexLastReportedTotalTokens: 0,
+    codexAppServerPid: null,
+    lastCodexEvent: null,
+    lastCodexMessage: null,
+    lastCodexTimestamp: null,
+  };
+}
+
+interface TokenDelta {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+}
+
+function mapValue(
+  map: Record<string, unknown>,
+  keys: readonly string[],
+): unknown {
+  for (const key of keys) {
+    if (Object.hasOwn(map, key) && map[key] !== undefined && map[key] !== null) {
+      return map[key];
+    }
+  }
+  return undefined;
+}
+
+function mapPath(obj: unknown, path: readonly string[]): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object" ||
+      Array.isArray(current)
+    ) {
+      return undefined;
+    }
+    const record = current as Record<string, unknown>;
+    current =
+      record[key] ??
+      record[key.replace(/_([a-z])/g, (_, c: string) => (c as string).toUpperCase())];
+  }
+  return current;
+}
+
+function extractTokenDelta(
+  entry: RunningEntry,
+  payload: Record<string, unknown>,
+): TokenDelta {
+  const inputRaw =
+    mapValue(payload, ["input_tokens", "inputTokens"]) ??
+    mapPath(payload, ["params", "usage", "inputTokens"]) ??
+    mapPath(payload, ["params", "usage", "input_tokens"]) ??
+    mapPath(payload, ["usage", "inputTokens"]) ??
+    mapPath(payload, ["usage", "input_tokens"]);
+  const outputRaw =
+    mapValue(payload, ["output_tokens", "outputTokens"]) ??
+    mapPath(payload, ["params", "usage", "outputTokens"]) ??
+    mapPath(payload, ["params", "usage", "output_tokens"]) ??
+    mapPath(payload, ["usage", "outputTokens"]) ??
+    mapPath(payload, ["usage", "output_tokens"]);
+  const totalRaw =
+    mapValue(payload, ["total_tokens", "totalTokens"]) ??
+    mapPath(payload, ["params", "usage", "totalTokens"]) ??
+    mapPath(payload, ["params", "usage", "total_tokens"]) ??
+    mapPath(payload, ["usage", "totalTokens"]) ??
+    mapPath(payload, ["usage", "total_tokens"]);
+
+  const reported = {
+    input: typeof inputRaw === "number" ? inputRaw : 0,
+    output: typeof outputRaw === "number" ? outputRaw : 0,
+    total: typeof totalRaw === "number" ? totalRaw : 0,
+  };
+
+  if (
+    reported.input === 0 &&
+    reported.output === 0 &&
+    reported.total === 0
+  ) {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+
+  const delta = {
+    inputTokens: Math.max(0, reported.input - entry.codexLastReportedInputTokens),
+    outputTokens: Math.max(
+      0,
+      reported.output - entry.codexLastReportedOutputTokens,
+    ),
+    totalTokens: Math.max(0, reported.total - entry.codexLastReportedTotalTokens),
+  };
+  return delta;
+}
+
+function extractSessionId(
+  entry: RunningEntry,
+  payload: Record<string, unknown>,
+): string | null {
+  const raw =
+    mapValue(payload, ["session_id", "sessionId"]) ??
+    mapPath(payload, ["params", "sessionId"]) ??
+    mapPath(payload, ["params", "session_id"]);
+  if (typeof raw === "string" && raw.length > 0) {
+    return raw;
+  }
+  return entry.sessionId;
+}
+
+function extractPid(payload: Record<string, unknown>): number | null {
+  const raw =
+    mapValue(payload, ["pid", "app_server_pid", "appServerPid"]) ??
+    mapPath(payload, ["params", "pid"]);
+  if (typeof raw === "number" && raw > 0) {
+    return raw;
+  }
+  return null;
+}
+
+export interface IntegrateResult {
+  readonly tokenDelta: TokenDelta;
+}
+
+export function integrateCodexUpdate(
+  entry: RunningEntry,
+  update: RunUpdateEvent,
+): IntegrateResult {
+  const payload =
+    update.payload !== null &&
+    typeof update.payload === "object" &&
+    !Array.isArray(update.payload)
+      ? (update.payload as Record<string, unknown>)
+      : {};
+
+  const prevSessionId = entry.sessionId;
+  const newSessionId = extractSessionId(entry, payload);
+  const tokenDelta = extractTokenDelta(entry, payload);
+  const pid = extractPid(payload);
+
+  if (tokenDelta.inputTokens > 0 || tokenDelta.outputTokens > 0 || tokenDelta.totalTokens > 0) {
+    entry.codexLastReportedInputTokens += tokenDelta.inputTokens;
+    entry.codexLastReportedOutputTokens += tokenDelta.outputTokens;
+    entry.codexLastReportedTotalTokens += tokenDelta.totalTokens;
+  }
+
+  entry.sessionId = newSessionId;
+  entry.lastCodexEvent = update.event;
+  entry.lastCodexMessage = update.payload;
+  entry.lastCodexTimestamp = update.timestamp;
+
+  if (pid !== null) {
+    entry.codexAppServerPid = pid;
+  }
+
+  entry.codexInputTokens += tokenDelta.inputTokens;
+  entry.codexOutputTokens += tokenDelta.outputTokens;
+  entry.codexTotalTokens += tokenDelta.totalTokens;
+
+  if (
+    newSessionId !== null &&
+    newSessionId !== prevSessionId &&
+    (update.event === "codex/event/task_started" ||
+      update.event === "thread/started")
+  ) {
+    entry.turnCount += 1;
+  }
+
+  return { tokenDelta };
+}

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -182,6 +182,16 @@ function extractTokenDelta(
       reported.total - entry.codexLastReportedTotalTokens,
     ),
   };
+
+  // Update high-water marks to the actual reported values so that
+  // counters stay in sync even when only some token types change.
+  if (reported.input > 0)
+    entry.codexLastReportedInputTokens = reported.input;
+  if (reported.output > 0)
+    entry.codexLastReportedOutputTokens = reported.output;
+  if (reported.total > 0)
+    entry.codexLastReportedTotalTokens = reported.total;
+
   return delta;
 }
 
@@ -235,16 +245,6 @@ export function integrateCodexUpdate(
 
   const tokenDelta = extractTokenDelta(entry, payload);
   const pid = extractPid(payload);
-
-  if (
-    tokenDelta.inputTokens > 0 ||
-    tokenDelta.outputTokens > 0 ||
-    tokenDelta.totalTokens > 0
-  ) {
-    entry.codexLastReportedInputTokens += tokenDelta.inputTokens;
-    entry.codexLastReportedOutputTokens += tokenDelta.outputTokens;
-    entry.codexLastReportedTotalTokens += tokenDelta.totalTokens;
-  }
 
   entry.sessionId = newSessionId;
   entry.lastCodexEvent = update.event;

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -96,18 +96,63 @@ function extractTokenDelta(
 ): TokenDelta {
   const inputRaw =
     mapValue(payload, ["input_tokens", "inputTokens"]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "payload",
+      "info",
+      "total_token_usage",
+      "input_tokens",
+    ]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "info",
+      "total_token_usage",
+      "input_tokens",
+    ]) ??
     mapPath(payload, ["params", "usage", "inputTokens"]) ??
     mapPath(payload, ["params", "usage", "input_tokens"]) ??
     mapPath(payload, ["usage", "inputTokens"]) ??
     mapPath(payload, ["usage", "input_tokens"]);
   const outputRaw =
     mapValue(payload, ["output_tokens", "outputTokens"]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "payload",
+      "info",
+      "total_token_usage",
+      "output_tokens",
+    ]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "info",
+      "total_token_usage",
+      "output_tokens",
+    ]) ??
     mapPath(payload, ["params", "usage", "outputTokens"]) ??
     mapPath(payload, ["params", "usage", "output_tokens"]) ??
     mapPath(payload, ["usage", "outputTokens"]) ??
     mapPath(payload, ["usage", "output_tokens"]);
   const totalRaw =
     mapValue(payload, ["total_tokens", "totalTokens"]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "payload",
+      "info",
+      "total_token_usage",
+      "total_tokens",
+    ]) ??
+    mapPath(payload, [
+      "params",
+      "msg",
+      "info",
+      "total_token_usage",
+      "total_tokens",
+    ]) ??
     mapPath(payload, ["params", "usage", "totalTokens"]) ??
     mapPath(payload, ["params", "usage", "total_tokens"]) ??
     mapPath(payload, ["usage", "totalTokens"]) ??

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -3,6 +3,7 @@ import type { RunUpdateEvent } from "../domain/run.js";
 export interface RunningEntry {
   readonly issueNumber: number;
   readonly identifier: string;
+  readonly issueState: string;
   readonly startedAt: Date;
   readonly retryAttempt: number;
   sessionId: string | null;
@@ -22,11 +23,13 @@ export interface RunningEntry {
 export function createRunningEntry(
   issueNumber: number,
   identifier: string,
+  issueState: string,
   retryAttempt: number,
 ): RunningEntry {
   return {
     issueNumber,
     identifier,
+    issueState,
     startedAt: new Date(),
     retryAttempt,
     sessionId: null,

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -185,12 +185,10 @@ function extractTokenDelta(
 
   // Update high-water marks to the actual reported values so that
   // counters stay in sync even when only some token types change.
-  if (reported.input > 0)
-    entry.codexLastReportedInputTokens = reported.input;
+  if (reported.input > 0) entry.codexLastReportedInputTokens = reported.input;
   if (reported.output > 0)
     entry.codexLastReportedOutputTokens = reported.output;
-  if (reported.total > 0)
-    entry.codexLastReportedTotalTokens = reported.total;
+  if (reported.total > 0) entry.codexLastReportedTotalTokens = reported.total;
 
   return delta;
 }

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -226,6 +226,13 @@ export function integrateCodexUpdate(
 
   const prevSessionId = entry.sessionId;
   const newSessionId = extractSessionId(entry, payload);
+
+  if (newSessionId !== null && newSessionId !== prevSessionId) {
+    entry.codexLastReportedInputTokens = 0;
+    entry.codexLastReportedOutputTokens = 0;
+    entry.codexLastReportedTotalTokens = 0;
+  }
+
   const tokenDelta = extractTokenDelta(entry, payload);
   const pid = extractPid(payload);
 
@@ -252,12 +259,7 @@ export function integrateCodexUpdate(
   entry.codexOutputTokens += tokenDelta.outputTokens;
   entry.codexTotalTokens += tokenDelta.totalTokens;
 
-  if (
-    newSessionId !== null &&
-    newSessionId !== prevSessionId &&
-    (update.event === "codex/event/task_started" ||
-      update.event === "thread/started")
-  ) {
+  if (update.event === "turn/completed") {
     entry.turnCount += 1;
   }
 

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -55,7 +55,11 @@ function mapValue(
   keys: readonly string[],
 ): unknown {
   for (const key of keys) {
-    if (Object.hasOwn(map, key) && map[key] !== undefined && map[key] !== null) {
+    if (
+      Object.hasOwn(map, key) &&
+      map[key] !== undefined &&
+      map[key] !== null
+    ) {
       return map[key];
     }
   }
@@ -76,7 +80,9 @@ function mapPath(obj: unknown, path: readonly string[]): unknown {
     const record = current as Record<string, unknown>;
     current =
       record[key] ??
-      record[key.replace(/_([a-z])/g, (_, c: string) => (c as string).toUpperCase())];
+      record[
+        key.replace(/_([a-z])/g, (_, c: string) => (c as string).toUpperCase())
+      ];
   }
   return current;
 }
@@ -110,21 +116,23 @@ function extractTokenDelta(
     total: typeof totalRaw === "number" ? totalRaw : 0,
   };
 
-  if (
-    reported.input === 0 &&
-    reported.output === 0 &&
-    reported.total === 0
-  ) {
+  if (reported.input === 0 && reported.output === 0 && reported.total === 0) {
     return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
   }
 
   const delta = {
-    inputTokens: Math.max(0, reported.input - entry.codexLastReportedInputTokens),
+    inputTokens: Math.max(
+      0,
+      reported.input - entry.codexLastReportedInputTokens,
+    ),
     outputTokens: Math.max(
       0,
       reported.output - entry.codexLastReportedOutputTokens,
     ),
-    totalTokens: Math.max(0, reported.total - entry.codexLastReportedTotalTokens),
+    totalTokens: Math.max(
+      0,
+      reported.total - entry.codexLastReportedTotalTokens,
+    ),
   };
   return delta;
 }
@@ -173,7 +181,11 @@ export function integrateCodexUpdate(
   const tokenDelta = extractTokenDelta(entry, payload);
   const pid = extractPid(payload);
 
-  if (tokenDelta.inputTokens > 0 || tokenDelta.outputTokens > 0 || tokenDelta.totalTokens > 0) {
+  if (
+    tokenDelta.inputTokens > 0 ||
+    tokenDelta.outputTokens > 0 ||
+    tokenDelta.totalTokens > 0
+  ) {
     entry.codexLastReportedInputTokens += tokenDelta.inputTokens;
     entry.codexLastReportedOutputTokens += tokenDelta.outputTokens;
     entry.codexLastReportedTotalTokens += tokenDelta.totalTokens;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -80,6 +80,7 @@ import {
 export interface TuiRunningEntry {
   readonly issueNumber: number;
   readonly identifier: string;
+  readonly issueState: string;
   readonly startedAt: Date;
   readonly retryAttempt: number;
   readonly sessionId: string | null;
@@ -98,7 +99,7 @@ export interface TuiRetryEntry {
   readonly identifier: string;
   readonly nextAttempt: number;
   readonly dueInMs: number;
-  readonly lastError: string;
+  readonly lastError: string | null;
 }
 
 export interface TuiSnapshot {
@@ -107,6 +108,8 @@ export interface TuiSnapshot {
   readonly codexTotals: CodexTotals;
   readonly rateLimits: RateLimits | null;
   readonly polling: PollingState;
+  readonly maxConcurrentRuns: number;
+  readonly projectUrl: string | null;
 }
 
 export interface Orchestrator {
@@ -177,6 +180,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       running.push({
         issueNumber: entry.issueNumber,
         identifier: entry.identifier,
+        issueState: entry.issueState,
         startedAt: entry.startedAt,
         retryAttempt: entry.retryAttempt,
         sessionId: entry.sessionId,
@@ -213,7 +217,17 @@ export class BootstrapOrchestrator implements Orchestrator {
       },
       rateLimits: this.#state.rateLimits,
       polling: { ...this.#state.polling },
+      maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
+      projectUrl: this.#deriveProjectUrl(),
     };
+  }
+
+  #deriveProjectUrl(): string | null {
+    const tracker = this.#config.tracker;
+    if (tracker.kind === "linear") {
+      return `https://linear.app/project/${tracker.projectSlug}/issues`;
+    }
+    return null;
   }
 
   #notifyDashboard(): void {
@@ -653,6 +667,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     const runEntry = createRunningEntry(
       issue.number,
       issue.identifier,
+      issue.state,
       attempt,
     );
     this.#state.runningEntries.set(issue.number, runEntry);

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -140,6 +140,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #factoryStartedAt: number = Date.now();
   #shutdownSignal: AbortSignal | undefined;
   #dashboardNotify: (() => void) | null = null;
+  readonly #factoryStartedAt: number = Date.now();
 
   constructor(
     config: ResolvedConfig,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -3,7 +3,12 @@ import { OrchestratorError, RunnerAbortedError } from "../domain/errors.js";
 import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RetryState } from "../domain/retry.js";
-import type { RunResult, RunSpawnEvent, RunSession } from "../domain/run.js";
+import type {
+  RunResult,
+  RunSpawnEvent,
+  RunSession,
+  RunUpdateEvent,
+} from "../domain/run.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -42,14 +47,23 @@ import {
   resolveRunSequence,
 } from "./follow-up-state.js";
 import { LocalIssueLeaseManager } from "./issue-lease.js";
-import { createOrchestratorState } from "./state.js";
 import type { LivenessProbe } from "./liveness-probe.js";
+import {
+  createRunningEntry,
+  integrateCodexUpdate,
+} from "./running-entry.js";
 import {
   type StallReason,
   checkStall,
   canRecover,
   DEFAULT_WATCHDOG_CONFIG,
 } from "./stall-detector.js";
+import {
+  createOrchestratorState,
+  type CodexTotals,
+  type RateLimits,
+  type PollingState,
+} from "./state.js";
 import {
   adjustTrackerIssueCounts,
   buildFactoryStatusSnapshot,
@@ -65,6 +79,38 @@ import {
   initWatchdogEntry,
   recordWatchdogRecovery,
 } from "./watchdog-state.js";
+
+export interface TuiRunningEntry {
+  readonly issueNumber: number;
+  readonly identifier: string;
+  readonly startedAt: Date;
+  readonly retryAttempt: number;
+  readonly sessionId: string | null;
+  readonly turnCount: number;
+  readonly codexTotalTokens: number;
+  readonly codexInputTokens: number;
+  readonly codexOutputTokens: number;
+  readonly codexAppServerPid: number | null;
+  readonly lastCodexEvent: string | null;
+  readonly lastCodexMessage: unknown | null;
+  readonly lastCodexTimestamp: string | null;
+}
+
+export interface TuiRetryEntry {
+  readonly issueNumber: number;
+  readonly identifier: string;
+  readonly nextAttempt: number;
+  readonly dueInMs: number;
+  readonly lastError: string;
+}
+
+export interface TuiSnapshot {
+  readonly running: readonly TuiRunningEntry[];
+  readonly retrying: readonly TuiRetryEntry[];
+  readonly codexTotals: CodexTotals;
+  readonly rateLimits: RateLimits | null;
+  readonly polling: PollingState;
+}
 
 export interface Orchestrator {
   runOnce(): Promise<void>;
@@ -84,14 +130,16 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #workspaceManager: WorkspaceManager;
   readonly #runner: Runner;
   readonly #logger: Logger;
-  readonly #state = createOrchestratorState();
+  readonly #state: ReturnType<typeof createOrchestratorState>;
   readonly #instanceId = randomUUID();
   readonly #leaseManager: LocalIssueLeaseManager;
   readonly #issueArtifactStore: IssueArtifactStore;
   readonly #statusFilePath: string;
   readonly #livenessProbe: LivenessProbe | null;
   readonly #watchdogConfig: WatchdogConfig;
+  readonly #factoryStartedAt: number = Date.now();
   #shutdownSignal: AbortSignal | undefined;
+  #dashboardNotify: (() => void) | null = null;
 
   constructor(
     config: ResolvedConfig,
@@ -109,6 +157,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#workspaceManager = workspaceManager;
     this.#runner = runner;
     this.#logger = logger;
+    this.#state = createOrchestratorState(config.polling.intervalMs);
     this.#leaseManager = new LocalIssueLeaseManager(
       config.workspace.root,
       logger,
@@ -120,7 +169,63 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#livenessProbe = livenessProbe ?? null;
   }
 
+  setDashboardNotify(notify: (() => void) | null): void {
+    this.#dashboardNotify = notify;
+  }
+
+  snapshot(): TuiSnapshot {
+    const now = Date.now();
+    const running: TuiRunningEntry[] = [];
+    for (const entry of this.#state.runningEntries.values()) {
+      running.push({
+        issueNumber: entry.issueNumber,
+        identifier: entry.identifier,
+        startedAt: entry.startedAt,
+        retryAttempt: entry.retryAttempt,
+        sessionId: entry.sessionId,
+        turnCount: entry.turnCount,
+        codexTotalTokens: entry.codexTotalTokens,
+        codexInputTokens: entry.codexInputTokens,
+        codexOutputTokens: entry.codexOutputTokens,
+        codexAppServerPid: entry.codexAppServerPid,
+        lastCodexEvent: entry.lastCodexEvent,
+        lastCodexMessage: entry.lastCodexMessage,
+        lastCodexTimestamp: entry.lastCodexTimestamp,
+      });
+    }
+    running.sort((a, b) => a.identifier.localeCompare(b.identifier));
+
+    const retrying: TuiRetryEntry[] = [];
+    for (const retry of this.#state.retries.values()) {
+      retrying.push({
+        issueNumber: retry.issue.number,
+        identifier: retry.issue.identifier,
+        nextAttempt: retry.nextAttempt,
+        dueInMs: Math.max(0, retry.dueAt - now),
+        lastError: retry.lastError,
+      });
+    }
+    retrying.sort((a, b) => a.dueInMs - b.dueInMs);
+
+    return {
+      running,
+      retrying,
+      codexTotals: {
+        ...this.#state.codexTotals,
+        secondsRunning: Math.floor((now - this.#factoryStartedAt) / 1000),
+      },
+      rateLimits: this.#state.rateLimits,
+      polling: { ...this.#state.polling },
+    };
+  }
+
+  #notifyDashboard(): void {
+    this.#dashboardNotify?.();
+  }
+
   async runOnce(): Promise<void> {
+    this.#state.polling.checkingNow = true;
+    this.#notifyDashboard();
     noteStatusAction(this.#state.status, {
       kind: "poll-started",
       summary: "Polling tracker for ready and running issues",
@@ -163,6 +268,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       summary: `Found ${readyCandidates.length.toString()} ready, ${runningCandidates.length.toString()} running, ${failedCandidates.length.toString()} failed issues`,
       issueNumber: null,
     });
+    this.#state.polling.checkingNow = false;
+    this.#notifyDashboard();
     await this.#persistStatusSnapshot();
 
     if (availableSlots <= 0) {
@@ -204,6 +311,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       if (signal?.aborted) {
         break;
       }
+      this.#state.polling.nextPollAtMs = Date.now() + this.#config.polling.intervalMs;
       await this.#sleep(this.#config.polling.intervalMs, signal);
     }
     // signal is optional — keep ?. for safety even though TypeScript narrows
@@ -544,6 +652,9 @@ export class BootstrapOrchestrator implements Orchestrator {
       issue.number,
       watchdogStop.signal,
     );
+    const runEntry = createRunningEntry(issue.number, issue.identifier, attempt);
+    this.#state.runningEntries.set(issue.number, runEntry);
+    this.#notifyDashboard();
 
     let result: RunResult;
     try {
@@ -551,6 +662,17 @@ export class BootstrapOrchestrator implements Orchestrator {
         signal: abortController.signal,
         onSpawn: (event) => {
           this.#recordRunnerSpawn(session, lockDir, event);
+          this.#notifyDashboard();
+        },
+        onUpdate: (event: RunUpdateEvent) => {
+          const entry = this.#state.runningEntries.get(issue.number);
+          if (entry !== undefined) {
+            const { tokenDelta } = integrateCodexUpdate(entry, event);
+            this.#state.codexTotals.inputTokens += tokenDelta.inputTokens;
+            this.#state.codexTotals.outputTokens += tokenDelta.outputTokens;
+            this.#state.codexTotals.totalTokens += tokenDelta.totalTokens;
+          }
+          this.#notifyDashboard();
         },
       });
     } finally {
@@ -559,6 +681,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       shutdownSignal?.removeEventListener("abort", handleShutdown);
       this.#state.runAbortControllers.delete(issue.number);
       clearActiveWatchdogEntry(this.#state.watchdog, issue.number);
+      this.#state.runningEntries.delete(issue.number);
+      this.#notifyDashboard();
     }
 
     if (result.exitCode !== 0) {
@@ -943,6 +1067,7 @@ export class BootstrapOrchestrator implements Orchestrator {
           .nextAttempt.toString()} scheduled for ${issue.identifier}`,
         issueNumber: issue.number,
       });
+      this.#notifyDashboard();
       await this.#persistStatusSnapshot();
       await this.#recordIssueArtifact(
         this.#createRetryScheduledObservation(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -203,7 +203,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: retry.issue.number,
         identifier: retry.issue.identifier,
         nextAttempt: retry.nextAttempt,
-        dueInMs: Math.max(0, retry.dueAt - now),
+        dueInMs: Math.max(0, Math.round((retry.dueAt - now) / 1000) * 1000),
         lastError: retry.lastError,
       });
     }
@@ -224,10 +224,9 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   #deriveProjectUrl(): string | null {
-    const tracker = this.#config.tracker;
-    if (tracker.kind === "linear") {
-      return `https://linear.app/project/${tracker.projectSlug}/issues`;
-    }
+    // Linear URLs require a workspace slug not yet available in LinearTrackerConfig.
+    // GitHub has no single canonical project board URL in the current config shape.
+    // Both cases return null until the config shape is extended.
     return null;
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -90,7 +90,7 @@ export interface TuiRunningEntry {
   readonly codexOutputTokens: number;
   readonly codexAppServerPid: number | null;
   readonly lastCodexEvent: string | null;
-  readonly lastCodexMessage: unknown | null;
+  readonly lastCodexMessage: unknown;
   readonly lastCodexTimestamp: string | null;
 }
 
@@ -140,7 +140,6 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #factoryStartedAt: number = Date.now();
   #shutdownSignal: AbortSignal | undefined;
   #dashboardNotify: (() => void) | null = null;
-  readonly #factoryStartedAt: number = Date.now();
 
   constructor(
     config: ResolvedConfig,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -48,10 +48,7 @@ import {
 } from "./follow-up-state.js";
 import { LocalIssueLeaseManager } from "./issue-lease.js";
 import type { LivenessProbe } from "./liveness-probe.js";
-import {
-  createRunningEntry,
-  integrateCodexUpdate,
-} from "./running-entry.js";
+import { createRunningEntry, integrateCodexUpdate } from "./running-entry.js";
 import {
   type StallReason,
   checkStall,
@@ -311,7 +308,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       if (signal?.aborted) {
         break;
       }
-      this.#state.polling.nextPollAtMs = Date.now() + this.#config.polling.intervalMs;
+      this.#state.polling.nextPollAtMs =
+        Date.now() + this.#config.polling.intervalMs;
       await this.#sleep(this.#config.polling.intervalMs, signal);
     }
     // signal is optional — keep ?. for safety even though TypeScript narrows
@@ -652,7 +650,11 @@ export class BootstrapOrchestrator implements Orchestrator {
       issue.number,
       watchdogStop.signal,
     );
-    const runEntry = createRunningEntry(issue.number, issue.identifier, attempt);
+    const runEntry = createRunningEntry(
+      issue.number,
+      issue.identifier,
+      attempt,
+    );
     this.#state.runningEntries.set(issue.number, runEntry);
     this.#notifyDashboard();
 

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -22,8 +22,16 @@ export interface CodexTotals {
 
 export interface RateLimits {
   readonly limitId: string | null;
-  readonly primary: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null;
-  readonly secondary: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null;
+  readonly primary: {
+    readonly used: number;
+    readonly limit: number;
+    readonly resetInMs: number;
+  } | null;
+  readonly secondary: {
+    readonly used: number;
+    readonly limit: number;
+    readonly resetInMs: number;
+  } | null;
   readonly credits: string | null;
 }
 
@@ -47,7 +55,9 @@ export interface OrchestratorState {
   readonly polling: PollingState;
 }
 
-export function createOrchestratorState(pollingIntervalMs: number): OrchestratorState {
+export function createOrchestratorState(
+  pollingIntervalMs: number,
+): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
     runAbortControllers: new Map<number, AbortController>(),

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -3,6 +3,7 @@ import {
   createFollowUpRuntimeState,
   type FollowUpRuntimeState,
 } from "./follow-up-state.js";
+import type { RunningEntry } from "./running-entry.js";
 import {
   createRuntimeStatusState,
   type RuntimeStatusState,
@@ -12,6 +13,26 @@ import {
   type WatchdogRuntimeState,
 } from "./watchdog-state.js";
 
+export interface CodexTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  secondsRunning: number;
+}
+
+export interface RateLimits {
+  readonly limitId: string | null;
+  readonly primary: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null;
+  readonly secondary: { readonly used: number; readonly limit: number; readonly resetInMs: number } | null;
+  readonly credits: string | null;
+}
+
+export interface PollingState {
+  checkingNow: boolean;
+  nextPollAtMs: number;
+  intervalMs: number;
+}
+
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
   readonly runAbortControllers: Map<number, AbortController>;
@@ -20,9 +41,13 @@ export interface OrchestratorState {
   readonly status: RuntimeStatusState;
   readonly artifactWriteQueues: Map<number, Promise<void>>;
   readonly watchdog: WatchdogRuntimeState;
+  readonly runningEntries: Map<number, RunningEntry>;
+  readonly codexTotals: CodexTotals;
+  rateLimits: RateLimits | null;
+  readonly polling: PollingState;
 }
 
-export function createOrchestratorState(): OrchestratorState {
+export function createOrchestratorState(pollingIntervalMs: number): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
     runAbortControllers: new Map<number, AbortController>(),
@@ -31,5 +56,18 @@ export function createOrchestratorState(): OrchestratorState {
     status: createRuntimeStatusState(),
     artifactWriteQueues: new Map<number, Promise<void>>(),
     watchdog: createWatchdogRuntimeState(),
+    runningEntries: new Map<number, RunningEntry>(),
+    codexTotals: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      secondsRunning: 0,
+    },
+    rateLimits: null,
+    polling: {
+      checkingNow: false,
+      nextPollAtMs: Date.now(),
+      intervalMs: pollingIntervalMs,
+    },
   };
 }

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -73,6 +73,7 @@ export class LocalRunner implements Runner {
 
       let stdout = "";
       let stderr = "";
+      let stdoutLineBuffer = "";
       let settled = false;
       let timedOut = false;
       let aborted = false;
@@ -178,7 +179,40 @@ export class LocalRunner implements Runner {
       }, this.#config.timeoutMs);
 
       child.stdout.on("data", (chunk: Buffer | string) => {
-        stdout += chunk.toString();
+        const text = chunk.toString();
+        stdout += text;
+        if (options?.onUpdate !== undefined) {
+          stdoutLineBuffer += text;
+          const lines = stdoutLineBuffer.split("\n");
+          stdoutLineBuffer = lines.pop() ?? "";
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (trimmed === "") continue;
+            try {
+              const parsed = JSON.parse(trimmed) as unknown;
+              if (
+                parsed !== null &&
+                typeof parsed === "object" &&
+                !Array.isArray(parsed)
+              ) {
+                const obj = parsed as Record<string, unknown>;
+                const event =
+                  typeof obj["event"] === "string"
+                    ? obj["event"]
+                    : typeof obj["method"] === "string"
+                      ? obj["method"]
+                      : "unknown";
+                options.onUpdate({
+                  event,
+                  payload: parsed,
+                  timestamp: new Date().toISOString(),
+                });
+              }
+            } catch {
+              // not a JSON line — ignore
+            }
+          }
+        }
       });
       child.stderr.on("data", (chunk: Buffer | string) => {
         stderr += chunk.toString();

--- a/src/runner/local.ts
+++ b/src/runner/local.ts
@@ -228,6 +228,32 @@ export class LocalRunner implements Runner {
         });
       });
       child.on("close", (exitCode) => {
+        // Flush any remaining partial line in the buffer
+        if (options?.onUpdate !== undefined && stdoutLineBuffer.trim() !== "") {
+          try {
+            const parsed = JSON.parse(stdoutLineBuffer.trim()) as unknown;
+            if (
+              parsed !== null &&
+              typeof parsed === "object" &&
+              !Array.isArray(parsed)
+            ) {
+              const obj = parsed as Record<string, unknown>;
+              const event =
+                typeof obj["event"] === "string"
+                  ? obj["event"]
+                  : typeof obj["method"] === "string"
+                    ? obj["method"]
+                    : "unknown";
+              options.onUpdate({
+                event,
+                payload: parsed,
+                timestamp: new Date().toISOString(),
+              });
+            }
+          } catch {
+            // not a complete JSON line — ignore
+          }
+        }
         void spawnNotificationPromise.finally(() => {
           finish(() => {
             const finishedAt = new Date().toISOString();

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,4 +1,9 @@
-import type { RunResult, RunSession, RunSpawnEvent } from "../domain/run.js";
+import type {
+  RunResult,
+  RunSession,
+  RunSpawnEvent,
+  RunUpdateEvent,
+} from "../domain/run.js";
 export interface RunnerLogPointer {
   readonly name: string;
   readonly location: string | null;
@@ -18,6 +23,7 @@ export interface RunnerSessionDescriber {
 export interface RunnerRunOptions {
   readonly signal?: AbortSignal;
   readonly onSpawn?: (event: RunSpawnEvent) => void | Promise<void>;
+  readonly onUpdate?: (event: RunUpdateEvent) => void;
 }
 
 export interface Runner extends RunnerSessionDescriber {

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../support/git.js";
 import { MockGitHubServer } from "../support/mock-github-server.js";
 import { waitForExit } from "../support/process.js";
+import { StatusDashboard } from "../../src/observability/tui.js";
 
 const originalEnv = { ...process.env };
 
@@ -633,5 +634,75 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     } finally {
       orphan.kill("SIGKILL");
     }
+  });
+});
+
+describe("TUI dashboard integration", () => {
+  let server: MockGitHubServer;
+  let tempDir: string;
+  let remotePath: string;
+  let fixturePath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("symphony-tui-");
+    const remote = await createSeedRemote();
+    remotePath = remote.remotePath;
+    server = new MockGitHubServer();
+    await server.start();
+    fixturePath = path.resolve("tests/fixtures");
+    process.env = {
+      ...originalEnv,
+      GH_TOKEN: "test-token",
+      MOCK_GITHUB_API_URL: server.baseUrl,
+      PATH: `${fixturePath}:${originalEnv.PATH ?? ""}`,
+    };
+    delete process.env["SYMPHONY_REPO"];
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await server.stop();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("renders SYMPHONY STATUS frames during a factory run and terminates with an offline frame", async () => {
+    server.seedIssue({
+      number: 1,
+      title: "TUI smoke issue",
+      body: "Verify dashboard renders during orchestrator run",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success.sh"),
+    });
+
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    const frames: string[] = [];
+    const dashboard = new StatusDashboard(
+      () => orchestrator.snapshot(),
+      () => ({ dashboardEnabled: true, refreshMs: 50, renderIntervalMs: 10 }),
+      {
+        enabled: true,
+        refreshMs: 50,
+        renderIntervalMs: 10,
+        renderFn: (content) => {
+          frames.push(content);
+        },
+      },
+    );
+
+    orchestrator.setDashboardNotify(() => dashboard.refresh());
+    dashboard.start();
+    await orchestrator.runOnce();
+    dashboard.stop();
+
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames[0]).toContain("SYMPHONY STATUS");
+    expect(frames[frames.length - 1]).toContain("app_status=offline");
   });
 });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -108,6 +108,11 @@ const baseConfig: ResolvedConfig = {
     timeoutMs: 1_000,
     env: {},
   },
+  observability: {
+    dashboardEnabled: false,
+    refreshMs: 1000,
+    renderIntervalMs: 16,
+  },
 };
 
 const staticPromptBuilder: PromptBuilder = {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -129,6 +129,24 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("error=rate limited");
   });
 
+  it("renders retry entry with null error without crashing", () => {
+    const snapshot = makeSnapshot({
+      retrying: [
+        {
+          issueNumber: 2,
+          identifier: "MT-102",
+          nextAttempt: 1,
+          dueInMs: 2_000,
+          lastError: null,
+        },
+      ],
+    });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toContain("MT-102");
+    expect(output).toContain("attempt=1");
+    expect(output).not.toContain("error=");
+  });
+
   it("renders polling as checking now", () => {
     const snapshot = makeSnapshot({
       polling: {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -27,6 +27,8 @@ function makeSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
       nextPollAtMs: Date.now() + 30_000,
       intervalMs: 30_000,
     },
+    maxConcurrentRuns: 5,
+    projectUrl: null,
     ...overrides,
   };
 }
@@ -83,6 +85,7 @@ describe("formatSnapshotContent", () => {
         {
           issueNumber: 1,
           identifier: "MT-101",
+          issueState: "In Progress",
           startedAt: new Date(Date.now() - 75_000), // 1m 15s ago
           retryAttempt: 1,
           sessionId: "abcdef1234567890",
@@ -99,9 +102,31 @@ describe("formatSnapshotContent", () => {
     });
     const output = formatSnapshotContent(snapshot, 0, 200);
     expect(output).toContain("MT-101");
+    expect(output).toContain("In Progress");
     expect(output).toContain("12345");
     expect(output).toContain("4,521");
     expect(output).toContain("abcd...567890");
+  });
+
+  it("renders agents count with max", () => {
+    const snapshot = makeSnapshot({ maxConcurrentRuns: 5 });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toContain("0");
+    expect(output).toMatch(/Agents:.*\/.*5/);
+  });
+
+  it("renders project URL when present", () => {
+    const snapshot = makeSnapshot({
+      projectUrl: "https://linear.app/project/PROJ/issues",
+    });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toContain("Project:");
+    expect(output).toContain("https://linear.app/project/PROJ/issues");
+  });
+
+  it("omits project line when projectUrl is null", () => {
+    const output = formatSnapshotContent(makeSnapshot({ projectUrl: null }), 0);
+    expect(output).not.toContain("Project:");
   });
 
   it("renders Backoff queue with no retries message", () => {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -500,6 +500,26 @@ describe("StatusDashboard", () => {
     expect(offlineOutput).toContain("app_status=offline");
   });
 
+  it("stop() is idempotent — calling twice does not render offline frame twice", () => {
+    const renders: string[] = [];
+    const dashboard = new StatusDashboard(
+      () => makeSnapshot(),
+      () => makeConfig(),
+      {
+        renderFn: (c) => renders.push(c),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+    dashboard.stop();
+    dashboard.stop();
+    const offlineCount = renders.filter((r) =>
+      r.includes("app_status=offline"),
+    ).length;
+    expect(offlineCount).toBe(1);
+  });
+
   it("refresh() triggers immediate render", () => {
     const rendered: string[] = [];
     const dashboard = new StatusDashboard(

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSnapshotContent,
+  humanizeEvent,
+  rollingTps,
+  StatusDashboard,
+  throttledTps,
+} from "../../src/observability/tui.js";
+import type { TuiSnapshot } from "../../src/orchestrator/service.js";
+import type { ObservabilityConfig } from "../../src/domain/workflow.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
+  return {
+    running: [],
+    retrying: [],
+    codexTotals: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      secondsRunning: 0,
+    },
+    rateLimits: null,
+    polling: {
+      checkingNow: false,
+      nextPollAtMs: Date.now() + 30_000,
+      intervalMs: 30_000,
+    },
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<ObservabilityConfig> = {}): ObservabilityConfig {
+  return {
+    dashboardEnabled: true,
+    refreshMs: 1000,
+    renderIntervalMs: 16,
+    ...overrides,
+  };
+}
+
+// ─── formatSnapshotContent ────────────────────────────────────────────────────
+
+describe("formatSnapshotContent", () => {
+  it("renders offline frame when snapshot is null", () => {
+    const output = formatSnapshotContent(null, 0);
+    expect(output).toContain("SYMPHONY STATUS");
+    expect(output).toContain("Orchestrator snapshot unavailable");
+    expect(output).toContain("╰─");
+  });
+
+  it("renders header with agent count and tokens", () => {
+    const snapshot = makeSnapshot({
+      codexTotals: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        secondsRunning: 125,
+      },
+    });
+    const output = formatSnapshotContent(snapshot, 250);
+    expect(output).toContain("Agents:");
+    expect(output).toContain("Throughput:");
+    expect(output).toContain("250"); // tps
+    expect(output).toContain("Runtime:");
+    expect(output).toContain("2m 5s");
+    expect(output).toContain("Tokens:");
+    expect(output).toContain("1,500"); // total
+  });
+
+  it("renders Running section with no active agents message", () => {
+    const output = formatSnapshotContent(makeSnapshot(), 0);
+    expect(output).toContain("Running");
+    expect(output).toContain("No active agents");
+  });
+
+  it("renders running agent row", () => {
+    const snapshot = makeSnapshot({
+      running: [
+        {
+          issueNumber: 1,
+          identifier: "MT-101",
+          startedAt: new Date(Date.now() - 75_000), // 1m 15s ago
+          retryAttempt: 1,
+          sessionId: "abcdef1234567890",
+          turnCount: 3,
+          codexTotalTokens: 4521,
+          codexInputTokens: 2000,
+          codexOutputTokens: 2521,
+          codexAppServerPid: 12345,
+          lastCodexEvent: "turn_completed",
+          lastCodexMessage: null,
+          lastCodexTimestamp: null,
+        },
+      ],
+    });
+    const output = formatSnapshotContent(snapshot, 0, 200);
+    expect(output).toContain("MT-101");
+    expect(output).toContain("12345");
+    expect(output).toContain("4,521");
+    expect(output).toContain("abcd...567890");
+  });
+
+  it("renders Backoff queue with no retries message", () => {
+    const output = formatSnapshotContent(makeSnapshot(), 0);
+    expect(output).toContain("Backoff queue");
+    expect(output).toContain("No queued retries");
+  });
+
+  it("renders retry entry with error", () => {
+    const snapshot = makeSnapshot({
+      retrying: [
+        {
+          issueNumber: 2,
+          identifier: "MT-102",
+          nextAttempt: 3,
+          dueInMs: 12_500,
+          lastError: "rate limited",
+        },
+      ],
+    });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toContain("MT-102");
+    expect(output).toContain("attempt=3");
+    expect(output).toContain("12.500s");
+    expect(output).toContain("error=rate limited");
+  });
+
+  it("renders polling as checking now", () => {
+    const snapshot = makeSnapshot({
+      polling: { checkingNow: true, nextPollAtMs: Date.now(), intervalMs: 30_000 },
+    });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toContain("checking now");
+  });
+
+  it("renders Next refresh countdown", () => {
+    const snapshot = makeSnapshot({
+      polling: {
+        checkingNow: false,
+        nextPollAtMs: Date.now() + 42_000,
+        intervalMs: 30_000,
+      },
+    });
+    const output = formatSnapshotContent(snapshot, 0);
+    expect(output).toMatch(/Next refresh:.*42s/);
+  });
+
+  it("renders offline frame", () => {
+    const output = formatSnapshotContent(null, 0);
+    expect(output).toContain("app_status=offline" + "\x1b[0m" === output
+      ? ""
+      : ""); // just check presence
+    expect(output).toContain("Orchestrator snapshot unavailable");
+  });
+});
+
+// ─── humanizeEvent ────────────────────────────────────────────────────────────
+
+describe("humanizeEvent", () => {
+  it("returns no codex message yet when message is null", () => {
+    expect(humanizeEvent(null, null)).toBe("no codex message yet");
+  });
+
+  it("humanizes task_started wrapper event", () => {
+    expect(humanizeEvent({ event: "codex/event/task_started" }, "codex/event/task_started")).toBe(
+      "task started",
+    );
+  });
+
+  it("humanizes user_message wrapper event", () => {
+    expect(humanizeEvent({}, "codex/event/user_message")).toBe("user message received");
+  });
+
+  it("humanizes mcp_startup_complete wrapper event", () => {
+    expect(humanizeEvent({}, "codex/event/mcp_startup_complete")).toBe("mcp startup complete");
+  });
+
+  it("humanizes exec_command_output_delta wrapper event", () => {
+    expect(humanizeEvent({}, "codex/event/exec_command_output_delta")).toBe(
+      "command output streaming",
+    );
+  });
+
+  it("humanizes exec_command_begin with command text", () => {
+    const msg = { params: { msg: { command: "git status" } } };
+    expect(humanizeEvent(msg, "codex/event/exec_command_begin")).toBe("git status");
+  });
+
+  it("humanizes exec_command_end with exit code", () => {
+    const msg = { params: { msg: { exit_code: 0 } } };
+    expect(humanizeEvent(msg, "codex/event/exec_command_end")).toBe("command completed (exit 0)");
+  });
+
+  it("humanizes token_count wrapper event with counts", () => {
+    const msg = {
+      params: {
+        tokenUsage: {
+          total: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+        },
+      },
+    };
+    expect(humanizeEvent(msg, "codex/event/token_count")).toContain("token count update");
+  });
+
+  it("humanizes thread/started method", () => {
+    const msg = { method: "thread/started", params: { thread: { id: "thread-abc" } } };
+    expect(humanizeEvent(msg, null)).toBe("thread started (thread-abc)");
+  });
+
+  it("humanizes turn/completed method with usage", () => {
+    const msg = {
+      method: "turn/completed",
+      params: {
+        turn: { status: "completed" },
+        usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+      },
+    };
+    const result = humanizeEvent(msg, null);
+    expect(result).toContain("turn completed");
+    expect(result).toContain("in 100");
+  });
+
+  it("humanizes turn/failed method with error message", () => {
+    const msg = {
+      method: "turn/failed",
+      params: { error: { message: "context too long" } },
+    };
+    expect(humanizeEvent(msg, null)).toBe("turn failed: context too long");
+  });
+
+  it("humanizes turn/cancelled method", () => {
+    const msg = { method: "turn/cancelled" };
+    expect(humanizeEvent(msg, null)).toBe("turn cancelled");
+  });
+
+  it("humanizes item/commandExecution/requestApproval with command", () => {
+    const msg = {
+      method: "item/commandExecution/requestApproval",
+      params: { parsedCmd: "rm -rf /" },
+    };
+    expect(humanizeEvent(msg, null)).toBe("command approval requested (rm -rf /)");
+  });
+
+  it("humanizes item/agentMessage/delta with preview", () => {
+    const msg = {
+      method: "item/agentMessage/delta",
+      params: { delta: "Hello, I'm working on" },
+    };
+    const result = humanizeEvent(msg, null);
+    expect(result).toContain("agent message streaming");
+    expect(result).toContain("Hello");
+  });
+
+  it("humanizes session_started event", () => {
+    expect(humanizeEvent({ session_id: "sess-1" }, "session_started")).toBe(
+      "session started (sess-1)",
+    );
+  });
+
+  it("truncates long events to 140 characters", () => {
+    const longText = "x".repeat(200);
+    const msg = { method: "turn/failed", params: { error: { message: longText } } };
+    const result = humanizeEvent(msg, null);
+    expect(result.length).toBeLessThanOrEqual(143); // 140 + "..."
+  });
+});
+
+// ─── rollingTps ───────────────────────────────────────────────────────────────
+
+describe("rollingTps", () => {
+  it("returns 0 with empty samples", () => {
+    expect(rollingTps([], 1000, 0)).toBe(0);
+  });
+
+  it("computes TPS with single prior sample within window", () => {
+    // samples=[[500,100]], now=1000, current=200 → 100 tokens over 500ms = 200 TPS
+    expect(rollingTps([[500, 100]], 1000, 200)).toBeCloseTo(200);
+  });
+
+  it("calculates TPS correctly over 1 second", () => {
+    const now = 2000;
+    const samples: [number, number][] = [[1000, 0]]; // 1s ago, 0 tokens
+    const tps = rollingTps(samples, now, 1000); // 1000 tokens in 1 second
+    expect(tps).toBeCloseTo(1000);
+  });
+
+  it("prunes samples older than 5 seconds", () => {
+    const now = 10_000;
+    // Old sample outside window
+    const samples: [number, number][] = [[4000, 0]]; // 6s ago
+    const tps = rollingTps(samples, now, 1000);
+    // Only 1 sample left after pruning + current => 0
+    expect(tps).toBe(0);
+  });
+
+  it("uses only samples within the 5-second window", () => {
+    const now = 10_000;
+    const samples: [number, number][] = [
+      [5500, 100], // 4.5s ago - within window
+      [4000, 0],   // 6s ago - outside window
+    ];
+    const tps = rollingTps(samples, now, 1600);
+    // Delta = 1600-100=1500 tokens over 4500ms = 333 tps
+    expect(tps).toBeCloseTo(333, 0);
+  });
+});
+
+// ─── throttledTps ─────────────────────────────────────────────────────────────
+
+describe("throttledTps", () => {
+  it("returns cached value within the same second", () => {
+    const nowMs = 5500; // second = 5
+    const result = throttledTps(5, 99.5, nowMs, [], 0);
+    expect(result.tps).toBe(99.5);
+    expect(result.second).toBe(5);
+  });
+
+  it("recalculates when second changes", () => {
+    const nowMs = 6100; // second = 6
+    const samples: [number, number][] = [[5100, 0]]; // 1s ago
+    const result = throttledTps(5, 99.5, nowMs, samples, 1000);
+    expect(result.second).toBe(6);
+    expect(result.tps).toBeCloseTo(1000, 0);
+  });
+
+  it("recalculates when no cached value exists", () => {
+    const nowMs = 3000;
+    const samples: [number, number][] = [[2000, 0]];
+    const result = throttledTps(null, 0, nowMs, samples, 500);
+    expect(result.second).toBe(3);
+    expect(result.tps).toBeCloseTo(500, 0);
+  });
+});
+
+// ─── StatusDashboard ─────────────────────────────────────────────────────────
+
+describe("StatusDashboard", () => {
+  it("does not render when dashboardEnabled is false", () => {
+    const rendered: string[] = [];
+    const dashboard = new StatusDashboard(
+      () => makeSnapshot(),
+      () => makeConfig({ dashboardEnabled: false }),
+      { renderFn: (c) => rendered.push(c), enabled: false },
+    );
+    dashboard.start();
+    expect(rendered).toHaveLength(0);
+    dashboard.stop();
+  });
+
+  it("captures rendered output via renderFn", async () => {
+    const rendered: string[] = [];
+    const snapshot = makeSnapshot();
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (c) => rendered.push(c),
+        enabled: true,
+        refreshMs: 10,
+        renderIntervalMs: 1,
+      },
+    );
+    dashboard.start();
+    await new Promise((r) => setTimeout(r, 30));
+    dashboard.stop();
+    expect(rendered.length).toBeGreaterThan(0);
+    expect(rendered[0]).toContain("SYMPHONY STATUS");
+  });
+
+  it("renders offline frame on stop", () => {
+    let offlineOutput = "";
+    const dashboard = new StatusDashboard(
+      () => makeSnapshot(),
+      () => makeConfig(),
+      {
+        renderFn: (c) => {
+          offlineOutput = c;
+        },
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+    dashboard.stop();
+    expect(offlineOutput).toContain("app_status=offline");
+  });
+
+  it("refresh() triggers immediate render", () => {
+    const rendered: string[] = [];
+    const dashboard = new StatusDashboard(
+      () => makeSnapshot(),
+      () => makeConfig(),
+      {
+        renderFn: (c) => rendered.push(c),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+    dashboard.refresh();
+    expect(rendered.length).toBeGreaterThan(0);
+    dashboard.stop();
+  });
+
+  it("content deduplication skips re-render for identical snapshot", async () => {
+    const rendered: string[] = [];
+    const snapshot = makeSnapshot();
+    const dashboard = new StatusDashboard(
+      () => snapshot, // same object, same fingerprint
+      () => makeConfig(),
+      {
+        renderFn: (c) => rendered.push(c),
+        enabled: true,
+        refreshMs: 5,
+        renderIntervalMs: 1,
+      },
+    );
+    dashboard.start();
+    await new Promise((r) => setTimeout(r, 30));
+    dashboard.stop();
+    // Deduplicated: should be 1 render (initial) + possibly 1 periodic rerender per second
+    expect(rendered.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -31,7 +31,9 @@ function makeSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
   };
 }
 
-function makeConfig(overrides: Partial<ObservabilityConfig> = {}): ObservabilityConfig {
+function makeConfig(
+  overrides: Partial<ObservabilityConfig> = {},
+): ObservabilityConfig {
   return {
     dashboardEnabled: true,
     refreshMs: 1000,
@@ -129,7 +131,11 @@ describe("formatSnapshotContent", () => {
 
   it("renders polling as checking now", () => {
     const snapshot = makeSnapshot({
-      polling: { checkingNow: true, nextPollAtMs: Date.now(), intervalMs: 30_000 },
+      polling: {
+        checkingNow: true,
+        nextPollAtMs: Date.now(),
+        intervalMs: 30_000,
+      },
     });
     const output = formatSnapshotContent(snapshot, 0);
     expect(output).toContain("checking now");
@@ -149,9 +155,9 @@ describe("formatSnapshotContent", () => {
 
   it("renders offline frame", () => {
     const output = formatSnapshotContent(null, 0);
-    expect(output).toContain("app_status=offline" + "\x1b[0m" === output
-      ? ""
-      : ""); // just check presence
+    expect(output).toContain(
+      "app_status=offline" + "\x1b[0m" === output ? "" : "",
+    ); // just check presence
     expect(output).toContain("Orchestrator snapshot unavailable");
   });
 });
@@ -164,17 +170,24 @@ describe("humanizeEvent", () => {
   });
 
   it("humanizes task_started wrapper event", () => {
-    expect(humanizeEvent({ event: "codex/event/task_started" }, "codex/event/task_started")).toBe(
-      "task started",
-    );
+    expect(
+      humanizeEvent(
+        { event: "codex/event/task_started" },
+        "codex/event/task_started",
+      ),
+    ).toBe("task started");
   });
 
   it("humanizes user_message wrapper event", () => {
-    expect(humanizeEvent({}, "codex/event/user_message")).toBe("user message received");
+    expect(humanizeEvent({}, "codex/event/user_message")).toBe(
+      "user message received",
+    );
   });
 
   it("humanizes mcp_startup_complete wrapper event", () => {
-    expect(humanizeEvent({}, "codex/event/mcp_startup_complete")).toBe("mcp startup complete");
+    expect(humanizeEvent({}, "codex/event/mcp_startup_complete")).toBe(
+      "mcp startup complete",
+    );
   });
 
   it("humanizes exec_command_output_delta wrapper event", () => {
@@ -185,12 +198,16 @@ describe("humanizeEvent", () => {
 
   it("humanizes exec_command_begin with command text", () => {
     const msg = { params: { msg: { command: "git status" } } };
-    expect(humanizeEvent(msg, "codex/event/exec_command_begin")).toBe("git status");
+    expect(humanizeEvent(msg, "codex/event/exec_command_begin")).toBe(
+      "git status",
+    );
   });
 
   it("humanizes exec_command_end with exit code", () => {
     const msg = { params: { msg: { exit_code: 0 } } };
-    expect(humanizeEvent(msg, "codex/event/exec_command_end")).toBe("command completed (exit 0)");
+    expect(humanizeEvent(msg, "codex/event/exec_command_end")).toBe(
+      "command completed (exit 0)",
+    );
   });
 
   it("humanizes token_count wrapper event with counts", () => {
@@ -201,11 +218,16 @@ describe("humanizeEvent", () => {
         },
       },
     };
-    expect(humanizeEvent(msg, "codex/event/token_count")).toContain("token count update");
+    expect(humanizeEvent(msg, "codex/event/token_count")).toContain(
+      "token count update",
+    );
   });
 
   it("humanizes thread/started method", () => {
-    const msg = { method: "thread/started", params: { thread: { id: "thread-abc" } } };
+    const msg = {
+      method: "thread/started",
+      params: { thread: { id: "thread-abc" } },
+    };
     expect(humanizeEvent(msg, null)).toBe("thread started (thread-abc)");
   });
 
@@ -240,7 +262,9 @@ describe("humanizeEvent", () => {
       method: "item/commandExecution/requestApproval",
       params: { parsedCmd: "rm -rf /" },
     };
-    expect(humanizeEvent(msg, null)).toBe("command approval requested (rm -rf /)");
+    expect(humanizeEvent(msg, null)).toBe(
+      "command approval requested (rm -rf /)",
+    );
   });
 
   it("humanizes item/agentMessage/delta with preview", () => {
@@ -261,7 +285,10 @@ describe("humanizeEvent", () => {
 
   it("truncates long events to 140 characters", () => {
     const longText = "x".repeat(200);
-    const msg = { method: "turn/failed", params: { error: { message: longText } } };
+    const msg = {
+      method: "turn/failed",
+      params: { error: { message: longText } },
+    };
     const result = humanizeEvent(msg, null);
     expect(result.length).toBeLessThanOrEqual(143); // 140 + "..."
   });
@@ -299,7 +326,7 @@ describe("rollingTps", () => {
     const now = 10_000;
     const samples: [number, number][] = [
       [5500, 100], // 4.5s ago - within window
-      [4000, 0],   // 6s ago - outside window
+      [4000, 0], // 6s ago - outside window
     ];
     const tps = rollingTps(samples, now, 1600);
     // Delta = 1600-100=1500 tokens over 4500ms = 333 tps

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -5,6 +5,7 @@ import {
   rollingTps,
   StatusDashboard,
   throttledTps,
+  tpsSparkline,
 } from "../../src/observability/tui.js";
 import type { TuiSnapshot } from "../../src/orchestrator/service.js";
 import type { ObservabilityConfig } from "../../src/domain/workflow.js";
@@ -374,6 +375,48 @@ describe("rollingTps", () => {
     const tps = rollingTps(samples, now, 1600);
     // Delta = 1600-100=1500 tokens over 4500ms = 333 tps
     expect(tps).toBeCloseTo(333, 0);
+  });
+});
+
+// ─── tpsSparkline ─────────────────────────────────────────────────────────────
+
+describe("tpsSparkline", () => {
+  it("returns empty string with fewer than 2 samples", () => {
+    expect(tpsSparkline([], 10_000)).toBe("");
+    expect(tpsSparkline([[5_000, 100]], 10_000)).toBe("");
+  });
+
+  it("returns 24-character string with sufficient samples", () => {
+    const now = 600_000;
+    const samples: [number, number][] = [
+      [0, 0],
+      [300_000, 5000],
+      [600_000, 10_000],
+    ];
+    const result = tpsSparkline(samples, now);
+    expect(result).toHaveLength(24);
+  });
+
+  it("only uses block chars and spaces", () => {
+    const now = 600_000;
+    const samples: [number, number][] = [
+      [0, 0],
+      [300_000, 5000],
+      [600_000, 10_000],
+    ];
+    const result = tpsSparkline(samples, now);
+    expect([...result].every((c) => " ▁▂▃▄▅▆▇█".includes(c))).toBe(true);
+  });
+
+  it("renders inline on Throughput line when provided", () => {
+    const snapshot = makeSnapshot();
+    const output = formatSnapshotContent(snapshot, 100, undefined, "▁▂▃▄▅▆▇█");
+    expect(output).toContain("100 tps");
+    expect(output).toContain("▁▂▃▄▅▆▇█");
+    // sparkline appears on the Throughput line (same line as tps)
+    const throughputLine =
+      output.split("\n").find((l) => l.includes("Throughput:")) ?? "";
+    expect(throughputLine).toContain("▁▂▃▄▅▆▇█");
   });
 });
 


### PR DESCRIPTION
## Summary
- tighten the symphony-operator merge rule for bot review feedback
- require checking top-level bot comments and summaries in addition to thread state
- prevent merges when actionable bot feedback still exists outside unresolved threads

## Testing
- not run (skill/playbook text change only)