### PR TITLE
Guard PR merges with a merge gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ from existing issue reports. They are written under:
 6. Symphony monitors CI and automated review feedback on the PR
 7. If CI fails or reviewers request changes, the agent pushes follow-up commits on the same branch
 8. When the PR is clean, Symphony waits for an explicit human landing signal such as a `/land` PR comment
-9. Symphony executes the landing path and comments on the issue and closes it only after merge is actually observed
+9. Symphony executes a guarded landing path that re-checks mergeability, required checks, and unresolved review threads before merge
+10. Symphony comments on the issue and closes it only after merge is actually observed
 
 If a run fails, Symphony retries. After retries are exhausted, it marks the issue `symphony:failed`.
 

--- a/docs/plans/082-guarded-pr-merge-gate/plan.md
+++ b/docs/plans/082-guarded-pr-merge-gate/plan.md
@@ -161,16 +161,16 @@ This issue does not introduce a new top-level handoff state. It tightens transit
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| PR head changed after `/land` approval | current head SHA from lifecycle | guarded snapshot no longer matches approved head | reject landing, re-enter normal lifecycle inspection |
-| Required checks pending | no landing attempt active | merge gate shows pending or non-terminal checks | do not merge; remain `awaiting-system-checks` |
-| Required checks failed | no landing attempt active | merge gate shows failing terminal checks | do not merge; lifecycle returns to follow-up path |
-| Unresolved non-outdated human review threads remain | no landing attempt active | merge gate unresolved thread count > 0 | do not merge; remain blocked on human review |
-| Only outdated or resolved threads remain | no landing attempt active | merge gate unresolved thread count = 0 | gate may open if other requirements pass |
-| GitHub reports PR not mergeable / merge blocked | no landing attempt active | mergeability fact is negative or unknown | do not merge; fail closed with explicit reason |
-| Merge request succeeds but PR remains open | landing request recorded | lifecycle still `awaiting-landing` | keep waiting; do not complete |
-| GitHub merge request returns conflict / branch protection / refusal | landing request attempted | merge gate or merge API returns refusal reason | record blocked landing result and stay non-terminal |
+| Observed condition                                                  | Local facts available           | Normalized tracker facts available               | Expected decision                                    |
+| ------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------ | ---------------------------------------------------- |
+| PR head changed after `/land` approval                              | current head SHA from lifecycle | guarded snapshot no longer matches approved head | reject landing, re-enter normal lifecycle inspection |
+| Required checks pending                                             | no landing attempt active       | merge gate shows pending or non-terminal checks  | do not merge; remain `awaiting-system-checks`        |
+| Required checks failed                                              | no landing attempt active       | merge gate shows failing terminal checks         | do not merge; lifecycle returns to follow-up path    |
+| Unresolved non-outdated human review threads remain                 | no landing attempt active       | merge gate unresolved thread count > 0           | do not merge; remain blocked on human review         |
+| Only outdated or resolved threads remain                            | no landing attempt active       | merge gate unresolved thread count = 0           | gate may open if other requirements pass             |
+| GitHub reports PR not mergeable / merge blocked                     | no landing attempt active       | mergeability fact is negative or unknown         | do not merge; fail closed with explicit reason       |
+| Merge request succeeds but PR remains open                          | landing request recorded        | lifecycle still `awaiting-landing`               | keep waiting; do not complete                        |
+| GitHub merge request returns conflict / branch protection / refusal | landing request attempted       | merge gate or merge API returns refusal reason   | record blocked landing result and stay non-terminal  |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/082-guarded-pr-merge-gate/plan.md
+++ b/docs/plans/082-guarded-pr-merge-gate/plan.md
@@ -1,0 +1,262 @@
+# Issue 82 Plan: Guarded PR Merge Gate
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Harden the centralized landing path so Symphony refuses to merge a pull request unless merge preconditions are explicitly verified at merge time. A clean review lifecycle is not enough on its own; merge must become a guarded capability with fail-closed behavior and inspectable reasons.
+
+## Scope
+
+- add a dedicated guarded landing helper/service for GitHub bootstrap merge execution
+- make the factory-owned landing path call that guarded helper instead of issuing a raw merge request
+- require the guarded path to verify, at minimum:
+  - the PR is mergeable
+  - required checks are terminal green
+  - unresolved non-outdated review thread count is `0`
+  - blocked-check policy is satisfied
+- return a structured failure reason when the gate is closed and keep the issue non-terminal
+- extend unit, integration, and e2e coverage for the unresolved-thread regression represented by PR `#80`
+
+## Non-goals
+
+- redesigning the broader landing/merge lifecycle introduced in `#100`
+- replacing the existing `/land` approval protocol
+- introducing remote merge services or non-GitHub landing adapters
+- redesigning tracker lifecycle semantics beyond the narrow landing gate seam
+- shipping a broad operator control CLI in this issue if no in-tree command surface already exists
+
+## Current Gaps
+
+- `src/tracker/github-bootstrap.ts` currently routes `executeLanding()` straight to `GitHubClient.mergePullRequest()`
+- the current landing path trusts the previously observed lifecycle instead of re-checking merge-time facts
+- review-thread information is normalized for follow-up and auto-resolution, but unresolved human threads do not block merge execution
+- GitHub transport does not currently expose mergeability / merge-state facts as a dedicated normalized merge-gate snapshot
+- no structured merge-gate failure classification exists for operator-facing logs, artifacts, or status output
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: define merge as a guarded action with explicit preconditions and fail-closed outcomes
+  - belongs: define that unresolved non-outdated threads and non-terminal checks block landing
+  - does not belong: raw GitHub API fields or HTTP error parsing
+- Configuration Layer
+  - belongs: no new workflow settings in this slice unless GitHub proves a minimal blocked-check configuration hook is already required by existing policy
+  - does not belong: per-PR mergeability parsing or landing gate decisions
+- Coordination Layer
+  - belongs: decide whether the orchestrator waits, retries later, requests follow-up, or records a blocked landing outcome after a guarded merge attempt
+  - does not belong: direct GitHub transport calls or GraphQL field mapping
+- Execution Layer
+  - belongs: the dedicated guarded landing executor/helper invoked by the centralized landing path
+  - does not belong: tracker-specific normalization rules leaking into runner or workspace code
+- Integration Layer
+  - belongs: fetch GitHub mergeability, check-state, and review-thread facts; normalize them into a merge-gate snapshot; execute merge only after policy approval
+  - does not belong: orchestrator retry counters or status-surface wording
+- Observability Layer
+  - belongs: explicit logs, issue-artifact events, and status summaries for guarded landing pass/fail results
+  - does not belong: recomputing merge-gate policy from raw GitHub payloads
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/tracker/github-client.ts`
+  - add the narrow GitHub reads needed to inspect merge-time gate facts
+- `src/tracker/`
+  - add a focused normalization/policy seam for guarded landing evaluation instead of burying checks inside `github-bootstrap.ts`
+- `src/tracker/service.ts`
+  - widen the landing contract only as much as needed to return structured gate failures instead of a bare throw/no-throw merge call
+- `src/orchestrator/`
+  - consume the guarded landing result and keep the issue in a non-terminal waiting/blocked state when the gate is closed
+- tests
+  - unit policy coverage, tracker integration coverage, and e2e regression coverage
+- docs
+  - update operator-facing docs so the landing path is described as guarded rather than implicit
+
+### Does not belong in this issue
+
+- a generic tracker-agnostic merge orchestration framework
+- large CLI/control-surface work unrelated to the existing landing path
+- Linear landing implementation beyond keeping shared tracker contracts compiling
+- runner, workspace, or prompt changes unrelated to guarded merge semantics
+
+## Layering Notes
+
+- `config/workflow`
+  - stays unchanged unless existing blocked-check policy already needs a typed config seam
+- `tracker`
+  - owns GitHub merge-gate transport, normalization, and merge policy
+  - must keep transport, normalization, and policy in separate focused modules
+- `workspace`
+  - remains untouched
+- `runner`
+  - remains untouched
+- `orchestrator`
+  - owns the decision to attempt landing and how to record a guarded refusal
+  - must not inspect raw GitHub mergeability or thread payloads itself
+- `observability`
+  - renders normalized gate outcomes
+  - must not infer unresolved-thread or mergeability state from GitHub fields
+
+## Slice Strategy And PR Seam
+
+This issue should stay one reviewable PR by limiting the seam to guarded execution on the already-centralized landing path from `#100`.
+
+Current PR:
+
+1. add a dedicated merge-gate snapshot + policy for GitHub bootstrap
+2. route factory landing through that guard
+3. expose structured gate-failure outcomes to orchestration and observability
+4. cover the PR `#80` unresolved-thread regression end-to-end
+
+Deferred:
+
+- any standalone operator control CLI surface from `#81`
+- broader tracker abstractions for non-GitHub landing
+- richer approval / review-bot policy beyond the minimum guarded checks above
+
+This seam is reviewable because it strengthens one existing path without reopening the full lifecycle redesign from `#100`.
+
+## Runtime State Model
+
+This issue does not introduce a new top-level handoff state. It tightens transitions inside the existing `awaiting-landing` path.
+
+### Landing execution sub-states
+
+- `awaiting-landing`
+  - PR has human `/land` approval and is eligible for a guarded landing attempt
+- `landing-gate-open`
+  - merge-time facts pass the guarded landing policy for the current PR head
+- `landing-gate-closed`
+  - merge-time facts fail policy; merge is not attempted and the refusal reason is recorded
+- `handoff-ready`
+  - merge is observed after a successful guarded landing request
+
+### Allowed transitions
+
+- `awaiting-landing` -> `landing-gate-open`
+  - GitHub merge-gate snapshot satisfies guarded merge policy
+- `awaiting-landing` -> `landing-gate-closed`
+  - mergeable/check/thread/blocked-check policy fails
+- `landing-gate-open` -> `handoff-ready`
+  - guarded merge request succeeds and merge is observed
+- `landing-gate-open` -> `awaiting-landing`
+  - merge request is accepted but merge is not yet observed
+- `landing-gate-closed` -> `awaiting-system-checks`
+  - failing or pending checks are the reason the gate closed
+- `landing-gate-closed` -> `awaiting-human-review`
+  - unresolved non-outdated human review threads are the reason the gate closed
+- `landing-gate-closed` -> `awaiting-landing`
+  - the PR is otherwise still awaiting human-approved landing but a transient mergeability / blocked-check condition cleared later
+
+### Coordination Decision Rules
+
+- keep `/land` as the handoff into the landing path
+- before any merge request, fetch a fresh merge-gate snapshot for the current PR head
+- execute merge only when the gate is open
+- when the gate is closed, record the refusal reason and re-inspect the normalized PR lifecycle instead of forcing completion or blind retry
+- preserve fail-closed behavior when GitHub returns incomplete or unknown mergeability facts
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| PR head changed after `/land` approval | current head SHA from lifecycle | guarded snapshot no longer matches approved head | reject landing, re-enter normal lifecycle inspection |
+| Required checks pending | no landing attempt active | merge gate shows pending or non-terminal checks | do not merge; remain `awaiting-system-checks` |
+| Required checks failed | no landing attempt active | merge gate shows failing terminal checks | do not merge; lifecycle returns to follow-up path |
+| Unresolved non-outdated human review threads remain | no landing attempt active | merge gate unresolved thread count > 0 | do not merge; remain blocked on human review |
+| Only outdated or resolved threads remain | no landing attempt active | merge gate unresolved thread count = 0 | gate may open if other requirements pass |
+| GitHub reports PR not mergeable / merge blocked | no landing attempt active | mergeability fact is negative or unknown | do not merge; fail closed with explicit reason |
+| Merge request succeeds but PR remains open | landing request recorded | lifecycle still `awaiting-landing` | keep waiting; do not complete |
+| GitHub merge request returns conflict / branch protection / refusal | landing request attempted | merge gate or merge API returns refusal reason | record blocked landing result and stay non-terminal |
+
+## Storage / Persistence Contract
+
+- tracker state remains the source of truth for mergeability, review-thread, and check facts
+- no new durable external store is introduced
+- issue artifacts should capture:
+  - merge gate evaluated
+  - merge gate refused with reason
+  - guarded landing requested
+  - merge observed
+- in-process landing runtime state may continue to suppress duplicate attempts per PR head, but gate decisions should be recomputed from fresh tracker facts
+
+## Observability Requirements
+
+- structured logs should distinguish:
+  - guarded landing evaluation started
+  - guarded landing refused and why
+  - guarded landing request sent
+  - merge observed after guarded landing
+- issue artifacts should add a merge-gate refusal event/outcome rather than overloading generic landing failure text
+- status/report surfaces should show a clear blocked reason when landing is refused because threads or checks remain unresolved
+
+## Decision Notes
+
+- The merge gate should be evaluated on fresh GitHub data at execution time, not inferred from a stale earlier lifecycle snapshot.
+- Keep unresolved review-thread counting in normalization, but move merge/no-merge decisions into a dedicated guarded landing policy module so the policy is unit-testable.
+- If the current repo still lacks an operator control CLI, satisfy the "dedicated merge helper" requirement with an internal guarded landing service now and let `#81` expose it via CLI later rather than widening this PR.
+
+## Implementation Steps
+
+1. Add GitHub transport reads for merge-time facts that are not already present in the review/check snapshot, including explicit mergeability data if needed.
+2. Introduce a normalized guarded-landing snapshot type plus a dedicated policy module that decides pass/fail and returns structured refusal reasons.
+3. Extend the tracker landing contract so GitHub bootstrap can execute guarded landing and return a structured outcome instead of a bare merge call.
+4. Update `GitHubBootstrapTracker.executeLanding()` to:
+   - fetch fresh gate facts
+   - evaluate guarded landing policy
+   - fail closed with a reason when the gate is not open
+   - execute the merge request only when the policy passes
+5. Update orchestrator landing handling and artifacts/status output to preserve non-terminal state and show the guarded refusal reason clearly.
+6. Extend the mock GitHub server with mergeability / blocked-merge fixtures needed to simulate guarded refusals.
+7. Add tests for unresolved non-outdated review threads, non-terminal checks, non-mergeable PRs, and the PR `#80` regression.
+8. Update README / self-hosting docs if they still imply that a `/land` comment alone is sufficient to merge.
+9. Run local self-review and repo gates:
+   - `pnpm format`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+   - local review tool if available and reliable
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- guarded landing policy rejects when unresolved non-outdated threads remain
+- guarded landing policy ignores outdated or resolved threads
+- guarded landing policy rejects when checks are pending or non-terminal
+- guarded landing policy rejects when GitHub reports not mergeable or unknown mergeability
+- guarded landing policy accepts only when all required conditions pass
+
+### Integration
+
+- `GitHubBootstrapTracker.executeLanding()` refuses to merge when unresolved human review threads remain
+- `GitHubBootstrapTracker.executeLanding()` refuses to merge when checks are not terminal green
+- `GitHubBootstrapTracker.executeLanding()` refuses to merge when GitHub mergeability is false/blocked
+- `GitHubBootstrapTracker.executeLanding()` merges successfully when the guard passes
+
+### End-to-End
+
+- factory run reaches `awaiting-landing`, receives `/land`, but remains open because unresolved non-outdated review threads still exist
+- factory run reaches `awaiting-landing`, receives `/land`, but remains open because required checks are pending/failing
+- regression: the PR `#80` shape with green top-level checks plus unresolved non-outdated review threads is blocked from merge
+- clean PR with `/land` and zero unresolved non-outdated threads still lands and completes normally
+
+## Exit Criteria
+
+1. the centralized landing path no longer issues a raw merge request without a fresh merge-gate evaluation
+2. merge is rejected when unresolved non-outdated review thread count is non-zero
+3. merge is rejected when required checks are not terminal green
+4. merge is rejected when the PR is not mergeable or blocked by merge policy
+5. guarded refusal reasons are visible in logs/artifacts/status
+6. the PR `#80` regression is covered explicitly in automated tests
+7. `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass
+
+## Deferred To Later Issues Or PRs
+
+- standalone operator control commands that expose guarded landing directly
+- richer review-bot terminality policy beyond the minimum blocked-check and unresolved-thread gate
+- non-GitHub tracker landing guards
+- broader landing automation redesign outside the centralized path from `#100`

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -12,6 +12,7 @@ export type IssueArtifactEventKind =
   | "waived"
   | "runner-spawned"
   | "pr-opened"
