### PR TITLE
Wire watchdog into production factory bootstrap

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -19,6 +19,11 @@ polling:
     max_attempts: 2
     max_follow_up_attempts: 25
     backoff_ms: 5000
+  watchdog:
+    enabled: true
+    check_interval_ms: 60000
+    stall_threshold_ms: 300000
+    max_recovery_attempts: 2
 workspace:
   root: ./.tmp/workspaces
   branch_prefix: symphony/

--- a/docs/plans/115-watchdog-bootstrap-liveness/plan.md
+++ b/docs/plans/115-watchdog-bootstrap-liveness/plan.md
@@ -1,0 +1,85 @@
+# Issue 115 Plan: Watchdog Bootstrap Liveness Wiring
+
+## Summary
+
+- Wire the existing stalled-runner watchdog into the production CLI bootstrap path.
+- Enable the repo-owned watchdog block in `WORKFLOW.md` so live factory runs can recover wedged agent processes.
+- Keep the slice narrow: configuration parsing, CLI orchestration bootstrap, runtime contract docs, and focused tests.
+
+## Review Status
+
+- Plan review is explicitly waived by operator/user instruction for this runtime-fix slice.
+
+## Abstraction Mapping
+
+- Policy: keep stall recovery fail-closed and retry-based rather than silently tolerating wedged runners.
+- Configuration: parse and validate `polling.watchdog` from `WORKFLOW.md`.
+- Coordination: ensure the orchestrator receives a real liveness probe in production bootstrap.
+- Execution: no runner-protocol redesign; reuse current log/diff/head-sha liveness signals.
+- Integration: wire CLI/runtime startup to construct `FsLivenessProbe`.
+- Observability: preserve watchdog status actions and make the live runtime contract explicit in docs.
+
+## Scope
+
+- Add workflow parsing for `polling.watchdog`.
+- Enable watchdog config in repo `WORKFLOW.md`.
+- Pass `FsLivenessProbe` into `BootstrapOrchestrator` in the production CLI path.
+- Add focused tests for watchdog config loading and the CLI/bootstrap wiring effect.
+
+## Non-goals
+
+- Redesigning the watchdog heuristics.
+- Introducing a richer heartbeat/session protocol.
+- Changing merge/review policy.
+- Taking over active implementation on `#113`.
+
+## Current Gap
+
+- `BootstrapOrchestrator` has watchdog logic.
+- `FsLivenessProbe` exists.
+- Production `runCli()` never passes a probe.
+- Repo `WORKFLOW.md` does not enable `polling.watchdog`.
+- Result: stalled `codex exec` processes can remain alive indefinitely with stale status snapshots and no recovery.
+
+## Architecture Boundaries
+
+- `src/config/workflow.ts`: parse boundary only; do not embed recovery policy here.
+- `src/cli/index.ts`: production composition root; wire the probe here instead of burying filesystem behavior in orchestrator internals.
+- `src/orchestrator/*`: keep existing stall logic intact unless a test exposes a real correctness bug.
+- `WORKFLOW.md`: repo-owned runtime contract; watchdog enablement belongs here.
+
+## Implementation Steps
+
+1. Add `polling.watchdog` parsing and validation in `src/config/workflow.ts`.
+2. Update `src/cli/index.ts` to construct `FsLivenessProbe` with the configured workspace root and pass it to `BootstrapOrchestrator`.
+3. Enable watchdog settings in repo `WORKFLOW.md`.
+4. Add focused unit coverage for watchdog config parsing.
+5. Add CLI/bootstrap coverage proving the production path runs with watchdog enabled and can recover a stalled runner.
+
+## Tests
+
+- `tests/unit/workflow.test.ts`
+  - parses valid watchdog config
+  - rejects malformed watchdog config
+- `tests/unit/cli.test.ts`
+  - production `runCli --once` with enabled watchdog recovers a stalled runner instead of hanging forever
+
+## Acceptance Scenarios
+
+- A valid `polling.watchdog` block loads into resolved config.
+- A malformed watchdog block fails fast with `ConfigError`.
+- Production CLI bootstrapping arms the watchdog with a filesystem liveness probe.
+- A stalled run is aborted and retried/fails according to existing watchdog policy instead of staying live forever.
+
+## Exit Criteria
+
+- Repo `WORKFLOW.md` explicitly enables watchdog recovery.
+- Production CLI path provides `FsLivenessProbe`.
+- Focused tests pass and demonstrate production wiring works.
+- PR is green and review-clean.
+
+## Deferred
+
+- Refining stall heuristics or thresholds.
+- Richer runner heartbeats.
+- Broader operator controls around stalled-run inspection.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -119,7 +119,10 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     logger,
   );
   const runner = createRunner(workflow.config.agent, logger);
