### PR TITLE
Count runner visibility as watchdog progress

### DIFF
--- a/docs/plans/124-progress-aware-watchdog/plan.md
+++ b/docs/plans/124-progress-aware-watchdog/plan.md
@@ -125,13 +125,13 @@ Allowed signal set for `watching-live` in this slice:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Clean workspace, no PR, runner visibility heartbeat/action timestamp advances | Active issue has running/session-start visibility updates | none required | Treat as live pre-write progress; do not abort |
-| Clean workspace, no PR, no visibility/log/diff movement within threshold | Active issue still owned locally | none required | Classify as `log-stall` or pre-write stall fallback; recover/abort using existing budget |
-| Dirty workspace diff unchanged, no visibility movement within threshold | Active issue still running | none required | Classify as `workspace-stall`; recover/abort using existing budget |
-| Actionable review feedback present, PR head unchanged, no visibility movement within threshold | Active issue has review metadata and PR head | actionable review count, PR head SHA | Classify as `pr-stall`; recover/abort using existing budget |
-| Visibility stops because runner already exited/failed before watchdog tick | Run controller/runner result path updates active issue state | none required | Watchdog stops with run completion/error path; no extra recovery |
+| Observed condition                                                                             | Local facts available                                        | Normalized tracker facts available   | Expected decision                                                                        |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Clean workspace, no PR, runner visibility heartbeat/action timestamp advances                  | Active issue has running/session-start visibility updates    | none required                        | Treat as live pre-write progress; do not abort                                           |
+| Clean workspace, no PR, no visibility/log/diff movement within threshold                       | Active issue still owned locally                             | none required                        | Classify as `log-stall` or pre-write stall fallback; recover/abort using existing budget |
+| Dirty workspace diff unchanged, no visibility movement within threshold                        | Active issue still running                                   | none required                        | Classify as `workspace-stall`; recover/abort using existing budget                       |
+| Actionable review feedback present, PR head unchanged, no visibility movement within threshold | Active issue has review metadata and PR head                 | actionable review count, PR head SHA | Classify as `pr-stall`; recover/abort using existing budget                              |
+| Visibility stops because runner already exited/failed before watchdog tick                     | Run controller/runner result path updates active issue state | none required                        | Watchdog stops with run completion/error path; no extra recovery                         |
 
 ## Observability Requirements
 