+  | "landing-blocked"
   | "landing-requested"
   | "review-feedback"
   | "retry-scheduled"

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -975,6 +975,19 @@ function buildTimelineEntry(
         sessionId: event.sessionId,
         details: formatEventDetails(event.details),
       };
+    case "landing-blocked":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Landing blocked",
+        summary: readEventSummary(
+          event.details,
+          "Symphony refused to land the current pull request.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
     case "landing-requested":
       return {
         kind: event.kind,
@@ -1388,16 +1401,18 @@ function timelineKindOrder(kind: string): number {
       return 4;
     case "pr-opened":
       return 5;
-    case "landing-requested":
+    case "landing-blocked":
       return 6;
-    case "review-feedback":
+    case "landing-requested":
       return 7;
-    case "retry-scheduled":
+    case "review-feedback":
       return 8;
+    case "retry-scheduled":
+      return 9;
     case "succeeded":
     case "failed":
     case "terminal-outcome":
-      return 9;
+      return 10;
     default:
       return 99;
   }
@@ -1424,6 +1439,10 @@ function inferOutcomeFromEvents(
         return (
           readLifecycleKindFromDetails(event.details) ??
           "awaiting-system-checks"
+        );
+      case "landing-blocked":
+        return (
+          readLifecycleKindFromDetails(event.details) ?? "awaiting-landing"
         );
       case "landing-requested":
         return "awaiting-landing";

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -40,6 +40,7 @@ import type {
   RunnerTurnResult,
 } from "../runner/service.js";
 import type { Tracker } from "../tracker/service.js";
+import type { LandingExecutionResult } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
 import {
   createContinuationRunTurn,
@@ -544,6 +545,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     await this.#persistStatusSnapshot();
 
     let landingError: string | null = null;
+    let landingResult: LandingExecutionResult | null = null;
     try {
       noteLandingAttempt(
         this.#state.landing,
@@ -553,7 +555,17 @@ export class BootstrapOrchestrator implements Orchestrator {
       if (lifecycle.pullRequest === null) {
         throw new Error("Cannot execute landing without a pull request handle");
       }
-      await this.#tracker.executeLanding(lifecycle.pullRequest);
+      landingResult = await this.#tracker.executeLanding(lifecycle.pullRequest);
+      if (landingResult.kind === "blocked") {
+        this.#logger.info("Landing blocked by guard", {
+          issueNumber: issue.number,
+          branchName,
+          pullRequestNumber: lifecycle.pullRequest.number,
+          reason: landingResult.reason,
+          lifecycleKind: landingResult.lifecycleKind,
+          summary: landingResult.summary,
+        });
+      }
     } catch (error) {
       landingError = this.#normalizeFailure(error as Error);
       this.#logger.warn("Landing execution failed", {
@@ -570,6 +582,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         branchName,
         lifecycle,
         observedAt,
+        landingResult,
         landingError,
       ),
     );
@@ -586,7 +599,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       return;
     }
 
-    if (refreshedLifecycle.kind !== "awaiting-landing") {
+    if (
+      landingResult?.kind === "blocked" ||
+      refreshedLifecycle.kind !== "awaiting-landing"
+    ) {
       clearLandingRuntimeState(this.#state.landing, issue.number);
     }
 
@@ -601,9 +617,39 @@ export class BootstrapOrchestrator implements Orchestrator {
       branchName,
       refreshedLifecycle,
     );
+    if (landingResult?.kind === "blocked") {
+      upsertActiveIssue(this.#state.status, issue, {
+        source,
+        runSequence: attempt,
+        branchName,
+        status:
+          refreshedLifecycle.kind === "rework-required"
+            ? "rework-required"
+            : refreshedLifecycle.kind === "awaiting-human-review"
+              ? "awaiting-human-review"
+              : refreshedLifecycle.kind === "awaiting-system-checks"
+                ? "awaiting-system-checks"
+                : refreshedLifecycle.kind === "awaiting-landing-command"
+                  ? "awaiting-landing-command"
+                  : "awaiting-landing",
+        summary: refreshedLifecycle.summary,
+        blockedReason: landingResult.summary,
+      });
+      noteStatusAction(this.#state.status, {
+        kind: "landing-blocked",
+        summary: landingResult.summary,
+        issueNumber: issue.number,
+      });
+    }
     noteStatusAction(this.#state.status, {
-      kind: refreshedLifecycle.kind,
-      summary: refreshedLifecycle.summary,
+      kind:
+        landingResult?.kind === "blocked"
+          ? "landing-blocked"
+          : refreshedLifecycle.kind,
+      summary:
+        landingResult?.kind === "blocked"
+          ? landingResult.summary
+          : refreshedLifecycle.summary,
       issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
@@ -1899,37 +1945,50 @@ export class BootstrapOrchestrator implements Orchestrator {
     branchName: string,
     lifecycle: HandoffLifecycle,
     observedAt: string,
+    result: LandingExecutionResult | null,
     error: string | null,
   ): IssueArtifactObservation {
+    const isBlocked = result?.kind === "blocked";
     return {
       issue: this.#createIssueArtifactUpdate(issue, {
         observedAt,
-        outcome: "awaiting-landing",
+        outcome: isBlocked ? result.lifecycleKind : "awaiting-landing",
         summary:
-          error === null
-            ? `Landing requested for ${issue.identifier}`
-            : `Landing request failed for ${issue.identifier}: ${error}`,
+          error !== null
+            ? `Landing request failed for ${issue.identifier}: ${error}`
+            : isBlocked
+              ? result.summary
+              : `Landing requested for ${issue.identifier}`,
         branchName,
         latestAttemptNumber: attempt,
       }),
       events: [
-        this.#createIssueEvent("landing-requested", issue, {
-          observedAt,
-          attemptNumber: attempt,
-          details: {
-            branch: branchName,
-            pullRequest:
-              lifecycle.pullRequest === null
-                ? null
-                : {
-                    number: lifecycle.pullRequest.number,
-                    url: lifecycle.pullRequest.url,
-                    headSha: lifecycle.pullRequest.headSha,
-                  },
-            success: error === null,
-            error,
+        this.#createIssueEvent(
+          isBlocked ? "landing-blocked" : "landing-requested",
+          issue,
+          {
+            observedAt,
+            attemptNumber: attempt,
+            details: {
+              branch: branchName,
+              pullRequest:
+                lifecycle.pullRequest === null
+                  ? null
+                  : {
+                      number: lifecycle.pullRequest.number,
+                      url: lifecycle.pullRequest.url,
+                      headSha: lifecycle.pullRequest.headSha,
+                    },
+              success: error === null && !isBlocked,
+              error,
+              reason: isBlocked ? result.reason : null,
+              summary: isBlocked ? result.summary : null,
+              lifecycleKind: isBlocked
+                ? result.lifecycleKind
+                : "awaiting-landing",
+            },
           },
-        }),
+        ),
       ],
     };
   }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -622,16 +622,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         source,
         runSequence: attempt,
         branchName,
