### PR TITLE
Fix TUI live runner telemetry parity

### DIFF
--- a/docs/plans/138-tui-live-runner-telemetry/plan.md
+++ b/docs/plans/138-tui-live-runner-telemetry/plan.md
@@ -124,12 +124,12 @@ Existing runner visibility states (`starting`, `running`, `waiting`, `completed`
 
 ## Failure-Class Matrix
 
-| Observed condition | Runtime facts available | TUI expectation |
-| --- | --- | --- |
-| Active run has no Codex event payloads and no `runnerVisibility.lastActionSummary`/`stdoutSummary` yet | running row exists, visibility is absent or silent | render `no codex message yet` |
-| Active run has `runnerVisibility.lastActionSummary` and recent heartbeat but no raw `lastCodexMessage` | normalized visibility proves live activity | render the visibility-derived event text, not the silent fallback |
-| Active run has `runnerVisibility.stdoutSummary` with Codex stdout preview such as `thread/started` | normalized visibility shows runner output preview | render the stdout/action-derived label and keep session details populated when available |
-| Active run has both raw Codex message payload and normalized visibility | both sources are present | prefer the normalized visibility fields when they carry newer or stronger live-state detail; preserve raw-message humanization as fallback |
+| Observed condition                                                                                     | Runtime facts available                            | TUI expectation                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Active run has no Codex event payloads and no `runnerVisibility.lastActionSummary`/`stdoutSummary` yet | running row exists, visibility is absent or silent | render `no codex message yet`                                                                                                              |
+| Active run has `runnerVisibility.lastActionSummary` and recent heartbeat but no raw `lastCodexMessage` | normalized visibility proves live activity         | render the visibility-derived event text, not the silent fallback                                                                          |
+| Active run has `runnerVisibility.stdoutSummary` with Codex stdout preview such as `thread/started`     | normalized visibility shows runner output preview  | render the stdout/action-derived label and keep session details populated when available                                                   |
+| Active run has both raw Codex message payload and normalized visibility                                | both sources are present                           | prefer the normalized visibility fields when they carry newer or stronger live-state detail; preserve raw-message humanization as fallback |
 
 ## Observability Requirements
 

--- a/docs/plans/138-tui-live-runner-telemetry/plan.md
+++ b/docs/plans/138-tui-live-runner-telemetry/plan.md
@@ -1,0 +1,195 @@
+# Issue 138 Plan: TUI Live Runner Telemetry Parity
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make the detached factory TUI reflect live runner telemetry for active Codex runs so an issue with recent heartbeat/action/stdout activity no longer renders the misleading fallback `no codex message yet`.
+
+## Scope
+
+- identify why the TUI running row can fall back to `lastCodexMessage` emptiness even when the normalized runtime snapshot already has live `runnerVisibility` facts
+- align the TUI running-row event and session display with the same authoritative live runner fields used by `factory status`
+- preserve the existing graceful fallback for genuinely silent runs that have not emitted any runner activity yet
+- add focused unit and regression coverage for the reproduced detached-factory shape
+- run the local TUI QA dump plus repo-required checks for touched surfaces
+
+## Non-goals
+
+- changing runner behavior, Codex transport, or app-server event parsing
+- redesigning the TUI layout or column model
+- changing factory-control startup, detached-session packaging, or watchdog policy
+- broad refactors across tracker, workspace, or retry/reconciliation logic
+- adding durable historical event storage beyond the existing snapshot
+
+## Current Gaps
+
+- `factory status` renders `activeIssue.runnerVisibility.*` directly, including `lastActionSummary`, `lastHeartbeatAt`, and `stdoutSummary`
+- the TUI `running` rows are still built from `runningEntries` fields such as `lastCodexEvent`, `lastCodexMessage`, and `sessionId`
+- a live Codex run can therefore show real runner activity in the normalized status snapshot while the TUI row still reports `no codex message yet`
+- the two operator surfaces disagree even though they are describing the same active issue
+
+## Decision Notes
+
+- The authoritative current-state source for live runner telemetry in this slice is the normalized `runnerVisibility` object already persisted in runtime status state.
+- The TUI should prefer normalized visibility facts before falling back to raw `lastCodexMessage` payloads from the running-entry event stream.
+- This issue remains an observability-surface correctness fix. If a tiny TUI snapshot-shape extension is needed, it should carry normalized observability data only and should not reopen runner or orchestrator behavior.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the operator-facing rule that live runner telemetry must be consistent across `factory status` and the TUI
+  - does not belong: Codex protocol parsing details or detached-runtime control flow changes
+- Configuration Layer
+  - belongs: unchanged existing observability/dashboard config
+  - does not belong: new workflow flags or TUI-specific configuration knobs
+- Coordination Layer
+  - belongs: only a minimal snapshot projection change if the TUI needs normalized active-issue visibility threaded into its row model
+  - does not belong: retry policy, continuation semantics, leases, or handoff state redesign
+- Execution Layer
+  - belongs: unchanged existing runner visibility production from the Codex app-server path
+  - does not belong: any new runner-side telemetry semantics in this slice
+- Integration Layer
+  - belongs: untouched; tracker adapters remain out of scope
+  - does not belong: status/TUI presentation logic
+- Observability Layer
+  - belongs: TUI row formatting, event/session fallback rules, snapshot consumption, and regression tests
+  - does not belong: direct child-process inspection or tracker-specific lifecycle inference at render time
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/orchestrator/service.ts`
+  - only if needed to expose normalized active-issue runner visibility to the TUI snapshot model
+- `src/observability/tui.ts`
+  - teach running rows to derive session/event text from normalized runner visibility first, then raw Codex message fields, then the silent fallback
+- `tests/unit/tui.test.ts`
+  - lock in row formatting for silent runs, live runner heartbeat/action shapes, and Codex stdout-preview activity
+- `tests/fixtures/tui-qa-dump.ts` or existing TUI QA path
+  - exercise the touched rendering path if a fixture update is needed
+
+### Does not belong in this issue
+
+- `src/runner/`
+  - no change to Codex transport or event normalization unless a minimal bug fix is required to preserve existing visibility fields
+- `src/tracker/`
+  - no tracker transport, normalization, or policy changes
+- `src/workspace/`
+  - no workspace lifecycle changes
+- detached factory control commands or status CLI redesign
+
+## Layering Notes
+
+- `config/workflow`
+  - continues to define dashboard refresh behavior only
+  - does not gain observability-parity toggles
+- `tracker`
+  - remains the source of issue/PR lifecycle facts
+  - does not influence TUI runner event selection
+- `workspace`
+  - remains unrelated to status rendering
+- `runner`
+  - continues to publish normalized visibility updates
+  - does not render human-readable dashboard labels
+- `orchestrator`
+  - may project existing normalized visibility into `TuiSnapshot`
+  - should not duplicate TUI-specific humanization logic in status state
+- `observability`
+  - owns the row-level preference order and human-readable fallback text
+  - should not infer liveness by reading runner internals outside the snapshot contract
+
+## Slice Strategy And PR Seam
+
+One reviewable PR with one seam:
+
+1. expose the already-normalized live runner visibility the TUI needs
+2. update TUI row rendering to prefer that visibility for session/event details
+3. add regression coverage for the detached factory shape where live Codex activity exists without a populated `lastCodexMessage`
+
+This stays narrow because it does not combine:
+
+- runner transport changes
+- control-plane launch fixes
+- broader TUI redesign
+- tracker or handoff policy work
+
+## Runtime State Model
+
+This issue does not change orchestration state transitions, retry policy, continuation logic, reconciliation, leases, or handoff states.
+
+Existing runner visibility states (`starting`, `running`, `waiting`, `completed`, `failed`, `cancelled`, `timed-out`) remain the source of truth. The work in this issue is limited to how observability consumes that already-normalized state.
+
+## Failure-Class Matrix
+
+| Observed condition | Runtime facts available | TUI expectation |
+| --- | --- | --- |
+| Active run has no Codex event payloads and no `runnerVisibility.lastActionSummary`/`stdoutSummary` yet | running row exists, visibility is absent or silent | render `no codex message yet` |
+| Active run has `runnerVisibility.lastActionSummary` and recent heartbeat but no raw `lastCodexMessage` | normalized visibility proves live activity | render the visibility-derived event text, not the silent fallback |
+| Active run has `runnerVisibility.stdoutSummary` with Codex stdout preview such as `thread/started` | normalized visibility shows runner output preview | render the stdout/action-derived label and keep session details populated when available |
+| Active run has both raw Codex message payload and normalized visibility | both sources are present | prefer the normalized visibility fields when they carry newer or stronger live-state detail; preserve raw-message humanization as fallback |
+
+## Observability Requirements
+
+- TUI and `factory status` must agree on whether a live run has runner activity
+- the running row should show the best available current session/event detail from the normalized snapshot
+- fallback text should remain explicit and only appear for truly silent runs
+- tests should prove parity for the reproduced `#137` shape where `factory status` had live runner heartbeat/action/stdout output
+
+## Implementation Steps
+
+1. Inspect the current `TuiSnapshot.running` contract and identify the smallest way to thread `runnerVisibility`-derived session/event data into each row.
+2. Extend the TUI row model only as needed, preferably by projecting normalized visibility into the snapshot builder rather than re-reading status state inside observability.
+3. Add a helper in `tui.ts` that chooses row session/event text in this order:
+   - normalized `runnerVisibility` fields
+   - existing raw `lastCodexMessage` plus `lastCodexEvent`
+   - silent fallback text
+4. Keep existing event humanization for raw Codex payloads, but add a small normalized-visibility formatter for live action/stdout cases.
+5. Update or add tests to cover silent, heartbeat-only, and stdout-preview cases.
+6. Run TUI QA and the repo-required checks.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- `tests/unit/tui.test.ts`
+  - active run with no raw message and no visibility detail still renders `no codex message yet`
+  - active run with `runnerVisibility.lastActionSummary` and `lastHeartbeatAt` does not render the silent fallback
+  - active run with `runnerVisibility.stdoutSummary` containing Codex app-server output does not render the silent fallback
+  - active run with both visibility data and raw `lastCodexMessage` renders the intended preference order
+
+### Visual QA
+
+- `npx tsx tests/fixtures/tui-qa-dump.ts`
+  - inspect the running row at common widths and verify the event column shows live runner telemetry text rather than the silent fallback for the regression fixture
+
+### Repository checks
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. A detached factory run has an active Codex session with recent heartbeat/action timestamps and stdout preview in `runnerVisibility`, but `lastCodexMessage` is still empty.
+   - Expected: the TUI row shows live session/event detail and does not show `no codex message yet`.
+2. A newly started run has not produced any raw message or normalized runner action yet.
+   - Expected: the TUI still shows `no codex message yet`.
+3. `factory status` and the TUI inspect the same active issue with live Codex activity.
+   - Expected: both surfaces agree that the runner is active and has emitted recent activity.
+
+## Exit Criteria
+
+- the TUI running row no longer shows `no codex message yet` when normalized live runner activity is present
+- the TUI and `factory status` agree on active runner telemetry for the reproduced detached-run shape
+- regression coverage exists for silent and live-activity cases
+- local QA and required checks pass
+
+## Deferred To Later Issues Or PRs
+
+- any redesign of the TUI layout or event taxonomy
+- changes to how runner visibility is produced in `src/runner/`
+- historical event timelines, richer transcript storage, or dashboard drill-down views
+- detached factory control-plane fixes unrelated to observability parity

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -784,8 +784,6 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
                 appServerPid: e.runnerVisibility.session.appServerPid,
                 latestTurnNumber: e.runnerVisibility.session.latestTurnNumber,
               },