--- a/docs/plans/124-progress-aware-watchdog/plan.md
+++ b/docs/plans/124-progress-aware-watchdog/plan.md
@@ -1,0 +1,193 @@
+# Issue 124 Plan: Progress-Aware Watchdog For Pre-Write Factory Runs
+
+Status: plan-ready
+
+## Goal
+
+Prevent the watchdog from cancelling healthy factory runs before the first filesystem write when the runner is still making observable progress through commentary, reasoning, or other live execution events.
+
+## Scope
+
+- broaden pre-write liveness detection beyond workspace diffs and PR movement
+- keep the existing detached local watchdog loop and recovery model
+- use existing provider-neutral runner visibility where possible instead of introducing tracker-specific signals
+- add targeted unit and orchestrator coverage for the reproduced `#81` failure mode
+
+## Non-goals
+
+- replacing the watchdog with a new supervision architecture
+- redesigning the queue scheduler or retry policy
+- changing tracker handoff policy outside watchdog-driven abort decisions
+- adding new `WORKFLOW.md` settings unless the current config proves insufficient
+
+## Current Gaps
+
+- `src/orchestrator/stall-detector.ts` treats progress as changes in log size, workspace diff hash, or PR head SHA only
+- `src/orchestrator/liveness-probe.ts` captures filesystem signals but ignores existing runner visibility timestamps already emitted by the runner/orchestrator path
+- a run that reads, plans, or comments for several minutes before writing can look stalled if workspace and PR state stay unchanged and watchdog log growth is absent or too narrow
+- the current tests cover generic stall detection, but not the concrete “runner still emitting live visibility while workspace is clean” regression
+
+## Spec Alignment By Abstraction Level
+
+### Policy Layer
+
+- Defines the liveness policy as “pre-write progress includes runner-visible activity, not only filesystem side effects.”
+- Does not add tracker-specific policy or alter plan-review / PR-review rules.
+
+### Configuration Layer
+
+- Reuses the existing `polling.watchdog` contract if possible.
+- Does not introduce new workflow knobs unless implementation proves the current threshold/check interval contract cannot express the behavior.
+
+### Coordination Layer
+
+- Updates watchdog state evaluation to consider runner-visible progress while preserving the current recovery budget and abort flow.
+- Keeps runtime ownership, retries, and watchdog recovery accounting in the orchestrator/runtime-state seam.
+- Does not move tracker logic or runner transport details into the watchdog policy.
+
+### Execution Layer
+
+- Reads provider-neutral runner visibility facts already produced by the runner/orchestrator execution path.
+- May extend the liveness snapshot shape to carry execution-progress timestamps or summaries.
+- Does not change workspace creation/cleanup semantics or runner command launching semantics.
+
+### Integration Layer
+
+- Remains untouched unless a narrow adapter change is needed to normalize a provider-neutral visibility signal.
+- Does not mix tracker transport, normalization, and watchdog policy.
+
+### Observability Layer
+
+- Keeps status/logging aligned with the new progress interpretation so operators can see why a run is considered live versus stalled.
+- Does not become the source of watchdog policy truth; it reports normalized decisions.
+
+## Architecture Boundaries
+
+- `src/orchestrator/stall-detector.ts` owns pure stall evaluation and classification.
+- `src/orchestrator/liveness-probe.ts` owns collection/assembly of normalized liveness facts.
+- `src/orchestrator/service.ts` owns watchdog loop scheduling, recovery decisions, and active issue status wiring.
+- `src/runner/*` remains the source of runner visibility events, not watchdog policy.
+- `src/observability/*` renders the state but does not decide liveness.
+
+What does not belong in this slice:
+
+- tracker API changes
+- workspace hook changes
+- new scheduler fairness logic
+- broad refactors of runner session management unrelated to watchdog progress detection
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one PR because the seam is narrow:
+
+- normalize one additional pre-write progress signal into the existing watchdog snapshot
+- teach the pure detector how to treat that signal as activity
+- cover the regression in unit/orchestrator tests
+
+Deferred from this PR:
+
+- richer semantic progress classification beyond “runner-visible activity”
+- any redesign of watchdog thresholds into multiple budgets
+- provider-specific parsing of commentary/reasoning payload content
+
+## Runtime State Machine
+
+This issue changes orchestration behavior, so the watchdog decision model must stay explicit.
+
+States for one active issue:
+
+1. `watching-unobserved`
+   - No concrete liveness signal has been seen yet.
+   - Transition to `watching-live` when any observable progress signal appears.
+2. `watching-live`
+   - At least one progress signal has been observed and the latest sample changed within threshold.
+   - Remains here while log size, workspace diff, PR head, or runner-progress timestamp advances.
+   - Transitions to `watching-idle-with-signal` when samples stop changing.
+3. `watching-idle-with-signal`
+   - Observable signals exist, but no signal changed in the latest sample.
+   - Returns to `watching-live` on any later change.
+   - Transitions to `stalled` once idle duration reaches `stallThresholdMs`.
+4. `stalled`
+   - Detector classifies the reason and hands control back to orchestrator recovery policy.
+   - Transitions to `recovering` when recovery budget remains.
+   - Transitions to `terminal-abort` when recovery budget is exhausted.
+5. `recovering`
+   - Orchestrator records recovery count and aborts the runner so normal retry handling can take over.
+6. `terminal-abort`
+   - Orchestrator aborts the runner and lets normal failure handling exhaust the issue attempt.
+
+Allowed signal set for `watching-live` in this slice:
+
+- watchdog log growth
+- workspace diff hash movement
+- PR head movement
+- runner visibility heartbeat/action progress while a turn is still active
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Clean workspace, no PR, runner visibility heartbeat/action timestamp advances | Active issue has running/session-start visibility updates | none required | Treat as live pre-write progress; do not abort |
+| Clean workspace, no PR, no visibility/log/diff movement within threshold | Active issue still owned locally | none required | Classify as `log-stall` or pre-write stall fallback; recover/abort using existing budget |
+| Dirty workspace diff unchanged, no visibility movement within threshold | Active issue still running | none required | Classify as `workspace-stall`; recover/abort using existing budget |
+| Actionable review feedback present, PR head unchanged, no visibility movement within threshold | Active issue has review metadata and PR head | actionable review count, PR head SHA | Classify as `pr-stall`; recover/abort using existing budget |
+| Visibility stops because runner already exited/failed before watchdog tick | Run controller/runner result path updates active issue state | none required | Watchdog stops with run completion/error path; no extra recovery |
+
+## Observability Requirements
+
+- preserve the existing last-action watchdog entries (`watchdog-recovery`, `watchdog-recovery-exhausted`)
+- ensure status snapshots continue to expose runner heartbeat/action timestamps that explain why a pre-write run stayed live
+- add or update focused logging only if needed to make watchdog decisions inspectable during regressions
+
+## Implementation Steps
+
+1. Extend the watchdog liveness snapshot to include normalized runner progress timestamps sourced from active issue runner visibility.
+2. Update the filesystem liveness probe interface and capture path so the probe can combine filesystem facts with runner visibility facts without depending on provider-specific payloads.
+3. Adjust `checkStall` and stall classification logic so advancing runner progress counts as change, especially before the first workspace write.
+4. Keep stall-reason precedence explicit so PR and workspace stalls still win when their conditions apply after progress stops.
+5. Add pure unit coverage for first-observed runner progress, repeated heartbeat/action advancement, and post-progress idle timeout.
+6. Add orchestrator coverage for a `#81`-style run that emits visibility progress while the workspace stays clean, proving the watchdog does not abort early.
+7. Update the plan status and issue thread if implementation uncovers a broader scope change.
+
+## Tests
+
+Unit:
+
+- `tests/unit/stall-detector.test.ts`
+  - first runner-progress signal counts as progress
+  - advancing runner heartbeat/action timestamps resets idle time
+  - runner-progress-only runs still stall after threshold once timestamps stop changing
+- `tests/unit/liveness-probe.test.ts`
+  - probe snapshots carry runner visibility progress fields through unchanged
+
+Orchestrator:
+
+- `tests/unit/orchestrator.test.ts`
+  - watchdog does not abort a run whose workspace diff stays clean while runner visibility keeps advancing
+  - existing stalled-run recovery behavior still aborts when all signals stop
+
+Acceptance scenarios:
+
+1. A planning-heavy first turn with no file writes for more than one check interval stays live while runner visibility keeps updating.
+2. A genuinely hung pre-write run with no diff, no PR movement, and no runner visibility updates still triggers watchdog recovery.
+3. Existing post-write and PR-feedback stall detection continues to classify unchanged diff/PR states correctly.
+
+## Exit Criteria
+
+- plan is reviewed and explicitly marked `approved` or `waived`
+- watchdog no longer treats healthy pre-write progress as stalled solely because the workspace is clean
+- reproduced regression is covered by tests
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Deferred To Later Issues Or PRs
+
+- separate thresholds for pre-write versus post-write stall classes
+- richer progress semantics from runner output content
+- status UI changes beyond the minimal visibility needed to explain watchdog decisions
+
+## Decision Notes
+
+- Prefer existing provider-neutral runner visibility timestamps over parsing provider-specific commentary logs. This keeps the fix inside the orchestrator/runner contract instead of baking Codex-specific session semantics into watchdog policy.
+- Keep the watchdog as a single detector with broader progress inputs. Splitting it into separate pre-write and post-write watchdog subsystems would enlarge the review surface without being required for the reproduced failure.