-        status:
-          refreshedLifecycle.kind === "rework-required"
-            ? "rework-required"
-            : refreshedLifecycle.kind === "awaiting-human-review"
-              ? "awaiting-human-review"
-              : refreshedLifecycle.kind === "awaiting-system-checks"
-                ? "awaiting-system-checks"
-                : refreshedLifecycle.kind === "awaiting-landing-command"
-                  ? "awaiting-landing-command"
-                  : "awaiting-landing",
+        status: landingResult.lifecycleKind,
         summary: refreshedLifecycle.summary,
         blockedReason: landingResult.summary,
       });

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -631,7 +631,7 @@ export class BootstrapOrchestrator implements Orchestrator {
                 ? "awaiting-system-checks"
                 : refreshedLifecycle.kind === "awaiting-landing-command"
                   ? "awaiting-landing-command"
-          : "awaiting-landing",
+                  : "awaiting-landing",
         summary: refreshedLifecycle.summary,
         blockedReason: landingResult.summary,
       });

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -623,7 +623,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         runSequence: attempt,
         branchName,
         status: landingResult.lifecycleKind,
-        summary: refreshedLifecycle.summary,
+        summary: landingResult.summary,
         blockedReason: landingResult.summary,
       });
     }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -631,14 +631,9 @@ export class BootstrapOrchestrator implements Orchestrator {
                 ? "awaiting-system-checks"
                 : refreshedLifecycle.kind === "awaiting-landing-command"
                   ? "awaiting-landing-command"
-                  : "awaiting-landing",
+          : "awaiting-landing",
         summary: refreshedLifecycle.summary,
         blockedReason: landingResult.summary,
-      });
-      noteStatusAction(this.#state.status, {
-        kind: "landing-blocked",
-        summary: landingResult.summary,
-        issueNumber: issue.number,
       });
     }
     noteStatusAction(this.#state.status, {

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -215,7 +215,6 @@ export class GitHubBootstrapTracker implements Tracker {
       draft: latestPullRequest.draft,
       pendingCheckNames: snapshot.pendingCheckNames,
       failingCheckNames: snapshot.failingCheckNames,
-      actionableReviewFeedback: snapshot.actionableReviewFeedback,
       botActionableReviewFeedback: snapshot.botActionableReviewFeedback,
       unresolvedReviewThreadCount: snapshot.actionableReviewFeedback.filter(
         (feedback) => feedback.kind === "review-thread",

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -217,7 +217,9 @@ export class GitHubBootstrapTracker implements Tracker {
       failingCheckNames: snapshot.failingCheckNames,
       botActionableReviewFeedback: snapshot.botActionableReviewFeedback,
       unresolvedReviewThreadCount: snapshot.actionableReviewFeedback.filter(
-        (feedback) => feedback.kind === "review-thread",
+        (feedback) =>
+          feedback.kind === "review-thread" &&
+          this.isHumanReviewFeedback(feedback.authorLogin),
       ).length,
     };
     const decision = evaluateGuardedLanding(gateSnapshot);

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -219,7 +219,7 @@ export class GitHubBootstrapTracker implements Tracker {
       unresolvedReviewThreadCount: snapshot.actionableReviewFeedback.filter(
         (feedback) =>
           feedback.kind === "review-thread" &&
-          this.isHumanReviewFeedback(feedback.authorLogin),
+          !this.#isBotReviewFeedback(feedback.authorLogin),
       ).length,
     };
     const decision = evaluateGuardedLanding(gateSnapshot);
@@ -288,6 +288,15 @@ export class GitHubBootstrapTracker implements Tracker {
       lifecycle,
     });
     return lifecycle;
+  }
+
+  #isBotReviewFeedback(authorLogin: string | null): boolean {
+    if (authorLogin === null) {
+      return false;
+    }
+    return this.#config.reviewBotLogins
+      .map((login) => login.toLowerCase())
+      .includes(authorLogin.toLowerCase());
   }
 
   async #isStaleMergedPullRequest(

