### PR TITLE
Add runner visibility contract and rich worker status

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ pnpm tsx bin/symphony.ts status          # terminal view
 pnpm tsx bin/symphony.ts status --json   # machine-readable
 ```
 
+The status snapshot includes normalized runner visibility for active issues,
+including worker state, current phase, session identity, heartbeat/action
+timestamps, waiting reason, and condensed output/error summaries.
+
 Generate a per-issue report from local artifacts:
 
 ```bash

--- a/docs/plans/039-runner-visibility-contract-and-rich-worker-status/plan.md
+++ b/docs/plans/039-runner-visibility-contract-and-rich-worker-status/plan.md
@@ -1,0 +1,298 @@
+# Issue 39 Plan: Runner Visibility Contract And Rich Worker Status
+
+## Status
+
+- approved
+
+## Goal
+
+Define a stable internal runner-visibility contract and use it to expose richer worker-level execution state in the factory status snapshot without coupling the status surface to Codex-specific process details.
+
+## Scope
+
+- define a normalized runner-visibility shape in `src/runner/` that can represent:
+  - runner state
+  - current phase
+  - session identity
+  - last heartbeat
+  - last meaningful action
+  - waiting reason
+  - stdout/stderr summary
+  - error state
+  - cancellation / timeout state
+- implement the contract for the local Codex runner path first, using normalized facts rather than raw subprocess internals in observability code
+- thread the visibility snapshot through the orchestration/runtime state so the factory status snapshot can expose it per active issue
+- extend status rendering and parsing so operators can tell what a live worker is doing from `.tmp/status.json` and `symphony status`
+- add contract tests that prove the visibility shape is runner-neutral and local-runner projection tests that lock in the first implementation
+
+## Non-goals
+
+- tracker transport, normalization, or lifecycle policy changes
+- Beads-specific behavior
+- a major TUI or dashboard redesign
+- deep historical analytics or long-term event storage
+- remote runner protocol work
+- changing retry budgets, continuation policy, or handoff lifecycle semantics beyond surfacing existing outcomes in visibility state
+
+## Current Gaps
+
+- `RunnerSessionDescription` captures static/session metadata, but it does not describe what a worker is doing right now
+- the status snapshot currently exposes only coarse issue-level fields such as `runnerPid`, `summary`, and `blockedReason`
+- operator-facing status output cannot distinguish useful worker states such as:
+  - app server starting
+  - prompt turn actively running
+  - waiting on tracker reconciliation
+  - cancelled or timed out turn
+  - latest meaningful worker action and heartbeat freshness
+- current orchestration code records spawn events and final turn results, but it does not maintain a normalized live visibility object that observability can consume directly
+- tests lock in the status snapshot contract, but not a provider-neutral runner visibility sub-shape
+
+## Decision Notes
+
+- This issue should build on the provider-neutral runner seam from `#89` rather than reopening runner backend selection or general contract extraction.
+- The first slice should keep the visibility contract small and current-state oriented. Historical event timelines remain deferred.
+- The orchestrator should consume and persist a normalized visibility object; observability should render that object and must not inspect Codex app-server internals directly.
+- The local Codex implementation may derive heartbeat/action updates from app-server lifecycle facts and turn boundaries, but those facts must be projected into stable provider-neutral fields before they reach the status snapshot.
+- Providers without reusable backend sessions must still be able to implement the contract by setting optional identity fields to `null`.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the issue scope, the rule that visibility is provider-neutral, and the decision to expose only current worker state in this slice
+  - does not belong: Codex app-server startup details or tracker-specific handoff rules
+- Configuration Layer
+  - belongs: unchanged existing runner timeout/max-turn settings already resolved from `WORKFLOW.md`
+  - does not belong: new workflow config fields or provider-specific status toggles in this slice
+- Coordination Layer
+  - belongs: runtime ownership of the current runner-visibility snapshot per active issue and the transitions that update it as a run progresses
+  - does not belong: parsing provider-specific stdout formats or tracker transport behavior
+- Execution Layer
+  - belongs: the runner-visibility contract, runner-side projection helpers, and backend-specific code that maps provider facts into normalized visibility
+  - does not belong: tracker mutations, prompt rendering, or operator-surface formatting
+- Integration Layer
+  - belongs: untouched in this slice; tracker adapters remain unaware of runner visibility internals
+  - does not belong: runner visibility translation or status formatting
+- Observability Layer
+  - belongs: status snapshot schema/rendering/parsing for the normalized visibility contract
+  - does not belong: reading live runner process state directly or inferring backend semantics from raw logs
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/runner/service.ts`
+  - add provider-neutral runner visibility types and update event/result types only as needed to support normalized visibility updates
+- `src/runner/`
+  - implement the local Codex projection into the visibility contract
+- `src/orchestrator/`
+  - store/update the current visibility snapshot for each active issue and persist it into status state
+- `src/observability/status.ts`
+  - extend the status snapshot contract, parser, and terminal rendering for the normalized visibility fields
+- `tests/unit/runner-contract.test.ts`
+  - add runner-neutral shape tests for the visibility contract
+- `tests/unit/status.test.ts` and `tests/unit/orchestrator.test.ts`
+  - verify snapshot parsing/rendering and orchestration updates
+- docs
+  - update any text that still describes the status surface as only coarse process visibility
+
+### Does not belong in this issue
+
+- `src/config/` runner selection or UX changes
+- tracker lifecycle policy changes
+- PR review / CI follow-up logic changes
+- a second new runner implementation beyond local Codex coverage
+- report-generation artifact redesign
+
+## Layering Notes
+
+- `config/workflow`
+  - keeps producing runner config and timeout settings
+  - does not gain visibility-specific knobs in this slice
+- `tracker`
+  - remains the source of issue/PR lifecycle facts
+  - does not store or interpret runner visibility state
+- `workspace`
+  - continues to own workspace preparation only
+  - does not manage worker visibility semantics
+- `runner`
+  - owns normalized visibility projection for backend execution state
+  - does not own tracker lifecycle summaries or status rendering
+- `orchestrator`
+  - owns when the active-issue visibility snapshot changes and when it is persisted
+  - does not read backend-specific internals directly
+- `observability`
+  - renders the normalized visibility contract
+  - does not inspect child processes, session logs, or provider-specific wire payloads at render time
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR with one seam:
+
+1. add a provider-neutral current-visibility contract at the runner boundary
+2. populate it for the local Codex path
+3. expose it in the status snapshot and terminal rendering
+4. lock it in with runner/orchestrator/status tests
+
+This stays reviewable because it does not combine:
+
+- status-surface enrichment with tracker changes
+- status-surface enrichment with a new runner backend
+- status-surface enrichment with retry-state redesign
+- status-surface enrichment with historical analytics or dashboard work
+
+## Runner Visibility State Model
+
+This issue introduces explicit current-state visibility for a live worker session.
+
+### States
+
+- `idle`
+  - session exists but no backend work has started yet
+- `starting`
+  - backend session or subprocess is launching
+- `running`
+  - a runner turn is actively executing
+- `waiting`
+  - the worker is healthy but blocked on an external or orchestration-controlled reason
+- `completed`
+  - the latest turn completed successfully and no active execution is in progress
+- `failed`
+  - the latest turn or backend session failed
+- `cancelled`
+  - the latest turn was cancelled by shutdown or explicit abort
+- `timed-out`
+  - the latest turn exceeded timeout and was terminated
+
+### Phases
+
+- `boot`
+- `session-start`
+- `turn-execution`
+- `turn-finished`
+- `handoff-reconciliation`
+- `awaiting-external`
+- `shutdown`
+
+The exact phase set can stay small, but the contract should distinguish backend startup, active turn execution, and healthy waiting.
+
+### Required fields
+
+- `state`
+- `phase`
+- `session`
+  - normalized provider/model/backend ids already known for the run
+- `lastHeartbeatAt`
+- `lastActionAt`
+- `lastActionSummary`
+- `waitingReason`
+- `stdoutSummary`
+- `stderrSummary`
+- `errorSummary`
+- `cancelledAt`
+- `timedOutAt`
+
+### Allowed transitions
+
+- `idle -> starting`
+- `starting -> running`
+- `starting -> failed`
+- `running -> waiting`
+- `running -> completed`
+- `running -> failed`
+- `running -> cancelled`
+- `running -> timed-out`
+- `waiting -> running`
+- `waiting -> completed`
+- `waiting -> failed`
+- `completed -> running`
+  - when a continuation turn begins
+
+### Contract rules
+
+- visibility must be representable without a PID or reusable backend session id
+- heartbeat and action fields must be safe to leave `null` when a backend cannot provide them yet
+- stdout/stderr are summaries, not full logs; observability must not rely on them as canonical artifacts
+- waiting reasons must be normalized labels/summaries, not backend-specific raw strings when a stable internal label exists
+
+## Failure-Class Matrix
+
+| Observed condition                                                    | Local facts available                       | Normalized runner visibility                                               | Expected decision                                                       |
+| --------------------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| backend process not yet spawned                                       | run session exists, no child pid            | `state=starting`, `phase=session-start`, no session id yet                 | show active startup state in status, not a failure                      |
+| turn actively executing with no fresh stdout                          | run session, turn number, heartbeat updates | `state=running`, `phase=turn-execution`, heartbeat present                 | show live execution rather than coarse "running" only                   |
+| turn finishes and tracker reconciliation begins                       | turn result available, tracker call pending | `state=waiting`, `phase=handoff-reconciliation`, waiting reason set        | show healthy waiting state instead of appearing idle                    |
+| shutdown abort fires during a turn                                    | abort signal observed, cleanup running      | `state=cancelled`, `phase=shutdown`, cancelled timestamp and error summary | show cancelled state and preserve failure path                          |
+| timeout fires during a turn                                           | timeout window elapsed, cleanup running     | `state=timed-out`, `phase=shutdown`, timed-out timestamp and error summary | surface timeout explicitly in status and failure artifacts              |
+| adapter cannot derive provider session metadata after successful work | stdout/stderr, provider known               | `state=failed`, `errorSummary` populated                                   | fail at adapter boundary; do not make observability infer missing state |
+
+## Storage / Persistence Contract
+
+- extend the in-memory active-issue status state with a nullable `runnerVisibility` object
+- extend `.tmp/status.json` snapshot version only if the parser cannot remain backward-compatible; otherwise prefer additive backward-compatible fields under version `1`
+- keep issue artifacts and other stored contracts unchanged unless a minimal additive visibility field is required for consistency
+- treat the status snapshot as the operator-facing current-state contract, not the system of record for historical execution
+
+## Observability Requirements
+
+- `symphony status --json` must expose the normalized runner-visibility shape for active issues
+- terminal rendering must summarize the most useful worker facts without requiring operators to inspect raw subprocess state
+- missing optional visibility fields must render clearly as unavailable rather than implying failure
+- observability code must parse and render normalized visibility only; it must not inspect provider-specific process details directly
+
+## Implementation Steps
+
+1. Define provider-neutral runner visibility types in `src/runner/service.ts`, including state/phase enums and the normalized current-visibility payload.
+2. Add runner-side or orchestrator-side helpers that update visibility in response to:
+   - session creation
+   - spawn events
+   - active turn start
+   - heartbeat / meaningful action updates where available
+   - turn completion, failure, cancellation, and timeout
+   - tracker reconciliation waiting
+3. Extend the local Codex path to populate the visibility contract using backend facts already available from the app-server session and turn lifecycle.
+4. Thread the normalized visibility object through active-issue runtime state in `src/orchestrator/status-state.ts` and related orchestration call sites.
+5. Extend `src/observability/status.ts` to parse, validate, and render the additive visibility fields in the status snapshot.
+6. Add tests for:
+   - runner-neutral visibility shape with a fake provider
+   - local Codex visibility projection
+   - orchestration updates into the status snapshot
+   - snapshot parsing/rendering for new visibility fields
+7. Update README or relevant docs to note that the status surface now includes normalized worker-level runner visibility.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- a fake runner provider can populate the visibility contract without Codex-specific fields
+- the local Codex runner/session reports normalized visibility transitions for startup, active turn, and completion or failure
+- status snapshot parsing accepts the new visibility object and rejects invalid field types
+- terminal status rendering includes useful worker visibility summaries when present
+- orchestrator status updates persist visibility changes without requiring observability code to inspect raw process state
+
+### Integration / end-to-end coverage
+
+- keep existing runner/orchestrator/status suites green with the enriched snapshot shape
+- if a realistic local-runner orchestration fixture already exists, assert that a live active issue exposes worker visibility in `.tmp/status.json`
+
+### Acceptance scenarios
+
+1. An operator running `symphony status` during a live worker turn can tell the worker is starting, executing, or waiting without inspecting process internals.
+2. A timeout or cancellation shows up in normalized worker visibility state rather than only as a coarse issue summary.
+3. A provider-neutral fake runner satisfies the visibility contract shape with optional ids left `null`.
+4. The status snapshot remains provider-neutral and does not require Codex-specific parsing in observability code.
+
+## Exit Criteria
+
+- a stable internal runner-visibility contract exists in code
+- the local runner path populates the contract
+- the factory status snapshot exposes the new visibility fields
+- terminal and JSON status surfaces show enough worker context to understand what a live worker is doing
+- tests lock in the contract shape and local projection behavior
+
+## Deferred To Later Issues Or PRs
+
+- alternate runner implementations beyond the local Codex path
+- historical worker event timelines and analytics
+- dashboard/TUI redesign work
+- tracker-surfaced or remotely published worker visibility
+- richer report-generation integration for runner visibility beyond the live status snapshot

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
+import type {
+  RunnerSessionDescription,
+  RunnerVisibilityPhase,
+  RunnerVisibilitySnapshot,
+  RunnerVisibilityState,
+} from "../runner/service.js";
 
 let snapshotWriteSequence = 0;
 
@@ -77,6 +83,7 @@ export interface FactoryActiveIssueSnapshot {
   readonly checks: FactoryCheckStatus;
   readonly review: FactoryReviewStatus;
   readonly blockedReason: string | null;
+  readonly runnerVisibility: RunnerVisibilitySnapshot | null;
 }
 
 export interface FactoryRetrySnapshot {
@@ -264,6 +271,45 @@ export function renderFactoryStatusSnapshot(
       );
       if (issue.blockedReason !== null) {
         lines.push(`    Blocked: ${issue.blockedReason}`);
+      }
+      if (issue.runnerVisibility !== null) {
+        const visibility = issue.runnerVisibility;
+        lines.push(
+          `    Runner: ${visibility.state} phase=${visibility.phase} provider=${visibility.session.provider}`,
+        );
+        if (visibility.session.model !== null) {
+          lines.push(`    Runner model: ${visibility.session.model}`);
+        }
+        if (visibility.lastActionSummary !== null) {
+          lines.push(
+            `    Runner action: ${visibility.lastActionSummary}${
+              visibility.lastActionAt === null
+                ? ""
+                : ` at ${visibility.lastActionAt}`
+            }`,
+          );
+        }
+        if (visibility.waitingReason !== null) {
+          lines.push(`    Runner waiting: ${visibility.waitingReason}`);
+        }
+        if (visibility.lastHeartbeatAt !== null) {
+          lines.push(`    Runner heartbeat: ${visibility.lastHeartbeatAt}`);
+        }
+        if (visibility.stdoutSummary !== null) {
+          lines.push(`    Runner stdout: ${visibility.stdoutSummary}`);
+        }
+        if (visibility.stderrSummary !== null) {
+          lines.push(`    Runner stderr: ${visibility.stderrSummary}`);
+        }
+        if (visibility.errorSummary !== null) {
+          lines.push(`    Runner error: ${visibility.errorSummary}`);
+        }
+        if (visibility.cancelledAt !== null) {
+          lines.push(`    Runner cancelled: ${visibility.cancelledAt}`);
+        }
+        if (visibility.timedOutAt !== null) {
+          lines.push(`    Runner timed out: ${visibility.timedOutAt}`);
+        }
       }
     }
   }
@@ -467,6 +513,169 @@ function parseActiveIssue(
       issue.blockedReason,
       filePath,
       `${field}.blockedReason`,
+    ),
+    runnerVisibility: parseRunnerVisibility(
+      issue.runnerVisibility,
+      filePath,
+      `${field}.runnerVisibility`,
+    ),
+  };
+}
+
+function parseRunnerVisibility(
+  value: unknown,
+  filePath: string,
+  field: string,
+): RunnerVisibilitySnapshot | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const visibility = expectObject(value, filePath, field);
+  return {
+    state: expectEnum<RunnerVisibilityState>(
+      visibility.state,
+      [
+        "idle",
+        "starting",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+        "cancelled",
+        "timed-out",
+      ],
+      filePath,
+      `${field}.state`,
+    ),
+    phase: expectEnum<RunnerVisibilityPhase>(
+      visibility.phase,
+      [
+        "boot",
+        "session-start",
+        "turn-execution",
+        "turn-finished",
+        "handoff-reconciliation",
+        "awaiting-external",
+        "shutdown",
+      ],
+      filePath,
+      `${field}.phase`,
+    ),
+    session: parseRunnerSessionDescription(
+      visibility.session,
+      filePath,
+      `${field}.session`,
+    ),
+    lastHeartbeatAt: expectNullableString(
+      visibility.lastHeartbeatAt,
+      filePath,
+      `${field}.lastHeartbeatAt`,
+    ),
+    lastActionAt: expectNullableString(
+      visibility.lastActionAt,
+      filePath,
+      `${field}.lastActionAt`,
+    ),
+    lastActionSummary: expectNullableString(
+      visibility.lastActionSummary,
+      filePath,
+      `${field}.lastActionSummary`,
+    ),
+    waitingReason: expectNullableString(
+      visibility.waitingReason,
+      filePath,
+      `${field}.waitingReason`,
+    ),
+    stdoutSummary: expectNullableString(
+      visibility.stdoutSummary,
+      filePath,
+      `${field}.stdoutSummary`,
+    ),
+    stderrSummary: expectNullableString(
+      visibility.stderrSummary,
+      filePath,
+      `${field}.stderrSummary`,
+    ),
+    errorSummary: expectNullableString(
+      visibility.errorSummary,
+      filePath,
+      `${field}.errorSummary`,
+    ),
+    cancelledAt: expectNullableString(
+      visibility.cancelledAt,
+      filePath,
+      `${field}.cancelledAt`,
+    ),
+    timedOutAt: expectNullableString(
+      visibility.timedOutAt,
+      filePath,
+      `${field}.timedOutAt`,
+    ),
+  };
+}
+
+function parseRunnerSessionDescription(
+  value: unknown,
+  filePath: string,
+  field: string,
+): RunnerSessionDescription {
+  const session = expectObject(value, filePath, field);
+  return {
+    provider: expectString(session.provider, filePath, `${field}.provider`),
+    model: expectNullableString(session.model, filePath, `${field}.model`),
+    backendSessionId: expectNullableString(
+      session.backendSessionId,
+      filePath,
+      `${field}.backendSessionId`,
+    ),
+    backendThreadId: expectNullableString(
+      session.backendThreadId,
+      filePath,
+      `${field}.backendThreadId`,
+    ),
+    latestTurnId: expectNullableString(
+      session.latestTurnId,
+      filePath,
+      `${field}.latestTurnId`,
+    ),
+    appServerPid: expectNullableInteger(
+      session.appServerPid,
+      filePath,
+      `${field}.appServerPid`,
+    ),
+    latestTurnNumber: expectNullableInteger(
+      session.latestTurnNumber,
+      filePath,
+      `${field}.latestTurnNumber`,
+    ),
+    logPointers: expectArray(
+      session.logPointers,
+      filePath,
+      `${field}.logPointers`,
+      (entry, index) => {
+        const pointer = expectObject(
+          entry,
+          filePath,
+          `${field}.logPointers[${index.toString()}]`,
+        );
+        return {
+          name: expectString(
+            pointer.name,
+            filePath,
+            `${field}.logPointers[${index.toString()}].name`,
+          ),
+          location: expectNullableString(
+            pointer.location,
+            filePath,
+            `${field}.logPointers[${index.toString()}].location`,
+          ),
+          archiveLocation: expectNullableString(
+            pointer.archiveLocation,
+            filePath,
+            `${field}.logPointers[${index.toString()}].archiveLocation`,
+          ),
+        };
+      },
     ),
   };
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -625,18 +625,6 @@ export class BootstrapOrchestrator implements Orchestrator {
           description: result.session,
           latestTurnNumber: turn.turnNumber,
         };
-        this.#setIssueRunnerVisibility(
-          issue.number,
-          this.#buildRunnerVisibility(result.session, {
-            state: "completed",
-            phase: "turn-finished",
-            lastHeartbeatAt: result.finishedAt,
-            lastActionAt: result.finishedAt,
-            lastActionSummary: `Turn ${turn.turnNumber.toString()} completed`,
-            stdoutSummary: summarizeRunnerText(result.stdout),
-            stderrSummary: summarizeRunnerText(result.stderr),
-          }),
-        );
 
         if (result.exitCode !== 0) {
           this.#setIssueRunnerVisibility(
@@ -662,6 +650,19 @@ export class BootstrapOrchestrator implements Orchestrator {
           );
           return;
         }
+
+        this.#setIssueRunnerVisibility(
+          issue.number,
+          this.#buildRunnerVisibility(result.session, {
+            state: "completed",
+            phase: "turn-finished",
+            lastHeartbeatAt: result.finishedAt,
+            lastActionAt: result.finishedAt,
+            lastActionSummary: `Turn ${turn.turnNumber.toString()} completed`,
+            stdoutSummary: summarizeRunnerText(result.stdout),
+            stderrSummary: summarizeRunnerText(result.stderr),
+          }),
+        );
 
         this.#setIssueRunnerVisibility(
           issue.number,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -33,9 +33,10 @@ import {
 } from "../observability/status.js";
 import type {
   LiveRunnerSession,
-  RunnerEvent,
   Runner,
+  RunnerEvent,
   RunnerSpawnedEvent,
+  RunnerVisibilitySnapshot,
   RunnerTurnResult,
 } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
@@ -78,6 +79,7 @@ import {
   initWatchdogEntry,
   recordWatchdogRecovery,
 } from "./watchdog-state.js";
+import { summarizeRunnerText } from "../runner/service.js";
 
 export interface Orchestrator {
   runOnce(): Promise<void>;
@@ -484,6 +486,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       ownerPid: process.pid,
       runnerPid: null,
       blockedReason: null,
+      runnerVisibility: null,
     });
     noteStatusAction(this.#state.status, {
       kind: "run-preparing",
@@ -538,6 +541,13 @@ export class BootstrapOrchestrator implements Orchestrator {
         unresolvedThreadCount: pullRequest?.unresolvedThreadIds.length ?? 0,
       },
       blockedReason: null,
+      runnerVisibility: this.#buildRunnerVisibility(sessionState.description, {
+        state: "starting",
+        phase: "boot",
+        lastHeartbeatAt: session.startedAt,
+        lastActionAt: session.startedAt,
+        lastActionSummary: "Runner session created",
+      }),
     });
     noteStatusAction(this.#state.status, {
       kind: "run-started",
@@ -592,6 +602,17 @@ export class BootstrapOrchestrator implements Orchestrator {
           currentLifecycle,
           turnNumber,
         );
+        this.#setIssueRunnerVisibility(
+          issue.number,
+          this.#buildRunnerVisibility(sessionState.description, {
+            state: "running",
+            phase: "turn-execution",
+            lastHeartbeatAt: new Date().toISOString(),
+            lastActionAt: new Date().toISOString(),
+            lastActionSummary: `Starting turn ${turn.turnNumber.toString()}`,
+          }),
+        );
+        await this.#persistStatusSnapshot();
         const result = await this.#runRunnerTurn(
           session,
           liveRunnerSession,
@@ -604,8 +625,35 @@ export class BootstrapOrchestrator implements Orchestrator {
           description: result.session,
           latestTurnNumber: turn.turnNumber,
         };
+        this.#setIssueRunnerVisibility(
+          issue.number,
+          this.#buildRunnerVisibility(result.session, {
+            state: "completed",
+            phase: "turn-finished",
+            lastHeartbeatAt: result.finishedAt,
+            lastActionAt: result.finishedAt,
+            lastActionSummary: `Turn ${turn.turnNumber.toString()} completed`,
+            stdoutSummary: summarizeRunnerText(result.stdout),
+            stderrSummary: summarizeRunnerText(result.stderr),
+          }),
+        );
 
         if (result.exitCode !== 0) {
+          this.#setIssueRunnerVisibility(
+            issue.number,
+            this.#buildRunnerVisibility(result.session, {
+              state: "failed",
+              phase: "turn-finished",
+              lastHeartbeatAt: result.finishedAt,
+              lastActionAt: result.finishedAt,
+              lastActionSummary: `Turn ${turn.turnNumber.toString()} failed`,
+              stdoutSummary: summarizeRunnerText(result.stdout),
+              stderrSummary: summarizeRunnerText(result.stderr),
+              errorSummary: summarizeRunnerText(
+                `Runner exited with ${result.exitCode}\n${result.stderr}`,
+              ),
+            }),
+          );
           await this.#handleFailure(
             sessionState,
             attempt,
@@ -615,6 +663,21 @@ export class BootstrapOrchestrator implements Orchestrator {
           return;
         }
 
+        this.#setIssueRunnerVisibility(
+          issue.number,
+          this.#buildRunnerVisibility(result.session, {
+            state: "waiting",
+            phase: "handoff-reconciliation",
+            lastHeartbeatAt: result.finishedAt,
+            lastActionAt: result.finishedAt,
+            lastActionSummary: `Reconciling handoff after turn ${turn.turnNumber.toString()}`,
+            waitingReason: "Waiting for tracker reconciliation",
+            stdoutSummary: summarizeRunnerText(result.stdout),
+            stderrSummary: summarizeRunnerText(result.stderr),
+          }),
+          result.finishedAt,
+        );
+        await this.#persistStatusSnapshot();
         const nextLifecycle = await this.#tracker.reconcileSuccessfulRun(
           workspace.branchName,
           currentLifecycle,
@@ -664,6 +727,11 @@ export class BootstrapOrchestrator implements Orchestrator {
         return;
       }
     } catch (error) {
+      this.#setIssueFailureVisibility(
+        sessionState.runSession.issue.number,
+        sessionState.description,
+        error as Error,
+      );
       await this.#handleFailure(
         sessionState,
         attempt,
@@ -710,31 +778,31 @@ export class BootstrapOrchestrator implements Orchestrator {
     lockDir: string,
     signal: AbortSignal,
   ): Promise<RunnerTurnResult> {
-    const runnerEventHandlers: {
-      [Kind in RunnerEvent["kind"]]: (
-        event: Extract<RunnerEvent, { kind: Kind }>,
-      ) => void;
-    } = {
-      spawned: (event): void => {
-        this.#recordRunnerSpawn(
-          {
-            runSession: session,
-            description:
-              liveRunnerSession?.describe() ??
-              this.#runner.describeSession(session),
-            latestTurnNumber: turn.turnNumber,
-          },
-          lockDir,
-          event,
-          turn.turnNumber,
-        );
-      },
-    };
     const onEvent = (event: RunnerEvent): void => {
-      // If `RunnerEvent` grows beyond spawn notifications, keep the dispatch
-      // map explicit and add a cast at this call site to preserve the
-      // correlation between `event.kind` and the handler parameter type.
-      runnerEventHandlers[event.kind](event);
+      switch (event.kind) {
+        case "spawned":
+          this.#recordRunnerSpawn(
+            {
+              runSession: session,
+              description:
+                liveRunnerSession?.describe() ??
+                this.#runner.describeSession(session),
+              latestTurnNumber: turn.turnNumber,
+            },
+            lockDir,
+            event,
+            turn.turnNumber,
+          );
+          return;
+        case "visibility":
+          this.#setIssueRunnerVisibility(
+            session.issue.number,
+            event.visibility,
+            event.visibility.lastHeartbeatAt ?? undefined,
+          );
+          void this.#persistStatusSnapshot();
+          return;
+      }
     };
     if (liveRunnerSession !== undefined) {
       return await liveRunnerSession.runTurn(turn, {
@@ -795,6 +863,18 @@ export class BootstrapOrchestrator implements Orchestrator {
       lifecycle.kind === "actionable-follow-up"
     ) {
       const summary = lifecycle.summary;
+      this.#setIssueRunnerVisibility(
+        issue.number,
+        this.#buildRunnerVisibility(session.description, {
+          state: "waiting",
+          phase: "awaiting-external",
+          lastHeartbeatAt: finishedAt,
+          lastActionAt: finishedAt,
+          lastActionSummary: `Turn ${session.latestTurnNumber?.toString() ?? "?"} handed off`,
+          waitingReason: summary,
+        }),
+        finishedAt,
+      );
       noteLifecycleForIssue(
         this.#state.status,
         issue,
@@ -1852,6 +1932,33 @@ export class BootstrapOrchestrator implements Orchestrator {
         ...entry,
         runnerPid: event.pid,
         updatedAt: event.spawnedAt,
+        runnerVisibility: this.#buildRunnerVisibility(
+          {
+            ...(entry.runnerVisibility?.session ?? session.description),
+            appServerPid: event.pid,
+          },
+          {
+            ...(entry.runnerVisibility === null
+              ? {
+                  state: "starting",
+                  phase: "session-start",
+                }
+              : {
+                  state: entry.runnerVisibility.state,
+                  phase: entry.runnerVisibility.phase,
+                }),
+            lastHeartbeatAt:
+              entry.runnerVisibility?.lastHeartbeatAt ?? event.spawnedAt,
+            lastActionAt: event.spawnedAt,
+            lastActionSummary: `Runner process spawned for turn ${turnNumber.toString()}`,
+            waitingReason: entry.runnerVisibility?.waitingReason ?? null,
+            stdoutSummary: entry.runnerVisibility?.stdoutSummary ?? null,
+            stderrSummary: entry.runnerVisibility?.stderrSummary ?? null,
+            errorSummary: entry.runnerVisibility?.errorSummary ?? null,
+            cancelledAt: entry.runnerVisibility?.cancelledAt ?? null,
+            timedOutAt: entry.runnerVisibility?.timedOutAt ?? null,
+          },
+        ),
       });
     }
     noteStatusAction(this.#state.status, {
@@ -1871,6 +1978,93 @@ export class BootstrapOrchestrator implements Orchestrator {
       spawnedAt: event.spawnedAt,
       turnNumber,
     });
+  }
+
+  #setIssueRunnerVisibility(
+    issueNumber: number,
+    runnerVisibility: RunnerVisibilitySnapshot,
+    updatedAt?: string,
+  ): void {
+    const entry = this.#state.status.activeIssues.get(issueNumber);
+    if (entry === undefined) {
+      return;
+    }
+    this.#state.status.activeIssues.set(issueNumber, {
+      ...entry,
+      updatedAt: updatedAt ?? runnerVisibility.lastActionAt ?? entry.updatedAt,
+      runnerVisibility,
+    });
+  }
+
+  #setIssueFailureVisibility(
+    issueNumber: number,
+    session: RunSessionArtifactsState["description"],
+    error: Error,
+  ): void {
+    const observedAt = new Date().toISOString();
+    const normalized = this.#normalizeFailure(error);
+    if (error instanceof RunnerAbortedError) {
+      this.#setIssueRunnerVisibility(
+        issueNumber,
+        this.#buildRunnerVisibility(session, {
+          state: "cancelled",
+          phase: "shutdown",
+          lastHeartbeatAt: observedAt,
+          lastActionAt: observedAt,
+          lastActionSummary: "Runner cancelled",
+          errorSummary: normalized,
+          cancelledAt: observedAt,
+        }),
+        observedAt,
+      );
+      return;
+    }
+    const timedOut = normalized.includes("timed out");
+    this.#setIssueRunnerVisibility(
+      issueNumber,
+      this.#buildRunnerVisibility(session, {
+        state: timedOut ? "timed-out" : "failed",
+        phase: timedOut ? "shutdown" : "turn-finished",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: timedOut ? "Runner timed out" : "Runner failed",
+        errorSummary: normalized,
+        ...(timedOut ? { timedOutAt: observedAt } : {}),
+      }),
+      observedAt,
+    );
+  }
+
+  #buildRunnerVisibility(
+    session: RunSessionArtifactsState["description"],
+    options: {
+      readonly state: RunnerVisibilitySnapshot["state"];
+      readonly phase: RunnerVisibilitySnapshot["phase"];
+      readonly lastHeartbeatAt?: string | null;
+      readonly lastActionAt?: string | null;
+      readonly lastActionSummary?: string | null;
+      readonly waitingReason?: string | null;
+      readonly stdoutSummary?: string | null;
+      readonly stderrSummary?: string | null;
+      readonly errorSummary?: string | null;
+      readonly cancelledAt?: string | null;
+      readonly timedOutAt?: string | null;
+    },
+  ): RunnerVisibilitySnapshot {
+    return {
+      state: options.state,
+      phase: options.phase,
+      session,
+      lastHeartbeatAt: options.lastHeartbeatAt ?? null,
+      lastActionAt: options.lastActionAt ?? null,
+      lastActionSummary: options.lastActionSummary ?? null,
+      waitingReason: options.waitingReason ?? null,
+      stdoutSummary: options.stdoutSummary ?? null,
+      stderrSummary: options.stderrSummary ?? null,
+      errorSummary: options.errorSummary ?? null,
+      cancelledAt: options.cancelledAt ?? null,
+      timedOutAt: options.timedOutAt ?? null,
+    };
   }
 
   #abortActiveRuns(): void {

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -135,6 +135,10 @@ export function upsertActiveIssue(
       update.blockedReason === undefined
         ? (existing?.blockedReason ?? null)
         : update.blockedReason,
+    runnerVisibility:
+      update.runnerVisibility === undefined
+        ? (existing?.runnerVisibility ?? null)
+        : update.runnerVisibility,
   });
 }
 

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -626,13 +626,6 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     if (method === "turn/completed") {
-      void this.#emitVisibility({
-        state: "completed",
-        phase: "turn-finished",
-        lastHeartbeatAt: new Date().toISOString(),
-        lastActionAt: new Date().toISOString(),
-        lastActionSummary: "Codex turn completed",
-      });
       this.#resolveActiveTurn();
       return;
     }

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -8,12 +8,14 @@ import {
   buildCodexAppServerCommand,
   type CodexAppServerCommand,
 } from "./codex-app-server-command.js";
+import { summarizeRunnerText } from "./service.js";
 import type {
   LiveRunnerSession,
   RunnerEvent,
   RunnerRunOptions,
   RunnerSessionDescription,
   RunnerTurnResult,
+  RunnerVisibilitySnapshot,
 } from "./service.js";
 
 const INITIALIZE_REQUEST_ID = 1;
@@ -61,6 +63,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   #closeTimersScheduled = false;
   #nextTurnStartRequestId = TURN_START_FIRST_REQUEST_ID;
   #startupStderr = "";
+  #currentOnEvent: ((event: RunnerEvent) => void | Promise<void>) | null = null;
 
   constructor(config: AgentConfig, logger: Logger, session: RunSession) {
     this.#config = config;
@@ -117,7 +120,15 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }, this.#config.timeoutMs);
 
     try {
+      this.#currentOnEvent = options?.onEvent ?? null;
       options?.signal?.addEventListener("abort", handleAbort, { once: true });
+      await this.#emitVisibility({
+        state: "starting",
+        phase: "session-start",
+        lastHeartbeatAt: new Date().toISOString(),
+        lastActionAt: new Date().toISOString(),
+        lastActionSummary: "Starting Codex app-server session",
+      });
 
       const runPromise = (async (): Promise<RunnerTurnResult> => {
         await this.#ensureStarted(options);
@@ -125,6 +136,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       })();
       return await Promise.race([runPromise, timeoutPromise, abortPromise]);
     } finally {
+      this.#currentOnEvent = null;
       clearTimeout(timeoutHandle);
       options?.signal?.removeEventListener("abort", handleAbort);
     }
@@ -230,33 +242,67 @@ export class CodexAppServerSession implements LiveRunnerSession {
     });
 
     if (child.pid !== undefined) {
+      const spawnedAt = new Date().toISOString();
       Promise.resolve(
         onEvent?.({
           kind: "spawned",
           pid: child.pid,
-          spawnedAt: new Date().toISOString(),
+          spawnedAt,
         }),
-      ).catch((error) => {
-        void this.close().finally(() => {
-          this.#rejectActiveState(
-            new RunnerError(
-              `Failed to record runner spawn: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            ),
-          );
+      )
+        .then(() =>
+          this.#emitVisibility({
+            state: "starting",
+            phase: "session-start",
+            lastHeartbeatAt: spawnedAt,
+            lastActionAt: spawnedAt,
+            lastActionSummary: "Codex app-server process spawned",
+          }),
+        )
+        .catch((error) => {
+          void this.close().finally(() => {
+            this.#rejectActiveState(
+              new RunnerError(
+                `Failed to record runner spawn: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              ),
+            );
+          });
         });
-      });
     }
 
     child.stdout.on("data", (chunk: Buffer | string) => {
-      this.#handleStdoutChunk(chunk.toString());
+      const text = chunk.toString();
+      this.#handleStdoutChunk(text);
+      if (this.#activeTurn !== null) {
+        const observedAt = new Date().toISOString();
+        void this.#emitVisibility({
+          state: "running",
+          phase: "turn-execution",
+          lastHeartbeatAt: observedAt,
+          lastActionAt: observedAt,
+          lastActionSummary: "Codex app-server stdout activity",
+          stdoutSummary: summarizeRunnerText(this.#activeTurn.stdout),
+          stderrSummary: summarizeRunnerText(this.#activeTurn.stderr),
+        });
+      }
     });
     child.stderr.on("data", (chunk: Buffer | string) => {
       const text = chunk.toString();
       this.#appendStartupStderr(text);
       if (this.#activeTurn !== null) {
         this.#activeTurn.stderr += text;
+        const observedAt = new Date().toISOString();
+        void this.#emitVisibility({
+          state: "running",
+          phase: "turn-execution",
+          lastHeartbeatAt: observedAt,
+          lastActionAt: observedAt,
+          lastActionSummary: "Codex app-server stderr activity",
+          stdoutSummary: summarizeRunnerText(this.#activeTurn.stdout),
+          stderrSummary: summarizeRunnerText(this.#activeTurn.stderr),
+        });
       }
     });
     child.on("error", (error) => {
@@ -330,6 +376,13 @@ export class CodexAppServerSession implements LiveRunnerSession {
       );
     }
     this.#threadId = threadId;
+    await this.#emitVisibility({
+      state: "starting",
+      phase: "session-start",
+      lastHeartbeatAt: new Date().toISOString(),
+      lastActionAt: new Date().toISOString(),
+      lastActionSummary: "Codex thread started",
+    });
   }
 
   async #startTurn(
@@ -344,6 +397,13 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     const startedAt = new Date().toISOString();
+    await this.#emitVisibility({
+      state: "running",
+      phase: "turn-execution",
+      lastHeartbeatAt: startedAt,
+      lastActionAt: startedAt,
+      lastActionSummary: `Starting Codex turn ${turn.turnNumber.toString()}`,
+    });
     const result = await new Promise<RunnerTurnResult>((resolve, reject) => {
       this.#activeTurn = {
         turnNumber: turn.turnNumber,
@@ -553,16 +613,45 @@ export class CodexAppServerSession implements LiveRunnerSession {
       if (turnId !== null) {
         this.#latestTurnId = turnId;
       }
+      void this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: new Date().toISOString(),
+        lastActionAt: new Date().toISOString(),
+        lastActionSummary: `Codex acknowledged turn ${
+          this.#activeTurn?.turnNumber.toString() ?? "?"
+        }`,
+      });
       return;
     }
 
     if (method === "turn/completed") {
+      void this.#emitVisibility({
+        state: "completed",
+        phase: "turn-finished",
+        lastHeartbeatAt: new Date().toISOString(),
+        lastActionAt: new Date().toISOString(),
+        lastActionSummary: "Codex turn completed",
+      });
       this.#resolveActiveTurn();
       return;
     }
 
     if (method === "turn/failed" || method === "turn/cancelled") {
       const params = asRecord(message["params"]);
+      const observedAt = new Date().toISOString();
+      void this.#emitVisibility({
+        state: method === "turn/cancelled" ? "cancelled" : "failed",
+        phase: method === "turn/cancelled" ? "shutdown" : "turn-finished",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary:
+          method === "turn/cancelled"
+            ? "Codex turn cancelled"
+            : "Codex turn failed",
+        errorSummary: summarizeRunnerText(JSON.stringify(params ?? {})),
+        cancelledAt: method === "turn/cancelled" ? observedAt : null,
+      });
       this.#rejectActiveTurn(
         new RunnerError(
           `Codex app-server reported ${method}: ${JSON.stringify(params ?? {})}`,
@@ -579,6 +668,15 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
     this.#latestTurnNumber = activeTurn.turnNumber;
     this.#activeTurn = null;
+    void this.#emitVisibility({
+      state: "completed",
+      phase: "turn-finished",
+      lastHeartbeatAt: new Date().toISOString(),
+      lastActionAt: new Date().toISOString(),
+      lastActionSummary: `Turn ${activeTurn.turnNumber.toString()} completed`,
+      stdoutSummary: summarizeRunnerText(activeTurn.stdout),
+      stderrSummary: summarizeRunnerText(activeTurn.stderr),
+    });
     activeTurn.resolve({
       exitCode: 0,
       stdout: activeTurn.stdout,
@@ -596,7 +694,31 @@ export class CodexAppServerSession implements LiveRunnerSession {
       return;
     }
     this.#activeTurn = null;
-    activeTurn.reject(asError(error));
+    const observedAt = new Date().toISOString();
+    const resolvedError = asError(error);
+    void this.#emitVisibility({
+      state:
+        this.#closingReason === "aborted"
+          ? "cancelled"
+          : this.#closingReason === "timeout"
+            ? "timed-out"
+            : "failed",
+      phase: this.#closingReason === null ? "turn-finished" : "shutdown",
+      lastHeartbeatAt: observedAt,
+      lastActionAt: observedAt,
+      lastActionSummary:
+        this.#closingReason === "aborted"
+          ? "Runner cancelled"
+          : this.#closingReason === "timeout"
+            ? "Runner timed out"
+            : "Runner failed",
+      stdoutSummary: summarizeRunnerText(activeTurn.stdout),
+      stderrSummary: summarizeRunnerText(activeTurn.stderr),
+      errorSummary: summarizeRunnerText(resolvedError.message),
+      cancelledAt: this.#closingReason === "aborted" ? observedAt : null,
+      timedOutAt: this.#closingReason === "timeout" ? observedAt : null,
+    });
+    activeTurn.reject(resolvedError);
   }
 
   #rejectActiveState(error: Error): void {
@@ -629,6 +751,52 @@ export class CodexAppServerSession implements LiveRunnerSession {
     return new RunnerError(`${error.message}\nStartup stderr:\n${stderr}`, {
       cause: error,
     });
+  }
+
+  async #emitVisibility(visibility: {
+    readonly state: RunnerVisibilitySnapshot["state"];
+    readonly phase: RunnerVisibilitySnapshot["phase"];
+    readonly lastHeartbeatAt?: string | null;
+    readonly lastActionAt?: string | null;
+    readonly lastActionSummary?: string | null;
+    readonly waitingReason?: string | null;
+    readonly stdoutSummary?: string | null;
+    readonly stderrSummary?: string | null;
+    readonly errorSummary?: string | null;
+    readonly cancelledAt?: string | null;
+    readonly timedOutAt?: string | null;
+  }): Promise<void> {
+    const onEvent = this.#currentOnEvent;
+    if (onEvent === null) {
+      return;
+    }
+    try {
+      await onEvent({
+        kind: "visibility",
+        visibility: {
+          session: this.describe(),
+          state: visibility.state,
+          phase: visibility.phase,
+          lastHeartbeatAt: visibility.lastHeartbeatAt ?? null,
+          lastActionAt: visibility.lastActionAt ?? null,
+          lastActionSummary: visibility.lastActionSummary ?? null,
+          waitingReason: visibility.waitingReason ?? null,
+          stdoutSummary: visibility.stdoutSummary ?? null,
+          stderrSummary: visibility.stderrSummary ?? null,
+          errorSummary: visibility.errorSummary ?? null,
+          cancelledAt: visibility.cancelledAt ?? null,
+          timedOutAt: visibility.timedOutAt ?? null,
+        },
+      });
+    } catch (error) {
+      this.#rejectActiveState(
+        new RunnerError(
+          `Failed to record runner visibility: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      );
+    }
   }
 }
 

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -109,5 +109,5 @@ export function summarizeRunnerText(text: string): string | null {
   if (collapsed.length <= SUMMARY_LIMIT) {
     return collapsed;
   }
-  return `${collapsed.slice(0, SUMMARY_LIMIT - 1)}...`;
+  return `${collapsed.slice(0, SUMMARY_LIMIT - 3)}...`;
 }

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -14,7 +14,24 @@ export interface RunnerSpawnedEvent {
   readonly spawnedAt: string;
 }
 
-export type RunnerEvent = RunnerSpawnedEvent;
+export type RunnerVisibilityState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "timed-out";
+
+export type RunnerVisibilityPhase =
+  | "boot"
+  | "session-start"
+  | "turn-execution"
+  | "turn-finished"
+  | "handoff-reconciliation"
+  | "awaiting-external"
+  | "shutdown";
 
 export interface RunnerLogPointer {
   readonly name: string;
@@ -32,6 +49,28 @@ export interface RunnerSessionDescription {
   readonly latestTurnNumber: number | null;
   readonly logPointers: readonly RunnerLogPointer[];
 }
+
+export interface RunnerVisibilitySnapshot {
+  readonly state: RunnerVisibilityState;
+  readonly phase: RunnerVisibilityPhase;
+  readonly session: RunnerSessionDescription;
+  readonly lastHeartbeatAt: string | null;
+  readonly lastActionAt: string | null;
+  readonly lastActionSummary: string | null;
+  readonly waitingReason: string | null;
+  readonly stdoutSummary: string | null;
+  readonly stderrSummary: string | null;
+  readonly errorSummary: string | null;
+  readonly cancelledAt: string | null;
+  readonly timedOutAt: string | null;
+}
+
+export interface RunnerVisibilityEvent {
+  readonly kind: "visibility";
+  readonly visibility: RunnerVisibilitySnapshot;
+}
+
+export type RunnerEvent = RunnerSpawnedEvent | RunnerVisibilityEvent;
 
 export interface RunnerSessionDescriber {
   describeSession(session: RunSession): RunnerSessionDescription;
@@ -58,4 +97,17 @@ export interface Runner extends RunnerSessionDescriber {
     options?: RunnerRunOptions,
   ): Promise<RunnerExecutionResult>;
   startSession?(session: RunSession): Promise<LiveRunnerSession>;
+}
+
+const SUMMARY_LIMIT = 160;
+
+export function summarizeRunnerText(text: string): string | null {
+  const collapsed = text.replace(/\s+/gu, " ").trim();
+  if (collapsed.length === 0) {
+    return null;
+  }
+  if (collapsed.length <= SUMMARY_LIMIT) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, SUMMARY_LIMIT - 1)}...`;
 }

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -13,7 +13,6 @@ import {
 import { CodexRunner } from "../../src/runner/codex.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
-import type { RunnerSpawnedEvent } from "../../src/runner/service.js";
 import { waitForExit } from "../support/process.js";
 import { createTempDir } from "../support/git.js";
 import type { Logger } from "../../src/observability/logger.js";
@@ -456,9 +455,10 @@ describe("runners", () => {
     const run = runner.run(session, {
       signal: abortController.signal,
       onEvent(event) {
-        expect(event.kind).toBe("spawned");
-        spawnedPid = event.pid;
-        abortController.abort();
+        if (event.kind === "spawned") {
+          spawnedPid = event.pid;
+          abortController.abort();
+        }
       },
     });
 
@@ -476,7 +476,10 @@ describe("runners", () => {
     let spawnedPid = -1;
 
     const run = runner.run(session, {
-      onEvent: async (event: RunnerSpawnedEvent) => {
+      onEvent: async (event) => {
+        if (event.kind !== "spawned") {
+          return;
+        }
         spawnedPid = event.pid;
         throw new Error("persist failed");
       },
@@ -711,7 +714,9 @@ describe("runners", () => {
         },
         {
           onEvent(event) {
-            spawnedPid = event.pid;
+            if (event.kind === "spawned") {
+              spawnedPid = event.pid;
+            }
           },
         },
       );
@@ -1023,7 +1028,9 @@ describe("runners", () => {
         },
         {
           onEvent(event) {
-            spawnedPid = event.pid;
+            if (event.kind === "spawned") {
+              spawnedPid = event.pid;
+            }
           },
         },
       ),

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -13,6 +13,7 @@ import {
 import { CodexRunner } from "../../src/runner/codex.js";
 import { GenericCommandRunner } from "../../src/runner/generic-command.js";
 import { describeLocalRunnerBackend } from "../../src/runner/local-command.js";
+import type { RunnerEvent } from "../../src/runner/service.js";
 import { waitForExit } from "../support/process.js";
 import { createTempDir } from "../support/git.js";
 import type { Logger } from "../../src/observability/logger.js";
@@ -963,6 +964,45 @@ describe("runners", () => {
     } finally {
       await liveSession.close();
     }
+  });
+
+  it("emits one completed visibility update per successful Codex turn", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const runner = createCodexRunnerForMode(fakeCodex, "success");
+    const liveSession = await runner.startSession(createSession());
+    const events: RunnerEvent[] = [];
+
+    try {
+      await liveSession.runTurn(
+        {
+          turnNumber: 1,
+          prompt: "first",
+        },
+        {
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+      );
+    } finally {
+      await liveSession.close();
+    }
+
+    const completedEvents = events.filter(
+      (event) =>
+        event.kind === "visibility" &&
+        event.visibility.state === "completed" &&
+        event.visibility.phase === "turn-finished",
+    );
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0]).toMatchObject({
+      kind: "visibility",
+      visibility: {
+        state: "completed",
+        phase: "turn-finished",
+        lastActionSummary: "Turn 1 completed",
+      },
+    });
   });
 
   it("rejects a Codex turn when turn/failed omits params", async () => {

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -9,6 +9,7 @@ import type {
   RunnerTurnResult,
   RunnerVisibilitySnapshot,
 } from "../../src/runner/service.js";
+import { summarizeRunnerText } from "../../src/runner/service.js";
 
 function createSession(): RunSession {
   return {
@@ -257,5 +258,12 @@ describe("runner contract", () => {
       cancelledAt: null,
       timedOutAt: null,
     });
+  });
+
+  it("keeps summarized runner text within the shared limit", () => {
+    const summary = summarizeRunnerText("x".repeat(200));
+
+    expect(summary).toBe(`${"x".repeat(157)}...`);
+    expect(summary).toHaveLength(160);
   });
 });

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -7,6 +7,7 @@ import type {
   RunnerExecutionResult,
   RunnerRunOptions,
   RunnerTurnResult,
+  RunnerVisibilitySnapshot,
 } from "../../src/runner/service.js";
 
 function createSession(): RunSession {
@@ -205,6 +206,56 @@ describe("runner contract", () => {
           },
         ],
       },
+    });
+  });
+
+  it("keeps the visibility shape provider-neutral", () => {
+    const visibility: RunnerVisibilitySnapshot = {
+      state: "waiting",
+      phase: "awaiting-external",
+      session: {
+        provider: "fake-provider",
+        model: null,
+        backendSessionId: null,
+        backendThreadId: null,
+        latestTurnId: null,
+        appServerPid: null,
+        latestTurnNumber: 2,
+        logPointers: [],
+      },
+      lastHeartbeatAt: "2026-03-12T10:00:02.000Z",
+      lastActionAt: "2026-03-12T10:00:02.000Z",
+      lastActionSummary: "Waiting for external review",
+      waitingReason: "Waiting for external review",
+      stdoutSummary: "completed turn 2",
+      stderrSummary: null,
+      errorSummary: null,
+      cancelledAt: null,
+      timedOutAt: null,
+    };
+
+    expect(visibility).toEqual({
+      state: "waiting",
+      phase: "awaiting-external",
+      session: {
+        provider: "fake-provider",
+        model: null,
+        backendSessionId: null,
+        backendThreadId: null,
+        latestTurnId: null,
+        appServerPid: null,
+        latestTurnNumber: 2,
+        logPointers: [],
+      },
+      lastHeartbeatAt: "2026-03-12T10:00:02.000Z",
+      lastActionAt: "2026-03-12T10:00:02.000Z",
+      lastActionSummary: "Waiting for external review",
+      waitingReason: "Waiting for external review",
+      stdoutSummary: "completed turn 2",
+      stderrSummary: null,
+      errorSummary: null,
+      cancelledAt: null,
+      timedOutAt: null,
     });
   });
 });

--- a/tests/unit/status-state.test.ts
+++ b/tests/unit/status-state.test.ts
@@ -66,6 +66,29 @@ describe("upsertActiveIssue", () => {
         latestCommitAt: "2026-03-06T11:02:00.000Z",
       },
       blockedReason: "Waiting on review",
+      runnerVisibility: {
+        state: "waiting",
+        phase: "awaiting-external",
+        session: {
+          provider: "codex",
+          model: "gpt-5.4",
+          backendSessionId: null,
+          backendThreadId: null,
+          latestTurnId: null,
+          appServerPid: null,
+          latestTurnNumber: 1,
+          logPointers: [],
+        },
+        lastHeartbeatAt: "2026-03-06T11:03:00.000Z",
+        lastActionAt: "2026-03-06T11:03:00.000Z",
+        lastActionSummary: "Waiting on review",
+        waitingReason: "Waiting on review",
+        stdoutSummary: null,
+        stderrSummary: null,
+        errorSummary: null,
+        cancelledAt: null,
+        timedOutAt: null,
+      },
     });
 
     upsertActiveIssue(state, issue, {
@@ -81,6 +104,7 @@ describe("upsertActiveIssue", () => {
       startedAt: null,
       pullRequest: null,
       blockedReason: null,
+      runnerVisibility: null,
     });
 
     expect(state.activeIssues.get(issue.number)).toMatchObject({
@@ -91,6 +115,7 @@ describe("upsertActiveIssue", () => {
       startedAt: null,
       pullRequest: null,
       blockedReason: null,
+      runnerVisibility: null,
     });
   });
 });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -71,6 +71,30 @@ function createSnapshot(
         },
         blockedReason:
           "Waiting for PR checks to appear on https://example.test/pr/12",
+        runnerVisibility: {
+          state: "waiting",
+          phase: "awaiting-external",
+          session: {
+            provider: "codex",
+            model: "gpt-5.4",
+            backendSessionId: "thread-12-turn-2",
+            backendThreadId: "thread-12",
+            latestTurnId: "turn-2",
+            appServerPid: 4321,
+            latestTurnNumber: 2,
+            logPointers: [],
+          },
+          lastHeartbeatAt: "2026-03-06T12:00:00.000Z",
+          lastActionAt: "2026-03-06T12:00:00.000Z",
+          lastActionSummary: "Waiting for PR checks",
+          waitingReason:
+            "Waiting for PR checks to appear on https://example.test/pr/12",
+          stdoutSummary: "Opened PR #12",
+          stderrSummary: null,
+          errorSummary: null,
+          cancelledAt: null,
+          timedOutAt: null,
+        },
       },
     ],
     retries: [
@@ -239,6 +263,7 @@ describe("factory status helpers", () => {
             startedAt: undefined,
             pullRequest: undefined,
             blockedReason: undefined,
+            runnerVisibility: undefined,
           },
         ],
       };
@@ -255,6 +280,7 @@ describe("factory status helpers", () => {
             startedAt: null,
             pullRequest: null,
             blockedReason: null,
+            runnerVisibility: null,
           },
         ],
       });
@@ -278,6 +304,10 @@ describe("factory status helpers", () => {
       "#12 Expose factory status [awaiting-system-checks]",
     );
     expect(output).toContain("PR: #12 https://example.test/pr/12");
+    expect(output).toContain(
+      "Runner: waiting phase=awaiting-external provider=codex",
+    );
+    expect(output).toContain("Runner action: Waiting for PR checks");
     expect(output).toContain("Pending checks: CI");
     expect(output).toContain("Retries:");
     expect(output).toContain("#9 Retry a failed run attempt 2");


### PR DESCRIPTION
Closes #39

## Summary
- add a provider-neutral runner visibility contract for live worker state, phase, session identity, heartbeat/action timestamps, waiting reason, and condensed output/error summaries
- project Codex app-server execution into that contract and thread visibility updates through orchestrator status state
- expose runner visibility in the factory status snapshot/renderer and add contract/status tests that lock in the shape

## Validation
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test