### PR TITLE
Add Claude Code runner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 
 ## Quick Start
 
-**Prerequisites:** Node.js 20+, `pnpm`, `git`, [`gh`](https://cli.github.com/) (authenticated), and [`codex`](https://github.com/openai/codex) installed locally.
+**Prerequisites:** Node.js 20+, `pnpm`, `git`, [`gh`](https://cli.github.com/) (authenticated), and at least one supported local runner installed: [`codex`](https://github.com/openai/codex) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview).
 
 ```bash
 git clone https://github.com/sociotechnica-org/symphony-ts.git
@@ -159,29 +159,55 @@ agent:
   max_turns: 20
 ```
 
-| Field                          | Purpose                                                        |
-| ------------------------------ | -------------------------------------------------------------- |
-| `tracker.repo`                 | GitHub repository to poll for labeled issues                   |
-| `tracker.review_bot_logins`    | PR comment authors treated as actionable bot review            |
-| `polling.interval_ms`          | How often to check for new work                                |
-| `polling.max_concurrent_runs`  | Local concurrency cap                                          |
-| `workspace.root`               | Where isolated workspaces are created                          |
-| `workspace.repo_url`           | SSH or HTTPS URL of the repository cloned for each workspace   |
-| `workspace.branch_prefix`      | Issue branch naming prefix                                     |
-| `agent.runner.kind`            | Selects the execution backend (`codex` or `generic-command`)   |
-| `agent.command`                | Subprocess command to launch the coding agent                  |
-| `agent.prompt_transport`       | Sends the prompt over `stdin` or via a temp file path          |
-| `agent.timeout_ms`             | Max wall-clock time per runner turn                            |
-| `agent.max_turns`              | Max in-process continuation turns per worker run               |
-| `workspace.cleanup_on_success` | Remove local workspace after a successful run (default `true`) |
+| Field                          | Purpose                                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| `tracker.repo`                 | GitHub repository to poll for labeled issues                                 |
+| `tracker.review_bot_logins`    | PR comment authors treated as actionable bot review                          |
+| `polling.interval_ms`          | How often to check for new work                                              |
+| `polling.max_concurrent_runs`  | Local concurrency cap                                                        |
+| `workspace.root`               | Where isolated workspaces are created                                        |
+| `workspace.repo_url`           | SSH or HTTPS URL of the repository cloned for each workspace                 |
+| `workspace.branch_prefix`      | Issue branch naming prefix                                                   |
+| `agent.runner.kind`            | Selects the execution backend (`codex`, `claude-code`, or `generic-command`) |
+| `agent.command`                | Subprocess command to launch the coding agent                                |
+| `agent.prompt_transport`       | Sends the prompt over `stdin` or via a temp file path                        |
+| `agent.timeout_ms`             | Max wall-clock time per runner turn                                          |
+| `agent.max_turns`              | Max in-process continuation turns per worker run                             |
+| `workspace.cleanup_on_success` | Remove local workspace after a successful run (default `true`)               |
 
 `agent.timeout_ms` applies to each runner turn. If `agent.max_turns` is greater
 than `1`, a single worker run can consume multiple per-turn timeout windows
 before it exits.
 
 `agent.runner.kind` keeps backend selection in `WORKFLOW.md`. Use `codex` for
-the built-in Codex continuation path, or `generic-command` to launch another
-local CLI through the same orchestrator path:
+the built-in Codex continuation path, `claude-code` for the first-class Claude
+Code adapter, or `generic-command` to launch another local CLI through the same
+orchestrator path:
+
+```yaml
+agent:
+  runner:
+    kind: claude-code
+  command: claude -p --output-format json --permission-mode bypassPermissions --model sonnet
+  prompt_transport: stdin
+  timeout_ms: 1800000
+  max_turns: 20
+```
+
+The Claude Code adapter expects a headless JSON command shape so Symphony can
+capture `session_id` for continuation turns and status artifacts. Keep these
+constraints in `WORKFLOW.md`:
+
+- use `claude -p` / `claude --print`
+- include `--output-format json`
+- use non-interactive permissions such as `--permission-mode bypassPermissions`
+  or `--dangerously-skip-permissions`
+- keep `agent.prompt_transport: stdin`
+- do not bake `--resume`, `--continue`, `--session-id`, or a prompt argument
+  into `agent.command`; the runner owns those continuation details
+
+Use `generic-command` when you want raw subprocess execution without
+Claude-specific session semantics:
 
 ```yaml
 agent:

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -29,6 +29,10 @@ agent:
   runner:
     kind: codex
   command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
+  # Claude Code example:
+  # runner:
+  #   kind: claude-code
+  # command: claude -p --output-format json --permission-mode bypassPermissions --model sonnet
   prompt_transport: stdin
   timeout_ms: 5400000
   max_turns: 20

--- a/docs/plans/091-claude-code-runner-integration/plan.md
+++ b/docs/plans/091-claude-code-runner-integration/plan.md
@@ -1,0 +1,271 @@
+# Issue 91 Plan: Claude Code Runner Integration For Local Factory Runs
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a first-class Claude Code local runner path on top of the provider-neutral runner seam from `#89` and the workflow-owned runner selection seam from `#90`, so a local Symphony factory run can execute a real issue through Claude Code when Codex capacity is constrained.
+
+## Scope
+
+- add an explicit Claude Code runner kind and typed configuration under `agent.runner`
+- implement a Claude Code runner adapter that launches the local `claude` CLI in headless mode through the existing runner contract
+- preserve prompt delivery through the existing prompt transport seam while defining the minimum supported Claude command shape
+- support Claude continuation turns through the runner live-session seam when `agent.max_turns > 1`
+- keep normalized runner session metadata and spawn events usable by the existing status/artifact/report surfaces
+- add tests for workflow parsing, runner factory selection, Claude command execution/session behavior, and one real local validation path
+- document the `WORKFLOW.md` shape and local prerequisites for selecting Claude Code explicitly
+
+## Non-goals
+
+- hosted or background Claude execution
+- remote workspace lifecycle changes
+- dynamic backend-routing policy across multiple providers
+- tracker transport, normalization, or policy changes
+- orchestration retry, lease, reconciliation, or handoff-policy redesign
+- broad observability redesign beyond the minimum normalized metadata needed to keep local runs inspectable
+- runner-log report enrichment for Claude session artifacts
+
+## Current Gaps
+
+- `src/domain/workflow.ts` only models `codex` and `generic-command` runner kinds
+- `src/config/workflow.ts` rejects `agent.runner.kind: claude-code` today
+- `src/runner/factory.ts` cannot construct a Claude-specific runner
+- the current generic command path can launch arbitrary CLIs, but it does not encode the Claude-specific command invariants we need for a reliable local fallback:
+  - headless execution flags
+  - permission-mode expectations
+  - continuation-session resume behavior
+  - normalized provider/model/session metadata
+- README and checked-in workflow examples describe only Codex or a generic command path, not an explicit Claude selection contract
+- there is no test or validation path proving a full local factory issue can run through Claude Code
+
+## Decision Notes
+
+- Keep Claude as an explicit execution-layer adapter rather than documenting it as a generic command recipe. We need a stable workflow contract and normalized session metadata, not a stringly-typed convention.
+- Reuse the existing subprocess execution helpers instead of introducing a second process-launch stack.
+- Treat the minimum supported Claude command shape as repo-owned configuration:
+  - non-interactive print mode
+  - explicit working directory
+  - a non-blocking permission configuration suitable for local factory runs
+- Keep Claude-specific CLI normalization inside `src/runner/`; do not leak Anthropic CLI flags into orchestrator policy.
+- Prefer a narrow adapter that validates required Claude flags and constructs continuation commands centrally, instead of scattering command-shape checks across config, tests, and docs.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the repo-owned decision that Claude Code is a supported local backend and must be selected explicitly in `WORKFLOW.md`
+  - does not belong: raw CLI flag parsing, subprocess launch mechanics, or tracker handoff behavior
+- Configuration Layer
+  - belongs: typed `agent.runner.kind: claude-code`, any minimal Claude-specific nested config, and validation of supported workflow-owned settings
+  - does not belong: process spawning, session discovery, or tracker mutations
+- Coordination Layer
+  - belongs: unchanged consumption of the provider-neutral `Runner` contract and existing continuation/retry policy
+  - does not belong: branching on Claude-specific flags, provider resume rules, or command rewriting
+- Execution Layer
+  - belongs: Claude runner adapter, command validation/building, continuation-session behavior, and normalized Claude session metadata
+  - does not belong: prompt template rendering, tracker lifecycle updates, or backend-routing policy
+- Integration Layer
+  - belongs: untouched in this slice
+  - does not belong: Claude CLI details or workflow runner selection
+- Observability Layer
+  - belongs: preserving normalized provider/model/session metadata so status, issue artifacts, and reports remain operable
+  - does not belong: parsing raw Claude CLI output in status/reporting code to infer provider behavior
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts`
+  - add a typed Claude runner config variant
+- `src/config/workflow.ts`
+  - parse and validate the Claude workflow selection seam
+- `src/runner/`
+  - add a Claude runner implementation
+  - add Claude command parsing/validation helpers
+  - add Claude continuation/resume command handling if supported by the CLI seam
+  - update runner factory wiring
+- tests
+  - workflow parsing
+  - runner factory selection
+  - Claude runner behavior and continuation semantics
+  - focused e2e/local validation coverage for a factory run using Claude
+- docs
+  - README and `WORKFLOW.md` examples for explicit Claude selection
+
+### Does not belong in this issue
+
+- tracker API changes
+- orchestrator state-machine changes
+- workspace lifecycle changes beyond what existing runner execution already uses
+- status-surface redesign
+- report-enricher work for Claude logs
+- dynamic provider selection or automatic fallback between Codex and Claude
+
+## Layering Notes
+
+- `config/workflow`
+  - owns typed Claude selection and validation
+  - does not infer tracker policy or mutate runner commands at runtime based on issue state
+- `tracker`
+  - remains isolated from runner selection and Claude-specific metadata
+  - does not special-case Claude-backed issues
+- `workspace`
+  - continues to provide filesystem context only
+  - does not own Claude CLI flag policy or session reuse behavior
+- `runner`
+  - owns Claude command validation, launch behavior, continuation-session handling, and normalized metadata
+  - does not render prompts, write tracker comments, or decide retries
+- `orchestrator`
+  - keeps consuming only the `Runner` interface
+  - does not branch on `claude-code`
+- `observability`
+  - keeps consuming normalized runner metadata
+  - does not become a second Claude adapter
+
+## Slice Strategy And PR Seam
+
+This should land as one reviewable PR by keeping the seam limited to workflow config, the runner adapter, tests, and docs:
+
+1. add typed Claude workflow selection
+2. implement the Claude runner adapter behind the existing runner contract
+3. prove the path with focused unit/integration coverage and one local factory validation path
+4. document the supported `WORKFLOW.md` contract and prerequisites
+
+This remains reviewable because it does not combine:
+
+- tracker-policy changes
+- orchestrator runtime-state refactors
+- workspace lifecycle redesign
+- broader provider capability modeling
+- report/archive enrichment work
+
+If local validation shows that Claude requires broader visibility or artifact changes, capture that as a follow-up issue instead of expanding this PR.
+
+## Runner Session State Model
+
+This issue does not change orchestrator retries, reconciliation, leases, or handoff states. The stateful surface is the Claude execution-layer session lifecycle behind the existing `LiveRunnerSession` seam.
+
+### States
+
+- `idle`
+  - Claude runner exists but no turn has started
+- `starting`
+  - Claude subprocess command for the current turn is being prepared and launched
+- `running`
+  - the turn is active and spawn metadata may be emitted
+- `completed`
+  - a turn finished with a normalized result
+- `failed`
+  - command validation, launch, or session-discovery/resume failed
+- `closed`
+  - no additional turns will execute in this live session
+
+### Allowed transitions
+
+- `idle -> starting`
+- `starting -> running`
+- `starting -> failed`
+- `running -> completed`
+- `running -> failed`
+- `completed -> starting`
+  - for continuation turns
+- `completed -> closed`
+- `failed -> closed`
+
+### Contract rules
+
+- turn 1 must use a Claude-compatible headless command shape
+- continuation turns may reuse Claude conversation state only through a runner-owned resume mechanism; the orchestrator must stay unaware of Claude CLI details
+- if Claude cannot provide a reusable backend session id for continuation, the runner must fail explicitly rather than silently changing continuation semantics
+- normalized session metadata may set `model` or `backendSessionId` to `null` only when those facts are unavailable from the supported Claude command/result seam
+
+## Failure-Class Matrix
+
+| Observed condition                                                                                                                | Local facts available                      | Normalized facts available                         | Expected decision                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `WORKFLOW.md` selects `claude-code` with an unsupported or malformed command shape                                                | workflow config, command string            | config parse / runner construction context         | fail fast during startup or runner construction with a config/runner error                                          |
+| Claude runner is selected but `claude` is not installed or not executable                                                         | command string, spawn error                | process launch failure                             | use existing orchestrator run-failure path; no tracker-policy change                                                |
+| Claude headless turn exits non-zero                                                                                               | workspace path, turn number                | normalized run result with exit code/stdout/stderr | use existing orchestrator failure handling                                                                          |
+| Claude turn succeeds but no resumable session id is discoverable while `agent.max_turns > 1` and a continuation turn is requested | prior successful turn result, runner state | missing `backendSessionId` after success           | fail at the runner adapter boundary; do not silently cold-start unless the documented contract explicitly allows it |
+| Claude run succeeds in one turn                                                                                                   | command config, workspace path             | normalized provider/model/session metadata         | complete through the existing orchestrator path                                                                     |
+| Claude output omits optional model metadata                                                                                       | command/result output                      | provider known, model unknown                      | preserve `provider: claude-code`, set `model: null`, keep status surfaces working                                   |
+
+## Storage / Persistence Contract
+
+- no new durable tracker state is introduced
+- existing issue artifact/status persistence should keep consuming normalized runner spawn/session/result metadata
+- if Claude session ids or log pointers are available, store them through the existing provider-neutral session shape rather than a Claude-only artifact schema
+- report enrichment for Claude-specific logs is explicitly deferred
+
+## Observability Requirements
+
+- session descriptions for Claude runs must identify the provider as `claude-code`
+- preserve spawn events so watchdog/status/artifact flows continue to work
+- capture model and backend session id when the supported Claude CLI path exposes them
+- keep logs and status readable even if Claude metadata is partially unavailable
+- update docs to make the supported headless command shape inspectable by operators
+
+## Implementation Steps
+
+1. Extend workflow domain/config parsing with an explicit `claude-code` runner kind and any minimal Claude-specific config needed to validate the local CLI contract.
+2. Add Claude command helper(s) in `src/runner/` to:
+   - identify Claude commands
+   - validate the supported headless command shape
+   - extract normalized metadata when available
+   - build continuation/resume commands if the CLI supports them
+3. Implement `ClaudeCodeRunner` behind the existing `Runner` contract, reusing the shared local execution helper and live-session seam.
+4. Update `src/runner/factory.ts` to construct the Claude runner from resolved workflow config.
+5. Add or update tests for:
+   - workflow parsing and validation
+   - runner factory selection
+   - Claude one-shot execution
+   - Claude continuation-session behavior
+   - failure handling for malformed config or missing continuation metadata
+6. Add one focused end-to-end or integration-style path that exercises a factory run configured for Claude through the existing local orchestration path.
+7. Update README and checked-in `WORKFLOW.md` documentation with the explicit Claude selection contract, prerequisites, and a minimal example.
+8. Run a real local validation flow against a local issue/repo path using Claude Code and record any follow-up gaps separately if they are outside this slice.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- workflow config accepts `agent.runner.kind: claude-code` with the supported command/config shape
+- workflow config rejects malformed Claude runner config or unsupported command expectations
+- runner factory returns `ClaudeCodeRunner` when the workflow selects Claude
+- Claude runner describes sessions with `provider: claude-code`
+- Claude live session reuses the backend session when continuation turns are supported
+- Claude runner fails clearly when continuation is requested but resumable session metadata is unavailable
+
+### Integration / end-to-end coverage
+
+- keep existing Codex and generic-command tests green
+- add one focused integration or e2e fixture that runs the factory with `agent.runner.kind: claude-code`
+- add one local validation run against the real Claude CLI if available in the operator environment; if that validation cannot run in CI, record it in issue/PR notes while keeping automated coverage on mocked/subprocess seams
+
+### Acceptance scenarios
+
+1. A workflow explicitly selecting Claude starts the Claude runner path without orchestrator branching.
+2. A local factory run can execute a real issue through Claude Code and reach the same handoff path used by other runners.
+3. Prompt delivery still works through the configured transport for Claude’s supported headless mode.
+4. Status and issue artifacts remain inspectable with normalized Claude session metadata.
+5. Existing Codex and generic-command paths remain unaffected.
+
+## Exit Criteria
+
+- `WORKFLOW.md` can select Claude explicitly through typed config
+- runtime wiring constructs a Claude runner outside the orchestrator
+- Claude can execute the factory prompt in headless local mode
+- continuation turns are either supported explicitly through the adapter or rejected with a documented, tested boundary error
+- automated tests cover workflow selection and Claude runner behavior
+- docs describe the supported local Claude setup clearly enough for operators to use it as a fallback backend
+- any richer visibility or remote follow-ups are captured separately instead of folded into this PR
+
+## Deferred To Later Issues Or PRs
+
+- Claude-specific report/log enrichment
+- remote or background Claude execution
+- provider capability negotiation beyond the minimum needed for this local slice
+- dynamic backend fallback/routing policy
+- visibility redesign for provider-specific progress details

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -38,7 +38,11 @@ const DEFAULT_LINEAR_TERMINAL_STATES = [
   "Done",
 ] as const;
 const SUPPORTED_TRACKER_KINDS = ["github-bootstrap", "linear"] as const;
-const SUPPORTED_AGENT_RUNNER_KINDS = ["codex", "generic-command"] as const;
+const SUPPORTED_AGENT_RUNNER_KINDS = [
+  "codex",
+  "generic-command",
+  "claude-code",
+] as const;
 type SupportedTrackerKind = (typeof SUPPORTED_TRACKER_KINDS)[number];
 type SupportedAgentRunnerKind = (typeof SUPPORTED_AGENT_RUNNER_KINDS)[number];
 
@@ -469,6 +473,8 @@ function resolveAgentRunnerConfig(
       return { kind: "codex" };
     case "generic-command":
       return { kind: "generic-command" };
+    case "claude-code":
+      return { kind: "claude-code" };
     default:
       return exhaustiveAgentRunnerKind(kind);
   }

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -63,7 +63,14 @@ export interface GenericCommandRunnerConfig {
   readonly kind: "generic-command";
 }
 
-export type AgentRunnerConfig = CodexRunnerConfig | GenericCommandRunnerConfig;
+export interface ClaudeCodeRunnerConfig {
+  readonly kind: "claude-code";
+}
+
+export type AgentRunnerConfig =
+  | CodexRunnerConfig
+  | GenericCommandRunnerConfig
+  | ClaudeCodeRunnerConfig;
 
 export interface AgentConfig {
   readonly runner: AgentRunnerConfig;

--- a/src/runner/claude-code-command.ts
+++ b/src/runner/claude-code-command.ts
@@ -33,6 +33,8 @@ const CLAUDE_VALUE_FLAGS = new Set([
   "--debug-file",
   "--agent",
   "--session-id",
+  "--continue",
+  "-c",
   "--resume",
   "-r",
   "--add-dir",

--- a/src/runner/claude-code-command.ts
+++ b/src/runner/claude-code-command.ts
@@ -7,6 +7,7 @@ import type { RunnerSessionDescription } from "./service.js";
 interface ParsedClaudeCodeResult {
   readonly sessionId: string | null;
   readonly model: string | null;
+  readonly modelCount: number;
 }
 
 const CLAUDE_RESULT_OUTPUT_FORMAT = "json";
@@ -14,6 +15,9 @@ const CLAUDE_HEADLESS_PERMISSION_FLAGS = [
   "--dangerously-skip-permissions",
   "--permission-mode=bypassPermissions",
 ] as const;
+// Keep this list aligned with Claude flags that consume the next token. If the
+// CLI adds new value-taking flags and this set is not updated,
+// ensureNoPromptArgument can misclassify the value token as a prompt argument.
 const CLAUDE_VALUE_FLAGS = new Set([
   "--model",
   "--output-format",
@@ -131,42 +135,51 @@ export function parseClaudeCodeResult(stdout: string): ParsedClaudeCodeResult {
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  const candidate = lines.at(-1);
-  if (candidate === undefined) {
+  if (lines.length === 0) {
     throw new RunnerError(
       "Claude Code runner requires JSON output but stdout was empty",
     );
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(candidate);
-  } catch (error) {
-    throw new RunnerError("Claude Code runner returned malformed JSON output", {
-      cause: error instanceof Error ? error : new Error(String(error)),
-    });
+  let fallbackCandidate: Record<string, unknown> | null = null;
+  for (const line of [...lines].reverse()) {
+    const parsed = tryParseResultLine(line);
+    if (parsed === null) {
+      continue;
+    }
+    if (fallbackCandidate === null) {
+      fallbackCandidate = parsed;
+    }
+    if (parsed["type"] === "result") {
+      return toParsedClaudeCodeResult(parsed);
+    }
   }
 
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new RunnerError(
-      "Claude Code runner requires a JSON object result payload",
-    );
+  if (fallbackCandidate !== null) {
+    return toParsedClaudeCodeResult(fallbackCandidate);
   }
 
-  const result = parsed as Record<string, unknown>;
+  throw new RunnerError("Claude Code runner returned malformed JSON output");
+}
+
+function toParsedClaudeCodeResult(
+  result: Record<string, unknown>,
+): ParsedClaudeCodeResult {
   const sessionId =
     typeof result["session_id"] === "string" ? result["session_id"] : null;
   const modelUsage = result["modelUsage"];
-  const model =
+  const modelKeys =
     modelUsage !== null &&
     typeof modelUsage === "object" &&
     !Array.isArray(modelUsage)
-      ? firstObjectKey(modelUsage as Record<string, unknown>)
-      : null;
+      ? Object.keys(modelUsage as Record<string, unknown>)
+      : [];
+  const model = modelKeys[0] ?? null;
 
   return {
     sessionId,
     model,
+    modelCount: modelKeys.length,
   };
 }
 
@@ -302,9 +315,18 @@ function flagConsumesNextValue(token: string): boolean {
   return CLAUDE_VALUE_FLAGS.has(token);
 }
 
-function firstObjectKey(object: Record<string, unknown>): string | null {
-  for (const key of Object.keys(object)) {
-    return key;
+function tryParseResultLine(line: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
   }
-  return null;
 }

--- a/src/runner/claude-code-command.ts
+++ b/src/runner/claude-code-command.ts
@@ -1,0 +1,308 @@
+import path from "node:path";
+import { RunnerError } from "../domain/errors.js";
+import type { AgentConfig } from "../domain/workflow.js";
+import { parseLocalRunnerCommand, quoteShellToken } from "./local-command.js";
+import type { RunnerSessionDescription } from "./service.js";
+
+interface ParsedClaudeCodeResult {
+  readonly sessionId: string | null;
+  readonly model: string | null;
+}
+
+const CLAUDE_RESULT_OUTPUT_FORMAT = "json";
+const CLAUDE_HEADLESS_PERMISSION_FLAGS = [
+  "--dangerously-skip-permissions",
+  "--permission-mode=bypassPermissions",
+] as const;
+const CLAUDE_VALUE_FLAGS = new Set([
+  "--model",
+  "--output-format",
+  "--permission-mode",
+  "--setting-sources",
+  "--settings",
+  "--system-prompt",
+  "--append-system-prompt",
+  "--allowed-tools",
+  "--allowedTools",
+  "--disallowed-tools",
+  "--disallowedTools",
+  "--tools",
+  "--input-format",
+  "--json-schema",
+  "--max-budget-usd",
+  "--debug-file",
+  "--agent",
+  "--session-id",
+  "--resume",
+  "-r",
+  "--add-dir",
+  "--mcp-config",
+  "--plugin-dir",
+  "--betas",
+  "--fallback-model",
+  "--effort",
+  "--file",
+]);
+
+export function describeClaudeCodeSession(
+  command: string,
+): RunnerSessionDescription {
+  return {
+    provider: "claude-code",
+    model: readOptionValue(command, ["--model"]),
+    backendSessionId: null,
+    latestTurnNumber: null,
+    logPointers: [],
+  };
+}
+
+export function validateClaudeCodeConfig(config: AgentConfig): void {
+  if (config.runner.kind !== "claude-code") {
+    throw new RunnerError(
+      `ClaudeCodeRunner requires agent.runner.kind 'claude-code', got '${config.runner.kind}'`,
+    );
+  }
+
+  if (config.promptTransport !== "stdin") {
+    throw new RunnerError(
+      "Claude Code runner requires agent.prompt_transport to be 'stdin'",
+    );
+  }
+
+  const parsed = parseLocalRunnerCommand(config.command);
+  if (
+    parsed.executable === null ||
+    path.basename(parsed.executable) !== "claude"
+  ) {
+    throw new RunnerError(
+      "Claude Code runner requires agent.command to invoke the claude CLI",
+    );
+  }
+
+  ensureFlag(
+    parsed.tokens,
+    ["-p", "--print"],
+    "Claude Code runner requires agent.command to include --print",
+  );
+  ensureFlagWithValue(
+    parsed.tokens,
+    ["--output-format"],
+    CLAUDE_RESULT_OUTPUT_FORMAT,
+    "Claude Code runner requires agent.command to include --output-format json",
+  );
+  ensureHeadlessPermissions(parsed.tokens);
+  ensureNoPromptArgument(parsed.tokens, parsed.executableIndex);
+  ensureNoSessionResumeFlags(parsed.tokens);
+
+  if (
+    config.maxTurns > 1 &&
+    hasFlag(parsed.tokens, ["--no-session-persistence"])
+  ) {
+    throw new RunnerError(
+      "Claude Code continuation turns require session persistence; remove --no-session-persistence from agent.command",
+    );
+  }
+}
+
+export function buildClaudeResumeCommand(
+  command: string,
+  sessionId: string,
+): string {
+  const parsed = parseLocalRunnerCommand(command);
+  if (parsed.executable === null) {
+    throw new RunnerError(
+      "Claude Code continuation turns require a valid claude command",
+    );
+  }
+
+  const prefix = parsed.tokens
+    .slice(0, parsed.executableIndex + 1)
+    .map(quoteShellToken);
+  const args = stripUnsupportedResumeArgs(
+    parsed.tokens.slice(parsed.executableIndex + 1),
+  ).map(quoteShellToken);
+  return [...prefix, "--resume", quoteShellToken(sessionId), ...args].join(" ");
+}
+
+export function parseClaudeCodeResult(stdout: string): ParsedClaudeCodeResult {
+  const lines = stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const candidate = lines.at(-1);
+  if (candidate === undefined) {
+    throw new RunnerError(
+      "Claude Code runner requires JSON output but stdout was empty",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch (error) {
+    throw new RunnerError("Claude Code runner returned malformed JSON output", {
+      cause: error instanceof Error ? error : new Error(String(error)),
+    });
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new RunnerError(
+      "Claude Code runner requires a JSON object result payload",
+    );
+  }
+
+  const result = parsed as Record<string, unknown>;
+  const sessionId =
+    typeof result["session_id"] === "string" ? result["session_id"] : null;
+  const modelUsage = result["modelUsage"];
+  const model =
+    modelUsage !== null &&
+    typeof modelUsage === "object" &&
+    !Array.isArray(modelUsage)
+      ? firstObjectKey(modelUsage as Record<string, unknown>)
+      : null;
+
+  return {
+    sessionId,
+    model,
+  };
+}
+
+function ensureFlag(
+  tokens: readonly string[],
+  flags: readonly string[],
+  message: string,
+): void {
+  if (!hasFlag(tokens, flags)) {
+    throw new RunnerError(message);
+  }
+}
+
+function ensureFlagWithValue(
+  tokens: readonly string[],
+  flags: readonly string[],
+  expectedValue: string,
+  message: string,
+): void {
+  const actualValue = readOptionValueFromTokens(tokens, flags);
+  if (actualValue !== expectedValue) {
+    throw new RunnerError(message);
+  }
+}
+
+function ensureHeadlessPermissions(tokens: readonly string[]): void {
+  if (
+    hasFlag(tokens, CLAUDE_HEADLESS_PERMISSION_FLAGS) ||
+    readOptionValueFromTokens(tokens, ["--permission-mode"]) ===
+      "bypassPermissions"
+  ) {
+    return;
+  }
+  throw new RunnerError(
+    "Claude Code runner requires non-interactive permissions; include --permission-mode bypassPermissions or --dangerously-skip-permissions in agent.command",
+  );
+}
+
+function ensureNoPromptArgument(
+  tokens: readonly string[],
+  executableIndex: number,
+): void {
+  for (let index = executableIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === undefined) {
+      continue;
+    }
+    if (token.startsWith("-")) {
+      index += flagConsumesNextValue(token) ? 1 : 0;
+      continue;
+    }
+    throw new RunnerError(
+      "Claude Code runner requires prompts to be delivered by Symphony over stdin; remove prompt arguments from agent.command",
+    );
+  }
+}
+
+function ensureNoSessionResumeFlags(tokens: readonly string[]): void {
+  if (hasFlag(tokens, ["--resume", "-r", "--continue", "-c", "--session-id"])) {
+    throw new RunnerError(
+      "Claude Code runner manages continuation sessions internally; remove --resume, --continue, and --session-id from agent.command",
+    );
+  }
+}
+
+function stripUnsupportedResumeArgs(tokens: readonly string[]): string[] {
+  const stripped: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === undefined) {
+      continue;
+    }
+    if (
+      token === "--resume" ||
+      token === "-r" ||
+      token === "--continue" ||
+      token === "-c" ||
+      token === "--session-id"
+    ) {
+      index += flagConsumesNextValue(token) ? 1 : 0;
+      continue;
+    }
+    stripped.push(token);
+  }
+  return stripped;
+}
+
+function hasFlag(tokens: readonly string[], flags: readonly string[]): boolean {
+  return tokens.some((token) => {
+    if (flags.includes(token)) {
+      return true;
+    }
+    return flags.some((flag) => token.startsWith(`${flag}=`));
+  });
+}
+
+function readOptionValue(
+  command: string,
+  flags: readonly string[],
+): string | null {
+  return readOptionValueFromTokens(
+    parseLocalRunnerCommand(command).tokens,
+    flags,
+  );
+}
+
+function readOptionValueFromTokens(
+  tokens: readonly string[],
+  flags: readonly string[],
+): string | null {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === undefined) {
+      continue;
+    }
+    if (flags.includes(token)) {
+      const value = tokens[index + 1];
+      if (value !== undefined && value.length > 0 && !value.startsWith("-")) {
+        return value;
+      }
+      return null;
+    }
+    const prefix = flags.find((flag) => token.startsWith(`${flag}=`));
+    if (prefix !== undefined) {
+      const value = token.slice(prefix.length + 1);
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+function flagConsumesNextValue(token: string): boolean {
+  return CLAUDE_VALUE_FLAGS.has(token);
+}
+
+function firstObjectKey(object: Record<string, unknown>): string | null {
+  for (const key of Object.keys(object)) {
+    return key;
+  }
+  return null;
+}

--- a/src/runner/claude-code-live-session.ts
+++ b/src/runner/claude-code-live-session.ts
@@ -1,0 +1,104 @@
+import { RunnerError } from "../domain/errors.js";
+import type { RunSession, RunTurn } from "../domain/run.js";
+import type { AgentConfig } from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import {
+  buildClaudeResumeCommand,
+  describeClaudeCodeSession,
+  parseClaudeCodeResult,
+  validateClaudeCodeConfig,
+} from "./claude-code-command.js";
+import {
+  type LocalCommandExecutionOptions,
+  executeLocalRunnerCommand,
+} from "./local-execution.js";
+import type {
+  LiveRunnerSession,
+  RunnerExecutionResult,
+  RunnerRunOptions,
+  RunnerSessionDescription,
+  RunnerTurnResult,
+} from "./service.js";
+
+export class ClaudeCodeLiveSession implements LiveRunnerSession {
+  readonly #config: AgentConfig;
+  readonly #logger: Logger;
+  readonly #runSession: RunSession;
+  readonly #executeCommand: (
+    logger: Logger,
+    config: AgentConfig,
+    execution: LocalCommandExecutionOptions,
+  ) => Promise<RunnerExecutionResult>;
+  #description: RunnerSessionDescription;
+
+  constructor(
+    config: AgentConfig,
+    logger: Logger,
+    session: RunSession,
+    executeCommand: (
+      logger: Logger,
+      config: AgentConfig,
+      execution: LocalCommandExecutionOptions,
+    ) => Promise<RunnerExecutionResult> = executeLocalRunnerCommand,
+  ) {
+    validateClaudeCodeConfig(config);
+    this.#config = config;
+    this.#logger = logger;
+    this.#runSession = session;
+    this.#executeCommand = executeCommand;
+    this.#description = describeClaudeCodeSession(config.command);
+  }
+
+  describe(): RunnerSessionDescription {
+    return this.#description;
+  }
+
+  async runTurn(
+    turn: RunTurn,
+    options?: RunnerRunOptions,
+  ): Promise<RunnerTurnResult> {
+    const executionResult = await this.#executeCommand(
+      this.#logger,
+      this.#config,
+      {
+        command: this.#commandForTurn(turn),
+        prompt: turn.prompt,
+        session: this.#runSession,
+        turnNumber: turn.turnNumber,
+        options,
+        promptTransport: "stdin",
+      },
+    );
+
+    if (executionResult.exitCode === 0) {
+      const result = parseClaudeCodeResult(executionResult.stdout);
+      this.#description = {
+        ...this.#description,
+        model: result.model ?? this.#description.model,
+        backendSessionId:
+          result.sessionId ?? this.#description.backendSessionId,
+        latestTurnNumber: turn.turnNumber,
+      };
+    }
+
+    return {
+      ...executionResult,
+      session: this.describe(),
+    };
+  }
+
+  #commandForTurn(turn: RunTurn): string {
+    if (turn.turnNumber === 1) {
+      return this.#config.command;
+    }
+    if (this.#description.backendSessionId === null) {
+      throw new RunnerError(
+        "Claude Code continuation turn requested but no backend session id was returned by the previous turn",
+      );
+    }
+    return buildClaudeResumeCommand(
+      this.#config.command,
+      this.#description.backendSessionId,
+    );
+  }
+}

--- a/src/runner/claude-code-live-session.ts
+++ b/src/runner/claude-code-live-session.ts
@@ -40,8 +40,11 @@ export class ClaudeCodeLiveSession implements LiveRunnerSession {
       config: AgentConfig,
       execution: LocalCommandExecutionOptions,
     ) => Promise<RunnerExecutionResult> = executeLocalRunnerCommand,
+    skipValidation = false,
   ) {
-    validateClaudeCodeConfig(config);
+    if (!skipValidation) {
+      validateClaudeCodeConfig(config);
+    }
     this.#config = config;
     this.#logger = logger;
     this.#runSession = session;
@@ -72,6 +75,14 @@ export class ClaudeCodeLiveSession implements LiveRunnerSession {
 
     if (executionResult.exitCode === 0) {
       const result = parseClaudeCodeResult(executionResult.stdout);
+      if (result.modelCount > 1) {
+        this.#logger.warn("Claude Code turn reported multiple models", {
+          issueNumber: this.#runSession.issue.number,
+          turnNumber: turn.turnNumber,
+          modelCount: result.modelCount,
+          selectedModel: result.model,
+        });
+      }
       this.#description = {
         ...this.#description,
         model: result.model ?? this.#description.model,

--- a/src/runner/claude-code.ts
+++ b/src/runner/claude-code.ts
@@ -1,0 +1,72 @@
+import type { RunSession } from "../domain/run.js";
+import type { AgentConfig } from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import {
+  describeClaudeCodeSession,
+  validateClaudeCodeConfig,
+} from "./claude-code-command.js";
+import { ClaudeCodeLiveSession } from "./claude-code-live-session.js";
+import { executeLocalRunnerCommand } from "./local-execution.js";
+import type {
+  Runner,
+  RunnerExecutionResult,
+  RunnerRunOptions,
+  RunnerSessionDescription,
+} from "./service.js";
+
+export class ClaudeCodeRunner implements Runner {
+  readonly #config: AgentConfig;
+  readonly #logger: Logger;
+
+  constructor(config: AgentConfig, logger: Logger) {
+    validateClaudeCodeConfig(config);
+    this.#config = config;
+    this.#logger = logger;
+  }
+
+  describeSession(_session: RunSession): RunnerSessionDescription {
+    return describeClaudeCodeSession(this.#config.command);
+  }
+
+  startSession(session: RunSession): Promise<ClaudeCodeLiveSession> {
+    try {
+      return Promise.resolve(
+        new ClaudeCodeLiveSession(
+          this.#config,
+          this.#logger,
+          session,
+          ClaudeCodeRunner.executeCommand,
+        ),
+      );
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  async run(
+    session: RunSession,
+    options?: RunnerRunOptions,
+  ): Promise<RunnerExecutionResult> {
+    const liveSession = await this.startSession(session);
+    const result = await liveSession.runTurn(
+      {
+        turnNumber: 1,
+        prompt: session.prompt,
+      },
+      options,
+    );
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      startedAt: result.startedAt,
+      finishedAt: result.finishedAt,
+    };
+  }
+
+  static async executeCommand(
+    ...args: Parameters<typeof executeLocalRunnerCommand>
+  ): Promise<RunnerExecutionResult> {
+    return await executeLocalRunnerCommand(...args);
+  }
+}

--- a/src/runner/claude-code.ts
+++ b/src/runner/claude-code.ts
@@ -36,6 +36,7 @@ export class ClaudeCodeRunner implements Runner {
           this.#logger,
           session,
           ClaudeCodeRunner.executeCommand,
+          true,
         ),
       );
     } catch (error) {

--- a/src/runner/factory.ts
+++ b/src/runner/factory.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import { ClaudeCodeRunner } from "./claude-code.js";
 import { CodexRunner } from "./codex.js";
 import { GenericCommandRunner } from "./generic-command.js";
 import type { Runner } from "./service.js";
@@ -10,5 +11,7 @@ export function createRunner(config: AgentConfig, logger: Logger): Runner {
       return new CodexRunner(config, logger);
     case "generic-command":
       return new GenericCommandRunner(config, logger);
+    case "claude-code":
+      return new ClaudeCodeRunner(config, logger);
   }
 }

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -36,7 +36,7 @@ async function writeWorkflow(options: {
   remotePath: string;
   apiUrl: string;
   agentCommand: string;
-  runnerKind?: "codex" | "generic-command";
+  runnerKind?: "codex" | "generic-command" | "claude-code";
   retryBackoffMs?: number;
   maxAttempts?: number;
   maxFollowUpAttempts?: number;
@@ -281,6 +281,61 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       "IMPLEMENTED.txt",
     );
     expect(implemented).toContain("sociotechnica-org/symphony-ts#1");
+  });
+
+  it("runs a complete GitHub factory handoff loop through the Claude Code runner", async () => {
+    server.seedIssue({
+      number: 12,
+      title: "Implement Symphony via Claude",
+      body: "Use the Claude runner path",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      runnerKind: "claude-code",
+      agentCommand:
+        "claude -p --output-format json --permission-mode bypassPermissions --model sonnet",
+      maxTurns: 2,
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/12", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    await orchestrator.runOnce();
+    server.mergePullRequest("symphony/12");
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(12);
+    expect(issue.state).toBe("closed");
+    expect(issue.comments).toContain(
+      "Symphony completed this issue successfully.",
+    );
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      12,
+    );
+    expect(artifactSummary.currentOutcome).toBe("succeeded");
+
+    const session = await readIssueArtifactSession(
+      path.join(tempDir, ".tmp", "workspaces"),
+      12,
+      artifactSummary.latestSessionId!,
+    );
+    expect(session.provider).toBe("claude-code");
+    expect(session.backendSessionId).toBe("claude-session-12-1");
+
+    const implemented = await readRemoteBranchFile(
+      remotePath,
+      "symphony/12",
+      "IMPLEMENTED.txt",
+    );
+    expect(implemented).toContain("via claude");
   });
 
   it("does not immediately re-close a reopened issue while its clean pull request is still open", async () => {

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -297,7 +297,7 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       apiUrl: server.baseUrl,
       runnerKind: "claude-code",
       agentCommand:
-        "claude -p --output-format json --permission-mode bypassPermissions --model sonnet",
+        "claude --add-dir . --file=WORKFLOW.md -p --output-format json --permission-mode bypassPermissions --model sonnet",
       maxTurns: 2,
     });
     const orchestrator = await createOrchestrator(workflowPath);

--- a/tests/e2e/linear-factory.test.ts
+++ b/tests/e2e/linear-factory.test.ts
@@ -28,7 +28,7 @@ async function writeWorkflow(options: {
   readonly remotePath: string;
   readonly endpoint: string;
   readonly agentCommand: string;
-  readonly runnerKind?: "codex" | "generic-command";
+  readonly runnerKind?: "codex" | "generic-command" | "claude-code";
 }): Promise<string> {
   const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
   await fs.writeFile(

--- a/tests/fixtures/claude
+++ b/tests/fixtures/claude
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="claude-sonnet-4-5"
+OUTPUT_FORMAT=""
+PRINT_MODE="false"
+RESUME_SESSION_ID=""
+
+while (($# > 0)); do
+  case "$1" in
+    -p|--print)
+      PRINT_MODE="true"
+      shift
+      ;;
+    --output-format)
+      OUTPUT_FORMAT="${2:-}"
+      shift 2
+      ;;
+    --output-format=*)
+      OUTPUT_FORMAT="${1#--output-format=}"
+      shift
+      ;;
+    --model)
+      MODEL="${2:-$MODEL}"
+      shift 2
+      ;;
+    --model=*)
+      MODEL="${1#--model=}"
+      shift
+      ;;
+    --resume|-r)
+      RESUME_SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    --permission-mode|--session-id|--allowedTools|--allowed-tools|--disallowedTools|--disallowed-tools|--tools|--append-system-prompt|--system-prompt|--fallback-model|--effort|--agent|--debug-file|--input-format|--json-schema|--max-budget-usd|--settings|--setting-sources)
+      shift 2
+      ;;
+    --permission-mode=*|--session-id=*|--allowedTools=*|--allowed-tools=*|--disallowedTools=*|--disallowed-tools=*|--tools=*|--append-system-prompt=*|--system-prompt=*|--fallback-model=*|--effort=*|--agent=*|--debug-file=*|--input-format=*|--json-schema=*|--max-budget-usd=*|--settings=*|--setting-sources=*)
+      shift
+      ;;
+    --dangerously-skip-permissions|--allow-dangerously-skip-permissions|--disable-slash-commands|--verbose)
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ "$PRINT_MODE" != "true" ]]; then
+  echo "fake claude fixture requires --print" >&2
+  exit 1
+fi
+
+if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+  echo "fake claude fixture requires --output-format json" >&2
+  exit 1
+fi
+
+PROMPT="$(cat)"
+printf '%s' "$PROMPT" > .agent-prompt.txt
+
+git config user.name "Symphony Test Claude"
+git config user.email "symphony-claude@example.com"
+
+SESSION_ID="${RESUME_SESSION_ID:-claude-session-${SYMPHONY_ISSUE_NUMBER}-${SYMPHONY_RUN_ATTEMPT}}"
+
+if [[ "${SYMPHONY_RUN_TURN}" == "1" ]]; then
+  echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER} via claude" > IMPLEMENTED.txt
+  git add .agent-prompt.txt IMPLEMENTED.txt
+  git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} via Claude"
+  git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+  curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
+    -H 'content-type: application/json' \
+    -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
+
+  gh pr create \
+    --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
+    --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER} via Claude" \
+    --base main \
+    --head "${SYMPHONY_BRANCH_NAME}"
+fi
+
+printf '{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"%s","modelUsage":{"%s":{"inputTokens":1,"outputTokens":1}}}\n' \
+  "$SESSION_ID" \
+  "$MODEL"

--- a/tests/fixtures/claude
+++ b/tests/fixtures/claude
@@ -32,10 +32,10 @@ while (($# > 0)); do
       RESUME_SESSION_ID="${2:-}"
       shift 2
       ;;
-    --permission-mode|--session-id|--allowedTools|--allowed-tools|--disallowedTools|--disallowed-tools|--tools|--append-system-prompt|--system-prompt|--fallback-model|--effort|--agent|--debug-file|--input-format|--json-schema|--max-budget-usd|--settings|--setting-sources)
+    --permission-mode|--session-id|--allowedTools|--allowed-tools|--disallowedTools|--disallowed-tools|--tools|--append-system-prompt|--system-prompt|--fallback-model|--effort|--agent|--debug-file|--input-format|--json-schema|--max-budget-usd|--settings|--setting-sources|--add-dir|--mcp-config|--plugin-dir|--betas|--file)
       shift 2
       ;;
-    --permission-mode=*|--session-id=*|--allowedTools=*|--allowed-tools=*|--disallowedTools=*|--disallowed-tools=*|--tools=*|--append-system-prompt=*|--system-prompt=*|--fallback-model=*|--effort=*|--agent=*|--debug-file=*|--input-format=*|--json-schema=*|--max-budget-usd=*|--settings=*|--setting-sources=*)
+    --permission-mode=*|--session-id=*|--allowedTools=*|--allowed-tools=*|--disallowedTools=*|--disallowed-tools=*|--tools=*|--append-system-prompt=*|--system-prompt=*|--fallback-model=*|--effort=*|--agent=*|--debug-file=*|--input-format=*|--json-schema=*|--max-budget-usd=*|--settings=*|--setting-sources=*|--add-dir=*|--mcp-config=*|--plugin-dir=*|--betas=*|--file=*)
       shift
       ;;
     --dangerously-skip-permissions|--allow-dangerously-skip-permissions|--disable-slash-commands|--verbose)

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -3,6 +3,7 @@ import type { RunSession } from "../../src/domain/run.js";
 import type { AgentConfig } from "../../src/domain/workflow.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
+import { ClaudeCodeRunner } from "../../src/runner/claude-code.js";
 import { CodexRunner } from "../../src/runner/codex.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
@@ -72,6 +73,21 @@ function createGenericCommandConfig(command: string): AgentConfig {
   };
 }
 
+function createClaudeCodeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
+  return {
+    runner: {
+      kind: "claude-code",
+    },
+    command:
+      "claude -p --output-format json --permission-mode bypassPermissions --model sonnet",
+    promptTransport: "stdin",
+    timeoutMs: 5_000,
+    maxTurns: 3,
+    env: {},
+    ...overrides,
+  };
+}
+
 describe("runners", () => {
   it("describes Codex-backed sessions with provider and model metadata", () => {
     const runner = new CodexRunner(createCodexConfig(), new JsonLogger());
@@ -94,6 +110,21 @@ describe("runners", () => {
     expect(runner.describeSession(createSession())).toEqual({
       provider: "generic-command",
       model: null,
+      backendSessionId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    });
+  });
+
+  it("describes Claude Code sessions with provider and model metadata", () => {
+    const runner = new ClaudeCodeRunner(
+      createClaudeCodeConfig(),
+      new JsonLogger(),
+    );
+
+    expect(runner.describeSession(createSession())).toEqual({
+      provider: "claude-code",
+      model: "sonnet",
       backendSessionId: null,
       latestTurnNumber: null,
       logPointers: [],
@@ -152,6 +183,37 @@ describe("runners", () => {
       await expect(runner.run(createSession())).resolves.toMatchObject({
         exitCode: 0,
         stdout: "ok",
+      });
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      executeSpy.mockRestore();
+    }
+  });
+
+  it("keeps ClaudeCodeRunner.run on the one-shot execute-and-return path", async () => {
+    const executeSpy = vi
+      .spyOn(ClaudeCodeRunner, "executeCommand")
+      .mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          session_id: "claude-session-1",
+          modelUsage: {
+            "claude-sonnet-4-5": {},
+          },
+        }),
+        stderr: "",
+        startedAt: "2026-03-11T10:00:00.000Z",
+        finishedAt: "2026-03-11T10:00:01.000Z",
+      });
+
+    try {
+      const runner = new ClaudeCodeRunner(
+        createClaudeCodeConfig(),
+        new JsonLogger(),
+      );
+
+      await expect(runner.run(createSession())).resolves.toMatchObject({
+        exitCode: 0,
       });
       expect(executeSpy).toHaveBeenCalledTimes(1);
     } finally {
@@ -221,6 +283,102 @@ describe("runners", () => {
     await expect(runner.run(session)).rejects.toMatchObject({
       message: "Runner timed out after 50ms",
     });
+  });
+
+  it("reuses the Claude backend session id for continuation turns", async () => {
+    const executeSpy = vi
+      .spyOn(ClaudeCodeRunner, "executeCommand")
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          session_id: "claude-session-1",
+          modelUsage: {
+            "claude-sonnet-4-5": {},
+          },
+        }),
+        stderr: "",
+        startedAt: "2026-03-11T10:00:00.000Z",
+        finishedAt: "2026-03-11T10:00:01.000Z",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          session_id: "claude-session-1",
+          modelUsage: {
+            "claude-sonnet-4-5": {},
+          },
+        }),
+        stderr: "",
+        startedAt: "2026-03-11T10:00:02.000Z",
+        finishedAt: "2026-03-11T10:00:03.000Z",
+      });
+
+    try {
+      const runner = new ClaudeCodeRunner(
+        createClaudeCodeConfig(),
+        new JsonLogger(),
+      );
+      const liveSession = await runner.startSession(createSession());
+
+      const firstTurn = await liveSession.runTurn({
+        turnNumber: 1,
+        prompt: "first",
+      });
+      const secondTurn = await liveSession.runTurn({
+        turnNumber: 2,
+        prompt: "second",
+      });
+
+      expect(firstTurn.session.backendSessionId).toBe("claude-session-1");
+      expect(secondTurn.session.backendSessionId).toBe("claude-session-1");
+      expect(secondTurn.session.latestTurnNumber).toBe(2);
+      expect(
+        (executeSpy.mock.calls[1]?.[2] as { command: string } | undefined)
+          ?.command,
+      ).toContain("--resume claude-session-1");
+    } finally {
+      executeSpy.mockRestore();
+    }
+  });
+
+  it("fails when a Claude continuation turn is requested without a session id", async () => {
+    const executeSpy = vi
+      .spyOn(ClaudeCodeRunner, "executeCommand")
+      .mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          modelUsage: {
+            "claude-sonnet-4-5": {},
+          },
+        }),
+        stderr: "",
+        startedAt: "2026-03-11T10:00:00.000Z",
+        finishedAt: "2026-03-11T10:00:01.000Z",
+      });
+
+    try {
+      const runner = new ClaudeCodeRunner(
+        createClaudeCodeConfig(),
+        new JsonLogger(),
+      );
+      const liveSession = await runner.startSession(createSession());
+
+      await liveSession.runTurn({
+        turnNumber: 1,
+        prompt: "first",
+      });
+
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 2,
+          prompt: "second",
+        }),
+      ).rejects.toThrowError(
+        "Claude Code continuation turn requested but no backend session id was returned by the previous turn",
+      );
+    } finally {
+      executeSpy.mockRestore();
+    }
   });
 
   it("selects the newest matching Codex session by parsed timestamp", async () => {
@@ -605,6 +763,66 @@ describe("runners", () => {
         ),
     ).toThrowError(
       "Codex runner requires agent.command to invoke the codex CLI",
+    );
+  });
+
+  it("rejects Claude Code runner construction when the command is not the claude CLI", () => {
+    expect(
+      () =>
+        new ClaudeCodeRunner(
+          {
+            ...createClaudeCodeConfig(),
+            command:
+              "codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -",
+          },
+          new JsonLogger(),
+        ),
+    ).toThrowError(
+      "Claude Code runner requires agent.command to invoke the claude CLI",
+    );
+  });
+
+  it("rejects Claude Code runner construction when the command is missing JSON print mode", () => {
+    expect(
+      () =>
+        new ClaudeCodeRunner(
+          {
+            ...createClaudeCodeConfig(),
+            command: "claude --permission-mode bypassPermissions",
+          },
+          new JsonLogger(),
+        ),
+    ).toThrowError(
+      "Claude Code runner requires agent.command to include --print",
+    );
+
+    expect(
+      () =>
+        new ClaudeCodeRunner(
+          {
+            ...createClaudeCodeConfig(),
+            command:
+              "claude -p --output-format text --permission-mode bypassPermissions",
+          },
+          new JsonLogger(),
+        ),
+    ).toThrowError(
+      "Claude Code runner requires agent.command to include --output-format json",
+    );
+  });
+
+  it("rejects Claude Code continuation sessions configured with file prompt transport", () => {
+    expect(
+      () =>
+        new ClaudeCodeRunner(
+          {
+            ...createClaudeCodeConfig(),
+            promptTransport: "file",
+          },
+          new JsonLogger(),
+        ),
+    ).toThrowError(
+      "Claude Code runner requires agent.prompt_transport to be 'stdin'",
     );
   });
 });

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -4,6 +4,7 @@ import type { AgentConfig } from "../../src/domain/workflow.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { ClaudeCodeRunner } from "../../src/runner/claude-code.js";
+import { buildClaudeResumeCommand } from "../../src/runner/claude-code-command.js";
 import { CodexRunner } from "../../src/runner/codex.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
@@ -379,6 +380,26 @@ describe("runners", () => {
     } finally {
       executeSpy.mockRestore();
     }
+  });
+
+  it("drops session ids paired with prior Claude continue flags during resume reconstruction", () => {
+    expect(
+      buildClaudeResumeCommand(
+        "claude --continue stale-session -p --output-format json --permission-mode bypassPermissions",
+        "fresh-session",
+      ),
+    ).toBe(
+      "claude --resume fresh-session -p --output-format json --permission-mode bypassPermissions",
+    );
+
+    expect(
+      buildClaudeResumeCommand(
+        "claude -c stale-session -p --output-format json --permission-mode bypassPermissions",
+        "fresh-session",
+      ),
+    ).toBe(
+      "claude --resume fresh-session -p --output-format json --permission-mode bypassPermissions",
+    );
   });
 
   it("selects the newest matching Codex session by parsed timestamp", async () => {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -4,7 +4,10 @@ import type { AgentConfig } from "../../src/domain/workflow.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { ClaudeCodeRunner } from "../../src/runner/claude-code.js";
-import { buildClaudeResumeCommand } from "../../src/runner/claude-code-command.js";
+import {
+  buildClaudeResumeCommand,
+  parseClaudeCodeResult,
+} from "../../src/runner/claude-code-command.js";
 import { CodexRunner } from "../../src/runner/codex.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
@@ -400,6 +403,68 @@ describe("runners", () => {
     ).toBe(
       "claude --resume fresh-session -p --output-format json --permission-mode bypassPermissions",
     );
+  });
+
+  it("parses the Claude result object even when stdout has trailing non-JSON lines", () => {
+    expect(
+      parseClaudeCodeResult(
+        [
+          '{"type":"result","session_id":"claude-session-1","modelUsage":{"claude-sonnet-4-5":{}}}',
+          "warning: trailing diagnostic",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      sessionId: "claude-session-1",
+      model: "claude-sonnet-4-5",
+      modelCount: 1,
+    });
+  });
+
+  it("warns when Claude reports multiple models in one turn", async () => {
+    const logger: Logger = {
+      info() {},
+      warn: vi.fn(),
+      error() {},
+    };
+    const executeSpy = vi
+      .spyOn(ClaudeCodeRunner, "executeCommand")
+      .mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          type: "result",
+          session_id: "claude-session-1",
+          modelUsage: {
+            "claude-sonnet-4-5": {},
+            "claude-haiku-4-5": {},
+          },
+        }),
+        stderr: "",
+        startedAt: "2026-03-11T10:00:00.000Z",
+        finishedAt: "2026-03-11T10:00:01.000Z",
+      });
+
+    try {
+      const runner = new ClaudeCodeRunner(createClaudeCodeConfig(), logger);
+      const liveSession = await runner.startSession(createSession());
+
+      const result = await liveSession.runTurn({
+        turnNumber: 1,
+        prompt: "first",
+      });
+
+      expect(result.session.model).toBe("claude-sonnet-4-5");
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Claude Code turn reported multiple models",
+        expect.objectContaining({
+          issueNumber: 1,
+          turnNumber: 1,
+          modelCount: 2,
+          selectedModel: "claude-sonnet-4-5",
+        }),
+      );
+    } finally {
+      executeSpy.mockRestore();
+    }
   });
 
   it("selects the newest matching Codex session by parsed timestamp", async () => {

--- a/tests/unit/runner-factory.test.ts
+++ b/tests/unit/runner-factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentConfig } from "../../src/domain/workflow.js";
 import { JsonLogger } from "../../src/observability/logger.js";
+import { ClaudeCodeRunner } from "../../src/runner/claude-code.js";
 import { CodexRunner } from "../../src/runner/codex.js";
 import { createRunner } from "../../src/runner/factory.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
@@ -38,5 +39,20 @@ describe("createRunner", () => {
     );
 
     expect(runner).toBeInstanceOf(GenericCommandRunner);
+  });
+
+  it("returns a ClaudeCodeRunner for claude-code workflow config", () => {
+    const runner = createRunner(
+      createAgentConfig({
+        runner: {
+          kind: "claude-code",
+        },
+        command:
+          "claude -p --output-format json --permission-mode bypassPermissions",
+      }),
+      new JsonLogger(),
+    );
+
+    expect(runner).toBeInstanceOf(ClaudeCodeRunner);
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -254,6 +254,51 @@ agent:
     });
   });
 
+  it("loads an explicit Claude Code runner selection", async () => {
+    const dir = await createTempDir("workflow-claude-code-runner-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 3
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: claude-code
+  command: claude -p --output-format json --permission-mode bypassPermissions
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+
+    expect(workflow.config.agent.runner).toEqual({
+      kind: "claude-code",
+    });
+  });
+
   it("rejects an unsupported agent.runner.kind", async () => {
     const dir = await createTempDir("workflow-invalid-runner-kind-");
     const workflowPath = path.join(dir, "WORKFLOW.md");
@@ -293,7 +338,7 @@ agent:
     );
 
     await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
-      "Unsupported agent.runner.kind 'claude'. Supported kinds: codex, generic-command",
+      "Unsupported agent.runner.kind 'claude'. Supported kinds: codex, generic-command, claude-code",
     );
   });
 


### PR DESCRIPTION
Closes #91.

## Summary
- add an explicit `claude-code` runner kind and wire a Claude-specific adapter into the runner factory
- validate Claude headless command requirements, capture `session_id` and model metadata, and resume continuation turns through `--resume`
- document the `WORKFLOW.md` contract and add unit plus mocked GitHub e2e coverage for the Claude path

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- real local `ClaudeCodeRunner` two-turn probe against the installed `claude` CLI using `claude -p --output-format json --permission-mode bypassPermissions --model sonnet`

## Plan
- approved plan: `docs/plans/091-claude-code-runner-integration/plan.md`