-  const livenessProbe = new FsLivenessProbe(workflow.config.workspace.root);
+  const livenessProbe =
+    workflow.config.polling.watchdog?.enabled === true
+      ? new FsLivenessProbe(workflow.config.workspace.root)
+      : undefined;
   const orchestrator = new BootstrapOrchestrator(
     workflow.config,
     promptBuilder,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import {
   renderFactoryStatusSnapshot,
 } from "../observability/status.js";
 import { BootstrapOrchestrator } from "../orchestrator/service.js";
+import { FsLivenessProbe } from "../orchestrator/liveness-probe.js";
 import { createRunner } from "../runner/factory.js";
 import { createTracker } from "../tracker/factory.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
@@ -118,6 +119,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     logger,
   );
   const runner = createRunner(workflow.config.agent, logger);
+  const livenessProbe = new FsLivenessProbe(workflow.config.workspace.root);
   const orchestrator = new BootstrapOrchestrator(
     workflow.config,
     promptBuilder,
@@ -125,6 +127,8 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     workspace,
     runner,
     logger,
+    undefined,
+    livenessProbe,
   );
 
   if (args.once) {

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -365,17 +365,26 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
     }
   }
 
+  const resolvedPolling = {
+    intervalMs: requireNumber(polling["interval_ms"], "polling.interval_ms"),
+    maxConcurrentRuns: requireNumber(
+      polling["max_concurrent_runs"],
+      "polling.max_concurrent_runs",
+    ),
+    retry: resolveRetryConfig(polling["retry"]),
+  };
+  const resolvedWatchdog = resolveWatchdogConfig(polling["watchdog"]);
+
   const resolved: ResolvedConfig = {
     workflowPath,
     tracker: resolvedTracker,
-    polling: {
-      intervalMs: requireNumber(polling["interval_ms"], "polling.interval_ms"),
-      maxConcurrentRuns: requireNumber(
-        polling["max_concurrent_runs"],
-        "polling.max_concurrent_runs",
-      ),
-      retry: resolveRetryConfig(polling["retry"]),
-    },
+    polling:
+      resolvedWatchdog === undefined
+        ? resolvedPolling
+        : {
+            ...resolvedPolling,
+            watchdog: resolvedWatchdog,
+          },
     workspace: {
       root: path.resolve(
         path.dirname(workflowPath),
@@ -625,6 +634,57 @@ function resolveRetryConfig(value: unknown): {
             "polling.retry.max_follow_up_attempts",
           ),
     backoffMs: requireNumber(retry["backoff_ms"], "polling.retry.backoff_ms"),
+  };
+}
+
+function resolveWatchdogConfig(value: unknown):
+  | {
+      readonly enabled: boolean;
+      readonly checkIntervalMs: number;
+      readonly stallThresholdMs: number;
+      readonly maxRecoveryAttempts: number;
+    }
+  | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigError("Expected object for polling.watchdog");
+  }
+
+  const watchdog = value as Record<string, unknown>;
+  const enabled =
+    watchdog["enabled"] === undefined ? true : Boolean(watchdog["enabled"]);
+  const checkIntervalMs = requireNumber(
+    watchdog["check_interval_ms"],
+    "polling.watchdog.check_interval_ms",
+  );
+  const stallThresholdMs = requireNumber(
+    watchdog["stall_threshold_ms"],
+    "polling.watchdog.stall_threshold_ms",
+  );
+  const maxRecoveryAttempts = requireNumber(
+    watchdog["max_recovery_attempts"],
+    "polling.watchdog.max_recovery_attempts",
+  );
+
+  if (checkIntervalMs < 0) {
+    throw new ConfigError("polling.watchdog.check_interval_ms must be >= 0");
+  }
+  if (stallThresholdMs < 0) {
+    throw new ConfigError("polling.watchdog.stall_threshold_ms must be >= 0");
+  }
+  if (!Number.isInteger(maxRecoveryAttempts) || maxRecoveryAttempts < 0) {
+    throw new ConfigError(
+      "polling.watchdog.max_recovery_attempts must be an integer >= 0",
+    );
+  }
+
+  return {
+    enabled,
+    checkIntervalMs,
+    stallThresholdMs,
+    maxRecoveryAttempts,
   };
 }
 

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -12,6 +12,7 @@ import type {
   PromptBuilder,
   ResolvedConfig,
   TrackerConfig,
+  WatchdogConfig,
   WorkflowDefinition,
 } from "../domain/workflow.js";
 