--- a/src/tracker/github-bootstrap.ts
+++ b/src/tracker/github-bootstrap.ts
@@ -2,6 +2,10 @@ import type { HandoffLifecycle, PullRequestHandle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { GitHubBootstrapTrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import {
+  evaluateGuardedLanding,
+  type GuardedLandingSnapshot,
+} from "./guarded-landing.js";
 import { GitHubClient } from "./github-client.js";
 import { evaluatePlanReviewProtocol } from "./plan-review-policy.js";
 import {
@@ -10,7 +14,7 @@ import {
   type NoCheckObservation,
 } from "./pull-request-policy.js";
 import { createPullRequestSnapshot } from "./pull-request-snapshot.js";
-import type { Tracker } from "./service.js";
+import type { LandingExecutionResult, Tracker } from "./service.js";
 
 export class GitHubBootstrapTracker implements Tracker {
   readonly #config: GitHubBootstrapTrackerConfig;
@@ -177,11 +181,68 @@ export class GitHubBootstrapTracker implements Tracker {
     return await this.inspectIssueHandoff(branchName);
   }
 
-  async executeLanding(pullRequest: PullRequestHandle): Promise<void> {
-    await this.#client.mergePullRequest(
+  async executeLanding(
+    pullRequest: PullRequestHandle,
+  ): Promise<LandingExecutionResult> {
+    const latestPullRequest = await this.#client.getPullRequest(
+      pullRequest.number,
+    );
+    const [checks, reviewState] = await Promise.all([
+      this.#client.getChecks(latestPullRequest.head.sha),
+      this.#client.getPullRequestReviewState(pullRequest.number),
+    ]);
+    const snapshot = createPullRequestSnapshot({
+      branchName: pullRequest.branchName,
+      pullRequest: {
+        number: latestPullRequest.number,
+        html_url: latestPullRequest.html_url,
+        state: latestPullRequest.state,
+        head: latestPullRequest.head,
+        landingState: latestPullRequest.merged_at === null ? "open" : "merged",
+        mergedAt: latestPullRequest.merged_at,
+      },
+      checks,
+      reviewState,
+      reviewBotLogins: this.#config.reviewBotLogins,
+    });
+    const gateSnapshot: GuardedLandingSnapshot = {
+      approvedHeadSha: pullRequest.headSha,
+      pullRequest: snapshot.pullRequest,
+      landingState: snapshot.landingState,
+      mergeable: latestPullRequest.mergeable,
+      mergeStateStatus:
+        latestPullRequest.mergeable_state?.toLowerCase() ?? null,
+      draft: latestPullRequest.draft,
+      pendingCheckNames: snapshot.pendingCheckNames,
+      failingCheckNames: snapshot.failingCheckNames,
+      actionableReviewFeedback: snapshot.actionableReviewFeedback,
+      botActionableReviewFeedback: snapshot.botActionableReviewFeedback,
+      unresolvedReviewThreadCount: snapshot.actionableReviewFeedback.filter(
+        (feedback) => feedback.kind === "review-thread",
+      ).length,
+    };
+    const decision = evaluateGuardedLanding(gateSnapshot);
+    if (decision.kind === "blocked") {
+      return decision;
+    }
+
+    const mergeResult = await this.#client.mergePullRequest(
       pullRequest.number,
       pullRequest.headSha,
     );
+    if (mergeResult.kind === "blocked") {
+      return {
+        kind: "blocked",
+        reason: "merge-request-refused",
+        lifecycleKind: "awaiting-landing",
+        summary: `Landing blocked for pull request ${snapshot.pullRequest.url}: ${mergeResult.message}`,
+      };
+    }
+
+    return {
+      kind: "requested",
+      summary: decision.summary,
+    };
   }
 
   async #inspectPlanReviewHandoff(

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -51,8 +51,11 @@ export interface GitHubPullRequestResponse extends GitHubPullRequestListResponse
   readonly mergedAt: string | null;
 }
 
-interface GitHubPullRequestDetailsResponse {
+export interface GitHubPullRequestDetailsResponse extends GitHubPullRequestListResponse {
   readonly merged_at: string | null;
+  readonly mergeable: boolean | null;
+  readonly mergeable_state: string | null;
+  readonly draft: boolean;
 }
 
 interface GitHubRepositoryResponse {
@@ -172,6 +175,22 @@ export interface PullRequestReviewState {
 }
 
 type GitHubMergeMethod = "merge" | "squash" | "rebase";
+
+export interface GitHubMergeRequestBlockedResult {
+  readonly kind: "blocked";
+  readonly status: number;
+  readonly message: string;
+}
+
+export interface GitHubMergeRequestAcceptedResult {
+  readonly kind: "accepted";
+  readonly merged: boolean;
+  readonly message: string;
+}
+
+export type GitHubMergeRequestResult =
+  | GitHubMergeRequestBlockedResult
+  | GitHubMergeRequestAcceptedResult;
 
 const NULL_LOGGER: Logger = {
   info() {},
@@ -462,15 +481,50 @@ export class GitHubClient {
   async mergePullRequest(
     number: number,
     headSha: string | null,
-  ): Promise<void> {
+  ): Promise<GitHubMergeRequestResult> {
     const mergeMethod = await this.#getMergeMethod();
-    await this.#request(
-      "PUT",
-      this.#issuePath(`pulls/${number.toString()}/merge`),
-      {
-        ...(headSha === null ? {} : { sha: headSha }),
-        merge_method: mergeMethod,
-      },
+    const response = await this.#requestDetailed<{
+      merged?: unknown;
+      message?: unknown;
+    }>("PUT", this.#issuePath(`pulls/${number.toString()}/merge`), {
+      ...(headSha === null ? {} : { sha: headSha }),
+      merge_method: mergeMethod,
+    });
+    if (
+      response.status === 405 ||
+      response.status === 409 ||
+      response.status === 422
+    ) {
+      return {
+        kind: "blocked",
+        status: response.status,
+        message:
+          typeof response.payload?.message === "string"
+            ? response.payload.message
+            : `merge request blocked with ${response.status.toString()}`,
+      };
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw new TrackerError(
+        `GitHub API PUT ${this.#issuePath(`pulls/${number.toString()}/merge`)} failed with ${response.status}: ${response.text}`,
+      );
+    }
+    return {
+      kind: "accepted",
+      merged: response.payload?.merged === true,
+      message:
+        typeof response.payload?.message === "string"
+          ? response.payload.message
+          : "landing request accepted",
+    };
+  }
+
+  async getPullRequest(
+    number: number,
+  ): Promise<GitHubPullRequestDetailsResponse> {
+    return await this.#request<GitHubPullRequestDetailsResponse>(
+      "GET",
+      this.#issuePath(`pulls/${number.toString()}`),
     );
   }
 
@@ -722,6 +776,26 @@ export class GitHubClient {
   }
 
   async #request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const response = await this.#requestDetailed<T>(method, path, body);
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new TrackerError(
+        `GitHub API ${method} ${path} failed with ${response.status}: ${response.text}`,
+      );
+    }
+
+    return response.payload as T;
+  }
+
+  async #requestDetailed<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<{
+    readonly status: number;
+    readonly payload: T | null;
+    readonly text: string;
+  }> {
     const token = await this.#tokenPromise;
     const requestInit: RequestInit = {
       method,
@@ -736,22 +810,24 @@ export class GitHubClient {
       requestInit.body = JSON.stringify(body);
     }
     const response = await fetch(`${this.#config.apiUrl}${path}`, requestInit);
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new TrackerError(
-        `GitHub API ${method} ${path} failed with ${response.status}: ${text}`,
-      );
+    const text = await response.text();
+    let payload: T | null = null;
+    if (text.trim() !== "") {
+      try {
+        payload = (JSON.parse(text) as T) ?? null;
+      } catch {
+        payload = null;
+      }
     }
-
-    return (await response.json()) as T;
+    return {
+      status: response.status,
+      payload,
+      text,
+    };
   }
 
   async #getPullRequestMergedAt(number: number): Promise<string | null> {
-    const pullRequest = await this.#request<GitHubPullRequestDetailsResponse>(
-      "GET",
-      this.#issuePath(`pulls/${number.toString()}`),
-    );
+    const pullRequest = await this.getPullRequest(number);
     return pullRequest.merged_at;
   }
 

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -785,7 +785,7 @@ export class GitHubClient {
     }
     if (response.payload === null) {
       throw new TrackerError(
-        `GitHub API ${method} ${path} returned no JSON payload`,
+        `GitHub API ${method} ${path} returned no JSON payload (body: ${JSON.stringify(response.text.slice(0, 200))})`,
       );
     }
 

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -783,8 +783,13 @@ export class GitHubClient {
         `GitHub API ${method} ${path} failed with ${response.status}: ${response.text}`,
       );
     }
+    if (response.payload === null) {
+      throw new TrackerError(
+        `GitHub API ${method} ${path} returned no JSON payload`,
+      );
+    }
 