-              lastHeartbeatAt: e.runnerVisibility.lastHeartbeatAt,
-              lastActionAt: e.runnerVisibility.lastActionAt,
               lastActionSummary: e.runnerVisibility.lastActionSummary,
               waitingReason: e.runnerVisibility.waitingReason,
               stdoutSummary: e.runnerVisibility.stdoutSummary,

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -540,12 +540,12 @@ function formatRunningRow(
     compactSessionId(resolveSessionDisplay(entry)),
     SESSION_WIDTH,
   );
-  const eventLabel = formatCell(
-    describeRunningEvent(entry),
-    eventWidth,
-  );
+  const eventLabel = formatCell(describeRunningEvent(entry), eventWidth);
 
-  const statusColor = statusDotColor(entry.lastCodexEvent, entry.runnerVisibility);
+  const statusColor = statusDotColor(
+    entry.lastCodexEvent,
+    entry.runnerVisibility,
+  );
 
   return (
     "│ " +
@@ -782,8 +782,7 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
                 backendThreadId: e.runnerVisibility.session.backendThreadId,
                 latestTurnId: e.runnerVisibility.session.latestTurnId,
                 appServerPid: e.runnerVisibility.session.appServerPid,
-                latestTurnNumber:
-                  e.runnerVisibility.session.latestTurnNumber,
+                latestTurnNumber: e.runnerVisibility.session.latestTurnNumber,
               },
               lastHeartbeatAt: e.runnerVisibility.lastHeartbeatAt,
               lastActionAt: e.runnerVisibility.lastActionAt,