--- a/src/orchestrator/liveness-probe.ts
+++ b/src/orchestrator/liveness-probe.ts
@@ -12,6 +12,8 @@ export interface LivenessProbe {
     readonly workspacePath: string | null;
     readonly runSessionId: string | null;
     readonly prHeadSha: string | null;
+    readonly runnerHeartbeatAt: string | null;
+    readonly runnerActionAt: string | null;
     readonly hasActionableFeedback: boolean;
   }): Promise<LivenessSnapshot>;
 }
@@ -35,11 +37,15 @@ export class NullLivenessProbe implements LivenessProbe {
     readonly runSessionId: string | null;
     readonly hasActionableFeedback: boolean;
     readonly prHeadSha: string | null;
+    readonly runnerHeartbeatAt: string | null;
+    readonly runnerActionAt: string | null;
   }): Promise<LivenessSnapshot> {
     return Promise.resolve({
       logSizeBytes: null,
       workspaceDiffHash: null,
       prHeadSha: options.prHeadSha,
+      runnerHeartbeatAt: options.runnerHeartbeatAt,
+      runnerActionAt: options.runnerActionAt,
       hasActionableFeedback: options.hasActionableFeedback,
       capturedAt: Date.now(),
     });
@@ -64,6 +70,8 @@ export class FsLivenessProbe implements LivenessProbe {
     readonly workspacePath: string | null;
     readonly runSessionId: string | null;
     readonly prHeadSha: string | null;
+    readonly runnerHeartbeatAt: string | null;
+    readonly runnerActionAt: string | null;
     readonly hasActionableFeedback: boolean;
   }): Promise<LivenessSnapshot> {
     const [logSize, diffHash] = await Promise.all([
@@ -75,6 +83,8 @@ export class FsLivenessProbe implements LivenessProbe {
       logSizeBytes: logSize,
       workspaceDiffHash: diffHash,
       prHeadSha: options.prHeadSha,
+      runnerHeartbeatAt: options.runnerHeartbeatAt,
+      runnerActionAt: options.runnerActionAt,
       hasActionableFeedback: options.hasActionableFeedback,
       capturedAt: Date.now(),
     };

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -2349,6 +2349,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       logSizeBytes: null,
       workspaceDiffHash: null,
       prHeadSha: null,
+      runnerHeartbeatAt: null,
+      runnerActionAt: null,
       hasActionableFeedback: false,
       capturedAt: now,
     });
@@ -2388,6 +2390,9 @@ export class BootstrapOrchestrator implements Orchestrator {
           workspacePath: activeIssue?.workspacePath ?? null,
           runSessionId: activeIssue?.runSessionId ?? null,
           prHeadSha: activeIssue?.pullRequest?.headSha ?? null,
+          runnerHeartbeatAt:
+            activeIssue?.runnerVisibility?.lastHeartbeatAt ?? null,
+          runnerActionAt: activeIssue?.runnerVisibility?.lastActionAt ?? null,
           hasActionableFeedback: (activeIssue?.review.actionableCount ?? 0) > 0,
         });
         const result = checkStall(entry, snapshot, this.#watchdogConfig);

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -8,6 +8,8 @@ export interface LivenessSnapshot {
   readonly logSizeBytes: number | null;
   readonly workspaceDiffHash: string | null;
   readonly prHeadSha: string | null;
+  readonly runnerHeartbeatAt: string | null;
+  readonly runnerActionAt: string | null;
   readonly hasActionableFeedback: boolean;
   readonly capturedAt: number;
 }
@@ -50,7 +52,9 @@ export function hasObservableLivenessSignal(
   return (
     snapshot.logSizeBytes !== null ||
     snapshot.workspaceDiffHash !== null ||
-    snapshot.prHeadSha !== null
+    snapshot.prHeadSha !== null ||
+    snapshot.runnerHeartbeatAt !== null ||
+    snapshot.runnerActionAt !== null
   );
 }
 
@@ -98,6 +102,20 @@ export function checkStall(
 
   // Check PR head movement
   if (current.prHeadSha !== null && current.prHeadSha !== previous.prHeadSha) {
+    changed = true;
+  }
+
+  // Check runner heartbeat and action progress
+  if (
+    current.runnerHeartbeatAt !== null &&
+    current.runnerHeartbeatAt !== previous.runnerHeartbeatAt
+  ) {
+    changed = true;
+  }
+  if (
+    current.runnerActionAt !== null &&
+    current.runnerActionAt !== previous.runnerActionAt
+  ) {
     changed = true;
   }
 

--- a/tests/unit/liveness-probe.test.ts
+++ b/tests/unit/liveness-probe.test.ts
@@ -33,11 +33,15 @@ describe("NullLivenessProbe", () => {
       workspacePath: "/tmp/workspaces/42",
       runSessionId: "session-42",
       prHeadSha: "abc123",
+      runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+      runnerActionAt: "2026-03-13T08:46:01.000Z",
       hasActionableFeedback: true,
     });
     expect(result.logSizeBytes).toBeNull();
     expect(result.workspaceDiffHash).toBeNull();
     expect(result.prHeadSha).toBe("abc123");
+    expect(result.runnerHeartbeatAt).toBe("2026-03-13T08:46:00.000Z");
+    expect(result.runnerActionAt).toBe("2026-03-13T08:46:01.000Z");
     expect(result.hasActionableFeedback).toBe(true);
     expect(result.capturedAt).toBeGreaterThan(0);
   });