-    return response.payload as T;
+    return response.payload;
   }
 
   async #requestDetailed<T>(

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -73,18 +73,6 @@ export function evaluateGuardedLanding(
   }
 
   if (
-    snapshot.mergeStateStatus !== null &&
-    !PASSING_MERGE_STATES.has(snapshot.mergeStateStatus)
-  ) {
-    return {
-      kind: "blocked",
-      reason: "pull-request-not-mergeable",
-      lifecycleKind: "awaiting-landing",
-      summary: `Landing blocked for ${formatPullRequest(snapshot)} because GitHub reports merge state '${snapshot.mergeStateStatus}'.`,
-    };
-  }
-
-  if (
     snapshot.failingCheckNames.length > 0 ||
     snapshot.pendingCheckNames.length > 0
   ) {
@@ -93,6 +81,18 @@ export function evaluateGuardedLanding(
       reason: "checks-not-green",
       lifecycleKind: "awaiting-system-checks",
       summary: `Landing blocked for ${formatPullRequest(snapshot)} because required checks are not terminal green.`,
+    };
+  }
+
+  if (
+    snapshot.mergeStateStatus !== null &&
+    !PASSING_MERGE_STATES.has(snapshot.mergeStateStatus)
+  ) {
+    return {
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because GitHub reports merge state '${snapshot.mergeStateStatus}'.`,
     };
   }
 

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -1,0 +1,113 @@
+import type { PullRequestSnapshot } from "./pull-request-snapshot.js";
+import type {
+  LandingBlockedResult,
+  LandingRequestedResult,
+} from "./service.js";
+
+export interface GuardedLandingSnapshot {
+  readonly approvedHeadSha: string | null;
+  readonly pullRequest: PullRequestSnapshot["pullRequest"];
+  readonly landingState: "open" | "merged";
+  readonly mergeable: boolean | null;
+  readonly mergeStateStatus: string | null;
+  readonly draft: boolean;
+  readonly pendingCheckNames: readonly string[];
+  readonly failingCheckNames: readonly string[];
+  readonly actionableReviewFeedback: PullRequestSnapshot["actionableReviewFeedback"];
+  readonly botActionableReviewFeedback: PullRequestSnapshot["botActionableReviewFeedback"];
+  readonly unresolvedReviewThreadCount: number;
+}
+
+const PASSING_MERGE_STATES = new Set(["clean", "has_hooks"]);
+
+function formatPullRequest(snapshot: GuardedLandingSnapshot): string {
+  return `pull request ${snapshot.pullRequest.url}`;
+}
+
+export function evaluateGuardedLanding(
+  snapshot: GuardedLandingSnapshot,
+): LandingRequestedResult | LandingBlockedResult {
+  if (
+    snapshot.approvedHeadSha !== null &&
+    snapshot.pullRequest.headSha !== null &&
+    snapshot.approvedHeadSha !== snapshot.pullRequest.headSha
+  ) {
+    return {
+      kind: "blocked",
+      reason: "stale-approved-head",
+      lifecycleKind: "awaiting-landing-command",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because the approved head SHA is stale.`,
+    };
+  }
+
+  if (snapshot.draft) {
+    return {
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because the pull request is still a draft.`,
+    };
+  }
+
+  if (snapshot.mergeable !== true) {
+    return {
+      kind: "blocked",
+      reason:
+        snapshot.mergeable === null
+          ? "mergeability-unknown"
+          : "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary:
+        snapshot.mergeable === null
+          ? `Landing blocked for ${formatPullRequest(snapshot)} because GitHub mergeability is still unknown.`
+          : `Landing blocked for ${formatPullRequest(snapshot)} because GitHub does not consider it mergeable.`,
+    };
+  }
+
+  if (
+    snapshot.mergeStateStatus !== null &&
+    !PASSING_MERGE_STATES.has(snapshot.mergeStateStatus)
+  ) {
+    return {
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because GitHub reports merge state '${snapshot.mergeStateStatus}'.`,
+    };
+  }
+
+  if (
+    snapshot.failingCheckNames.length > 0 ||
+    snapshot.pendingCheckNames.length > 0
+  ) {
+    return {
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because required checks are not terminal green.`,
+    };
+  }
+
+  if (snapshot.botActionableReviewFeedback.length > 0) {
+    return {
+      kind: "blocked",
+      reason: "actionable-review-feedback",
+      lifecycleKind: "rework-required",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because actionable review feedback is still open.`,
+    };
+  }
+
+  if (snapshot.unresolvedReviewThreadCount > 0) {
+    return {
+      kind: "blocked",
+      reason: "review-threads-unresolved",
+      lifecycleKind: "awaiting-human-review",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because unresolved non-outdated review threads remain.`,
+    };
+  }
+
+  return {
+    kind: "requested",
+    summary: `Landing requested for ${formatPullRequest(snapshot)}.`,
+  };
+}

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -13,7 +13,6 @@ export interface GuardedLandingSnapshot {
   readonly draft: boolean;
   readonly pendingCheckNames: readonly string[];
   readonly failingCheckNames: readonly string[];
-  readonly actionableReviewFeedback: PullRequestSnapshot["actionableReviewFeedback"];
   readonly botActionableReviewFeedback: PullRequestSnapshot["botActionableReviewFeedback"];
   readonly unresolvedReviewThreadCount: number;
 }
@@ -27,6 +26,15 @@ function formatPullRequest(snapshot: GuardedLandingSnapshot): string {
 export function evaluateGuardedLanding(
   snapshot: GuardedLandingSnapshot,
 ): LandingRequestedResult | LandingBlockedResult {
+  if (snapshot.landingState === "merged") {
+    return {
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because it is already merged.`,
+    };
+  }
+
   if (
     snapshot.approvedHeadSha !== null &&
     snapshot.pullRequest.headSha !== null &&

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -23,6 +23,15 @@ function formatPullRequest(snapshot: GuardedLandingSnapshot): string {
   return `pull request ${snapshot.pullRequest.url}`;
 }
 
+function checksBlockedLifecycleKind(
+  snapshot: GuardedLandingSnapshot,
+): "awaiting-system-checks" | "rework-required" {
+  return snapshot.failingCheckNames.length > 0 &&
+    snapshot.pendingCheckNames.length === 0
+    ? "rework-required"
+    : "awaiting-system-checks";
+}
+
 export function evaluateGuardedLanding(
   snapshot: GuardedLandingSnapshot,
 ): LandingRequestedResult | LandingBlockedResult {
@@ -79,7 +88,7 @@ export function evaluateGuardedLanding(
     return {
       kind: "blocked",
       reason: "checks-not-green",
-      lifecycleKind: "awaiting-system-checks",
+      lifecycleKind: checksBlockedLifecycleKind(snapshot),
       summary: `Landing blocked for ${formatPullRequest(snapshot)} because required checks are not terminal green.`,
     };
   }

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -17,6 +17,8 @@ export interface GuardedLandingSnapshot {
   readonly unresolvedReviewThreadCount: number;
 }
 
+// Fail closed: GitHub can report "unstable" when only non-required checks fail,
+// but Symphony intentionally refuses to land while any check is failing.
 const PASSING_MERGE_STATES = new Set(["clean", "has_hooks"]);
 
 function formatPullRequest(snapshot: GuardedLandingSnapshot): string {

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -3,7 +3,7 @@ import type { RuntimeIssue } from "../domain/issue.js";
 import { TrackerError } from "../domain/errors.js";
 import type { LinearTrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import type { Tracker } from "./service.js";
+import type { LandingExecutionResult, Tracker } from "./service.js";
 import { LinearClient } from "./linear-client.js";
 import {
   classifyLinearIssue,
@@ -191,7 +191,9 @@ export class LinearTracker implements Tracker {
     return createLinearHandoffLifecycle(updatedIssue, branchName, this.#config);
   }
 
-  executeLanding(_pullRequest: PullRequestHandle): Promise<void> {
+  executeLanding(
+    _pullRequest: PullRequestHandle,
+  ): Promise<LandingExecutionResult> {
     return Promise.reject(
       new TrackerError(
         "Linear landing execution is not implemented in this tracker",

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -1,6 +1,36 @@
 import type { HandoffLifecycle, PullRequestHandle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 
+export type LandingBlockedReason =
+  | "stale-approved-head"
+  | "mergeability-unknown"
+  | "pull-request-not-mergeable"
+  | "checks-not-green"
+  | "review-threads-unresolved"
+  | "actionable-review-feedback"
+  | "merge-request-refused";
+
+export interface LandingRequestedResult {
+  readonly kind: "requested";
+  readonly summary: string;
+}
+
+export interface LandingBlockedResult {
+  readonly kind: "blocked";
+  readonly reason: LandingBlockedReason;
+  readonly summary: string;
+  readonly lifecycleKind:
+    | "awaiting-human-review"
+    | "awaiting-system-checks"
+    | "awaiting-landing-command"
+    | "awaiting-landing"
+    | "rework-required";
+}
+
+export type LandingExecutionResult =
+  | LandingRequestedResult
+  | LandingBlockedResult;
+
 export interface Tracker {
   subject(): string;
   isHumanReviewFeedback(authorLogin: string | null): boolean;
@@ -15,7 +45,9 @@ export interface Tracker {
     branchName: string,
     lifecycle: HandoffLifecycle | null,
   ): Promise<HandoffLifecycle>;
-  executeLanding(pullRequest: PullRequestHandle): Promise<void>;
+  executeLanding(
+    pullRequest: PullRequestHandle,
+  ): Promise<LandingExecutionResult>;
   recordRetry(issueNumber: number, reason: string): Promise<void>;
   completeIssue(issueNumber: number): Promise<void>;
   markIssueFailed(issueNumber: number, reason: string): Promise<void>;

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -292,6 +292,86 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     expect(implemented).toContain("sociotechnica-org/symphony-ts#1");
   });
 
+  it("blocks landing when unresolved non-outdated review threads remain even if checks are green", async () => {
+    server.seedIssue({
+      number: 80,
+      title: "Guard merge with unresolved review threads",
+      body: "Reproduce the PR 80 merge regression",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success-unique.sh"),
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+
+    server.setPullRequestCheckRuns("symphony/80", [
+      { name: "CI", status: "completed", conclusion: "success" },
+      { name: "Lint", status: "completed", conclusion: "success" },
+    ]);
+
+    await orchestrator.runOnce();
+
+    server.addPullRequestComment({
+      head: "symphony/80",
+      authorLogin: "jessmartin",
+      body: "/land",
+    });
+    server.injectPullRequestReviewThreadOnReviewStateRead({
+      head: "symphony/80",
+      afterReads: 1,
+      authorLogin: "reviewer",
+      body: "This thread is still unresolved",
+      path: "src/index.ts",
+      line: 12,
+    });
+
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(80);
+    expect(issue.state).toBe("open");
+    expect(issue.comments).not.toContain(
+      "Symphony completed this issue successfully.",
+    );
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.lastAction?.kind).toBe("landing-blocked");
+    expect(status.activeIssues[0]).toMatchObject({
+      issueNumber: 80,
+      status: "awaiting-human-review",
+    });
+    expect(status.activeIssues[0]?.blockedReason).toMatch(
+      /unresolved non-outdated review threads remain/i,
+    );
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      80,
+    );
+    expect(artifactSummary.currentOutcome).toBe("awaiting-human-review");
+
+    const artifactEvents = await readIssueArtifactEvents(
+      path.join(tempDir, ".tmp", "workspaces"),
+      80,
+    );
+    expect(artifactEvents).toContainEqual(
+      expect.objectContaining({
+        kind: "landing-blocked",
+        details: expect.objectContaining({
+          reason: "review-threads-unresolved",
+          lifecycleKind: "awaiting-human-review",
+        }),
+      }),
+    );
+  });
+
   it("pushes the reviewed plan branch before plan-ready and keeps the plan recoverable from the remote", async () => {
     server.seedIssue({
       number: 53,

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -556,6 +556,43 @@ describe("GitHubBootstrapTracker", () => {
     expect(refreshed.kind).toBe("awaiting-human-review");
   });
 
+  it("treats bot-authored review threads as actionable bot feedback instead of human unresolved threads", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+    server.addPullRequestReviewThread({
+      head: "symphony/7",
+      authorLogin: "greptile[bot]",
+      body: "Needs a follow-up commit",
+      path: "src/index.ts",
+      line: 10,
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "actionable-review-feedback",
+      lifecycleKind: "rework-required",
+    });
+  });
+
   it("refuses landing when required checks are not terminal green", async () => {
     const tracker = createTracker(server);
 

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -660,6 +660,36 @@ describe("GitHubBootstrapTracker", () => {
     });
   });
 
+  it("treats failed required checks as rework-required during landing", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "failure" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "rework-required",
+    });
+  });
+
   it("refuses landing when the pull request is not mergeable", async () => {
     const tracker = createTracker(server);
 

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -428,13 +428,15 @@ describe("GitHubBootstrapTracker", () => {
       createdAt: new Date(Date.now() + 1_000).toISOString(),
       body: "/land",
     });
-    await tracker.executeLanding({
-      number: 1,
-      url: `${server.baseUrl}/pulls/1`,
-      branchName: "symphony/7",
-      headSha: openLifecycle.pullRequest?.headSha ?? null,
-      latestCommitAt: openLifecycle.pullRequest?.latestCommitAt ?? null,
-    });
+    await expect(
+      tracker.executeLanding({
+        number: 1,
+        url: `${server.baseUrl}/pulls/1`,
+        branchName: "symphony/7",
+        headSha: openLifecycle.pullRequest?.headSha ?? null,
+        latestCommitAt: openLifecycle.pullRequest?.latestCommitAt ?? null,
+      }),
+    ).resolves.toMatchObject({ kind: "requested" });
 
     const mergedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
     expect(mergedLifecycle.kind).toBe("handoff-ready");
@@ -468,7 +470,9 @@ describe("GitHubBootstrapTracker", () => {
     const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
     expect(approvedLifecycle.kind).toBe("awaiting-landing");
 
-    await tracker.executeLanding(approvedLifecycle.pullRequest!);
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({ kind: "requested" });
 
     const mergedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
     expect(mergedLifecycle.kind).toBe("handoff-ready");
@@ -502,10 +506,118 @@ describe("GitHubBootstrapTracker", () => {
 
     await expect(
       tracker.executeLanding(approvedLifecycle.pullRequest!),
-    ).rejects.toThrow(/head sha does not match/i);
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "stale-approved-head",
+      lifecycleKind: "awaiting-landing-command",
+    });
 
     const refreshed = await tracker.inspectIssueHandoff("symphony/7");
     expect(refreshed.kind).toBe("awaiting-system-checks");
+  });
+
+  it("refuses landing when unresolved non-outdated review threads remain", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+    server.addPullRequestReviewThread({
+      head: "symphony/7",
+      authorLogin: "reviewer",
+      body: "Please address this before merge",
+      path: "src/index.ts",
+      line: 10,
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "review-threads-unresolved",
+      lifecycleKind: "awaiting-human-review",
+    });
+
+    const refreshed = await tracker.inspectIssueHandoff("symphony/7");
+    expect(refreshed.kind).toBe("awaiting-human-review");
+  });
+
+  it("refuses landing when required checks are not terminal green", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "in_progress" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+    });
+  });
+
+  it("refuses landing when the pull request is not mergeable", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.setPullRequestMergeGate("symphony/7", {
+      mergeable: false,
+      mergeableState: "blocked",
+    });
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+    });
   });
 
   it("targets the latest open pull request when the same branch is reopened", async () => {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -556,6 +556,43 @@ describe("GitHubBootstrapTracker", () => {
     expect(refreshed.kind).toBe("awaiting-human-review");
   });
 
+  it("refuses landing when an unresolved review thread has no author login", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/7",
+      authorLogin: "jessmartin",
+      createdAt: new Date(Date.now() + 1_000).toISOString(),
+      body: "/land",
+    });
+    server.addPullRequestReviewThread({
+      head: "symphony/7",
+      authorLogin: null,
+      body: "Deleted user feedback still needs resolution",
+      path: "src/index.ts",
+      line: 10,
+    });
+
+    const approvedLifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    await expect(
+      tracker.executeLanding(approvedLifecycle.pullRequest!),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "review-threads-unresolved",
+      lifecycleKind: "awaiting-human-review",
+    });
+  });
+
   it("treats bot-authored review threads as actionable bot feedback instead of human unresolved threads", async () => {
     const tracker = createTracker(server);
 

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -18,6 +18,13 @@ interface PullRequestRecord {
   checkRuns: MockCheckRun[];
   statuses: MockCommitStatus[];
   landingBehavior: MockLandingBehavior;
+  mergeable: boolean | null;
+  mergeableState: string | null;
+  draft: boolean;
+  reviewThreadInjection: {
+    remainingReads: number;
+    thread: MockReviewThread | null;
+  };
 }
 
 interface MockLandingBehavior {
@@ -300,6 +307,13 @@ export class MockGitHubServer {
         failureStatus: null,
         failureMessage: null,
       },
+      mergeable: true,
+      mergeableState: "clean",
+      draft: false,
+      reviewThreadInjection: {
+        remainingReads: -1,
+        thread: null,
+      },
     });
   }
 
@@ -312,6 +326,26 @@ export class MockGitHubServer {
       ...pullRequest.landingBehavior,
       ...behavior,
     };
+  }
+
+  setPullRequestMergeGate(
+    head: string,
+    gate: {
+      mergeable?: boolean | null;
+      mergeableState?: string | null;
+      draft?: boolean;
+    },
+  ): void {
+    const pullRequest = this.#requirePullRequestByHead(head);
+    if (gate.mergeable !== undefined) {
+      pullRequest.mergeable = gate.mergeable;
+    }
+    if (gate.mergeableState !== undefined) {
+      pullRequest.mergeableState = gate.mergeableState;
+    }
+    if (gate.draft !== undefined) {
+      pullRequest.draft = gate.draft;
+    }
   }
 
   mergePullRequest(head: string, mergedAt = new Date().toISOString()): void {
@@ -420,6 +454,39 @@ export class MockGitHubServer {
       ],
     });
     return threadId;
+  }
+
+  injectPullRequestReviewThreadOnReviewStateRead(input: {
+    head: string;
+    afterReads: number;
+    authorLogin: string;
+    body: string;
+    path?: string | null;
+    line?: number | null;
+    createdAt?: string;
+  }): void {
+    const pullRequest = this.#requirePullRequestByHead(input.head);
+    const threadId = randomUUID();
+    const commentId = randomUUID();
+    pullRequest.reviewThreadInjection = {
+      remainingReads: input.afterReads,
+      thread: {
+        id: threadId,
+        isResolved: false,
+        isOutdated: false,
+        comments: [
+          {
+            id: commentId,
+            authorLogin: input.authorLogin,
+            body: input.body,
+            createdAt: input.createdAt ?? new Date().toISOString(),
+            url: `${pullRequest.html_url}#discussion_r${commentId}`,
+            path: input.path ?? null,
+            line: input.line ?? null,
+          },
+        ],
+      },
+    };
   }
 
   isReviewThreadResolved(threadId: string): boolean {
@@ -570,6 +637,9 @@ export class MockGitHubServer {
         html_url: pullRequest.html_url,
         state: pullRequest.state,
         merged_at: pullRequest.mergedAt,
+        mergeable: pullRequest.mergeable,
+        mergeable_state: pullRequest.mergeableState,
+        draft: pullRequest.draft,
         head: {
           ref: pullRequest.head,
           sha: pullRequest.latestCommitSha,
@@ -768,6 +838,20 @@ export class MockGitHubServer {
           },
         });
         return;
+      }
+
+      if (pullRequest.reviewThreadInjection.thread !== null) {
+        if (pullRequest.reviewThreadInjection.remainingReads <= 0) {
+          pullRequest.reviewThreads.push(
+            pullRequest.reviewThreadInjection.thread,
+          );
+          pullRequest.reviewThreadInjection = {
+            remainingReads: -1,
+            thread: null,
+          };
+        } else {
+          pullRequest.reviewThreadInjection.remainingReads -= 1;
+        }
       }
 
       json(response, 200, {

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -57,7 +57,7 @@ interface MockReviewThread {
 
 interface MockReviewComment {
   readonly id: string;
-  readonly authorLogin: string;
+  readonly authorLogin: string | null;
   readonly body: string;
   readonly createdAt: string;
   readonly url: string;
@@ -428,7 +428,7 @@ export class MockGitHubServer {
 
   addPullRequestReviewThread(input: {
     head: string;
-    authorLogin: string;
+    authorLogin: string | null;
     body: string;
     path?: string | null;
     line?: number | null;
@@ -459,7 +459,7 @@ export class MockGitHubServer {
   injectPullRequestReviewThreadOnReviewStateRead(input: {
     head: string;
     afterReads: number;
-    authorLogin: string;
+    authorLogin: string | null;
     body: string;
     path?: string | null;
     line?: number | null;
@@ -899,9 +899,12 @@ export class MockGitHubServer {
                       url: comment.url,
                       path: comment.path,
                       line: comment.line,
-                      author: {
-                        login: comment.authorLogin,
-                      },
+                      author:
+                        comment.authorLogin === null
+                          ? null
+                          : {
+                              login: comment.authorLogin,
+                            },
                     })),
                   },
                   latestComments: {
@@ -912,9 +915,12 @@ export class MockGitHubServer {
                       url: comment.url,
                       path: comment.path,
                       line: comment.line,
-                      author: {
-                        login: comment.authorLogin,
-                      },
+                      author:
+                        comment.authorLogin === null
+                          ? null
+                          : {
+                              login: comment.authorLogin,
+                            },
                     })),
                   },
                 })),

--- a/tests/unit/github-client.test.ts
+++ b/tests/unit/github-client.test.ts
@@ -26,6 +26,22 @@ describe("GitHubClient", () => {
     };
   }
 
+  function createClient(logger?: Logger): GitHubClient {
+    return new GitHubClient(
+      {
+        kind: "github-bootstrap",
+        repo: "sociotechnica-org/symphony-ts",
+        apiUrl: "https://example.invalid",
+        readyLabel: "symphony:ready",
+        runningLabel: "symphony:running",
+        failedLabel: "symphony:failed",
+        successComment: "done",
+        reviewBotLogins: ["greptile-apps", "cursor"],
+      },
+      logger,
+    );
+  }
+
   it("does not duplicate exhausted review data while another stream paginates", async () => {
     const requests: Array<{
       includeComments: boolean;
@@ -174,16 +190,7 @@ describe("GitHubClient", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new GitHubClient({
-      kind: "github-bootstrap",
-      repo: "sociotechnica-org/symphony-ts",
-      apiUrl: "https://example.invalid",
-      readyLabel: "symphony:ready",
-      runningLabel: "symphony:running",
-      failedLabel: "symphony:failed",
-      successComment: "done",
-      reviewBotLogins: ["greptile-apps", "cursor"],
-    });
+    const client = createClient();
 
     const result = await client.getPullRequestReviewState(23);
 
@@ -238,16 +245,7 @@ describe("GitHubClient", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new GitHubClient({
-      kind: "github-bootstrap",
-      repo: "sociotechnica-org/symphony-ts",
-      apiUrl: "https://example.invalid",
-      readyLabel: "symphony:ready",
-      runningLabel: "symphony:running",
-      failedLabel: "symphony:failed",
-      successComment: "done",
-      reviewBotLogins: ["greptile-apps", "cursor"],
-    });
+    const client = createClient();
 
     await expect(client.mergePullRequest(23, "head-sha-23")).resolves.toEqual({
       kind: "accepted",
@@ -272,19 +270,28 @@ describe("GitHubClient", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new GitHubClient({
-      kind: "github-bootstrap",
-      repo: "sociotechnica-org/symphony-ts",
-      apiUrl: "https://example.invalid",
-      readyLabel: "symphony:ready",
-      runningLabel: "symphony:running",
-      failedLabel: "symphony:failed",
-      successComment: "done",
-      reviewBotLogins: ["greptile-apps", "cursor"],
-    });
+    const client = createClient();
 
     await expect(client.getIssue(23)).rejects.toThrow(
       /returned no json payload/i,
+    );
+  });
+
+  it("includes the raw response body when a 2xx REST response is non-JSON", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("<html>proxy error</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient();
+
+    await expect(client.getIssue(23)).rejects.toThrow(
+      'GitHub API GET /repos/sociotechnica-org/symphony-ts/issues/23 returned no JSON payload (body: "<html>proxy error</html>")',
     );
   });
 
@@ -316,16 +323,7 @@ describe("GitHubClient", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new GitHubClient({
-      kind: "github-bootstrap",
-      repo: "sociotechnica-org/symphony-ts",
-      apiUrl: "https://example.invalid",
-      readyLabel: "symphony:ready",
-      runningLabel: "symphony:running",
-      failedLabel: "symphony:failed",
-      successComment: "done",
-      reviewBotLogins: ["greptile-apps", "cursor"],
-    });
+    const client = createClient();
 
     await expect(client.mergePullRequest(23, "head-sha-23")).rejects.toThrow(
       /failed with 500/i,
@@ -363,19 +361,7 @@ describe("GitHubClient", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new GitHubClient(
-      {
-        kind: "github-bootstrap",
-        repo: "sociotechnica-org/symphony-ts",
-        apiUrl: "https://example.invalid",
-        readyLabel: "symphony:ready",
-        runningLabel: "symphony:running",
-        failedLabel: "symphony:failed",
-        successComment: "done",
-        reviewBotLogins: ["greptile-apps", "cursor"],
-      },
-      logger,
-    );
+    const client = createClient(logger);
 
     await expect(client.mergePullRequest(23, "head-sha-23")).resolves.toEqual({
       kind: "accepted",

--- a/tests/unit/github-client.test.ts
+++ b/tests/unit/github-client.test.ts
@@ -283,7 +283,9 @@ describe("GitHubClient", () => {
       reviewBotLogins: ["greptile-apps", "cursor"],
     });
 
-    await expect(client.getIssue(23)).rejects.toThrow(/returned no json payload/i);
+    await expect(client.getIssue(23)).rejects.toThrow(
+      /returned no json payload/i,
+    );
   });
 
   it("retries merge-method discovery after a transient repository lookup failure", async () => {

--- a/tests/unit/github-client.test.ts
+++ b/tests/unit/github-client.test.ts
@@ -249,7 +249,11 @@ describe("GitHubClient", () => {
       reviewBotLogins: ["greptile-apps", "cursor"],
     });
 
-    await client.mergePullRequest(23, "head-sha-23");
+    await expect(client.mergePullRequest(23, "head-sha-23")).resolves.toEqual({
+      kind: "accepted",
+      merged: false,
+      message: "landing request accepted",
+    });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1]).toBeDefined();
@@ -305,9 +309,11 @@ describe("GitHubClient", () => {
     await expect(client.mergePullRequest(23, "head-sha-23")).rejects.toThrow(
       /failed with 500/i,
     );
-    await expect(
-      client.mergePullRequest(23, "head-sha-23"),
-    ).resolves.toBeUndefined();
+    await expect(client.mergePullRequest(23, "head-sha-23")).resolves.toEqual({
+      kind: "accepted",
+      merged: false,
+      message: "landing request accepted",
+    });
     expect(repositoryRequests).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
@@ -350,7 +356,11 @@ describe("GitHubClient", () => {
       logger,
     );
 
-    await client.mergePullRequest(23, "head-sha-23");
+    await expect(client.mergePullRequest(23, "head-sha-23")).resolves.toEqual({
+      kind: "accepted",
+      merged: false,
+      message: "landing request accepted",
+    });
 
     expect(logger.info).toHaveBeenCalledWith(
       "Auto-detected GitHub merge method",

--- a/tests/unit/github-client.test.ts
+++ b/tests/unit/github-client.test.ts
@@ -267,6 +267,25 @@ describe("GitHubClient", () => {
     });
   });
 
+  it("throws when a REST request succeeds without a JSON payload", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient({
+      kind: "github-bootstrap",
+      repo: "sociotechnica-org/symphony-ts",
+      apiUrl: "https://example.invalid",
+      readyLabel: "symphony:ready",
+      runningLabel: "symphony:running",
+      failedLabel: "symphony:failed",
+      successComment: "done",
+      reviewBotLogins: ["greptile-apps", "cursor"],
+    });
+
+    await expect(client.getIssue(23)).rejects.toThrow(/returned no json payload/i);
+  });
+
   it("retries merge-method discovery after a transient repository lookup failure", async () => {
     let repositoryRequests = 0;
     const fetchMock = vi.fn(async (input: string | URL | Request) => {

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -68,7 +68,21 @@ describe("evaluateGuardedLanding", () => {
     expect(result).toMatchObject({
       kind: "blocked",
       reason: "checks-not-green",
-      lifecycleKind: "awaiting-system-checks",
+      lifecycleKind: "rework-required",
+    });
+  });
+
+  it("treats failed terminal checks as rework-required", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        failingCheckNames: ["CI"],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "rework-required",
     });
   });
 

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -22,7 +22,6 @@ function createSnapshot(
     draft: false,
     pendingCheckNames: [],
     failingCheckNames: [],
-    actionableReviewFeedback: [],
     botActionableReviewFeedback: [],
     unresolvedReviewThreadCount: 0,
     ...overrides,
@@ -90,6 +89,23 @@ describe("evaluateGuardedLanding", () => {
       kind: "blocked",
       reason: "mergeability-unknown",
       lifecycleKind: "awaiting-landing",
+    });
+  });
+
+  it("rejects already merged pull requests explicitly", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        landingState: "merged",
+        mergeable: null,
+        mergeStateStatus: "unknown",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: expect.stringContaining("already merged"),
     });
   });
 

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateGuardedLanding,
+  type GuardedLandingSnapshot,
+} from "../../src/tracker/guarded-landing.js";
+
+function createSnapshot(
+  overrides: Partial<GuardedLandingSnapshot> = {},
+): GuardedLandingSnapshot {
+  return {
+    approvedHeadSha: "approved-head",
+    pullRequest: {
+      number: 23,
+      url: "https://example.test/pulls/23",
+      branchName: "symphony/23",
+      headSha: "approved-head",
+      latestCommitAt: "2026-03-13T00:00:00.000Z",
+    },
+    landingState: "open",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    draft: false,
+    pendingCheckNames: [],
+    failingCheckNames: [],
+    actionableReviewFeedback: [],
+    botActionableReviewFeedback: [],
+    unresolvedReviewThreadCount: 0,
+    ...overrides,
+  };
+}
+
+describe("evaluateGuardedLanding", () => {
+  it("rejects unresolved review threads", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        unresolvedReviewThreadCount: 1,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "review-threads-unresolved",
+      lifecycleKind: "awaiting-human-review",
+    });
+  });
+
+  it("rejects non-terminal checks", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        pendingCheckNames: ["CI"],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+    });
+  });
+
+  it("rejects stale approved head shas", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        pullRequest: {
+          number: 23,
+          url: "https://example.test/pulls/23",
+          branchName: "symphony/23",
+          headSha: "new-head",
+          latestCommitAt: "2026-03-13T00:01:00.000Z",
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "stale-approved-head",
+      lifecycleKind: "awaiting-landing-command",
+    });
+  });
+
+  it("rejects unknown mergeability", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        mergeable: null,
+        mergeStateStatus: "unknown",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "mergeability-unknown",
+      lifecycleKind: "awaiting-landing",
+    });
+  });
+
+  it("accepts a clean guarded landing snapshot", () => {
+    expect(evaluateGuardedLanding(createSnapshot())).toEqual({
+      kind: "requested",
+      summary:
+        "Landing requested for pull request https://example.test/pulls/23.",
+    });
+  });
+});

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -57,6 +57,21 @@ describe("evaluateGuardedLanding", () => {
     });
   });
 
