### PR TITLE
Add factory control CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ pnpm tsx bin/symphony.ts status          # terminal view
 pnpm tsx bin/symphony.ts status --json   # machine-readable
 ```
 
+Control the local detached factory runtime from the repo root:
+
+```bash
+pnpm tsx bin/symphony.ts factory start
+pnpm tsx bin/symphony.ts factory status
+pnpm tsx bin/symphony.ts factory restart
+pnpm tsx bin/symphony.ts factory stop
+```
+
+These commands target the checked-out runtime under `.tmp/factory-main`, so the
+operator no longer needs to `cd` into the runtime checkout or manually combine
+`screen` with `pkill` cleanup.
+
 The status snapshot includes normalized runner visibility for active issues,
 including worker state, current phase, session identity, heartbeat/action
 timestamps, waiting reason, and condensed output/error summaries.

--- a/docs/plans/081-factory-control-cli/plan.md
+++ b/docs/plans/081-factory-control-cli/plan.md
@@ -192,16 +192,16 @@ The control seam should not depend on:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Status snapshot facts available | Expected decision |
-| --- | --- | --- | --- |
-| No screen session, no `bin/symphony.ts run`, no `codex exec` child | process table only | snapshot may be absent or stale | report `stopped`; `factory status` exits zero because idle/stopped is not an operator failure |
-| Screen session present and worker process alive | wrapper pid, worker pid | readable snapshot with matching live worker | report `running`; `factory status` mirrors current runtime status |
-| Screen session gone but worker or runner still alive | orphaned child pids | snapshot may still be readable | report `degraded`; `factory stop` kills remaining descendants and exits zero on successful cleanup |
-| Screen session present but worker pid from snapshot is dead | wrapper pid, maybe intermediate `pnpm`/`tsx` pids | readable but stale snapshot | report `degraded`; `factory status` exits non-zero because the operator surface found a broken runtime |
-| `factory start` finds an already running healthy factory | wrapper and live worker already present | readable snapshot | return a no-op success and print the active runtime information |
-| `factory start` launches screen but worker never appears | wrapper pid may exist briefly | missing or unchanged snapshot | fail the command and report startup failure with next-step guidance |
-| `factory stop` terminates wrapper but `codex exec` remains alive | orphan runner pid | snapshot may still show active run | continue process-tree cleanup, escalate signal if needed, and fail only if descendants remain after timeout |
-| Multiple candidate runtime checkouts or session owners are discovered | repo-root scan results conflict | one or more snapshots may exist | fail loudly and require operator intervention rather than guessing |
+| Observed condition                                                    | Local facts available                             | Status snapshot facts available             | Expected decision                                                                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| No screen session, no `bin/symphony.ts run`, no `codex exec` child    | process table only                                | snapshot may be absent or stale             | report `stopped`; `factory status` exits zero because idle/stopped is not an operator failure               |
+| Screen session present and worker process alive                       | wrapper pid, worker pid                           | readable snapshot with matching live worker | report `running`; `factory status` mirrors current runtime status                                           |
+| Screen session gone but worker or runner still alive                  | orphaned child pids                               | snapshot may still be readable              | report `degraded`; `factory stop` kills remaining descendants and exits zero on successful cleanup          |
+| Screen session present but worker pid from snapshot is dead           | wrapper pid, maybe intermediate `pnpm`/`tsx` pids | readable but stale snapshot                 | report `degraded`; `factory status` exits non-zero because the operator surface found a broken runtime      |
+| `factory start` finds an already running healthy factory              | wrapper and live worker already present           | readable snapshot                           | return a no-op success and print the active runtime information                                             |
+| `factory start` launches screen but worker never appears              | wrapper pid may exist briefly                     | missing or unchanged snapshot               | fail the command and report startup failure with next-step guidance                                         |
+| `factory stop` terminates wrapper but `codex exec` remains alive      | orphan runner pid                                 | snapshot may still show active run          | continue process-tree cleanup, escalate signal if needed, and fail only if descendants remain after timeout |
+| Multiple candidate runtime checkouts or session owners are discovered | repo-root scan results conflict                   | one or more snapshots may exist             | fail loudly and require operator intervention rather than guessing                                          |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/081-factory-control-cli/plan.md
+++ b/docs/plans/081-factory-control-cli/plan.md
@@ -1,0 +1,310 @@
+# Issue 81 Plan: Factory Control CLI
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a checked-in `symphony factory` control surface that operators can run from the repository root to start, stop, restart, and inspect the active local factory without remembering `.tmp/factory-main` or using ad hoc `screen` and `pkill` commands.
+
+The first slice should preserve the current detached local-process model and make its runtime checkout, wrapper session, and process-tree cleanup explicit behind one CLI seam.
+
+## Scope
+
+- add `symphony factory start`
+- add `symphony factory stop`
+- add `symphony factory restart`
+- add `symphony factory status`
+- make those commands work from the repository root by locating the active runtime checkout under `.tmp/factory-main`
+- centralize detached-session startup and process-discovery logic in checked-in code instead of operator notes or shell history
+- terminate the active factory process tree, including stray `bin/symphony.ts run` and factory-owned `codex exec --dangerously-bypass-approvals-and-sandbox` children
+- cover the control path with focused unit tests and a narrow integration-style process test where practical
+- document the operator-facing command usage in `README.md`
+
+## Non-goals
+
+- replacing the detached local-process model with launchd, systemd, or another service manager
+- redesigning the orchestrator, tracker lifecycle, retry policy, or status snapshot schema
+- building a TUI, dashboard, or continuous log streaming surface
+- supporting remote factory control
+- solving runtime checkout refresh/update workflows beyond using the current checked-out `.tmp/factory-main`
+- changing issue/PR handoff policy or tracker integration behavior
+
+## Current Gaps
+
+- the root CLI only exposes `run` and `status`; operators still have to know when to `cd .tmp/factory-main`
+- detached factory startup currently depends on manual `screen` invocation and an implicit session name
+- clean shutdown is manual and error-prone because killing the `screen` wrapper can leave the `pnpm`, `tsx`, `bin/symphony.ts run`, or `codex exec` processes alive
+- the active runtime checkout path lives in operator notes and shell commands rather than a checked-in contract
+- status is available only if the operator manually points the command at the runtime checkout that owns `.tmp/status.json`
+- there is no single place to improve future pause/resume or richer control behavior
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: repo-owned operator contract that `symphony factory` controls the local runtime checkout at `.tmp/factory-main` and uses the existing detached-session operating model
+  - does not belong: tracker-specific lifecycle policy or review-loop decisions
+- Configuration Layer
+  - belongs: resolving the repository root, runtime checkout path, workflow path, and any fixed control defaults such as the detached session name
+  - does not belong: reparsing tracker payloads or embedding process-tree traversal policy inside workflow loading
+- Coordination Layer
+  - belongs: a small control-state read model for deciding whether the factory is running, stopped, stale, or partially orphaned
+  - does not belong: orchestrator polling, retry, reconciliation, or issue handoff logic
+- Execution Layer
+  - belongs: starting the detached wrapper, discovering the process tree, and terminating factory-owned subprocesses cleanly
+  - does not belong: tracker mutations, prompt rendering, or status formatting rules
+- Integration Layer
+  - belongs: shelling out to `screen`, `ps`, and the existing `pnpm tsx bin/symphony.ts ...` entrypoint as local machine integrations
+  - does not belong: mixing those host-process details into tracker adapters or the orchestrator service
+- Observability Layer
+  - belongs: reading the existing `.tmp/status.json` snapshot from the active runtime checkout, rendering operator-facing status output, and distinguishing healthy stopped state from operator failure
+  - does not belong: inventing a second status snapshot schema or coupling control behavior to `.ralph` notes
+
+## Architecture Boundaries
+
+### CLI / control seam
+
+Belongs here:
+
+- parsing `symphony factory <start|stop|restart|status>` arguments
+- resolving the outer repository root versus the runtime checkout root
+- mapping command results to operator-facing output and exit codes
+
+Does not belong here:
+
+- raw `ps` parsing
+- status snapshot parsing details
+- orchestrator logic
+
+### Configuration / repo-root resolution
+
+Belongs here:
+
+- deriving the active runtime checkout path from the repo root
+- locating the runtime `WORKFLOW.md` and status snapshot without requiring the operator to `cd`
+
+Does not belong here:
+
+- session management
+- subtree kill logic
+
+### Execution / process control
+
+Belongs here:
+
+- detached `screen` startup using the existing `pnpm tsx bin/symphony.ts run` command
+- process discovery for the wrapper session, `bin/symphony.ts run`, and factory-owned runner children
+- clean shutdown sequencing and escalation when a process ignores termination
+
+Does not belong here:
+
+- tracker reads
+- status rendering
+- workflow parsing beyond what is needed to launch the runtime
+
+### Observability
+
+Belongs here:
+
+- reusing the existing factory status snapshot contract for `factory status`
+- reporting when the wrapper is missing, when the worker PID is stale, and when stop/start actions succeed
+
+Does not belong here:
+
+- a second persistent control-state file for this first slice
+- `.ralph/status.json` as a source of truth
+
+### Tracker / orchestrator
+
+Untouched except for consuming their existing public surfaces:
+
+- tracker policy stays at the edge and should not learn about `screen` or detached process management
+- orchestrator status snapshot semantics stay unchanged; control code reads them but does not redefine them
+
+## Slice Strategy And PR Seam
+
+This issue should stay one reviewable PR by landing one narrow operator-control slice:
+
+1. extend the checked-in CLI with a `factory` command group
+2. add a focused local control module for runtime-root resolution, process discovery, detached startup, and shutdown
+3. reuse the current status snapshot for `factory status`
+4. add focused tests and README usage updates
+
+Deliberately deferred from this PR:
+
+- runtime checkout refresh/update workflows
+- pause/resume semantics distinct from stop/start
+- richer logs/dashboard integration
+- service-manager support
+- multiple named factories or remote control
+
+This seam is reviewable because it changes operator control only. It does not redesign orchestrator state, tracker policy, or runtime observability contracts.
+
+## Runtime State Model
+
+This feature is stateful enough to require an explicit control-state model, but it should remain a read model over local host-process facts plus the existing status snapshot.
+
+### Control States
+
+1. `stopped`
+   - no active factory wrapper, worker, or runner process is present
+2. `starting`
+   - `factory start` has launched the detached wrapper and is waiting for the worker/status snapshot to appear
+3. `running`
+   - detached wrapper and live worker exist; status snapshot is readable
+4. `degraded`
+   - some but not all expected facts exist, for example:
+   - wrapper missing but worker or runner still alive
+   - wrapper present but status snapshot unreadable or stale
+   - status snapshot points at dead worker PID while factory-owned descendants still exist
+5. `stopping`
+   - `factory stop` is terminating the wrapper and then any remaining factory-owned descendants
+
+### Allowed Transitions
+
+- `stopped -> starting`
+- `starting -> running`
+- `starting -> degraded`
+- `running -> stopping`
+- `running -> degraded`
+- `degraded -> stopping`
+- `degraded -> starting`
+- `stopping -> stopped`
+- `stopping -> degraded`
+
+### Decision Facts
+
+The control seam should decide state from:
+
+- resolved repo root and runtime checkout path
+- `screen -ls` results for the named session
+- local process table matches for the runtime checkout command tree
+- the existing factory status snapshot and `worker.pid`
+
+The control seam should not depend on:
+
+- tracker issue labels
+- `.ralph/status.json`
+- undocumented shell aliases
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Status snapshot facts available | Expected decision |
+| --- | --- | --- | --- |
+| No screen session, no `bin/symphony.ts run`, no `codex exec` child | process table only | snapshot may be absent or stale | report `stopped`; `factory status` exits zero because idle/stopped is not an operator failure |
+| Screen session present and worker process alive | wrapper pid, worker pid | readable snapshot with matching live worker | report `running`; `factory status` mirrors current runtime status |
+| Screen session gone but worker or runner still alive | orphaned child pids | snapshot may still be readable | report `degraded`; `factory stop` kills remaining descendants and exits zero on successful cleanup |
+| Screen session present but worker pid from snapshot is dead | wrapper pid, maybe intermediate `pnpm`/`tsx` pids | readable but stale snapshot | report `degraded`; `factory status` exits non-zero because the operator surface found a broken runtime |
+| `factory start` finds an already running healthy factory | wrapper and live worker already present | readable snapshot | return a no-op success and print the active runtime information |
+| `factory start` launches screen but worker never appears | wrapper pid may exist briefly | missing or unchanged snapshot | fail the command and report startup failure with next-step guidance |
+| `factory stop` terminates wrapper but `codex exec` remains alive | orphan runner pid | snapshot may still show active run | continue process-tree cleanup, escalate signal if needed, and fail only if descendants remain after timeout |
+| Multiple candidate runtime checkouts or session owners are discovered | repo-root scan results conflict | one or more snapshots may exist | fail loudly and require operator intervention rather than guessing |
+
+## Storage / Persistence Contract
+
+- no new durable control-state file in this first slice
+- runtime status continues to come from `.tmp/factory-main/.tmp/status.json`
+- control decisions are derived from live host-process inspection plus the existing status snapshot
+- any transient startup/shutdown wait logic stays in memory inside the command invocation
+
+## Observability Requirements
+
+- `factory status` should show the resolved runtime checkout path so operators can verify which checkout is active
+- `factory status` should reuse the existing human-readable and JSON status snapshot output where possible
+- `factory status` should exit non-zero only for real operator failures such as unreadable runtime metadata, broken runtime state, or ambiguous process ownership; a cleanly stopped factory should not be treated as failure
+- `factory start` and `factory stop` should print concise action summaries, including session name and key PIDs when available
+- logs remain owned by the existing runtime; this issue may print a minimal pointer to the runtime checkout or snapshot file, but should not introduce log streaming
+
+## Implementation Steps
+
+1. Add a focused factory-control module, for example under `src/cli/` or `src/factory/`, that:
+   - resolves the repo root and active runtime checkout path
+   - defines typed control-state snapshots
+   - discovers the detached wrapper and related process tree
+2. Extend `src/cli/index.ts` argument parsing to support:
+   - `symphony factory start`
+   - `symphony factory stop`
+   - `symphony factory restart`
+   - `symphony factory status`
+3. Implement `factory start` by:
+   - resolving the runtime checkout under `.tmp/factory-main`
+   - launching the current detached `screen` session against `pnpm tsx bin/symphony.ts run`
+   - waiting for a live worker or readable status snapshot
+4. Implement `factory stop` by:
+   - locating the wrapper session and all runtime-owned descendants
+   - terminating the wrapper first
+   - terminating remaining worker/runner descendants until none remain or timeout is reached
+5. Implement `factory restart` as `stop` then `start`, preserving helpful summaries for no-op stop or already-running start cases
+6. Implement `factory status` by:
+   - resolving the runtime checkout from the repo root
+   - reading the existing status snapshot when present
+   - combining it with live process facts to classify `stopped`, `running`, or `degraded`
+   - mapping that result to exit status
+7. Add unit tests for argument parsing, runtime-root resolution, state classification, exit-code behavior, and process-discovery parsing
+8. Add a narrow integration-style test for detached start/stop behavior using fixture subprocesses or a fake session/process model where practical
+9. Update `README.md` with the operator-facing control commands and clarify that the root checkout controls `.tmp/factory-main`
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `parseArgs` accepts the new `factory` subcommands and rejects invalid combinations
+- repo-root resolution finds `.tmp/factory-main` from the outer checkout and does not require `cd` into the runtime
+- status classification distinguishes `stopped`, `running`, and `degraded` from process facts plus snapshot facts
+- `factory status` exits zero for healthy stopped and healthy running states, and non-zero for degraded or unreadable runtime states
+- stop planning collects wrapper, worker, and runner pids without targeting unrelated local Codex processes
+
+### Integration
+
+- starting from the repo root launches the detached session against `.tmp/factory-main` and produces a readable status snapshot
+- stopping from the repo root tears down the wrapper plus remaining runtime-owned descendants
+- restart composes the two operations without leaving duplicate sessions
+
+### End-to-End Operator Scenarios
+
+1. From the outer repo root, the operator runs `symphony factory start` and the factory starts in the runtime checkout without manually changing directories.
+2. While the factory is active, `symphony factory status` reports the same effective runtime information as `pnpm tsx bin/symphony.ts status` inside `.tmp/factory-main`.
+3. After `symphony factory stop`, no factory-owned `bin/symphony.ts run` or `codex exec --dangerously-bypass-approvals-and-sandbox` process remains.
+4. If the wrapper or worker state is broken, `symphony factory status` reports a degraded state and exits non-zero so automation can notice the operator failure.
+
+### Repo Gate
+
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main`
+
+## Acceptance Scenarios
+
+1. Operators can use checked-in `symphony factory start|stop|restart|status` commands from the repository root instead of manual `screen` and `pkill` sequences.
+2. The command surface preserves the current local operating model by controlling `.tmp/factory-main` rather than redesigning the runtime.
+3. `factory stop` removes stray factory-owned runner or worker processes instead of only killing the wrapper session.
+4. `factory status` reports the live runtime checkout status and treats a clean stop differently from a broken runtime.
+
+## Exit Criteria
+
+- the CLI exposes the four required `factory` subcommands
+- commands work from the repository root against the active `.tmp/factory-main` runtime checkout
+- start/stop/restart use the existing detached local-process strategy under the hood
+- stop leaves no factory-owned `bin/symphony.ts run` or runner child process behind in normal operation
+- status reuses the current runtime status snapshot and has clear, tested exit-code semantics
+- README usage is updated and the relevant tests pass
+
+## Deferred To Later Issues Or PRs
+
+- service-manager integration
+- multiple runtime checkouts or named environments
+- pause/resume distinct from stop/start
+- direct log tailing or richer dashboard surfaces
+- runtime checkout refresh/update commands
+- persistent operator history beyond the existing runtime status and issue-artifact contracts
+
+## Decision Notes
+
+- The control seam should prefer a fixed repo-owned runtime checkout contract (`.tmp/factory-main`) over trying to infer arbitrary checkouts from operator notes. That is the minimum change that removes operator memorization without inventing new runtime metadata.
+- Process discovery should treat `screen` as wrapper mechanism, not source of truth. The source of truth for runtime health is the combination of live child processes plus the existing status snapshot.
+- This first slice should avoid wiring `.ralph` files into production control logic. They are operator aids, not runtime contracts.

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -656,7 +656,9 @@ async function defaultLaunchScreenSession(options: {
 }
 
 async function defaultQuitScreenSession(sessionId: string): Promise<void> {
-  await execFile("screen", ["-S", sessionId, "-X", "quit"]);
+  await execFile("screen", ["-S", sessionId, "-X", "quit"], {
+    timeout: 5_000,
+  });
 }
 
 async function defaultSleep(ms: number): Promise<void> {

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -100,12 +100,6 @@ export async function resolveFactoryPaths(
   const repoRoot = await findFactoryRepoRoot(cwd(), pathExists);
   const runtimeRoot = path.join(repoRoot, FACTORY_RUNTIME_DIRECTORY);
 
-  if (!(await pathExists(runtimeRoot))) {
-    throw new Error(
-      `Factory runtime checkout not found at ${runtimeRoot}. Prepare ${FACTORY_RUNTIME_DIRECTORY} before using 'symphony factory'.`,
-    );
-  }
-
   const workflowPath = path.join(runtimeRoot, "WORKFLOW.md");
   if (!(await pathExists(workflowPath))) {
     throw new Error(

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -1,0 +1,630 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { loadWorkflowWorkspaceRoot } from "../config/workflow.js";
+import {
+  deriveStatusFilePath,
+  isProcessAlive,
+  parseFactoryStatusSnapshotContent,
+  renderFactoryStatusSnapshot,
+  type FactoryStatusSnapshot,
+} from "../observability/status.js";
+
+const execFile = promisify(execFileCallback);
+
+export const FACTORY_RUNTIME_DIRECTORY = path.join(".tmp", "factory-main");
+export const FACTORY_SCREEN_SESSION_NAME = "symphony-factory";
+const START_TIMEOUT_MS = 15_000;
+const STOP_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 250;
+
+export interface FactoryPaths {
+  readonly repoRoot: string;
+  readonly runtimeRoot: string;
+  readonly workflowPath: string;
+  readonly statusFilePath: string;
+}
+
+export interface HostProcessSnapshot {
+  readonly pid: number;
+  readonly ppid: number;
+  readonly command: string;
+}
+
+export interface ScreenSessionSnapshot {
+  readonly id: string;
+  readonly pid: number;
+  readonly name: string;
+  readonly state: string;
+}
+
+export type FactoryControlState = "stopped" | "running" | "degraded";
+
+export interface FactoryControlStatusSnapshot {
+  readonly controlState: FactoryControlState;
+  readonly paths: FactoryPaths;
+  readonly sessionName: string;
+  readonly sessions: readonly ScreenSessionSnapshot[];
+  readonly workerAlive: boolean;
+  readonly statusSnapshot: FactoryStatusSnapshot | null;
+  readonly processIds: readonly number[];
+  readonly problems: readonly string[];
+}
+
+export interface FactoryControlStartResult {
+  readonly kind: "started" | "already-running";
+  readonly status: FactoryControlStatusSnapshot;
+}
+
+export interface FactoryControlStopResult {
+  readonly kind: "stopped" | "already-stopped";
+  readonly status: FactoryControlStatusSnapshot;
+  readonly terminatedPids: readonly number[];
+}
+
+interface StatusSnapshotReadResult {
+  readonly raw: string | null;
+  readonly snapshot: FactoryStatusSnapshot | null;
+  readonly error: Error | null;
+}
+
+export interface FactoryControlDeps {
+  readonly cwd?: () => string;
+  readonly pathExists?: (targetPath: string) => Promise<boolean>;
+  readonly loadWorkflowWorkspaceRoot?: (
+    workflowPath: string,
+  ) => Promise<string>;
+  readonly readFile?: (filePath: string, encoding: "utf8") => Promise<string>;
+  readonly listProcesses?: () => Promise<readonly HostProcessSnapshot[]>;
+  readonly listScreenSessions?: () => Promise<readonly ScreenSessionSnapshot[]>;
+  readonly launchScreenSession?: (options: {
+    readonly runtimeRoot: string;
+    readonly sessionName: string;
+  }) => Promise<void>;
+  readonly quitScreenSession?: (sessionId: string) => Promise<void>;
+  readonly signalProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  readonly isProcessAlive?: (pid: number) => boolean;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+}
+
+export async function resolveFactoryPaths(
+  deps: FactoryControlDeps = {},
+): Promise<FactoryPaths> {
+  const cwd = deps.cwd ?? (() => process.cwd());
+  const pathExists = deps.pathExists ?? defaultPathExists;
+  const loadWorkspaceRoot =
+    deps.loadWorkflowWorkspaceRoot ?? loadWorkflowWorkspaceRoot;
+
+  const repoRoot = await findFactoryRepoRoot(cwd(), pathExists);
+  const runtimeRoot = path.join(repoRoot, FACTORY_RUNTIME_DIRECTORY);
+
+  if (!(await pathExists(runtimeRoot))) {
+    throw new Error(
+      `Factory runtime checkout not found at ${runtimeRoot}. Prepare ${FACTORY_RUNTIME_DIRECTORY} before using 'symphony factory'.`,
+    );
+  }
+
+  const workflowPath = path.join(runtimeRoot, "WORKFLOW.md");
+  if (!(await pathExists(workflowPath))) {
+    throw new Error(
+      `Factory runtime workflow not found at ${workflowPath}. The runtime checkout is incomplete.`,
+    );
+  }
+
+  const workspaceRoot = await loadWorkspaceRoot(workflowPath).catch((error) => {
+    throw new Error(
+      `Could not determine the factory status file path from ${workflowPath}.`,
+      { cause: error as Error },
+    );
+  });
+
+  return {
+    repoRoot,
+    runtimeRoot,
+    workflowPath,
+    statusFilePath: deriveStatusFilePath(workspaceRoot),
+  };
+}
+
+export async function inspectFactoryControl(
+  deps: FactoryControlDeps = {},
+): Promise<FactoryControlStatusSnapshot> {
+  const paths = await resolveFactoryPaths(deps);
+  return inspectFactoryControlAtPaths(paths, deps);
+}
+
+export async function startFactory(
+  deps: FactoryControlDeps = {},
+): Promise<FactoryControlStartResult> {
+  const paths = await resolveFactoryPaths(deps);
+  const current = await inspectFactoryControlAtPaths(paths, deps);
+  if (current.controlState === "running") {
+    return {
+      kind: "already-running",
+      status: current,
+    };
+  }
+
+  if (current.controlState === "degraded" && current.sessions.length > 1) {
+    throw new Error(
+      "Factory control found multiple detached screen sessions; run 'symphony factory stop' after inspecting the runtime.",
+    );
+  }
+
+  if (current.controlState === "degraded") {
+    await stopFactoryAtPaths(paths, deps);
+  }
+
+  const launchScreenSession =
+    deps.launchScreenSession ?? defaultLaunchScreenSession;
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? (() => Date.now());
+
+  await launchScreenSession({
+    runtimeRoot: paths.runtimeRoot,
+    sessionName: FACTORY_SCREEN_SESSION_NAME,
+  });
+
+  const deadline = now() + START_TIMEOUT_MS;
+  for (;;) {
+    const status = await inspectFactoryControlAtPaths(paths, deps);
+    if (status.controlState === "running") {
+      return {
+        kind: "started",
+        status,
+      };
+    }
+    if (now() >= deadline) {
+      throw new Error(
+        `Factory start timed out before a healthy runtime appeared under ${paths.runtimeRoot}.`,
+      );
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+export async function stopFactory(
+  deps: FactoryControlDeps = {},
+): Promise<FactoryControlStopResult> {
+  const paths = await resolveFactoryPaths(deps);
+  return stopFactoryAtPaths(paths, deps);
+}
+
+export function renderFactoryControlStatus(
+  snapshot: FactoryControlStatusSnapshot,
+  options?: {
+    readonly format?: "human" | "json";
+  },
+): string {
+  const format = options?.format ?? "human";
+  if (format === "json") {
+    return `${JSON.stringify(snapshot, null, 2)}\n`;
+  }
+
+  const lines = [
+    `Factory control: ${snapshot.controlState}`,
+    `Repository root: ${snapshot.paths.repoRoot}`,
+    `Runtime root: ${snapshot.paths.runtimeRoot}`,
+    `Screen session: ${snapshot.sessionName}`,
+  ];
+
+  if (snapshot.sessions.length === 0) {
+    lines.push("Screen session state: none");
+  } else {
+    lines.push(
+      `Screen session state: ${snapshot.sessions
+        .map((session) => `${session.id} (${session.state})`)
+        .join(", ")}`,
+    );
+  }
+
+  if (snapshot.problems.length > 0) {
+    lines.push(`Problems: ${snapshot.problems.join(" | ")}`);
+  }
+
+  if (snapshot.statusSnapshot === null) {
+    lines.push(`Status snapshot: ${snapshot.paths.statusFilePath}`);
+    lines.push("Status detail: no readable runtime snapshot");
+  } else {
+    lines.push("");
+    lines.push(
+      renderFactoryStatusSnapshot(snapshot.statusSnapshot, {
+        workerAlive: snapshot.workerAlive,
+        statusFilePath: snapshot.paths.statusFilePath,
+      }),
+    );
+  }
+
+  if (
+    snapshot.controlState !== "stopped" &&
+    snapshot.statusSnapshot === null &&
+    snapshot.processIds.length > 0
+  ) {
+    lines.push(`Tracked PIDs: ${snapshot.processIds.join(", ")}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function parsePsOutput(output: string): readonly HostProcessSnapshot[] {
+  const processes: HostProcessSnapshot[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    processes.push({
+      pid: Number.parseInt(match[1]!, 10),
+      ppid: Number.parseInt(match[2]!, 10),
+      command: match[3]!,
+    });
+  }
+  return processes;
+}
+
+export function parseScreenLsOutput(
+  output: string,
+): readonly ScreenSessionSnapshot[] {
+  const sessions: ScreenSessionSnapshot[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match =
+      /^\s*(\d+)\.([^\s]+)\s+\(([^)]+)\)\s*$/.exec(line) ??
+      /^\t*(\d+)\.([^\s]+)\t+\(([^)]+)\)\s*$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    sessions.push({
+      id: `${match[1]!}.${match[2]!}`,
+      pid: Number.parseInt(match[1]!, 10),
+      name: match[2]!,
+      state: match[3]!,
+    });
+  }
+  return sessions;
+}
+
+export function collectDescendantProcessIds(
+  processes: readonly HostProcessSnapshot[],
+  rootPids: readonly number[],
+): readonly number[] {
+  const byParent = new Map<number, number[]>();
+  for (const processSnapshot of processes) {
+    const children = byParent.get(processSnapshot.ppid) ?? [];
+    children.push(processSnapshot.pid);
+    byParent.set(processSnapshot.ppid, children);
+  }
+
+  const seen = new Set<number>();
+  const queue = [...rootPids];
+  while (queue.length > 0) {
+    const pid = queue.shift()!;
+    if (seen.has(pid)) {
+      continue;
+    }
+    seen.add(pid);
+    for (const childPid of byParent.get(pid) ?? []) {
+      queue.push(childPid);
+    }
+  }
+
+  return [...seen];
+}
+
+async function inspectFactoryControlAtPaths(
+  paths: FactoryPaths,
+  deps: FactoryControlDeps,
+): Promise<FactoryControlStatusSnapshot> {
+  const listProcesses = deps.listProcesses ?? defaultListProcesses;
+  const listScreenSessions =
+    deps.listScreenSessions ?? defaultListScreenSessions;
+  const isAlive = deps.isProcessAlive ?? isProcessAlive;
+
+  const [processes, sessions, snapshotRead] = await Promise.all([
+    listProcesses(),
+    listScreenSessions(),
+    readStatusSnapshot(paths.statusFilePath, deps),
+  ]);
+
+  const matchingSessions = sessions.filter(
+    (session) => session.name === FACTORY_SCREEN_SESSION_NAME,
+  );
+  const processIds = collectObservedFactoryPids(
+    processes,
+    matchingSessions,
+    snapshotRead.snapshot,
+    isAlive,
+  );
+  const problems: string[] = [];
+
+  if (matchingSessions.length > 1) {
+    problems.push(
+      `multiple detached screen sessions match ${FACTORY_SCREEN_SESSION_NAME}`,
+    );
+  }
+  if (snapshotRead.error !== null) {
+    problems.push(snapshotRead.error.message);
+  }
+
+  const workerAlive =
+    snapshotRead.snapshot === null
+      ? false
+      : isAlive(snapshotRead.snapshot.worker.pid);
+
+  let controlState: FactoryControlState = "stopped";
+  if (matchingSessions.length === 0 && processIds.length === 0) {
+    controlState = "stopped";
+  } else if (
+    matchingSessions.length === 1 &&
+    snapshotRead.snapshot !== null &&
+    workerAlive &&
+    problems.length === 0
+  ) {
+    controlState = "running";
+  } else {
+    controlState = "degraded";
+    if (
+      snapshotRead.snapshot !== null &&
+      !workerAlive &&
+      !problems.includes("worker pid from status snapshot is not alive")
+    ) {
+      problems.push("worker pid from status snapshot is not alive");
+    }
+    if (matchingSessions.length === 0 && processIds.length > 0) {
+      problems.push(
+        "detached screen session is missing but factory-owned processes remain",
+      );
+    }
+    if (matchingSessions.length > 0 && snapshotRead.snapshot === null) {
+      problems.push(
+        "screen session exists but no readable runtime status snapshot was found",
+      );
+    }
+  }
+
+  return {
+    controlState,
+    paths,
+    sessionName: FACTORY_SCREEN_SESSION_NAME,
+    sessions: matchingSessions,
+    workerAlive,
+    statusSnapshot: snapshotRead.snapshot,
+    processIds,
+    problems,
+  };
+}
+
+async function stopFactoryAtPaths(
+  paths: FactoryPaths,
+  deps: FactoryControlDeps,
+): Promise<FactoryControlStopResult> {
+  const listProcesses = deps.listProcesses ?? defaultListProcesses;
+  const quitScreenSession = deps.quitScreenSession ?? defaultQuitScreenSession;
+  const signalProcess =
+    deps.signalProcess ??
+    ((pid: number, signal: NodeJS.Signals) => {
+      process.kill(pid, signal);
+    });
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? (() => Date.now());
+
+  const initialStatus = await inspectFactoryControlAtPaths(paths, deps);
+  if (
+    initialStatus.controlState === "stopped" &&
+    initialStatus.processIds.length === 0
+  ) {
+    return {
+      kind: "already-stopped",
+      status: initialStatus,
+      terminatedPids: [],
+    };
+  }
+
+  for (const session of initialStatus.sessions) {
+    await quitScreenSession(session.id).catch((error) => {
+      throw new Error(`Failed to stop detached screen session ${session.id}.`, {
+        cause: error as Error,
+      });
+    });
+  }
+
+  let targetPids = new Set<number>(initialStatus.processIds);
+  targetPids.delete(process.pid);
+  const terminatedPids = new Set<number>();
+  const deadline = now() + STOP_TIMEOUT_MS;
+  let escalated = false;
+
+  for (;;) {
+    const processes = await listProcesses();
+    const liveProcessIds = new Set(
+      processes.map((processSnapshot) => processSnapshot.pid),
+    );
+    targetPids = new Set(
+      collectDescendantProcessIds(processes, [...targetPids]).filter(
+        (pid) => pid !== process.pid,
+      ),
+    );
+    const remaining = [...targetPids].filter((pid) => liveProcessIds.has(pid));
+
+    if (remaining.length === 0) {
+      const finalStatus = await inspectFactoryControlAtPaths(paths, deps);
+      return {
+        kind: "stopped",
+        status: finalStatus,
+        terminatedPids: [...terminatedPids],
+      };
+    }
+
+    for (const pid of remaining) {
+      try {
+        signalProcess(pid, escalated ? "SIGKILL" : "SIGTERM");
+        terminatedPids.add(pid);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ESRCH") {
+          throw error;
+        }
+      }
+    }
+
+    if (now() >= deadline) {
+      if (escalated) {
+        throw new Error(
+          `Factory stop timed out; processes still running: ${remaining.join(", ")}`,
+        );
+      }
+      escalated = true;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+async function findFactoryRepoRoot(
+  startingPath: string,
+  pathExists: (targetPath: string) => Promise<boolean>,
+): Promise<string> {
+  let current = path.resolve(startingPath);
+
+  for (;;) {
+    const runtimeRoot = path.join(current, FACTORY_RUNTIME_DIRECTORY);
+    if (await pathExists(runtimeRoot)) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(
+        `Could not find a repository root containing ${FACTORY_RUNTIME_DIRECTORY} from ${startingPath}. Run 'symphony factory' from the repository root.`,
+      );
+    }
+    current = parent;
+  }
+}
+
+function collectObservedFactoryPids(
+  processes: readonly HostProcessSnapshot[],
+  sessions: readonly ScreenSessionSnapshot[],
+  snapshot: FactoryStatusSnapshot | null,
+  isAlive: (pid: number) => boolean,
+): readonly number[] {
+  const rootPids = new Set<number>(sessions.map((session) => session.pid));
+
+  if (snapshot !== null) {
+    for (const pid of collectSnapshotProcessIds(snapshot)) {
+      if (isAlive(pid)) {
+        rootPids.add(pid);
+      }
+    }
+  }
+
+  return collectDescendantProcessIds(processes, [...rootPids]).filter(
+    (pid) => pid !== process.pid,
+  );
+}
+
+function collectSnapshotProcessIds(
+  snapshot: FactoryStatusSnapshot,
+): readonly number[] {
+  const pids = new Set<number>();
+  pids.add(snapshot.worker.pid);
+  for (const issue of snapshot.activeIssues) {
+    if (issue.ownerPid !== null && issue.ownerPid > 0) {
+      pids.add(issue.ownerPid);
+    }
+    if (issue.runnerPid !== null && issue.runnerPid > 0) {
+      pids.add(issue.runnerPid);
+    }
+  }
+  return [...pids];
+}
+
+async function readStatusSnapshot(
+  filePath: string,
+  deps: FactoryControlDeps,
+): Promise<StatusSnapshotReadResult> {
+  const readFile = deps.readFile ?? fs.readFile;
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return {
+      raw,
+      snapshot: parseFactoryStatusSnapshotContent(raw, filePath),
+      error: null,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        raw: null,
+        snapshot: null,
+        error: null,
+      };
+    }
+
+    return {
+      raw: null,
+      snapshot: null,
+      error: new Error(
+        `Failed to read factory status snapshot at ${filePath}. Re-run 'symphony run' inside the runtime checkout to regenerate it.`,
+        { cause: error as Error },
+      ),
+    };
+  }
+}
+
+async function defaultPathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function defaultListProcesses(): Promise<readonly HostProcessSnapshot[]> {
+  const { stdout } = await execFile("ps", ["-ax", "-o", "pid=,ppid=,command="]);
+  return parsePsOutput(stdout);
+}
+
+async function defaultListScreenSessions(): Promise<
+  readonly ScreenSessionSnapshot[]
+> {
+  try {
+    const { stdout } = await execFile("screen", ["-ls"]);
+    return parseScreenLsOutput(stdout);
+  } catch (error) {
+    const stdout = String((error as { stdout?: string }).stdout ?? "");
+    const stderr = String((error as { stderr?: string }).stderr ?? "");
+    if (
+      stdout.includes("No Sockets found") ||
+      stderr.includes("No Sockets found")
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function defaultLaunchScreenSession(options: {
+  readonly runtimeRoot: string;
+  readonly sessionName: string;
+}): Promise<void> {
+  await execFile(
+    "screen",
+    ["-dmS", options.sessionName, "pnpm", "tsx", "bin/symphony.ts", "run"],
+    {
+      cwd: options.runtimeRoot,
+    },
+  );
+}
+
+async function defaultQuitScreenSession(sessionId: string): Promise<void> {
+  await execFile("screen", ["-S", sessionId, "-X", "quit"]);
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -438,13 +438,21 @@ async function stopFactoryAtPaths(
     };
   }
 
-  for (const session of initialStatus.sessions) {
-    await quitScreenSession(session.id).catch((error) => {
-      throw new Error(`Failed to stop detached screen session ${session.id}.`, {
-        cause: error as Error,
-      });
-    });
-  }
+  await Promise.all(
+    initialStatus.sessions.map((session) =>
+      quitScreenSession(session.id).catch((error) => {
+        if (isMissingScreenSessionError(error)) {
+          return;
+        }
+        throw new Error(
+          `Failed to stop detached screen session ${session.id}.`,
+          {
+            cause: error as Error,
+          },
+        );
+      }),
+    ),
+  );
 
   let targetPids = new Set<number>(initialStatus.processIds);
   targetPids.delete(process.pid);
@@ -653,4 +661,25 @@ async function defaultQuitScreenSession(sessionId: string): Promise<void> {
 
 async function defaultSleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isMissingScreenSessionError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ESRCH") {
+    return true;
+  }
+
+  const stdout = String(
+    (error as { stdout?: string } | undefined)?.stdout ?? "",
+  );
+  const stderr = String(
+    (error as { stderr?: string } | undefined)?.stderr ?? "",
+  );
+  const message = error instanceof Error ? error.message : "";
+  const combined = `${stdout}\n${stderr}\n${message}`.toLowerCase();
+  return (
+    combined.includes("no screen session found") ||
+    combined.includes("no such screen session") ||
+    combined.includes("no such session")
+  );
 }

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -651,6 +651,7 @@ async function defaultLaunchScreenSession(options: {
     ["-dmS", options.sessionName, "pnpm", "tsx", "bin/symphony.ts", "run"],
     {
       cwd: options.runtimeRoot,
+      timeout: 5_000,
     },
   );
 }

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -272,7 +272,9 @@ export function parseScreenLsOutput(
 ): readonly ScreenSessionSnapshot[] {
   const sessions: ScreenSessionSnapshot[] = [];
   for (const line of output.split(/\r?\n/)) {
-    const match = /^\s*(\d+)\.([^\s]+)\s+\(([^)]+)\)\s*$/.exec(line);
+    const match = /^\s*(\d+)\.([^\s]+)(?:\s+\([^)]+\))*\s+\(([^)]+)\)\s*$/.exec(
+      line,
+    );
     if (!match) {
       continue;
     }
@@ -284,6 +286,21 @@ export function parseScreenLsOutput(
     });
   }
   return sessions;
+}
+
+export function parseScreenLsFailureOutput(
+  stdout: string,
+  stderr: string,
+): readonly ScreenSessionSnapshot[] | null {
+  if (
+    stdout.includes("No Sockets found") ||
+    stderr.includes("No Sockets found")
+  ) {
+    return [];
+  }
+
+  const sessions = parseScreenLsOutput(stdout);
+  return sessions.length > 0 ? sessions : null;
 }
 
 export function collectDescendantProcessIds(
@@ -600,11 +617,9 @@ async function defaultListScreenSessions(): Promise<
   } catch (error) {
     const stdout = String((error as { stdout?: string }).stdout ?? "");
     const stderr = String((error as { stderr?: string }).stderr ?? "");
-    if (
-      stdout.includes("No Sockets found") ||
-      stderr.includes("No Sockets found")
-    ) {
-      return [];
+    const sessions = parseScreenLsFailureOutput(stdout, stderr);
+    if (sessions !== null) {
+      return sessions;
     }
     throw error;
   }

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -60,6 +60,7 @@ export interface FactoryControlStartResult {
 export interface FactoryControlStopResult {
   readonly kind: "stopped" | "already-stopped";
   readonly status: FactoryControlStatusSnapshot;
+  // PIDs that were sent at least one termination signal while stopping.
   readonly terminatedPids: readonly number[];
 }
 
@@ -272,11 +273,15 @@ export function parseScreenLsOutput(
     if (!match) {
       continue;
     }
+    const state = match[3]!;
+    if (/^dead$/i.test(state)) {
+      continue;
+    }
     sessions.push({
       id: `${match[1]!}.${match[2]!}`,
       pid: Number.parseInt(match[1]!, 10),
       name: match[2]!,
-      state: match[3]!,
+      state,
     });
   }
   return sessions;
@@ -609,6 +614,13 @@ async function defaultListScreenSessions(): Promise<
     const { stdout } = await execFile("screen", ["-ls"]);
     return parseScreenLsOutput(stdout);
   } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOEXEC") {
+      throw new Error(
+        "Could not run 'screen'. Install GNU Screen before using 'symphony factory'.",
+        { cause: error as Error },
+      );
+    }
     const stdout = String((error as { stdout?: string }).stdout ?? "");
     const stderr = String((error as { stderr?: string }).stderr ?? "");
     const sessions = parseScreenLsFailureOutput(stdout, stderr);

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -272,9 +272,7 @@ export function parseScreenLsOutput(
 ): readonly ScreenSessionSnapshot[] {
   const sessions: ScreenSessionSnapshot[] = [];
   for (const line of output.split(/\r?\n/)) {
-    const match =
-      /^\s*(\d+)\.([^\s]+)\s+\(([^)]+)\)\s*$/.exec(line) ??
-      /^\t*(\d+)\.([^\s]+)\t+\(([^)]+)\)\s*$/.exec(line);
+    const match = /^\s*(\d+)\.([^\s]+)\s+\(([^)]+)\)\s*$/.exec(line);
     if (!match) {
       continue;
     }
@@ -413,10 +411,7 @@ async function stopFactoryAtPaths(
   const now = deps.now ?? (() => Date.now());
 
   const initialStatus = await inspectFactoryControlAtPaths(paths, deps);
-  if (
-    initialStatus.controlState === "stopped" &&
-    initialStatus.processIds.length === 0
-  ) {
+  if (initialStatus.controlState === "stopped") {
     return {
       kind: "already-stopped",
       status: initialStatus,
@@ -437,6 +432,7 @@ async function stopFactoryAtPaths(
   const terminatedPids = new Set<number>();
   const deadline = now() + STOP_TIMEOUT_MS;
   let escalated = false;
+  let awaitingPostKillPoll = false;
 
   for (;;) {
     const processes = await listProcesses();
@@ -473,11 +469,17 @@ async function stopFactoryAtPaths(
 
     if (now() >= deadline) {
       if (escalated) {
-        throw new Error(
-          `Factory stop timed out; processes still running: ${remaining.join(", ")}`,
-        );
+        if (awaitingPostKillPoll) {
+          awaitingPostKillPoll = false;
+        } else {
+          throw new Error(
+            `Factory stop timed out; processes still running: ${remaining.join(", ")}`,
+          );
+        }
+      } else {
+        escalated = true;
+        awaitingPostKillPoll = true;
       }
-      escalated = true;
     }
 
     await sleep(POLL_INTERVAL_MS);

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -347,15 +347,18 @@ async function inspectFactoryControlAtPaths(
   const matchingSessions = sessions.filter(
     (session) => session.name === FACTORY_SCREEN_SESSION_NAME,
   );
+  const liveSessions = matchingSessions.filter(
+    (session) => !/^dead$/i.test(session.state),
+  );
   const processIds = collectObservedFactoryPids(
     processes,
-    matchingSessions,
+    liveSessions,
     snapshotRead.snapshot,
     isAlive,
   );
   const problems: string[] = [];
 
-  if (matchingSessions.length > 1) {
+  if (liveSessions.length > 1) {
     problems.push(
       `multiple detached screen sessions match ${FACTORY_SCREEN_SESSION_NAME}`,
     );
@@ -370,10 +373,10 @@ async function inspectFactoryControlAtPaths(
       : isAlive(snapshotRead.snapshot.worker.pid);
 
   let controlState: FactoryControlState = "stopped";
-  if (matchingSessions.length === 0 && processIds.length === 0) {
+  if (liveSessions.length === 0 && processIds.length === 0) {
     controlState = "stopped";
   } else if (
-    matchingSessions.length === 1 &&
+    liveSessions.length === 1 &&
     snapshotRead.snapshot !== null &&
     workerAlive &&
     problems.length === 0
@@ -388,12 +391,12 @@ async function inspectFactoryControlAtPaths(
     ) {
       problems.push("worker pid from status snapshot is not alive");
     }
-    if (matchingSessions.length === 0 && processIds.length > 0) {
+    if (liveSessions.length === 0 && processIds.length > 0) {
       problems.push(
         "detached screen session is missing but factory-owned processes remain",
       );
     }
-    if (matchingSessions.length > 0 && snapshotRead.snapshot === null) {
+    if (liveSessions.length > 0 && snapshotRead.snapshot === null) {
       problems.push(
         "screen session exists but no readable runtime status snapshot was found",
       );
@@ -404,7 +407,7 @@ async function inspectFactoryControlAtPaths(
     controlState,
     paths,
     sessionName: FACTORY_SCREEN_SESSION_NAME,
-    sessions: matchingSessions,
+    sessions: liveSessions,
     workerAlive,
     statusSnapshot: snapshotRead.snapshot,
     processIds,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -92,6 +92,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         format: args.includes("--json") ? "json" : "human",
       };
     }
+    throw new Error("Usage: symphony factory <start|stop|restart|status>");
   }
 
   throw new Error(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -92,7 +92,9 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         format: args.includes("--json") ? "json" : "human",
       };
     }
-    throw new Error("Usage: symphony factory <start|stop|restart|status>");
+    throw new Error(
+      "Usage: symphony factory <start|stop|restart|status> [--json]",
+    );
   }
 
   throw new Error(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,12 @@ import { FsLivenessProbe } from "../orchestrator/liveness-probe.js";
 import { createRunner } from "../runner/factory.js";
 import { createTracker } from "../tracker/factory.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
+import {
+  inspectFactoryControl,
+  renderFactoryControlStatus,
+  startFactory,
+  stopFactory,
+} from "./factory-control.js";
 
 export type CliArgs =
   | {
@@ -29,6 +35,15 @@ export type CliArgs =
       readonly format: "human" | "json";
       readonly workflowPath: string | null;
       readonly statusFilePath: string | null;
+    }
+  | {
+      readonly command: "factory";
+      readonly action: "start" | "stop" | "restart";
+    }
+  | {
+      readonly command: "factory";
+      readonly action: "status";
+      readonly format: "human" | "json";
     };
 
 export function parseArgs(argv: readonly string[]): CliArgs {
@@ -62,51 +77,129 @@ export function parseArgs(argv: readonly string[]): CliArgs {
     };
   }
 
+  if (command === "factory") {
+    const action = args[1];
+    if (action === "start" || action === "stop" || action === "restart") {
+      return {
+        command: "factory",
+        action,
+      };
+    }
+    if (action === "status") {
+      return {
+        command: "factory",
+        action: "status",
+        format: args.includes("--json") ? "json" : "human",
+      };
+    }
+  }
+
   throw new Error(
-    "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
+    "Usage: symphony <run|status|factory> [--once] [--json] [--workflow <path>] [--status-file <path>]",
   );
 }
 
 export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseArgs(argv);
-  if (args.command === "status") {
-    const effectiveWorkflowPath =
-      args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md");
-    const statusFilePath =
-      args.statusFilePath ??
-      (await resolveStatusFilePath(effectiveWorkflowPath).catch((error) => {
-        throw new Error(
-          `Could not determine status file path from workflow at ${effectiveWorkflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
-          { cause: error as Error },
+  switch (args.command) {
+    case "factory":
+      switch (args.action) {
+        case "start": {
+          const result = await startFactory();
+          process.stdout.write(
+            `Factory ${result.kind === "started" ? "started" : "already running"}.\n`,
+          );
+          process.stdout.write(renderFactoryControlStatus(result.status));
+          return;
+        }
+
+        case "stop": {
+          const result = await stopFactory();
+          process.stdout.write(
+            `Factory ${result.kind === "stopped" ? "stopped" : "already stopped"}.\n`,
+          );
+          if (result.terminatedPids.length > 0) {
+            process.stdout.write(
+              `Terminated PIDs: ${result.terminatedPids.join(", ")}\n`,
+            );
+          }
+          process.stdout.write(renderFactoryControlStatus(result.status));
+          return;
+        }
+
+        case "restart": {
+          const stopResult = await stopFactory();
+          const startResult = await startFactory();
+          process.stdout.write(
+            `Factory ${stopResult.kind === "already-stopped" ? "was already stopped and is now running again" : "restarted"}.\n`,
+          );
+          if (stopResult.terminatedPids.length > 0) {
+            process.stdout.write(
+              `Terminated PIDs: ${stopResult.terminatedPids.join(", ")}\n`,
+            );
+          }
+          process.stdout.write(renderFactoryControlStatus(startResult.status));
+          return;
+        }
+
+        case "status": {
+          const snapshot = await inspectFactoryControl();
+          process.stdout.write(
+            renderFactoryControlStatus(snapshot, {
+              format: args.format,
+            }),
+          );
+          process.exitCode = snapshot.controlState === "degraded" ? 1 : 0;
+          return;
+        }
+      }
+      return;
+
+    case "status": {
+      const effectiveWorkflowPath =
+        args.workflowPath ?? path.resolve(process.cwd(), "WORKFLOW.md");
+      const statusFilePath =
+        args.statusFilePath ??
+        (await resolveStatusFilePath(effectiveWorkflowPath).catch((error) => {
+          throw new Error(
+            `Could not determine status file path from workflow at ${effectiveWorkflowPath}. Use --status-file <path> to specify the snapshot location directly.`,
+            { cause: error as Error },
+          );
+        }));
+      let snapshot;
+      let rawSnapshot = "";
+      try {
+        rawSnapshot = await fs.readFile(statusFilePath, "utf8");
+        snapshot = parseFactoryStatusSnapshotContent(
+          rawSnapshot,
+          statusFilePath,
         );
-      }));
-    let snapshot;
-    let rawSnapshot = "";
-    try {
-      rawSnapshot = await fs.readFile(statusFilePath, "utf8");
-      snapshot = parseFactoryStatusSnapshotContent(rawSnapshot, statusFilePath);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") {
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          throw new Error(
+            `No factory status snapshot found at ${statusFilePath}. Start Symphony with 'symphony run' first.`,
+            { cause: error as Error },
+          );
+        }
         throw new Error(
-          `No factory status snapshot found at ${statusFilePath}. Start Symphony with 'symphony run' first.`,
+          `Failed to read factory status snapshot at ${statusFilePath}. The file may be corrupt; re-running 'symphony run' will regenerate it.`,
           { cause: error as Error },
         );
       }
-      throw new Error(
-        `Failed to read factory status snapshot at ${statusFilePath}. The file may be corrupt; re-running 'symphony run' will regenerate it.`,
-        { cause: error as Error },
-      );
+      const output =
+        args.format === "json"
+          ? rawSnapshot
+          : `${renderFactoryStatusSnapshot(snapshot, {
+              workerAlive: isProcessAlive(snapshot.worker.pid),
+              statusFilePath,
+            })}\n`;
+      process.stdout.write(output);
+      return;
     }
-    const output =
-      args.format === "json"
-        ? rawSnapshot
-        : `${renderFactoryStatusSnapshot(snapshot, {
-            workerAlive: isProcessAlive(snapshot.worker.pid),
-            statusFilePath,
-          })}\n`;
-    process.stdout.write(output);
-    return;
+
+    case "run":
+      break;
   }
 
   const logger = new JsonLogger();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,6 +39,7 @@ export type CliArgs =
   | {
       readonly command: "factory";
       readonly action: "start" | "stop" | "restart";
+      readonly format: "human" | "json";
     }
   | {
       readonly command: "factory";
@@ -83,6 +84,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
       return {
         command: "factory",
         action,
+        format: args.includes("--json") ? "json" : "human",
       };
     }
     if (action === "status") {
@@ -112,7 +114,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
           process.stdout.write(
             `Factory ${result.kind === "started" ? "started" : "already running"}.\n`,
           );
-          process.stdout.write(renderFactoryControlStatus(result.status));
+          process.stdout.write(
+            renderFactoryControlStatus(result.status, {
+              format: args.format,
+            }),
+          );
           return;
         }
 
@@ -126,7 +132,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
               `Terminated PIDs: ${result.terminatedPids.join(", ")}\n`,
             );
           }
-          process.stdout.write(renderFactoryControlStatus(result.status));
+          process.stdout.write(
+            renderFactoryControlStatus(result.status, {
+              format: args.format,
+            }),
+          );
           return;
         }
 
@@ -148,7 +158,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
               `Terminated PIDs: ${stopResult.terminatedPids.join(", ")}\n`,
             );
           }
-          process.stdout.write(renderFactoryControlStatus(startResult.status));
+          process.stdout.write(
+            renderFactoryControlStatus(startResult.status, {
+              format: args.format,
+            }),
+          );
           return;
         }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -133,9 +133,16 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         case "restart": {
           const stopResult = await stopFactory();
           const startResult = await startFactory();
-          process.stdout.write(
-            `Factory ${stopResult.kind === "already-stopped" ? "was already stopped and is now running again" : "restarted"}.\n`,
-          );
+          const verb =
+            stopResult.kind === "already-stopped" &&
+            startResult.kind === "already-running"
+              ? "was already running"
+              : stopResult.kind === "already-stopped"
+                ? "was already stopped and is now running again"
+                : startResult.kind === "already-running"
+                  ? "was stopped but is already running again"
+                  : "restarted";
+          process.stdout.write(`Factory ${verb}.\n`);
           if (stopResult.terminatedPids.length > 0) {
             process.stdout.write(
               `Terminated PIDs: ${stopResult.terminatedPids.join(", ")}\n`,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -483,6 +483,68 @@ describe("runCli run", () => {
 });
 
 describe("runCli factory", () => {
+  it("renders a precise restart message when the factory is already running again", async () => {
+    vi.resetModules();
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
+      startFactory: vi.fn(async () => ({
+        kind: "already-running",
+        status: {
+          controlState: "running",
+          paths: {
+            repoRoot: "/repo",
+            runtimeRoot: "/repo/.tmp/factory-main",
+            workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+            statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+          },
+          sessionName: "symphony-factory",
+          sessions: [],
+          workerAlive: true,
+          statusSnapshot: null,
+          processIds: [],
+          problems: [],
+        },
+      })),
+      stopFactory: vi.fn(async () => ({
+        kind: "already-stopped",
+        status: {
+          controlState: "stopped",
+          paths: {
+            repoRoot: "/repo",
+            runtimeRoot: "/repo/.tmp/factory-main",
+            workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+            statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+          },
+          sessionName: "symphony-factory",
+          sessions: [],
+          workerAlive: false,
+          statusSnapshot: null,
+          processIds: [],
+          problems: [],
+        },
+        terminatedPids: [],
+      })),
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await mockedRunCli(["node", "symphony", "factory", "restart"]);
+
+    expect(stdout.join("")).toContain("Factory was already running.");
+  });
+
   it("renders factory status and exits zero for stopped control state", async () => {
     vi.resetModules();
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -175,6 +175,7 @@ describe("parseArgs", () => {
     expect(args).toEqual({
       command: "factory",
       action: "restart",
+      format: "human",
     });
   });
 
@@ -182,10 +183,36 @@ describe("parseArgs", () => {
     expect(parseArgs(["node", "symphony", "factory", "start"])).toEqual({
       command: "factory",
       action: "start",
+      format: "human",
     });
     expect(parseArgs(["node", "symphony", "factory", "stop"])).toEqual({
       command: "factory",
       action: "stop",
+      format: "human",
+    });
+  });
+
+  it("parses --json for factory start, stop, and restart", () => {
+    expect(
+      parseArgs(["node", "symphony", "factory", "start", "--json"]),
+    ).toEqual({
+      command: "factory",
+      action: "start",
+      format: "json",
+    });
+    expect(
+      parseArgs(["node", "symphony", "factory", "stop", "--json"]),
+    ).toEqual({
+      command: "factory",
+      action: "stop",
+      format: "json",
+    });
+    expect(
+      parseArgs(["node", "symphony", "factory", "restart", "--json"]),
+    ).toEqual({
+      command: "factory",
+      action: "restart",
+      format: "json",
     });
   });
 
@@ -543,6 +570,54 @@ describe("runCli factory", () => {
     await mockedRunCli(["node", "symphony", "factory", "restart"]);
 
     expect(stdout.join("")).toContain("Factory was already running.");
+  });
+
+  it("renders factory start status as JSON when requested", async () => {
+    vi.resetModules();
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(),
+      renderFactoryControlStatus: vi.fn((_snapshot, options) =>
+        options?.format === "json"
+          ? '{\n  "controlState": "running"\n}\n'
+          : "Factory control: running\n",
+      ),
+      startFactory: vi.fn(async () => ({
+        kind: "started",
+        status: {
+          controlState: "running",
+          paths: {
+            repoRoot: "/repo",
+            runtimeRoot: "/repo/.tmp/factory-main",
+            workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+            statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+          },
+          sessionName: "symphony-factory",
+          sessions: [],
+          workerAlive: true,
+          statusSnapshot: null,
+          processIds: [],
+          problems: [],
+        },
+      })),
+      stopFactory: vi.fn(),
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await mockedRunCli(["node", "symphony", "factory", "start", "--json"]);
+
+    expect(stdout.join("")).toContain('{\n  "controlState": "running"\n}\n');
   });
 
   it("renders factory status and exits zero for stopped control state", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -117,6 +117,7 @@ function createSnapshot(): FactoryStatusSnapshot {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  process.exitCode = undefined;
 });
 
 describe("parseArgs", () => {
@@ -131,7 +132,7 @@ describe("parseArgs", () => {
 
   it("fails when the run command is missing", () => {
     expect(() => parseArgs(["node", "symphony"])).toThrowError(
-      "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
+      "Usage: symphony <run|status|factory> [--once] [--json] [--workflow <path>] [--status-file <path>]",
     );
   });
 
@@ -156,8 +157,25 @@ describe("parseArgs", () => {
     expect(() =>
       parseArgs(["node", "symphony", "deploy", "--workflow"]),
     ).toThrowError(
-      "Usage: symphony <run|status> [--once] [--json] [--workflow <path>] [--status-file <path>]",
+      "Usage: symphony <run|status|factory> [--once] [--json] [--workflow <path>] [--status-file <path>]",
     );
+  });
+
+  it("parses the factory status command", () => {
+    const args = parseArgs(["node", "symphony", "factory", "status", "--json"]);
+    expect(args).toEqual({
+      command: "factory",
+      action: "status",
+      format: "json",
+    });
+  });
+
+  it("parses the factory restart command", () => {
+    const args = parseArgs(["node", "symphony", "factory", "restart"]);
+    expect(args).toEqual({
+      command: "factory",
+      action: "restart",
+    });
   });
 });
 
@@ -439,5 +457,80 @@ describe("runCli run", () => {
     expect(orchestratorArgs).not.toBeNull();
     expect(orchestratorArgs?.[7]).toBeDefined();
     expect(runOnce).toHaveBeenCalledOnce();
+  });
+});
+
+describe("runCli factory", () => {
+  it("renders factory status and exits zero for stopped control state", async () => {
+    vi.resetModules();
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(async () => ({
+        controlState: "stopped",
+        paths: {
+          repoRoot: "/repo",
+          runtimeRoot: "/repo/.tmp/factory-main",
+          workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+          statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+        },
+        sessionName: "symphony-factory",
+        sessions: [],
+        workerAlive: false,
+        statusSnapshot: null,
+        processIds: [],
+        problems: [],
+      })),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: stopped\n"),
+      startFactory: vi.fn(),
+      stopFactory: vi.fn(),
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await mockedRunCli(["node", "symphony", "factory", "status"]);
+
+    expect(stdout.join("")).toBe("Factory control: stopped\n");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("sets a non-zero exit code for degraded factory status", async () => {
+    vi.resetModules();
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(async () => ({
+        controlState: "degraded",
+        paths: {
+          repoRoot: "/repo",
+          runtimeRoot: "/repo/.tmp/factory-main",
+          workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+          statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+        },
+        sessionName: "symphony-factory",
+        sessions: [],
+        workerAlive: false,
+        statusSnapshot: null,
+        processIds: [1234],
+        problems: ["broken runtime"],
+      })),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: degraded\n"),
+      startFactory: vi.fn(),
+      stopFactory: vi.fn(),
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    await mockedRunCli(["node", "symphony", "factory", "status", "--json"]);
+
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -177,6 +177,26 @@ describe("parseArgs", () => {
       action: "restart",
     });
   });
+
+  it("parses the factory start and stop commands", () => {
+    expect(parseArgs(["node", "symphony", "factory", "start"])).toEqual({
+      command: "factory",
+      action: "start",
+    });
+    expect(parseArgs(["node", "symphony", "factory", "stop"])).toEqual({
+      command: "factory",
+      action: "stop",
+    });
+  });
+
+  it("shows factory-specific usage for missing or unknown factory actions", () => {
+    expect(() => parseArgs(["node", "symphony", "factory"])).toThrowError(
+      "Usage: symphony factory <start|stop|restart|status>",
+    );
+    expect(() =>
+      parseArgs(["node", "symphony", "factory", "deploy"]),
+    ).toThrowError("Usage: symphony factory <start|stop|restart|status>");
+  });
 });
 
 describe("runCli status", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -191,11 +191,13 @@ describe("parseArgs", () => {
 
   it("shows factory-specific usage for missing or unknown factory actions", () => {
     expect(() => parseArgs(["node", "symphony", "factory"])).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status>",
+      "Usage: symphony factory <start|stop|restart|status> [--json]",
     );
     expect(() =>
       parseArgs(["node", "symphony", "factory", "deploy"]),
-    ).toThrowError("Usage: symphony factory <start|stop|restart|status>");
+    ).toThrowError(
+      "Usage: symphony factory <start|stop|restart|status> [--json]",
+    );
   });
 });
 

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -221,6 +221,21 @@ describe("process parsing helpers", () => {
     ]);
   });
 
+  it("ignores dead screen sessions in screen -ls output", () => {
+    expect(
+      parseScreenLsOutput(
+        "There are screens on:\n\t1234.symphony-factory\t(Dead)\n\t1235.symphony-factory\t(Detached)\n2 Sockets in /tmp/screens.\n",
+      ),
+    ).toEqual([
+      {
+        id: "1235.symphony-factory",
+        pid: 1235,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ]);
+  });
+
   it("parses screen -ls stdout from a non-zero exit when a session list is present", () => {
     expect(
       parseScreenLsFailureOutput(
@@ -557,6 +572,58 @@ describe("stopFactory", () => {
     );
     expect(result.kind).toBe("stopped");
     expect(result.status.controlState).toBe("stopped");
+  });
+
+  it("treats dead screen sessions as stopped once all live processes are gone", async () => {
+    const workerPid = 9101;
+    const sessionsState: ScreenSessionSnapshot[] = [
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ];
+    const processesState: HostProcessSnapshot[] = [
+      { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+      { pid: workerPid, ppid: 9001, command: "node bin/symphony.ts run" },
+    ];
+
+    const result = await stopFactory({
+      ...createControlDeps({
+        sessions: sessionsState,
+        processes: processesState,
+        snapshot: createStatusSnapshot(workerPid),
+        quitScreenSession: async () => {
+          sessionsState.splice(0, sessionsState.length, {
+            id: "9001.symphony-factory",
+            pid: 9001,
+            name: "symphony-factory",
+            state: "Dead",
+          });
+          processesState.splice(0, processesState.length);
+        },
+      }),
+      listProcesses: async () => processesState,
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      isProcessAlive: () => false,
+      now: (() => {
+        let current = 0;
+        return () => {
+          current += 100;
+          return current;
+        };
+      })(),
+    });
+
+    expect(result.kind).toBe("stopped");
+    expect(result.status.controlState).toBe("stopped");
+    expect(result.status.sessions).toEqual([]);
   });
 });
 

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -1,0 +1,468 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FactoryStatusSnapshot } from "../../src/observability/status.js";
+import {
+  collectDescendantProcessIds,
+  inspectFactoryControl,
+  parsePsOutput,
+  parseScreenLsOutput,
+  renderFactoryControlStatus,
+  resolveFactoryPaths,
+  startFactory,
+  stopFactory,
+  type FactoryControlDeps,
+  type HostProcessSnapshot,
+  type ScreenSessionSnapshot,
+} from "../../src/cli/factory-control.js";
+import { createTempDir } from "../support/git.js";
+
+function createStatusSnapshot(
+  workerPid: number,
+  overrides: Partial<FactoryStatusSnapshot> = {},
+): FactoryStatusSnapshot {
+  return {
+    version: 1,
+    generatedAt: "2026-03-13T12:00:00.000Z",
+    factoryState: "idle",
+    worker: {
+      instanceId: "worker-1",
+      pid: workerPid,
+      startedAt: "2026-03-13T11:59:00.000Z",
+      pollIntervalMs: 1000,
+      maxConcurrentRuns: 1,
+    },
+    counts: {
+      ready: 0,
+      running: 0,
+      failed: 0,
+      activeLocalRuns: 0,
+      retries: 0,
+    },
+    lastAction: null,
+    activeIssues: [],
+    retries: [],
+    ...overrides,
+  };
+}
+
+function createControlDeps(
+  options: {
+    readonly processes?: readonly HostProcessSnapshot[];
+    readonly sessions?: readonly ScreenSessionSnapshot[];
+    readonly snapshot?: FactoryStatusSnapshot | null;
+    readonly nowValues?: readonly number[];
+    readonly launchScreenSession?: FactoryControlDeps["launchScreenSession"];
+    readonly quitScreenSession?: FactoryControlDeps["quitScreenSession"];
+    readonly signalProcess?: FactoryControlDeps["signalProcess"];
+    readonly sleep?: FactoryControlDeps["sleep"];
+  } = {},
+): FactoryControlDeps {
+  const repoRoot = "/repo";
+  const runtimeRoot = path.join(repoRoot, ".tmp", "factory-main");
+  const workflowPath = path.join(runtimeRoot, "WORKFLOW.md");
+  const statusFilePath = path.join(runtimeRoot, ".tmp", "status.json");
+  const nowValues = [...(options.nowValues ?? [0])];
+
+  return {
+    cwd: () => runtimeRoot,
+    pathExists: async (targetPath) =>
+      [
+        repoRoot,
+        runtimeRoot,
+        workflowPath,
+        path.dirname(statusFilePath),
+        statusFilePath,
+      ].includes(targetPath),
+    loadWorkflowWorkspaceRoot: async () =>
+      path.join(runtimeRoot, ".tmp", "workspaces"),
+    readFile: async (filePath) => {
+      if (filePath !== statusFilePath || options.snapshot === null) {
+        const error = new Error(
+          `ENOENT: no such file or directory, open '${filePath}'`,
+        ) as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      }
+      if (options.snapshot === undefined) {
+        const error = new Error(
+          `ENOENT: no such file or directory, open '${filePath}'`,
+        ) as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      }
+      return `${JSON.stringify(options.snapshot, null, 2)}\n`;
+    },
+    listProcesses: async () => options.processes ?? [],
+    listScreenSessions: async () => options.sessions ?? [],
+    sleep: options.sleep ?? (async () => {}),
+    isProcessAlive: (pid) =>
+      (options.processes ?? []).some(
+        (processSnapshot) => processSnapshot.pid === pid,
+      ),
+    now: () => {
+      if (nowValues.length === 0) {
+        return 0;
+      }
+      return nowValues.shift() ?? 0;
+    },
+    ...(options.launchScreenSession === undefined
+      ? {}
+      : { launchScreenSession: options.launchScreenSession }),
+    ...(options.quitScreenSession === undefined
+      ? {}
+      : { quitScreenSession: options.quitScreenSession }),
+    ...(options.signalProcess === undefined
+      ? {}
+      : { signalProcess: options.signalProcess }),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveFactoryPaths", () => {
+  it("finds the outer repo root from a nested working directory", async () => {
+    const tempDir = await createTempDir("symphony-factory-paths-");
+    const runtimeRoot = path.join(tempDir, ".tmp", "factory-main");
+    const nestedCwd = path.join(runtimeRoot, "src");
+
+    await fs.mkdir(path.join(runtimeRoot, ".tmp"), { recursive: true });
+    await fs.mkdir(nestedCwd, { recursive: true });
+    await fs.writeFile(
+      path.join(runtimeRoot, "WORKFLOW.md"),
+      `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+workspace:
+  root: ./.tmp/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+      "utf8",
+    );
+
+    try {
+      const paths = await resolveFactoryPaths({
+        cwd: () => nestedCwd,
+      });
+      expect(paths.repoRoot).toBe(tempDir);
+      expect(paths.runtimeRoot).toBe(runtimeRoot);
+      expect(paths.workflowPath).toBe(path.join(runtimeRoot, "WORKFLOW.md"));
+      expect(paths.statusFilePath).toBe(
+        path.join(runtimeRoot, ".tmp", "status.json"),
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("process parsing helpers", () => {
+  it("parses ps output into pid, ppid, and command fields", () => {
+    expect(
+      parsePsOutput(" 123  1 node bin/symphony.ts run\n 456 123 codex exec\n"),
+    ).toEqual([
+      {
+        pid: 123,
+        ppid: 1,
+        command: "node bin/symphony.ts run",
+      },
+      {
+        pid: 456,
+        ppid: 123,
+        command: "codex exec",
+      },
+    ]);
+  });
+
+  it("parses screen -ls output", () => {
+    expect(
+      parseScreenLsOutput(
+        "There is a screen on:\n\t1234.symphony-factory\t(Detached)\n1 Socket in /tmp/screens.\n",
+      ),
+    ).toEqual([
+      {
+        id: "1234.symphony-factory",
+        pid: 1234,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ]);
+  });
+
+  it("collects descendant process ids", () => {
+    expect(
+      collectDescendantProcessIds(
+        [
+          { pid: 10, ppid: 1, command: "screen" },
+          { pid: 11, ppid: 10, command: "pnpm" },
+          { pid: 12, ppid: 11, command: "tsx" },
+          { pid: 13, ppid: 12, command: "codex exec" },
+          { pid: 20, ppid: 1, command: "other" },
+        ],
+        [10],
+      ),
+    ).toEqual([10, 11, 12, 13]);
+  });
+});
+
+describe("inspectFactoryControl", () => {
+  it("reports stopped when there is no session, process, or snapshot", async () => {
+    const snapshot = await inspectFactoryControl(createControlDeps());
+    expect(snapshot.controlState).toBe("stopped");
+    expect(snapshot.processIds).toEqual([]);
+  });
+
+  it("reports running when the session and snapshot worker are healthy", async () => {
+    const workerPid = 9101;
+    const snapshot = await inspectFactoryControl(
+      createControlDeps({
+        sessions: [
+          {
+            id: "9001.symphony-factory",
+            pid: 9001,
+            name: "symphony-factory",
+            state: "Detached",
+          },
+        ],
+        processes: [
+          { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+          { pid: 9002, ppid: 9001, command: "pnpm tsx bin/symphony.ts run" },
+          { pid: workerPid, ppid: 9002, command: "node bin/symphony.ts run" },
+        ],
+        snapshot: createStatusSnapshot(workerPid),
+      }),
+    );
+
+    expect(snapshot.controlState).toBe("running");
+    expect(snapshot.workerAlive).toBe(true);
+    expect(snapshot.problems).toEqual([]);
+  });
+
+  it("reports degraded when factory-owned processes remain without the screen session", async () => {
+    const workerPid = 9101;
+    const snapshot = await inspectFactoryControl(
+      createControlDeps({
+        processes: [
+          { pid: 9002, ppid: 1, command: "pnpm tsx bin/symphony.ts run" },
+          { pid: workerPid, ppid: 9002, command: "node bin/symphony.ts run" },
+        ],
+        snapshot: createStatusSnapshot(workerPid),
+      }),
+    );
+
+    expect(snapshot.controlState).toBe("degraded");
+    expect(snapshot.problems).toContain(
+      "detached screen session is missing but factory-owned processes remain",
+    );
+  });
+});
+
+describe("startFactory", () => {
+  it("returns already-running when the factory is healthy", async () => {
+    const workerPid = 9101;
+    const result = await startFactory(
+      createControlDeps({
+        sessions: [
+          {
+            id: "9001.symphony-factory",
+            pid: 9001,
+            name: "symphony-factory",
+            state: "Detached",
+          },
+        ],
+        processes: [
+          { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+          { pid: workerPid, ppid: 9001, command: "node bin/symphony.ts run" },
+        ],
+        snapshot: createStatusSnapshot(workerPid),
+      }),
+    );
+
+    expect(result.kind).toBe("already-running");
+    expect(result.status.controlState).toBe("running");
+  });
+
+  it("launches the detached session and waits until the runtime becomes healthy", async () => {
+    const sessionsState: ScreenSessionSnapshot[] = [];
+    const processesState: HostProcessSnapshot[] = [];
+    const workerPid = 9101;
+    let currentSnapshot: FactoryStatusSnapshot | null = null;
+    const launched: Array<{ runtimeRoot: string; sessionName: string }> = [];
+
+    const result = await startFactory({
+      ...createControlDeps({
+        launchScreenSession: async (options) => {
+          launched.push(options);
+          sessionsState.push({
+            id: "9001.symphony-factory",
+            pid: 9001,
+            name: options.sessionName,
+            state: "Detached",
+          });
+          processesState.push(
+            { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+            { pid: 9002, ppid: 9001, command: "pnpm tsx bin/symphony.ts run" },
+            { pid: workerPid, ppid: 9002, command: "node bin/symphony.ts run" },
+          );
+          currentSnapshot = createStatusSnapshot(workerPid, {
+            factoryState: "running",
+          });
+        },
+      }),
+      listProcesses: async () => processesState,
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        if (currentSnapshot === null) {
+          const error = new Error("missing") as NodeJS.ErrnoException;
+          error.code = "ENOENT";
+          throw error;
+        }
+        return `${JSON.stringify(currentSnapshot, null, 2)}\n`;
+      },
+      isProcessAlive: (pid) =>
+        processesState.some((processSnapshot) => processSnapshot.pid === pid),
+      now: (() => {
+        let now = 0;
+        return () => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(launched).toHaveLength(1);
+    expect(result.kind).toBe("started");
+    expect(result.status.controlState).toBe("running");
+  });
+});
+
+describe("stopFactory", () => {
+  it("returns already-stopped when there is no active runtime", async () => {
+    const result = await stopFactory(createControlDeps());
+    expect(result.kind).toBe("already-stopped");
+    expect(result.terminatedPids).toEqual([]);
+  });
+
+  it("quits the screen session and terminates remaining descendants", async () => {
+    const workerPid = 9101;
+    const sessionsState: ScreenSessionSnapshot[] = [
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ];
+    const processesState: HostProcessSnapshot[] = [
+      { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+      { pid: 9002, ppid: 9001, command: "pnpm tsx bin/symphony.ts run" },
+      { pid: workerPid, ppid: 9002, command: "node bin/symphony.ts run" },
+      {
+        pid: 9102,
+        ppid: workerPid,
+        command: "codex exec --dangerously-bypass-approvals-and-sandbox",
+      },
+    ];
+    const quitCalls: string[] = [];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await stopFactory({
+      ...createControlDeps({
+        sessions: sessionsState,
+        processes: processesState,
+        snapshot: createStatusSnapshot(workerPid),
+        quitScreenSession: async (sessionId) => {
+          quitCalls.push(sessionId);
+          sessionsState.splice(0, sessionsState.length);
+          const remaining = processesState.filter(
+            (processSnapshot) => processSnapshot.pid !== 9001,
+          );
+          processesState.splice(0, processesState.length, ...remaining);
+        },
+        signalProcess: (pid, signal) => {
+          signals.push({ pid, signal });
+          const index = processesState.findIndex(
+            (processSnapshot) => processSnapshot.pid === pid,
+          );
+          if (index >= 0) {
+            processesState.splice(index, 1);
+          }
+        },
+      }),
+      listProcesses: async () => processesState,
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        if (
+          processesState.some(
+            (processSnapshot) => processSnapshot.pid === workerPid,
+          )
+        ) {
+          return `${JSON.stringify(createStatusSnapshot(workerPid), null, 2)}\n`;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      isProcessAlive: (pid) =>
+        processesState.some((processSnapshot) => processSnapshot.pid === pid),
+      now: (() => {
+        let now = 0;
+        return () => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(quitCalls).toEqual(["9001.symphony-factory"]);
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        { pid: 9002, signal: "SIGTERM" },
+        { pid: workerPid, signal: "SIGTERM" },
+        { pid: 9102, signal: "SIGTERM" },
+      ]),
+    );
+    expect(result.kind).toBe("stopped");
+    expect(result.status.controlState).toBe("stopped");
+  });
+});
+
+describe("renderFactoryControlStatus", () => {
+  it("renders the runtime path and snapshot guidance for stopped state", () => {
+    const output = renderFactoryControlStatus({
+      controlState: "stopped",
+      paths: {
+        repoRoot: "/repo",
+        runtimeRoot: "/repo/.tmp/factory-main",
+        workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+        statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+      },
+      sessionName: "symphony-factory",
+      sessions: [],
+      workerAlive: false,
+      statusSnapshot: null,
+      processIds: [],
+      problems: [],
+    });
+
+    expect(output).toContain("Factory control: stopped");
+    expect(output).toContain("Runtime root: /repo/.tmp/factory-main");
+    expect(output).toContain("Status detail: no readable runtime snapshot");
+  });
+});

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -441,6 +441,91 @@ describe("stopFactory", () => {
     expect(result.kind).toBe("stopped");
     expect(result.status.controlState).toBe("stopped");
   });
+
+  it("waits for one post-SIGKILL poll before timing out", async () => {
+    const workerPid = 9101;
+    const sessionsState: ScreenSessionSnapshot[] = [
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ];
+    const processesState: HostProcessSnapshot[] = [
+      { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+      { pid: workerPid, ppid: 9001, command: "node bin/symphony.ts run" },
+      {
+        pid: 9102,
+        ppid: workerPid,
+        command: "codex exec --dangerously-bypass-approvals-and-sandbox",
+      },
+    ];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await stopFactory({
+      ...createControlDeps({
+        sessions: sessionsState,
+        processes: processesState,
+        snapshot: createStatusSnapshot(workerPid),
+        quitScreenSession: async () => {
+          sessionsState.splice(0, sessionsState.length);
+          processesState.splice(
+            0,
+            processesState.length,
+            ...processesState.filter(
+              (processSnapshot) => processSnapshot.pid !== 9001,
+            ),
+          );
+        },
+        signalProcess: (pid, signal) => {
+          signals.push({ pid, signal });
+          if (signal === "SIGKILL") {
+            const index = processesState.findIndex(
+              (processSnapshot) => processSnapshot.pid === pid,
+            );
+            if (index >= 0) {
+              processesState.splice(index, 1);
+            }
+          }
+        },
+      }),
+      listProcesses: async () => processesState,
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        if (
+          processesState.some(
+            (processSnapshot) => processSnapshot.pid === workerPid,
+          )
+        ) {
+          return `${JSON.stringify(createStatusSnapshot(workerPid), null, 2)}\n`;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      isProcessAlive: (pid) =>
+        processesState.some((processSnapshot) => processSnapshot.pid === pid),
+      now: (() => {
+        let current = 0;
+        return () => {
+          current += 15_000;
+          return current;
+        };
+      })(),
+    });
+
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        { pid: workerPid, signal: "SIGTERM" },
+        { pid: 9102, signal: "SIGTERM" },
+        { pid: workerPid, signal: "SIGKILL" },
+        { pid: 9102, signal: "SIGKILL" },
+      ]),
+    );
+    expect(result.kind).toBe("stopped");
+    expect(result.status.controlState).toBe("stopped");
+  });
 });
 
 describe("renderFactoryControlStatus", () => {

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -625,6 +625,54 @@ describe("stopFactory", () => {
     expect(result.status.controlState).toBe("stopped");
     expect(result.status.sessions).toEqual([]);
   });
+
+  it("ignores already-missing screen sessions while stopping multiple sessions", async () => {
+    const sessionsState: ScreenSessionSnapshot[] = [
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+      {
+        id: "9002.symphony-factory",
+        pid: 9002,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ];
+
+    const result = await stopFactory({
+      ...createControlDeps({
+        sessions: sessionsState,
+        processes: [],
+        snapshot: null,
+        quitScreenSession: async (sessionId) => {
+          if (sessionId === "9001.symphony-factory") {
+            sessionsState.splice(0, sessionsState.length);
+            return;
+          }
+          const error = new Error("No screen session found.") as Error & {
+            stderr: string;
+          };
+          error.stderr = "No screen session found.";
+          throw error;
+        },
+      }),
+      listProcesses: async () => [],
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      isProcessAlive: () => false,
+    });
+
+    expect(result.kind).toBe("stopped");
+    expect(result.status.controlState).toBe("stopped");
+    expect(result.status.sessions).toEqual([]);
+  });
 });
 
 describe("renderFactoryControlStatus", () => {

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -6,6 +6,7 @@ import {
   collectDescendantProcessIds,
   inspectFactoryControl,
   parsePsOutput,
+  parseScreenLsFailureOutput,
   parseScreenLsOutput,
   renderFactoryControlStatus,
   resolveFactoryPaths,
@@ -194,6 +195,37 @@ describe("process parsing helpers", () => {
     expect(
       parseScreenLsOutput(
         "There is a screen on:\n\t1234.symphony-factory\t(Detached)\n1 Socket in /tmp/screens.\n",
+      ),
+    ).toEqual([
+      {
+        id: "1234.symphony-factory",
+        pid: 1234,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ]);
+  });
+
+  it("parses date-stamped screen -ls output", () => {
+    expect(
+      parseScreenLsOutput(
+        "There is a screen on:\n\t1234.symphony-factory\t(03/13/26 12:00:00)\t(Detached)\n1 Socket in /tmp/screens.\n",
+      ),
+    ).toEqual([
+      {
+        id: "1234.symphony-factory",
+        pid: 1234,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ]);
+  });
+
+  it("parses screen -ls stdout from a non-zero exit when a session list is present", () => {
+    expect(
+      parseScreenLsFailureOutput(
+        "There is a screen on:\n\t1234.symphony-factory\t(03/13/26 12:00:00)\t(Detached)\n1 Socket in /tmp/screens.\n",
+        "",
       ),
     ).toEqual([
       {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -889,9 +889,7 @@ describe("runners", () => {
           turnNumber: 1,
           prompt: "first",
         }),
-      ).rejects.toThrowError(
-        "Startup stderr:\nstartup failed: invalid fake configuration",
-      );
+      ).rejects.toThrowError(/startup failed: invalid fake configuration/);
     } finally {
       await liveSession.close().catch(() => {});
     }


### PR DESCRIPTION
Closes #81

## Summary
- add a checked-in `symphony factory` command group for `start`, `stop`, `restart`, and `status`
- centralize runtime checkout resolution, detached `screen` startup, and process-tree shutdown in `src/cli/factory-control.ts`
- add unit coverage for CLI parsing/exit codes and factory control state transitions, plus README usage updates

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`

## Notes
- plan review was approved on issue #81 before implementation