@@ -1012,9 +1011,7 @@ function parseJsonObject(value: string): Record<string, unknown> | null {
   return null;
 }
 
-function extractEventType(
-  payload: Record<string, unknown>,
-): string | null {
+function extractEventType(payload: Record<string, unknown>): string | null {
   const method = getKey(payload, "method");
   if (typeof method === "string" && method.trim() !== "") {
     return method;

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -10,6 +10,7 @@
 import type { ObservabilityConfig } from "../domain/workflow.js";
 import { getKey, getMapKey, mapPath } from "../domain/codex-payload.js";
 import type { TuiSnapshot } from "../orchestrator/service.js";
+import type { RunnerVisibilitySnapshot } from "../runner/service.js";
 import { setLogFile, getLogFilePath } from "./logger.js";
 
 // ─── ANSI constants ────────────────────────────────────────────────────────
@@ -535,13 +536,16 @@ function formatRunningRow(
     TOKENS_WIDTH,
     "right",
   );
-  const session = formatCell(compactSessionId(entry.sessionId), SESSION_WIDTH);
+  const session = formatCell(
+    compactSessionId(resolveSessionDisplay(entry)),
+    SESSION_WIDTH,
+  );
   const eventLabel = formatCell(
-    humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent),
+    describeRunningEvent(entry),
     eventWidth,
   );
 
-  const statusColor = statusDotColor(entry.lastCodexEvent);
+  const statusColor = statusDotColor(entry.lastCodexEvent, entry.runnerVisibility);
 
   return (
     "│ " +
@@ -565,7 +569,30 @@ function formatRunningRow(
 
 // Event names are normalized to canonical slash form by integrateCodexUpdate,
 // so downstream consumers only need to handle one form per event.
-function statusDotColor(event: string | null): string {
+function statusDotColor(
+  event: string | null,
+  visibility: RunnerVisibilitySnapshot | null,
+): string {
+  if (visibility !== null) {
+    switch (visibility.state) {
+      case "completed":
+        return MAGENTA;
+      case "failed":
+      case "timed-out":
+      case "cancelled":
+        return RED;
+      case "starting":
+        return CYAN;
+      case "waiting":
+        return YELLOW;
+      case "running":
+        return BLUE;
+      case "idle":
+        return GRAY;
+      default:
+        break;
+    }
+  }
   if (event === null || event === "none") return RED;
   if (event === "codex/event/token_count") return YELLOW;
   if (event === "codex/event/task_started") return GREEN;
@@ -742,6 +769,32 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
       lastCodexEvent: e.lastCodexEvent,
       lastCodexMessage: e.lastCodexMessage,
       lastCodexTimestamp: e.lastCodexTimestamp,
+      runnerVisibility:
+        e.runnerVisibility === null
+          ? null
+          : {
+              state: e.runnerVisibility.state,
+              phase: e.runnerVisibility.phase,
+              session: {
+                provider: e.runnerVisibility.session.provider,
+                model: e.runnerVisibility.session.model,
+                backendSessionId: e.runnerVisibility.session.backendSessionId,
+                backendThreadId: e.runnerVisibility.session.backendThreadId,
+                latestTurnId: e.runnerVisibility.session.latestTurnId,
+                appServerPid: e.runnerVisibility.session.appServerPid,
+                latestTurnNumber:
+                  e.runnerVisibility.session.latestTurnNumber,
+              },
+              lastHeartbeatAt: e.runnerVisibility.lastHeartbeatAt,
+              lastActionAt: e.runnerVisibility.lastActionAt,
+              lastActionSummary: e.runnerVisibility.lastActionSummary,
+              waitingReason: e.runnerVisibility.waitingReason,
+              stdoutSummary: e.runnerVisibility.stdoutSummary,
+              stderrSummary: e.runnerVisibility.stderrSummary,
+              errorSummary: e.runnerVisibility.errorSummary,
+              cancelledAt: e.runnerVisibility.cancelledAt,
+              timedOutAt: e.runnerVisibility.timedOutAt,
+            },
     })),
     retrying: snapshot.retrying.map((r) => ({
       issueNumber: r.issueNumber,
@@ -877,6 +930,97 @@ export function humanizeEvent(
   const byEvent =
     eventType !== null ? humanizeByEvent(eventType, message, payload) : null;
   return truncate(byEvent ?? humanizePayload(payload), 140);
+}
+
+function describeRunningEvent(entry: TuiSnapshot["running"][number]): string {
+  const fromVisibility = humanizeRunnerVisibility(entry.runnerVisibility);
+  if (fromVisibility !== null) {
+    return fromVisibility;
+  }
+  return humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
+}
+
+function resolveSessionDisplay(
+  entry: TuiSnapshot["running"][number],
+): string | null {
+  if (entry.sessionId !== null) {
+    return entry.sessionId;
+  }
+  const visibility = entry.runnerVisibility;
+  if (visibility === null) {
+    return null;
+  }
+  return (
+    visibility.session.backendThreadId ??
+    visibility.session.backendSessionId ??
+    visibility.session.latestTurnId
+  );
+}
+
+function humanizeRunnerVisibility(
+  visibility: RunnerVisibilitySnapshot | null,
+): string | null {
+  if (visibility === null) {
+    return null;
+  }
+
+  const stdoutSummary = visibility.stdoutSummary;
+  if (stdoutSummary !== null) {
+    const humanized = humanizeVisibilitySummary(stdoutSummary);
+    if (humanized !== null) {
+      return humanized;
+    }
+  }
+
+  if (visibility.lastActionSummary !== null) {
+    return visibility.lastActionSummary;
+  }
+  if (visibility.waitingReason !== null) {
+    return `waiting: ${visibility.waitingReason}`;
+  }
+  if (visibility.errorSummary !== null) {
+    return visibility.errorSummary;
+  }
+  return null;
+}
+
+function humanizeVisibilitySummary(summary: string): string | null {
+  const trimmed = summary.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const parsed = parseJsonObject(trimmed);
+  if (parsed !== null) {
+    return humanizeEvent(parsed, extractEventType(parsed));
+  }
+  return trimmed;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall back to the raw summary
+  }
+  return null;
+}
+
+function extractEventType(
+  payload: Record<string, unknown>,
+): string | null {
+  const method = getKey(payload, "method");
+  if (typeof method === "string" && method.trim() !== "") {
+    return method;
+  }
+  const type = getMapKey(payload, ["type", "event"]);
+  return typeof type === "string" && type.trim() !== "" ? type : null;
 }
 
 function unwrapPayload(message: unknown): unknown {

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -589,15 +589,18 @@ function statusDotColor(
         return BLUE;
       case "idle":
         return GRAY;
-      default:
-        break;
     }
+    return unreachableVisibilityState(visibility.state);
   }
   if (event === null || event === "none") return RED;
   if (event === "codex/event/token_count") return YELLOW;
   if (event === "codex/event/task_started") return GREEN;
   if (event === "turn/completed") return MAGENTA;
   return BLUE;
+}
+
+function unreachableVisibilityState(state: never): never {
+  throw new Error(`Unhandled runner visibility state: ${state as string}`);
 }
 
 // ─── Backoff queue ────────────────────────────────────────────────────────

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -936,6 +936,8 @@ function describeRunningEvent(entry: TuiSnapshot["running"][number]): string {
   if (fromVisibility !== null) {
     return fromVisibility;
   }
+  // Keep the event column on the best available text source even when
+  // runnerVisibility still only contributes state for the dot color.
   return humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
 }
 

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -790,7 +790,6 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
               lastActionSummary: e.runnerVisibility.lastActionSummary,
               waitingReason: e.runnerVisibility.waitingReason,
               stdoutSummary: e.runnerVisibility.stdoutSummary,
-              stderrSummary: e.runnerVisibility.stderrSummary,
               errorSummary: e.runnerVisibility.errorSummary,
               cancelledAt: e.runnerVisibility.cancelledAt,
               timedOutAt: e.runnerVisibility.timedOutAt,

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -777,15 +777,10 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
           ? null
           : {
               state: e.runnerVisibility.state,
-              phase: e.runnerVisibility.phase,
               session: {
-                provider: e.runnerVisibility.session.provider,
-                model: e.runnerVisibility.session.model,
                 backendSessionId: e.runnerVisibility.session.backendSessionId,
                 backendThreadId: e.runnerVisibility.session.backendThreadId,
                 latestTurnId: e.runnerVisibility.session.latestTurnId,
-                appServerPid: e.runnerVisibility.session.appServerPid,
-                latestTurnNumber: e.runnerVisibility.session.latestTurnNumber,
               },
               lastActionSummary: e.runnerVisibility.lastActionSummary,
               waitingReason: e.runnerVisibility.waitingReason,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -107,6 +107,7 @@ export interface TuiRunningEntry {
   readonly lastCodexEvent: string | null;
   readonly lastCodexMessage: unknown;
   readonly lastCodexTimestamp: string | null;
+  readonly runnerVisibility: RunnerVisibilitySnapshot | null;
 }
 
 export interface TuiRetryEntry {
@@ -207,6 +208,9 @@ export class BootstrapOrchestrator implements Orchestrator {
         lastCodexEvent: entry.lastCodexEvent,
         lastCodexMessage: entry.lastCodexMessage,
         lastCodexTimestamp: entry.lastCodexTimestamp,
+        runnerVisibility:
+          this.#state.status.activeIssues.get(entry.issueNumber)
+            ?.runnerVisibility ?? null,
       });
     }
     running.sort((a, b) => a.identifier.localeCompare(b.identifier));

--- a/tests/fixtures/tui-qa-dump.ts
+++ b/tests/fixtures/tui-qa-dump.ts
@@ -20,9 +20,9 @@ import {
   formatSnapshotContent,
   humanizeEvent,
 } from "../../src/observability/tui.js";
+import type { TuiSnapshot } from "../../src/orchestrator/service.js";
 
 function stripAnsi(s: string): string {
-  // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
@@ -30,7 +30,7 @@ const nowMs = Date.now();
 
 // ─── Scenario 1: Active agents with Codex events ─────────────────────────────
 
-const activeSnapshot = {
+const activeSnapshot: TuiSnapshot = {
   running: [
     {
       issueNumber: 9,
@@ -56,6 +56,7 @@ const activeSnapshot = {
         },
       },
       lastCodexTimestamp: new Date().toISOString(),
+      runnerVisibility: null,
     },
     {
       issueNumber: 11,
@@ -78,6 +79,30 @@ const activeSnapshot = {
         },
       },
       lastCodexTimestamp: new Date().toISOString(),
+      runnerVisibility: {
+        state: "running",
+        phase: "turn-execution",
+        session: {
+          provider: "codex",
+          model: "gpt-5.4",
+          backendSessionId: "thread-live-123-turn-1",
+          backendThreadId: "thread-live-123",
+          latestTurnId: "turn-1",
+          appServerPid: 12346,
+          latestTurnNumber: 1,
+          logPointers: [],
+        },
+        lastHeartbeatAt: new Date().toISOString(),
+        lastActionAt: new Date().toISOString(),
+        lastActionSummary: "Codex app-server stdout activity",
+        waitingReason: null,
+        stdoutSummary:
+          '{"method":"thread/started","params":{"thread":{"id":"thread-live-123"}}}',
+        stderrSummary: null,
+        errorSummary: null,
+        cancelledAt: null,
+        timedOutAt: null,
+      },
     },
     {
       issueNumber: 13,
@@ -96,6 +121,7 @@ const activeSnapshot = {
         params: { msg: { payload: { type: "session.end" } } },
       },
       lastCodexTimestamp: new Date().toISOString(),
+      runnerVisibility: null,
     },
   ],
   retrying: [
@@ -149,7 +175,7 @@ console.log(
 // ─── Scenario 2: Idle factory ─────────────────────────────────────────────────
 
 console.log("\n\n=== SCENARIO 2: Idle (no agents) ===\n");
-const idleSnapshot = {
+const idleSnapshot: TuiSnapshot = {
   running: [],
   retrying: [],
   codexTotals: {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -902,4 +902,64 @@ describe("StatusDashboard", () => {
     // Deduplicated: should be 1 render (initial) + possibly 1 periodic rerender per second
     expect(rendered.length).toBeLessThanOrEqual(3);
   });
+
+  it("ignores runner visibility heartbeat-only timestamp churn in the fingerprint", () => {
+    const rendered: string[] = [];
+    let snapshot = makeSnapshot({
+      running: [
+        {
+          issueNumber: 138,
+          identifier: "#138",
+          issueState: "running",
+          startedAt: new Date("2026-03-13T10:00:00.000Z"),
+          retryAttempt: 1,
+          sessionId: null,
+          turnCount: 1,
+          codexTotalTokens: 0,
+          codexInputTokens: 0,
+          codexOutputTokens: 0,
+          codexAppServerPid: 12345,
+          lastCodexEvent: null,
+          lastCodexMessage: null,
+          lastCodexTimestamp: null,
+          runnerVisibility: makeRunnerVisibility({
+            lastHeartbeatAt: "2026-03-13T10:00:05.000Z",
+            lastActionAt: "2026-03-13T10:00:05.000Z",
+            lastActionSummary: "Codex app-server stdout activity",
+          }),
+        },
+      ],
+    });
+
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (content) => rendered.push(content),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+
+    dashboard.refresh();
+    snapshot = makeSnapshot({
+      running: [
+        {
+          ...snapshot.running[0]!,
+          runnerVisibility: makeRunnerVisibility({
+            lastHeartbeatAt: "2026-03-13T10:00:06.000Z",
+            lastActionAt: "2026-03-13T10:00:06.000Z",
+            lastActionSummary: "Codex app-server stdout activity",
+          }),
+        },
+      ],
+    });
+    dashboard.refresh();
+    dashboard.stop();
+
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toContain("thread");
+    expect(rendered[1]).toContain("app_status=offline");
+  });
 });

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -1028,4 +1028,80 @@ describe("StatusDashboard", () => {
     expect(rendered[0]).toContain("thread started (thread-live-123)");
     expect(rendered[1]).toContain("app_status=offline");
   });
+
+  it("ignores non-rendered runner visibility phase and session churn in the fingerprint", () => {
+    const rendered: string[] = [];
+    let snapshot = makeSnapshot({
+      running: [
+        {
+          issueNumber: 138,
+          identifier: "#138",
+          issueState: "running",
+          startedAt: new Date("2026-03-13T10:00:00.000Z"),
+          retryAttempt: 1,
+          sessionId: null,
+          turnCount: 1,
+          codexTotalTokens: 0,
+          codexInputTokens: 0,
+          codexOutputTokens: 0,
+          codexAppServerPid: 12345,
+          lastCodexEvent: null,
+          lastCodexMessage: null,
+          lastCodexTimestamp: null,
+          runnerVisibility: makeRunnerVisibility({
+            phase: "turn-execution",
+            session: {
+              ...makeRunnerVisibility().session,
+              model: "gpt-5.4",
+              appServerPid: 12345,
+              latestTurnNumber: 1,
+            },
+            stdoutSummary: JSON.stringify({
+              method: "thread/started",
+              params: { thread: { id: "thread-live-123" } },
+            }),
+          }),
+        },
+      ],
+    });
+
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (content) => rendered.push(content),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+
+    dashboard.refresh();
+    snapshot = makeSnapshot({
+      running: [
+        {
+          ...snapshot.running[0]!,
+          runnerVisibility: makeRunnerVisibility({
+            phase: "awaiting-external",
+            session: {
+              ...makeRunnerVisibility().session,
+              model: "gpt-5.5",
+              appServerPid: 54321,
+              latestTurnNumber: 2,
+            },
+            stdoutSummary: JSON.stringify({
+              method: "thread/started",
+              params: { thread: { id: "thread-live-123" } },
+            }),
+          }),
+        },
+      ],
+    });
+    dashboard.refresh();
+    dashboard.stop();
+
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toContain("thread started (thread-live-123)");
+    expect(rendered[1]).toContain("app_status=offline");
+  });
 });

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -962,4 +962,70 @@ describe("StatusDashboard", () => {
     expect(rendered[0]).toContain("thread");
     expect(rendered[1]).toContain("app_status=offline");
   });
+
+  it("ignores runner visibility stderr-only churn in the fingerprint", () => {
+    const rendered: string[] = [];
+    let snapshot = makeSnapshot({
+      running: [
+        {
+          issueNumber: 138,
+          identifier: "#138",
+          issueState: "running",
+          startedAt: new Date("2026-03-13T10:00:00.000Z"),
+          retryAttempt: 1,
+          sessionId: null,
+          turnCount: 1,
+          codexTotalTokens: 0,
+          codexInputTokens: 0,
+          codexOutputTokens: 0,
+          codexAppServerPid: 12345,
+          lastCodexEvent: null,
+          lastCodexMessage: null,
+          lastCodexTimestamp: null,
+          runnerVisibility: makeRunnerVisibility({
+            lastActionSummary: "Codex app-server stdout activity",
+            stdoutSummary: JSON.stringify({
+              method: "thread/started",
+              params: { thread: { id: "thread-live-123" } },
+            }),
+            stderrSummary: "warning: first diagnostic",
+          }),
+        },
+      ],
+    });
+
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (content) => rendered.push(content),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 1,
+      },
+    );
+
+    dashboard.refresh();
+    snapshot = makeSnapshot({
+      running: [
+        {
+          ...snapshot.running[0]!,
+          runnerVisibility: makeRunnerVisibility({
+            lastActionSummary: "Codex app-server stdout activity",
+            stdoutSummary: JSON.stringify({
+              method: "thread/started",
+              params: { thread: { id: "thread-live-123" } },
+            }),
+            stderrSummary: "warning: second diagnostic",
+          }),
+        },
+      ],
+    });
+    dashboard.refresh();
+    dashboard.stop();
+
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toContain("thread started (thread-live-123)");
+    expect(rendered[1]).toContain("app_status=offline");
+  });
 });

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -333,10 +333,7 @@ describe("formatSnapshotContent", () => {
     const output = formatSnapshotContent(snapshot, 150.5, 120, "▁▂▃▄▅▆", nowMs);
 
     // Strip ANSI codes for easier inspection
-    const plain = output.replace(
-      /\x1b\[[0-9;]*m/g,
-      "",
-    );
+    const plain = output.replace(/\x1b\[[0-9;]*m/g, "");
     const lines = plain.split("\n");
 
     // --- Header section ---

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../src/observability/tui.js";
 import type { TuiSnapshot } from "../../src/orchestrator/service.js";
 import type { ObservabilityConfig } from "../../src/domain/workflow.js";
+import type { RunnerVisibilitySnapshot } from "../../src/runner/service.js";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -41,6 +42,35 @@ function makeConfig(
     dashboardEnabled: true,
     refreshMs: 1000,
     renderIntervalMs: 16,
+    ...overrides,
+  };
+}
+
+function makeRunnerVisibility(
+  overrides: Partial<RunnerVisibilitySnapshot> = {},
+): RunnerVisibilitySnapshot {
+  return {
+    state: "running",
+    phase: "turn-execution",
+    session: {
+      provider: "codex",
+      model: "gpt-5.4",
+      backendSessionId: "thread-abc-turn-1",
+      backendThreadId: "thread-abc",
+      latestTurnId: "turn-1",
+      appServerPid: 12345,
+      latestTurnNumber: 1,
+      logPointers: [],
+    },
+    lastHeartbeatAt: "2026-03-13T10:00:05.000Z",
+    lastActionAt: "2026-03-13T10:00:05.000Z",
+    lastActionSummary: "Codex app-server stdout activity",
+    waitingReason: null,
+    stdoutSummary: null,
+    stderrSummary: null,
+    errorSummary: null,
+    cancelledAt: null,
+    timedOutAt: null,
     ...overrides,
   };
 }
@@ -107,6 +137,7 @@ describe("formatSnapshotContent", () => {
             },
           },
           lastCodexTimestamp: null,
+          runnerVisibility: null,
         },
       ],
     });
@@ -254,6 +285,7 @@ describe("formatSnapshotContent", () => {
             },
           },
           lastCodexTimestamp: new Date().toISOString(),
+          runnerVisibility: null,
         },
         {
           issueNumber: 11,
@@ -276,6 +308,7 @@ describe("formatSnapshotContent", () => {
             },
           },
           lastCodexTimestamp: new Date().toISOString(),
+          runnerVisibility: null,
         },
       ],
       retrying: [
@@ -301,7 +334,6 @@ describe("formatSnapshotContent", () => {
 
     // Strip ANSI codes for easier inspection
     const plain = output.replace(
-      // eslint-disable-next-line no-control-regex
       /\x1b\[[0-9;]*m/g,
       "",
     );
@@ -546,6 +578,112 @@ describe("humanizeEvent", () => {
     };
     const result = humanizeEvent(msg, null);
     expect(result.length).toBeLessThanOrEqual(143); // 140 + "..."
+  });
+
+  it("renders no codex message yet for truly silent runs", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 138,
+            identifier: "#138",
+            issueState: "running",
+            startedAt: new Date("2026-03-13T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: null,
+          },
+        ],
+      }),
+      0,
+      140,
+      "",
+      new Date("2026-03-13T10:00:30.000Z").getTime(),
+    );
+
+    expect(output).toContain("no codex message yet");
+  });
+
+  it("prefers runner visibility stdout over the silent fallback", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 138,
+            identifier: "#138",
+            issueState: "running",
+            startedAt: new Date("2026-03-13T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: makeRunnerVisibility({
+              stdoutSummary: JSON.stringify({
+                method: "thread/started",
+                params: { thread: { id: "thread-live-123" } },
+              }),
+            }),
+          },
+        ],
+      }),
+      0,
+      160,
+      "",
+      new Date("2026-03-13T10:00:30.000Z").getTime(),
+    );
+
+    expect(output).not.toContain("no codex message yet");
+    expect(output).toContain("thread started (thread-live-123)");
+    expect(output).toContain("thread-abc");
+  });
+
+  it("falls back to runner action text when visibility has no stdout preview", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 138,
+            identifier: "#138",
+            issueState: "running",
+            startedAt: new Date("2026-03-13T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: makeRunnerVisibility({
+              lastActionSummary: "Planning step 2",
+            }),
+          },
+        ],
+      }),
+      0,
+      160,
+      "",
+      new Date("2026-03-13T10:00:30.000Z").getTime(),
+    );
+
+    expect(output).toContain("Planning step 2");
+    expect(output).not.toContain("no codex message yet");
   });
 });
 


### PR DESCRIPTION
## Summary\n- project normalized runner visibility into the TUI running-row snapshot\n- prefer live runner stdout/action/session details over stale `no codex message yet` fallbacks\n- add regression coverage and QA fixture updates for live Codex app-server activity\n\n## Testing\n- pnpm typecheck\n- pnpm lint\n- pnpm test\n- npx tsx tests/fixtures/tui-qa-dump.ts\n\nCloses #138