@@ -37,6 +38,11 @@ const DEFAULT_LINEAR_TERMINAL_STATES = [
   "Duplicate",
   "Done",
 ] as const;
+const DEFAULT_DISABLED_WATCHDOG_CONFIG: Omit<WatchdogConfig, "enabled"> = {
+  checkIntervalMs: 60_000,
+  stallThresholdMs: 300_000,
+  maxRecoveryAttempts: 2,
+};
 const SUPPORTED_TRACKER_KINDS = ["github-bootstrap", "linear"] as const;
 const SUPPORTED_AGENT_RUNNER_KINDS = ["codex", "generic-command"] as const;
 type SupportedTrackerKind = (typeof SUPPORTED_TRACKER_KINDS)[number];
@@ -109,6 +115,13 @@ function requireUrlString(value: unknown, field: string): string {
 function requireNumber(value: unknown, field: string): number {
   if (typeof value !== "number" || Number.isNaN(value)) {
     throw new ConfigError(`Expected number for ${field}`);
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new ConfigError(`Expected boolean for ${field}`);
   }
   return value;
 }
@@ -637,14 +650,7 @@ function resolveRetryConfig(value: unknown): {
   };
 }
 
-function resolveWatchdogConfig(value: unknown):
-  | {
-      readonly enabled: boolean;
-      readonly checkIntervalMs: number;
-      readonly stallThresholdMs: number;
-      readonly maxRecoveryAttempts: number;
-    }
-  | undefined {
+function resolveWatchdogConfig(value: unknown): WatchdogConfig | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -654,35 +660,24 @@ function resolveWatchdogConfig(value: unknown):
 
   const watchdog = value as Record<string, unknown>;
   const enabled =
-    watchdog["enabled"] === undefined ? true : Boolean(watchdog["enabled"]);
-  const checkIntervalMs = requireNumber(
+    watchdog["enabled"] === undefined
+      ? true
+      : requireBoolean(watchdog["enabled"], "polling.watchdog.enabled");
+  const checkIntervalMs = requireOptionalPositiveInteger(
     watchdog["check_interval_ms"],
     "polling.watchdog.check_interval_ms",
+    enabled ? undefined : DEFAULT_DISABLED_WATCHDOG_CONFIG.checkIntervalMs,
   );
-  const stallThresholdMs = requireNumber(
+  const stallThresholdMs = requireOptionalPositiveInteger(
     watchdog["stall_threshold_ms"],
     "polling.watchdog.stall_threshold_ms",
+    enabled ? undefined : DEFAULT_DISABLED_WATCHDOG_CONFIG.stallThresholdMs,
   );
-  const maxRecoveryAttempts = requireNumber(
+  const maxRecoveryAttempts = requireOptionalRecoveryAttempts(
     watchdog["max_recovery_attempts"],
     "polling.watchdog.max_recovery_attempts",
+    enabled ? undefined : DEFAULT_DISABLED_WATCHDOG_CONFIG.maxRecoveryAttempts,
   );
-
-  if (!Number.isInteger(checkIntervalMs) || checkIntervalMs <= 0) {
-    throw new ConfigError(
-      "polling.watchdog.check_interval_ms must be an integer > 0",
-    );
-  }
-  if (!Number.isInteger(stallThresholdMs) || stallThresholdMs <= 0) {
-    throw new ConfigError(
-      "polling.watchdog.stall_threshold_ms must be an integer > 0",
-    );
-  }
-  if (!Number.isInteger(maxRecoveryAttempts) || maxRecoveryAttempts < 0) {
-    throw new ConfigError(
-      "polling.watchdog.max_recovery_attempts must be an integer >= 0",
-    );
-  }
 
   return {
     enabled,
@@ -690,6 +685,44 @@ function resolveWatchdogConfig(value: unknown):
     stallThresholdMs,
     maxRecoveryAttempts,
   };
+}
+
+function requireOptionalPositiveInteger(
+  value: unknown,
+  field: string,
+  fallback: number | undefined,
+): number {
+  if (value === undefined) {
+    if (fallback === undefined) {
+      throw new ConfigError(`Expected number for ${field}`);
+    }
+    return fallback;
+  }
+
+  const resolved = requireNumber(value, field);
+  if (!Number.isInteger(resolved) || resolved <= 0) {
+    throw new ConfigError(`${field} must be an integer > 0`);
+  }
+  return resolved;
+}
+
+function requireOptionalRecoveryAttempts(
+  value: unknown,
+  field: string,
+  fallback: number | undefined,
+): number {
+  if (value === undefined) {
+    if (fallback === undefined) {
+      throw new ConfigError(`Expected number for ${field}`);
+    }
+    return fallback;
+  }
+
+  const resolved = requireNumber(value, field);
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new ConfigError(`${field} must be an integer >= 0`);
+  }
+  return resolved;
 }
 
 export async function loadWorkflow(

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -668,11 +668,15 @@ function resolveWatchdogConfig(value: unknown):
     "polling.watchdog.max_recovery_attempts",
   );
 
-  if (checkIntervalMs < 0) {
-    throw new ConfigError("polling.watchdog.check_interval_ms must be >= 0");
+  if (!Number.isInteger(checkIntervalMs) || checkIntervalMs <= 0) {
+    throw new ConfigError(
+      "polling.watchdog.check_interval_ms must be an integer > 0",
+    );
   }
-  if (stallThresholdMs < 0) {
-    throw new ConfigError("polling.watchdog.stall_threshold_ms must be >= 0");
+  if (!Number.isInteger(stallThresholdMs) || stallThresholdMs <= 0) {
+    throw new ConfigError(
+      "polling.watchdog.stall_threshold_ms must be an integer > 0",
+    );
   }
   if (!Number.isInteger(maxRecoveryAttempts) || maxRecoveryAttempts < 0) {
     throw new ConfigError(

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -438,7 +438,7 @@ describe("runCli run", () => {
 
     expect(probeRoots).toEqual(["/tmp/factory-root"]);
     expect(orchestratorArgs).not.toBeNull();
-    expect(orchestratorArgs).toHaveLength(8);
+    expect(orchestratorArgs?.[7]).toBeDefined();
     expect(runOnce).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -388,6 +388,7 @@ describe("runCli run", () => {
       loadWorkflow: vi.fn(async () => ({
         config: {
           tracker: { kind: "github-bootstrap" },
+          polling: { watchdog: { enabled: true } },
           workspace: { root: "/tmp/factory-root" },
           hooks: { afterCreate: [] },
           agent: {},

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -375,3 +375,70 @@ describe("runCli status", () => {
     expect(chunks.join("")).toContain('"factoryState": "idle"');
   });
 });
+
+describe("runCli run", () => {
+  it("wires FsLivenessProbe into the production orchestrator bootstrap", async () => {
+    vi.resetModules();
+
+    const runOnce = vi.fn(async () => {});
+    const probeRoots: string[] = [];
+    let orchestratorArgs: unknown[] | null = null;
+
+    vi.doMock("../../src/config/workflow.js", () => ({
+      loadWorkflow: vi.fn(async () => ({
+        config: {
+          tracker: { kind: "github-bootstrap" },
+          workspace: { root: "/tmp/factory-root" },
+          hooks: { afterCreate: [] },
+          agent: {},
+        },
+      })),
+      loadWorkflowWorkspaceRoot: vi.fn(),
+      createPromptBuilder: vi.fn(() => "prompt-builder"),
+    }));
+    vi.doMock("../../src/tracker/factory.js", () => ({
+      createTracker: vi.fn(() => "tracker"),
+    }));
+    vi.doMock("../../src/runner/factory.js", () => ({
+      createRunner: vi.fn(() => "runner"),
+    }));
+    vi.doMock("../../src/workspace/local.js", () => ({
+      LocalWorkspaceManager: vi.fn(function MockWorkspaceManager() {}),
+    }));
+    vi.doMock("../../src/observability/logger.js", () => ({
+      JsonLogger: vi.fn(function MockLogger() {}),
+    }));
+    vi.doMock("../../src/orchestrator/liveness-probe.js", () => ({
+      FsLivenessProbe: vi.fn(function MockFsLivenessProbe(root: string) {
+        probeRoots.push(root);
+      }),
+    }));
+    vi.doMock("../../src/orchestrator/service.js", () => ({
+      BootstrapOrchestrator: vi.fn(function MockBootstrapOrchestrator(
+        ...args: unknown[]
+      ) {
+        orchestratorArgs = args;
+        return {
+          runOnce,
+          runLoop: vi.fn(),
+        };
+      }),
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "run",
+      "--once",
+      "--workflow",
+      "/tmp/workflow.md",
+    ]);
+
+    expect(probeRoots).toEqual(["/tmp/factory-root"]);
+    expect(orchestratorArgs).not.toBeNull();
+    expect(orchestratorArgs).toHaveLength(8);
+    expect(runOnce).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -335,6 +335,56 @@ agent:
     );
   });
 
+  it("allows a disabled polling.watchdog block without timing fields", async () => {
+    const dir = await createTempDir("workflow-watchdog-disabled-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 3
+    backoff_ms: 10
+  watchdog:
+    enabled: false
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+
+    expect(workflow.config.polling.watchdog).toEqual({
+      enabled: false,
+      checkIntervalMs: 60000,
+      stallThresholdMs: 300000,
+      maxRecoveryAttempts: 2,
+    });
+  });
+
   it("rejects a non-integer agent.max_turns", async () => {
     const dir = await createTempDir("workflow-max-turns-fractional-");
     const workflowPath = path.join(dir, "WORKFLOW.md");

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -85,6 +85,7 @@ ${buildSharedWorkflowSections()}`,
     expect(workflow.config.tracker.kind).toBe("github-bootstrap");
     expect(workflow.config.polling.retry.maxAttempts).toBe(2);
     expect(workflow.config.polling.retry.maxFollowUpAttempts).toBe(3);
+    expect(workflow.config.polling.watchdog).toBeUndefined();
     expect(workflow.config.agent.runner.kind).toBe("codex");
     expect(workflow.config.agent.maxTurns).toBe(1);
     expect(workflow.config.agent.env["GITHUB_REPO"]).toBe(
@@ -182,6 +183,107 @@ agent:
     expect(rendered).not.toContain("previous Codex turn");
     expect(rendered).not.toContain(
       "Issue repo#1 / sociotechnica-org/symphony-ts",
+    );
+  });
+
+  it("loads an explicit polling.watchdog block", async () => {
+    const dir = await createTempDir("workflow-watchdog-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 3
+    backoff_ms: 10
+  watchdog:
+    enabled: true
+    check_interval_ms: 60000
+    stall_threshold_ms: 300000
+    max_recovery_attempts: 2
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+
+    expect(workflow.config.polling.watchdog).toEqual({
+      enabled: true,
+      checkIntervalMs: 60000,
+      stallThresholdMs: 300000,
+      maxRecoveryAttempts: 2,
+    });
+  });
+
+  it("rejects an invalid polling.watchdog block", async () => {
+    const dir = await createTempDir("workflow-watchdog-invalid-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 3
+    backoff_ms: 10
+  watchdog:
+    enabled: true
+    check_interval_ms: 60000
+    stall_threshold_ms: 300000
+    max_recovery_attempts: -1
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "polling.watchdog.max_recovery_attempts must be an integer >= 0",
     );
   });
 

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -287,6 +287,54 @@ agent:
     );
   });
 
+  it("rejects a non-positive polling.watchdog interval", async () => {
+    const dir = await createTempDir("workflow-watchdog-zero-interval-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    max_follow_up_attempts: 3
+    backoff_ms: 10
+  watchdog:
+    enabled: true
+    check_interval_ms: 0
+    stall_threshold_ms: 300000
+    max_recovery_attempts: 2
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "polling.watchdog.check_interval_ms must be an integer > 0",
+    );
+  });
+
   it("rejects a non-integer agent.max_turns", async () => {
     const dir = await createTempDir("workflow-max-turns-fractional-");
     const workflowPath = path.join(dir, "WORKFLOW.md");


### PR DESCRIPTION
## Summary
- parse and validate `polling.watchdog` in workflow config
- wire `FsLivenessProbe` into the production CLI bootstrap path
- enable watchdog recovery in repo `WORKFLOW.md` and cover the wiring with focused tests

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #115.
