### PR TITLE
Tighten operator merge gate for bot reviews

### DIFF
--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -12,6 +12,7 @@ Use this skill when acting as the operator for the local Symphony factory.
 - Observe the live factory, not just the repository.
 - Repair broken or stalled execution.
 - Drive PRs through CI and automated review to a mergeable state.
+- Handle `plan-ready` issues: review plans, request changes when needed, and approve when ready.
 - Keep GitHub as a thin queue and rely on Symphony's own polling and concurrency.
 - Maintain a persistent local operator notebook in `.ralph/operator-scratchpad.md`.
 
@@ -22,7 +23,12 @@ Use this skill when acting as the operator for the local Symphony factory.
 3. Check the live Symphony worker process and determine whether it is healthy, progressing, stuck, crashed, or misconfigured.
 4. If the factory is unhealthy, fix the concrete problem and restart it.
 5. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-6. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+6. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
+   - `Plan review: approved`
+   - `Plan review: changes-requested`
+   - `Plan review: waived`
+7. After posting a review decision, verify the factory acknowledges it and transitions correctly.
+8. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
 
@@ -33,6 +39,10 @@ Use this skill when acting as the operator for the local Symphony factory.
 - Use an isolated checkout when fixing PR branches so local operator-only modifications do not leak into tracked work.
 - The factory owns PR follow-up by default. If a fresh actionable review batch lands and the factory does not pick it up, debug the miss as a factory/runtime problem before taking over the branch manually.
 - Do not silently replace the worker on an active PR just because the next fix is obvious. Operator PR intervention is for stalled or broken factory behavior, not the normal path.
+- Treat plan review as a required operator checkpoint:
+  - if the plan is sound, post `Plan review: approved`,
+  - if revisions are needed, post `Plan review: changes-requested` with concrete guidance,
+  - if explicitly bypassing review, post `Plan review: waived` and record why.
 
 ## Factory Fix Rule
 
@@ -51,6 +61,7 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 
 - Do not merge while required CI is red or while actionable review comments remain.
 - Greptile and Bugbot comments count as review feedback.
+- Do not treat "all threads resolved" as sufficient by itself. Before merging, also check for top-level bot review comments or review summaries that still contain unaddressed actionable feedback.
 - Low-severity cleanup comments can be answered instead of fixed only when the tradeoff is explicit and defensible.
 
 ## Learned Heuristics

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -26,7 +26,7 @@ Use this skill when acting as the operator for the local Symphony factory.
 6. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
    - `Plan review: approved`
    - `Plan review: changes-requested`
-   - `Plan review: waived`
+   - `Plan review: waived` (record why in the comment)
 7. After posting a review decision, verify the factory acknowledges it and transitions correctly.
 8. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 


### PR DESCRIPTION
## Summary
- tighten the symphony-operator merge rule for bot review feedback
- require checking top-level bot comments and summaries in addition to thread state
- prevent merges when actionable bot feedback still exists outside unresolved threads

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check