+  it("prefers checks-not-green over an unstable merge state", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        mergeStateStatus: "unstable",
+        failingCheckNames: ["CI"],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+    });
+  });
+
   it("rejects stale approved head shas", () => {
     const result = evaluateGuardedLanding(
       createSnapshot({

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -92,6 +92,62 @@ describe("evaluateGuardedLanding", () => {
     });
   });
 
+  it("rejects draft pull requests", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        draft: true,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: expect.stringContaining("still a draft"),
+    });
+  });
+
+  it("rejects non-passing merge state statuses", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        mergeStateStatus: "blocked",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "pull-request-not-mergeable",
+      lifecycleKind: "awaiting-landing",
+      summary: expect.stringContaining("merge state 'blocked'"),
+    });
+  });
+
+  it("rejects open bot review feedback", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        botActionableReviewFeedback: [
+          {
+            kind: "issue-comment",
+            id: "bot-feedback-1",
+            threadId: null,
+            authorLogin: "greptile-apps",
+            body: "Please fix this",
+            createdAt: "2026-03-13T00:02:00.000Z",
+            url: "https://example.test/comments/1",
+            path: null,
+            line: null,
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "actionable-review-feedback",
+      lifecycleKind: "rework-required",
+    });
+  });
+
   it("rejects already merged pull requests explicitly", () => {
     const result = evaluateGuardedLanding(
       createSnapshot({

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1517,7 +1517,7 @@ describe("BootstrapOrchestrator", () => {
         status: "awaiting-landing-command",
         branchName: "symphony/76",
       });
-      expect(status.activeIssues[0]?.summary).toMatch(/checks/i);
+      expect(status.activeIssues[0]?.summary).toMatch(/approved head is stale/i);
       expect(status.activeIssues[0]?.blockedReason).toMatch(
         /approved head is stale/i,
       );

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -32,6 +32,7 @@ import type {
   RunnerTurnResult,
 } from "../../src/runner/service.js";
 import type { Tracker } from "../../src/tracker/service.js";
+import type { LandingExecutionResult } from "../../src/tracker/service.js";
 import type { WorkspaceManager } from "../../src/workspace/service.js";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -275,8 +276,12 @@ class SequencedTracker implements Tracker {
 
   async executeLanding(
     pullRequest: NonNullable<HandoffLifecycle["pullRequest"]>,
-  ): Promise<void> {
+  ): Promise<LandingExecutionResult> {
     this.landingRequests.push(pullRequest.number);
+    return {
+      kind: "requested",
+      summary: `Landing requested for ${pullRequest.url}.`,
+    };
   }
 
   async recordRetry(issueNumber: number, reason: string): Promise<void> {
@@ -342,12 +347,30 @@ class FailOnceLandingTracker extends SequencedTracker {
 
   override async executeLanding(
     pullRequest: NonNullable<HandoffLifecycle["pullRequest"]>,
-  ): Promise<void> {
+  ): Promise<LandingExecutionResult> {
     this.landingRequests.push(pullRequest.number);
     if (this.landingFailuresRemaining > 0) {
       this.landingFailuresRemaining -= 1;
       throw new Error("merge temporarily blocked");
     }
+    return {
+      kind: "requested",
+      summary: `Landing requested for ${pullRequest.url}.`,
+    };
+  }
+}
+
+class BlockedLandingTracker extends SequencedTracker {
+  override async executeLanding(
+    pullRequest: NonNullable<HandoffLifecycle["pullRequest"]>,
+  ): Promise<LandingExecutionResult> {
+    this.landingRequests.push(pullRequest.number);
+    return {
+      kind: "blocked",
+      reason: "review-threads-unresolved",
+      lifecycleKind: "awaiting-human-review",
+      summary: `Landing blocked for ${pullRequest.url} because unresolved non-outdated review threads remain.`,
+    };
   }
 }
 
@@ -1350,6 +1373,72 @@ describe("BootstrapOrchestrator", () => {
             pullRequest: null,
           }),
         }),
+      );
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("records a blocked landing attempt and retries the same head on a later poll", async () => {
+    const tempRoot = await createTempDir("symphony-blocked-landing-test-");
+    const tracker = new BlockedLandingTracker({
+      running: [createIssue(75, "symphony:running")],
+    });
+    tracker.setLifecycleSequence(75, [
+      lifecycle("awaiting-landing", "symphony/75"),
+      lifecycle("awaiting-human-review", "symphony/75"),
+      lifecycle("awaiting-landing", "symphony/75"),
+      lifecycle("awaiting-human-review", "symphony/75"),
+    ]);
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        workspace: {
+          ...baseConfig.workspace,
+          root: tempRoot,
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunnerExecutionResult> {
+          throw new Error("runner should not be called");
+        },
+      },
+      new NullLogger(),
+    );
+
+    try {
+      await orchestrator.runOnce();
+      await orchestrator.runOnce();
+
+      expect(tracker.landingRequests).toEqual([1, 1]);
+
+      const summary = await readIssueArtifactSummary(tempRoot, 75);
+      expect(summary.currentOutcome).toBe("awaiting-human-review");
+
+      const events = await readIssueArtifactEvents(tempRoot, 75);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          kind: "landing-blocked",
+          details: expect.objectContaining({
+            reason: "review-threads-unresolved",
+            lifecycleKind: "awaiting-human-review",
+            success: false,
+          }),
+        }),
+      );
+
+      const status = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(status.lastAction?.kind).toBe("landing-blocked");
+      expect(status.activeIssues[0]?.blockedReason).toMatch(
+        /unresolved non-outdated review threads remain/i,
       );
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1518,7 +1518,9 @@ describe("BootstrapOrchestrator", () => {
         branchName: "symphony/76",
       });
       expect(status.activeIssues[0]?.summary).toMatch(/checks/i);
-      expect(status.activeIssues[0]?.blockedReason).toMatch(/approved head is stale/i);
+      expect(status.activeIssues[0]?.blockedReason).toMatch(
+        /approved head is stale/i,
+      );
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -374,6 +374,20 @@ class BlockedLandingTracker extends SequencedTracker {
   }
 }
 
+class StaleApprovedHeadLandingTracker extends SequencedTracker {
+  override async executeLanding(
+    pullRequest: NonNullable<HandoffLifecycle["pullRequest"]>,
+  ): Promise<LandingExecutionResult> {
+    this.landingRequests.push(pullRequest.number);
+    return {
+      kind: "blocked",
+      reason: "stale-approved-head",
+      lifecycleKind: "awaiting-landing-command",
+      summary: `Landing blocked for ${pullRequest.url} because the approved head is stale.`,
+    };
+  }
+}
+
 class StaticWorkspaceManager implements WorkspaceManager {
   readonly prepared: string[] = [];
 
@@ -1440,6 +1454,71 @@ describe("BootstrapOrchestrator", () => {
       expect(status.activeIssues[0]?.blockedReason).toMatch(
         /unresolved non-outdated review threads remain/i,
       );
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps blocked landing status aligned with the landing result lifecycle kind", async () => {
+    const tempRoot = await createTempDir("symphony-stale-approved-head-test-");
+    const tracker = new StaleApprovedHeadLandingTracker({
+      running: [createIssue(76, "symphony:running")],
+    });
+    tracker.setLifecycleSequence(76, [
+      lifecycle("awaiting-landing", "symphony/76"),
+      lifecycle("awaiting-system-checks", "symphony/76"),
+    ]);
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        workspace: {
+          ...baseConfig.workspace,
+          root: tempRoot,
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunnerExecutionResult> {
+          throw new Error("runner should not be called");
+        },
+      },
+      new NullLogger(),
+    );
+
+    try {
+      await orchestrator.runOnce();
+
+      const summary = await readIssueArtifactSummary(tempRoot, 76);
+      expect(summary.currentOutcome).toBe("awaiting-system-checks");
+
+      const events = await readIssueArtifactEvents(tempRoot, 76);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          kind: "landing-blocked",
+          details: expect.objectContaining({
+            reason: "stale-approved-head",
+            lifecycleKind: "awaiting-landing-command",
+            success: false,
+          }),
+        }),
+      );
+
+      const status = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(status.lastAction?.kind).toBe("landing-blocked");
+      expect(status.activeIssues[0]).toMatchObject({
+        issueNumber: 76,
+        status: "awaiting-landing-command",
+        branchName: "symphony/76",
+      });
+      expect(status.activeIssues[0]?.summary).toMatch(/checks/i);
+      expect(status.activeIssues[0]?.blockedReason).toMatch(/approved head is stale/i);
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1517,7 +1517,9 @@ describe("BootstrapOrchestrator", () => {
         status: "awaiting-landing-command",
         branchName: "symphony/76",
       });
-      expect(status.activeIssues[0]?.summary).toMatch(/approved head is stale/i);
+      expect(status.activeIssues[0]?.summary).toMatch(
+        /approved head is stale/i,
+      );
       expect(status.activeIssues[0]?.blockedReason).toMatch(
         /approved head is stale/i,
       );

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -145,6 +145,29 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.unresolvedThreadIds).toEqual([]);
   });
 
+  it("keeps a deleted-author thread actionable and non-bot", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [],
+      reviewState: createReviewState([
+        {
+          id: "comment-1",
+          authorLogin: null,
+          body: "Please adjust this logic",
+          createdAt: "2026-03-06T01:00:00.000Z",
+          url: "https://example.test/thread/1#comment-1",
+        },
+      ]),
+      reviewBotLogins: ["greptile-apps", "cursor"],
+    });
+
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(0);
+    expect(snapshot.actionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.actionableReviewFeedback[0]?.authorLogin).toBeNull();
+    expect(snapshot.unresolvedThreadIds).toEqual([]);
+  });
+
   it("detects a human /land command on the current PR head", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",


### PR DESCRIPTION
Closes #82

## Summary
- add a guarded landing policy and GitHub merge-time snapshot before factory-owned merges
- return structured blocked landing outcomes to the orchestrator and observability artifacts/status surfaces
- cover unresolved review-thread, non-green check, stale-head, and non-mergeable regressions including the PR #80 shape

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test