@@ -70,10 +74,14 @@ describe("FsLivenessProbe", () => {
       workspacePath: null,
       runSessionId,
       prHeadSha: null,
+      runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+      runnerActionAt: "2026-03-13T08:46:01.000Z",
       hasActionableFeedback: false,
     });
 
     expect(result.logSizeBytes).toBe("runner-a".length);
+    expect(result.runnerHeartbeatAt).toBe("2026-03-13T08:46:00.000Z");
+    expect(result.runnerActionAt).toBe("2026-03-13T08:46:01.000Z");
   });
 
   it("falls back to an issue-specific log path when session id is missing", async () => {
@@ -96,6 +104,8 @@ describe("FsLivenessProbe", () => {
       workspacePath: null,
       runSessionId: null,
       prHeadSha: null,
+      runnerHeartbeatAt: null,
+      runnerActionAt: null,
       hasActionableFeedback: false,
     });
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -73,6 +73,24 @@ function createObservableStalledProbe(): LivenessProbe {
         logSizeBytes: 1,
         workspaceDiffHash: null,
         prHeadSha: options.prHeadSha,
+        runnerHeartbeatAt: options.runnerHeartbeatAt,
+        runnerActionAt: options.runnerActionAt,
+        hasActionableFeedback: options.hasActionableFeedback,
+        capturedAt: Date.now(),
+      };
+    },
+  };
+}
+
+function createRunnerVisibilityProbe(): LivenessProbe {
+  return {
+    async capture(options) {
+      return {
+        logSizeBytes: null,
+        workspaceDiffHash: null,
+        prHeadSha: options.prHeadSha,
+        runnerHeartbeatAt: options.runnerHeartbeatAt,
+        runnerActionAt: options.runnerActionAt,
         hasActionableFeedback: options.hasActionableFeedback,
         capturedAt: Date.now(),
       };
@@ -2771,6 +2789,103 @@ describe("BootstrapOrchestrator watchdog", () => {
     await runOncePromise;
 
     expect(runAborted).toBe(true);
+  });
+
+  it("keeps a pre-write run alive while runner visibility keeps advancing", async () => {
+    const issue = createIssue(91);
+    const tracker = new SequencedTracker({ ready: [issue] });
+    tracker.setLifecycleSequence(91, [
+      lifecycle("handoff-ready", "symphony/91"),
+    ]);
+
+    let runAborted = false;
+
+    const progressRunner: Runner = {
+      describeSession() {
+        return createRunnerSessionDescription();
+      },
+      async run(_session, options) {
+        const startedAt = new Date().toISOString();
+        for (let index = 0; index < 3; index += 1) {
+          const observedAt = new Date(Date.now() + index + 1).toISOString();
+          await options?.onEvent?.({
+            kind: "visibility",
+            visibility: {
+              state: "running",
+              phase: "turn-execution",
+              session: createRunnerSessionDescription(),
+              lastHeartbeatAt: observedAt,
+              lastActionAt: observedAt,
+              lastActionSummary: `Planning step ${(index + 1).toString()}`,
+              waitingReason: null,
+              stdoutSummary: null,
+              stderrSummary: null,
+              errorSummary: null,
+              cancelledAt: null,
+              timedOutAt: null,
+            },
+          });
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => {
+              options?.signal?.removeEventListener("abort", handleAbort);
+              resolve();
+            }, 5);
+            const handleAbort = (): void => {
+              clearTimeout(timer);
+              runAborted = true;
+              reject(new RunnerAbortedError("Aborted"));
+            };
+            if (options?.signal?.aborted) {
+              handleAbort();
+              return;
+            }
+            options?.signal?.addEventListener("abort", handleAbort, {
+              once: true,
+            });
+          });
+        }
+
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+      },
+    };
+
+    const watchdogConfig = {
+      ...baseConfig,
+      workspace: { ...baseConfig.workspace, root: tmpDir },
+      polling: {
+        ...baseConfig.polling,
+        watchdog: {
+          enabled: true,
+          checkIntervalMs: 1,
+          stallThresholdMs: 20,
+          maxRecoveryAttempts: 1,
+        },
+      },
+    };
+
+    const orchestrator = new BootstrapOrchestrator(
+      watchdogConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      progressRunner,
+      new NullLogger(),
+      undefined,
+      createRunnerVisibilityProbe(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(runAborted).toBe(false);
+    expect(tracker.retried).toEqual([]);
+    expect(tracker.failed).toEqual([]);
+    expect(tracker.completed).toEqual([91]);
   });
 
   it("does not recover beyond maxRecoveryAttempts across retries", async () => {

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -22,6 +22,8 @@ function snapshot(overrides: Partial<LivenessSnapshot> = {}): LivenessSnapshot {
     logSizeBytes: null,
     workspaceDiffHash: null,
     prHeadSha: null,
+    runnerHeartbeatAt: null,
+    runnerActionAt: null,
     hasActionableFeedback: false,
     capturedAt: Date.now(),
     ...overrides,
@@ -79,6 +81,44 @@ describe("checkStall", () => {
     expect(result.stalled).toBe(false);
   });
 
+  it("treats the first runner heartbeat signal as progress", () => {
+    const entry = createWatchdogEntry(1, snapshot({ capturedAt: 1000 }));
+    const result = checkStall(
+      entry,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+        capturedAt: 7000,
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(false);
+    expect(result.reason).toBeNull();
+    expect(entry.lastChangeAt).toBe(7000);
+  });
+
+  it("resets idle time when runner progress timestamps advance", () => {
+    const entry = createWatchdogEntry(
+      1,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+        runnerActionAt: "2026-03-13T08:46:00.000Z",
+        capturedAt: 1000,
+      }),
+    );
+    const result = checkStall(
+      entry,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:03.000Z",
+        runnerActionAt: "2026-03-13T08:46:04.000Z",
+        capturedAt: 7000,
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(false);
+    expect(result.reason).toBeNull();
+    expect(entry.lastChangeAt).toBe(7000);
+  });
+
   it("reports not stalled within threshold window", () => {
     const entry = createWatchdogEntry(
       1,
@@ -122,6 +162,29 @@ describe("checkStall", () => {
     const result = checkStall(
       entry,
       snapshot({ logSizeBytes: 100, capturedAt: 7000 }),
+      config,
+    );
+    expect(result.stalled).toBe(true);
+    expect(result.reason).toBe("log-stall");
+    expect(result.stalledForMs).toBe(6000);
+  });
+
+  it("stalls runner-progress-only runs after timestamps stop changing", () => {
+    const entry = createWatchdogEntry(
+      1,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+        runnerActionAt: "2026-03-13T08:46:01.000Z",
+        capturedAt: 1000,
+      }),
+    );
+    const result = checkStall(
+      entry,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
+        runnerActionAt: "2026-03-13T08:46:01.000Z",
+        capturedAt: 7000,
+      }),
       config,
     );
     expect(result.stalled).toBe(true);
@@ -217,6 +280,11 @@ describe("hasObservableLivenessSignal", () => {
     expect(hasObservableLivenessSignal(snapshot({ logSizeBytes: 1 }))).toBe(
       true,
     );
+    expect(
+      hasObservableLivenessSignal(
+        snapshot({ runnerHeartbeatAt: "2026-03-13T08:46:00.000Z" }),
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- count provider-neutral runner heartbeat/action timestamps as watchdog liveness signals
- keep the existing watchdog/recovery model while avoiding false pre-write stall aborts
- add unit and orchestrator regressions for `#81`-style clean-workspace runs that still show live runner progress

## Plan
- approved plan: `docs/plans/124-progress-aware-watchdog/plan.md`
- issue: Closes #124

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`

## Self-review
- manual diff review completed
- `codex review --base origin/main` did not return actionable findings in this workspace run
