### PR TITLE
Add safe detached factory watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Control or inspect the local detached factory runtime from the repo root:
 ```bash
 pnpm tsx bin/symphony.ts factory start
 pnpm tsx bin/symphony.ts factory status        # control/runtime view
+pnpm tsx bin/symphony.ts factory watch         # live read-only watch surface
 pnpm tsx bin/symphony.ts factory status --json
 pnpm tsx bin/symphony.ts factory restart
 pnpm tsx bin/symphony.ts factory stop
@@ -71,7 +72,11 @@ These commands target the checked-out runtime under `.tmp/factory-main`. Use
 `status` when you want the raw runtime snapshot for a specific workflow path,
 and use `factory status` when you want the detached runtime control state plus
 the embedded status snapshot. Operators should generally start with
-`factory status`.
+`factory status`, then use `factory watch` for continuous monitoring.
+
+For detached monitoring, do not use raw `screen -r symphony-factory` as the
+normal watch path. Attaching that way gives your terminal the worker's
+foreground signal boundary, so an accidental `Ctrl-C` can stop the factory.
 
 The status snapshot includes normalized runner visibility for active issues,
 including worker state, current phase, session identity, heartbeat/action
@@ -374,6 +379,7 @@ What works today:
 - CI and automated review follow-up loop
 - Orphaned run recovery on restart
 - Local factory status surface and per-issue reporting
+- Safe detached factory watch surface via `symphony factory watch`
 - Self-hosting: Symphony builds itself
 
 What's planned:

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -68,6 +68,7 @@ Or start the detached local factory runtime from the repo root:
 ```bash
 pnpm tsx bin/symphony.ts factory start
 pnpm tsx bin/symphony.ts factory status
+pnpm tsx bin/symphony.ts factory watch
 ```
 
 In continuous mode, Symphony will keep polling for additional ready issues. The
@@ -80,7 +81,12 @@ Symphony now has two status surfaces:
 - `pnpm tsx bin/symphony.ts factory status` inspects the detached runtime and
   embeds the latest status snapshot when available
 
-For self-hosting operations, prefer `factory status` first.
+For self-hosting operations, prefer `factory status` first, then `factory watch`
+when you want a live read-only monitor.
+
+Do not use raw `screen -r symphony-factory` as the normal watch path. That
+attach path gives your terminal direct foreground ownership of the worker, so
+an accidental `Ctrl-C` can stop the detached factory.
 
 ### 5. Watch the issue lifecycle
 
@@ -133,5 +139,5 @@ That is the self-hosting loop:
 - Run only one local Symphony instance against this repo at a time (Phase 1.2 constraint).
 - If you want to inspect a failed run, set `workspace.cleanup_on_success: false` temporarily or inspect the workspace before the next retry.
 - Use `--once` when you want tight control over one issue at a time.
-- Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart|status` over ad hoc `screen` and
+- Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart|status|watch` over ad hoc `screen` and
   process cleanup when operating the detached runtime.

--- a/docs/plans/139-safe-detached-factory-watch/plan.md
+++ b/docs/plans/139-safe-detached-factory-watch/plan.md
@@ -1,0 +1,228 @@
+# Issue 139 Plan: Safe Detached Factory Watch
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Provide a safe supported way to observe the detached local factory without attaching the operator terminal directly to the worker-owned `screen` session.
+
+This slice should make the normal observation path safe by default: `Ctrl-C` in the watch client should stop the watch client, not the detached `symphony run` worker.
+
+## Scope
+
+- document the current unsafe behavior of raw `screen -r symphony-factory`
+- add a first-class detached observation command in the existing factory-control CLI
+- implement a watch loop that renders detached factory control/status data without attaching to the worker terminal
+- make the watch loop stop cleanly on `SIGINT`/`SIGTERM` without calling `factory stop`
+- add focused tests for CLI parsing, watch rendering/loop behavior, and interrupt handling
+- update operator-facing docs and skills to point to the safe watch path instead of raw `screen -r`
+
+## Non-Goals
+
+- redesigning the detached runtime launch mechanism
+- replacing `screen` with another service manager
+- changing orchestrator retry, reconciliation, or issue handoff policy
+- redesigning the status TUI for all runtime modes
+- adding write/control operations to the watch path beyond read-only observation
+
+## Current Gaps
+
+- the detached runtime is commonly observed by running `screen -r symphony-factory`
+- attaching this way gives the operator terminal direct foreground ownership of the worker process
+- an accidental `Ctrl-C` while attached can send `SIGINT` to the detached `symphony run` process and stop the factory
+- current checked-in docs prefer the factory-control surface for start/stop/status, but there is no first-class safe live watch command
+- operators therefore still have an incentive to use raw `screen` attach when they want continuous visibility
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned operator contract that detached observation must be safe by default and should not rely on raw worker-terminal attach
+  - does not belong: changing plan-review workflow, tracker lifecycle semantics, or runner provider policy
+- Configuration Layer
+  - belongs: CLI-level watch defaults such as refresh interval if kept internal and fixed for this slice
+  - does not belong: new `WORKFLOW.md` settings for watch behavior unless the implementation proves a repo-owned config seam is required
+- Coordination Layer
+  - belongs: detached factory-control watch behavior, including the explicit signal boundary between the watch client and the detached worker
+  - does not belong: orchestrator dispatch, retry budgeting, reconciliation, or worker shutdown policy
+- Execution Layer
+  - belongs: the local process behavior of the watch command itself as a separate client process
+  - does not belong: workspace management or runner subprocess changes
+- Integration Layer
+  - belongs: local host integration with the existing factory status snapshot and process/screen inspection already used by `factory status`
+  - does not belong: tracker transport, normalization, or remote API changes
+- Observability Layer
+  - belongs: rendering a live operator-facing watch surface from the existing control/status snapshot
+  - does not belong: changing the canonical snapshot schema unless the watch surface proves a missing read-side field
+
+## Architecture Boundaries
+
+### Factory control / coordination seam
+
+Belongs here:
+
+- a safe `factory watch` command that polls the detached control surface
+- signal handling that terminates the watch client without stopping the worker
+- reuse of `inspectFactoryControl()` as the source of truth for watch snapshots
+
+Does not belong here:
+
+- worker-terminal attach
+- detached runtime startup/shutdown redesign
+- orchestrator runtime policy changes
+
+### Observability seam
+
+Belongs here:
+
+- rendering a readable continuous watch view from the existing control/status snapshot
+- lightweight watch-specific framing such as refresh timing or clear-screen behavior
+
+Does not belong here:
+
+- new tracker-derived policy
+- unrelated TUI redesign or richer live runner telemetry work beyond what the current snapshot already exposes
+
+### CLI seam
+
+Belongs here:
+
+- argument parsing and command dispatch for `symphony factory watch`
+- process-local `SIGINT`/`SIGTERM` handling for the watch client
+
+Does not belong here:
+
+- hidden fallback behavior that shells into `screen -r`
+- implicit operator control actions on interrupt
+
+### Tracker / workspace / runner seams
+
+Untouched for this slice:
+
+- tracker adapters should not learn about detached observation commands
+- workspace code should not absorb watch-loop or signal-boundary behavior
+- runners should continue to run exactly as they do today under the detached worker
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR because it stays on one detached observation seam:
+
+1. add a safe first-class watch command on top of existing factory control/status data
+2. prove the watch client exits on interrupt without invoking worker shutdown
+3. update docs so operators use the safe path instead of raw `screen -r`
+
+Deferred from this PR:
+
+- replacing `screen`
+- introducing a supervisor in front of the worker
+- broad factory-control packaging changes from `#136`
+- live log streaming or interactive control features
+
+This seam is reviewable because it stays in CLI/factory-control plus operator docs and tests. It does not mix tracker transport, orchestrator state, watchdog behavior, or runner internals.
+
+## Runtime State Model
+
+This issue does not change the detached factory runtime state machine itself. It adds a separate watch-client state model:
+
+1. `idle`
+   - `symphony factory watch` starts and performs the first control inspection
+2. `rendering`
+   - the client renders the current detached control/status snapshot
+3. `sleeping`
+   - the client waits for the next poll interval
+4. `stopping`
+   - the client receives `SIGINT` or `SIGTERM` and stops its own loop
+5. `stopped`
+   - the client exits without calling `factory stop` and without signaling detached worker pids
+
+Allowed transitions:
+
+- `idle -> rendering`
+- `rendering -> sleeping`
+- `sleeping -> rendering`
+- `idle|rendering|sleeping -> stopping -> stopped`
+
+Healthy waiting vs broken behavior:
+
+- healthy: detached runtime may be `running`, `stopped`, or `degraded`; the watch client still renders what the control surface reports
+- broken: watch client swallows an interrupt but continues polling, or it triggers detached-worker shutdown as part of interrupt handling
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Snapshot facts available | Expected decision |
+| --- | --- | --- | --- |
+| Detached runtime is healthy and watch starts normally | watch client pid only; existing `screen`/worker process tree remains untouched | readable control snapshot with `running` state | render live watch view; `Ctrl-C` stops only the watch client |
+| Detached runtime is stopped before watch starts | no session/process tree | stopped or missing snapshot | render stopped/degraded state as today; watch keeps polling until operator exits |
+| Detached runtime is degraded while watching | existing control problems from process/snapshot inspection | degraded control snapshot | render degraded state; watch exits non-zero only if the command contract chooses to on normal completion, not on interrupt |
+| Operator presses `Ctrl-C` while watching | watch client receives `SIGINT`; detached worker remains a separate process tree | last rendered snapshot unchanged until next launch of watch/status | stop the watch loop and exit cleanly without calling `stopFactory()` or signaling worker pids |
+| Watch render/read hits a transient inspection error | error from control inspection | snapshot unavailable or unreadable | render/report the current control error using the existing control semantics; keep the failure isolated to the watch client |
+
+## Storage / Persistence Contract
+
+- no new durable files
+- no new local coordination state
+- reuse the existing factory status snapshot and control inspection as read-only inputs
+
+## Observability Requirements
+
+- operators must have a documented supported command for continuous detached observation that does not attach to the worker terminal
+- watch rendering should clearly identify that it is reading the detached control/status surface, not the raw worker terminal
+- tests should prove interrupt handling stops the watch client only
+
+## Implementation Steps
+
+1. Add a `factory watch` CLI action and keep its argument surface minimal for this slice, likely `--json` unsupported and a fixed poll interval.
+2. Introduce a small watch-loop helper in the CLI/factory-control boundary that:
+   - polls `inspectFactoryControl()`
+   - clears and redraws the terminal for human mode
+   - installs `SIGINT`/`SIGTERM` handlers that only stop the watch loop
+3. Reuse `renderFactoryControlStatus()` for the content body unless a tiny watch-specific wrapper is needed for framing.
+4. Add unit coverage for argument parsing and dispatch of the new watch command.
+5. Add watch-loop tests that prove:
+   - the loop renders snapshots repeatedly
+   - `SIGINT` stops the loop
+   - interrupt handling does not call `stopFactory()` or any worker-targeting signal path
+6. Update `README.md`, `docs/guides/self-hosting-loop.md`, and `skills/symphony-operator/SKILL.md` to document `symphony factory watch` as the supported live observation path and to call out raw `screen -r` as unsafe for normal monitoring.
+7. Manually validate a detached runtime by starting the factory, running the new watch command, sending `Ctrl-C` to the watch client, and confirming `factory status` still reports a live detached runtime.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `parseArgs()` accepts `symphony factory watch`
+- `runCli()` dispatches the watch action and installs watch-loop shutdown behavior
+- watch-loop helper exits when its abort/stop path is triggered by `SIGINT`
+- watch-loop helper does not invoke `stopFactory()` or any process-signal dependency on interrupt
+
+### Integration / e2e
+
+- a detached runtime can be observed continuously through `symphony factory watch` without attaching to `screen`
+- after interrupting the watch client, `symphony factory status` still reports the detached runtime as healthy/running
+
+### Acceptance Scenarios
+
+1. An operator starts the detached factory, runs `pnpm tsx bin/symphony.ts factory watch`, and sees the live detached control/status surface update without attaching to the worker terminal.
+2. While the watch command is running, the operator presses `Ctrl-C`; the watch command exits, and a subsequent `pnpm tsx bin/symphony.ts factory status` still shows the detached factory alive.
+3. An operator reading the checked-in docs sees `factory watch` as the supported live observation path and is warned that raw `screen -r symphony-factory` is unsafe for normal monitoring.
+
+## Exit Criteria
+
+- a supported safe detached watch path exists in the checked-in CLI
+- interrupting the watch client does not stop the detached worker
+- docs and operator guidance point to the safe watch path instead of raw fragile attach
+- tests cover the interrupt boundary for the watch surface
+
+## Deferred
+
+- wrapper/supervisor process designs that change detached runtime ownership
+- non-`screen` detached backends
+- richer live log-follow or read-only attach mechanisms
+- broader factory operator-loop packaging tracked under `#136`
+
+## Decision Notes
+
+- Prefer a first-class safe watch command over trying to make raw `screen -r` safe. The current bug is that observation and control share the same terminal boundary; the narrowest fix is to separate them.
+- Keep the watch surface read-only for this slice. Mixing observation with stop/restart controls in the same interactive client would blur the signal-safety contract and broaden review scope.

--- a/docs/plans/139-safe-detached-factory-watch/plan.md
+++ b/docs/plans/139-safe-detached-factory-watch/plan.md
@@ -152,13 +152,13 @@ Healthy waiting vs broken behavior:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Snapshot facts available | Expected decision |
-| --- | --- | --- | --- |
-| Detached runtime is healthy and watch starts normally | watch client pid only; existing `screen`/worker process tree remains untouched | readable control snapshot with `running` state | render live watch view; `Ctrl-C` stops only the watch client |
-| Detached runtime is stopped before watch starts | no session/process tree | stopped or missing snapshot | render stopped/degraded state as today; watch keeps polling until operator exits |
-| Detached runtime is degraded while watching | existing control problems from process/snapshot inspection | degraded control snapshot | render degraded state; watch exits non-zero only if the command contract chooses to on normal completion, not on interrupt |
-| Operator presses `Ctrl-C` while watching | watch client receives `SIGINT`; detached worker remains a separate process tree | last rendered snapshot unchanged until next launch of watch/status | stop the watch loop and exit cleanly without calling `stopFactory()` or signaling worker pids |
-| Watch render/read hits a transient inspection error | error from control inspection | snapshot unavailable or unreadable | render/report the current control error using the existing control semantics; keep the failure isolated to the watch client |
+| Observed condition                                    | Local facts available                                                           | Snapshot facts available                                           | Expected decision                                                                                                           |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Detached runtime is healthy and watch starts normally | watch client pid only; existing `screen`/worker process tree remains untouched  | readable control snapshot with `running` state                     | render live watch view; `Ctrl-C` stops only the watch client                                                                |
+| Detached runtime is stopped before watch starts       | no session/process tree                                                         | stopped or missing snapshot                                        | render stopped/degraded state as today; watch keeps polling until operator exits                                            |
+| Detached runtime is degraded while watching           | existing control problems from process/snapshot inspection                      | degraded control snapshot                                          | render degraded state; watch exits non-zero only if the command contract chooses to on normal completion, not on interrupt  |
+| Operator presses `Ctrl-C` while watching              | watch client receives `SIGINT`; detached worker remains a separate process tree | last rendered snapshot unchanged until next launch of watch/status | stop the watch loop and exit cleanly without calling `stopFactory()` or signaling worker pids                               |
+| Watch render/read hits a transient inspection error   | error from control inspection                                                   | snapshot unavailable or unreadable                                 | render/report the current control error using the existing control semantics; keep the failure isolated to the watch client |
 
 ## Storage / Persistence Contract
 

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -35,6 +35,7 @@ Use this skill when acting as the operator for the local Symphony factory.
 - Do not act as a second scheduler.
 - Keep concurrency conservative.
 - Treat the factory-control surface as the primary local runtime contract; use ad hoc `screen`, `ps`, or `pkill` inspection only when the control command is unavailable or inconsistent.
+- Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring; do not use raw `screen -r symphony-factory` as the normal watch path because `Ctrl-C` there can kill the worker.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart` over manual `screen` and process cleanup.
 - Prefer detached worker sessions that survive outside the current interactive shell.
@@ -71,6 +72,7 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 
 - Detached `screen` sessions have been more reliable for unattended local operation than short-lived interactive exec sessions.
 - `pnpm tsx bin/symphony.ts factory status --json` is the fastest trustworthy read of detached runtime health, embedded status snapshot state, and degraded-control problems.
+- `pnpm tsx bin/symphony.ts factory watch` is the supported live watch surface for the detached factory; it should absorb operator `Ctrl-C` without stopping the worker.
 - A closed issue plus an open PR usually means the factory reached the PR stage; inspect the PR before restarting anything.
 - If the factory has no `symphony:ready` issues, idle is healthy.
 

--- a/src/cli/factory-watch.ts
+++ b/src/cli/factory-watch.ts
@@ -1,0 +1,130 @@
+import {
+  inspectFactoryControl,
+  renderFactoryControlStatus,
+  type FactoryControlStatusSnapshot,
+} from "./factory-control.js";
+
+const DEFAULT_WATCH_INTERVAL_MS = 1_000;
+
+export interface FactoryWatchDeps {
+  readonly inspectFactoryControl?: () => Promise<FactoryControlStatusSnapshot>;
+  readonly renderFactoryControlStatus?: (
+    snapshot: FactoryControlStatusSnapshot,
+    options?: {
+      readonly format?: "human" | "json";
+    },
+  ) => string;
+  readonly writeStdout?: (chunk: string) => void;
+  readonly isStdoutTTY?: () => boolean;
+  readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  readonly clearScreen?: () => string;
+  readonly onSignal?: (
+    signal: NodeJS.Signals,
+    listener: () => void,
+  ) => void;
+  readonly offSignal?: (
+    signal: NodeJS.Signals,
+    listener: () => void,
+  ) => void;
+}
+
+export async function watchFactory(
+  deps: FactoryWatchDeps = {},
+): Promise<void> {
+  const inspect = deps.inspectFactoryControl ?? inspectFactoryControl;
+  const render = deps.renderFactoryControlStatus ?? renderFactoryControlStatus;
+  const writeStdout = deps.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
+  const isStdoutTTY = deps.isStdoutTTY ?? (() => process.stdout.isTTY);
+  const sleep = deps.sleep ?? sleepWithAbort;
+  const clearScreen = deps.clearScreen ?? defaultClearScreen;
+  const onSignal = deps.onSignal ?? ((signal, listener) => process.on(signal, listener));
+  const offSignal = deps.offSignal ?? ((signal, listener) => process.off(signal, listener));
+
+  const abortController = new AbortController();
+  const stopWatching = (): void => {
+    abortController.abort();
+  };
+
+  onSignal("SIGINT", stopWatching);
+  onSignal("SIGTERM", stopWatching);
+
+  try {
+    while (!abortController.signal.aborted) {
+      const snapshot = await inspect();
+      const frame = renderWatchFrame(
+        render(snapshot, { format: "human" }),
+        isStdoutTTY(),
+        clearScreen,
+      );
+      writeStdout(frame);
+
+      await sleep(DEFAULT_WATCH_INTERVAL_MS, abortController.signal).catch(
+        (error: unknown) => {
+          if (isAbortError(error)) {
+            return;
+          }
+          throw error;
+        },
+      );
+    }
+  } finally {
+    offSignal("SIGINT", stopWatching);
+    offSignal("SIGTERM", stopWatching);
+  }
+}
+
+export function renderWatchFrame(
+  body: string,
+  isTTY: boolean,
+  clearScreen: () => string = defaultClearScreen,
+): string {
+  const lines = [
+    "Detached factory watch",
+    "Ctrl-C stops this watch client only.",
+    "",
+    body.endsWith("\n") ? body.slice(0, -1) : body,
+  ];
+  const prefix = isTTY ? clearScreen() : "";
+  return `${prefix}${lines.join("\n")}\n`;
+}
+
+export function defaultClearScreen(): string {
+  return "\x1b[2J\x1b[H";
+}
+
+async function sleepWithAbort(
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) {
+    throw createAbortError();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function createAbortError(): Error {
+  const error = new Error("Factory watch aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.message === "Factory watch aborted.")
+  );
+}

--- a/src/cli/factory-watch.ts
+++ b/src/cli/factory-watch.ts
@@ -27,7 +27,7 @@ export async function watchFactory(deps: FactoryWatchDeps = {}): Promise<void> {
   const render = deps.renderFactoryControlStatus ?? renderFactoryControlStatus;
   const writeStdout =
     deps.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
-  const isStdoutTTY = deps.isStdoutTTY ?? (() => process.stdout.isTTY);
+  const isStdoutTTY = deps.isStdoutTTY ?? (() => Boolean(process.stdout.isTTY));
   const sleep = deps.sleep ?? sleepWithAbort;
   const clearScreen = deps.clearScreen ?? defaultClearScreen;
   const onSignal =
@@ -45,12 +45,10 @@ export async function watchFactory(deps: FactoryWatchDeps = {}): Promise<void> {
 
   try {
     while (!abortController.signal.aborted) {
-      const snapshot = await inspect();
-      const frame = renderWatchFrame(
-        render(snapshot, { format: "human" }),
-        isStdoutTTY(),
-        clearScreen,
-      );
+      const body = await inspect()
+        .then((snapshot) => render(snapshot, { format: "human" }))
+        .catch((error: unknown) => renderWatchError(error));
+      const frame = renderWatchFrame(body, isStdoutTTY(), clearScreen);
       writeStdout(frame);
 
       await sleep(DEFAULT_WATCH_INTERVAL_MS, abortController.signal).catch(
@@ -81,6 +79,16 @@ export function renderWatchFrame(
   ];
   const prefix = isTTY ? clearScreen() : "";
   return `${prefix}${lines.join("\n")}\n`;
+}
+
+export function renderWatchError(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : "Unknown factory watch error.";
+  return [
+    "Factory control: degraded",
+    `Watch error: ${message}`,
+    "Status detail: watch will retry on the next poll.",
+  ].join("\n");
 }
 
 export function defaultClearScreen(): string {
@@ -115,8 +123,5 @@ function createAbortError(): Error {
 }
 
 function isAbortError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.name === "AbortError" || error.message === "Factory watch aborted.")
-  );
+  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/cli/factory-watch.ts
+++ b/src/cli/factory-watch.ts
@@ -18,27 +18,22 @@ export interface FactoryWatchDeps {
   readonly isStdoutTTY?: () => boolean;
   readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   readonly clearScreen?: () => string;
-  readonly onSignal?: (
-    signal: NodeJS.Signals,
-    listener: () => void,
-  ) => void;
-  readonly offSignal?: (
-    signal: NodeJS.Signals,
-    listener: () => void,
-  ) => void;
+  readonly onSignal?: (signal: NodeJS.Signals, listener: () => void) => void;
+  readonly offSignal?: (signal: NodeJS.Signals, listener: () => void) => void;
 }
 
-export async function watchFactory(
-  deps: FactoryWatchDeps = {},
-): Promise<void> {
+export async function watchFactory(deps: FactoryWatchDeps = {}): Promise<void> {
   const inspect = deps.inspectFactoryControl ?? inspectFactoryControl;
   const render = deps.renderFactoryControlStatus ?? renderFactoryControlStatus;
-  const writeStdout = deps.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
+  const writeStdout =
+    deps.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
   const isStdoutTTY = deps.isStdoutTTY ?? (() => process.stdout.isTTY);
   const sleep = deps.sleep ?? sleepWithAbort;
   const clearScreen = deps.clearScreen ?? defaultClearScreen;
-  const onSignal = deps.onSignal ?? ((signal, listener) => process.on(signal, listener));
-  const offSignal = deps.offSignal ?? ((signal, listener) => process.off(signal, listener));
+  const onSignal =
+    deps.onSignal ?? ((signal, listener) => process.on(signal, listener));
+  const offSignal =
+    deps.offSignal ?? ((signal, listener) => process.off(signal, listener));
 
   const abortController = new AbortController();
   const stopWatching = (): void => {
@@ -92,10 +87,7 @@ export function defaultClearScreen(): string {
   return "\x1b[2J\x1b[H";
 }
 
-async function sleepWithAbort(
-  ms: number,
-  signal: AbortSignal,
-): Promise<void> {
+async function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) {
     throw createAbortError();
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import {
   startFactory,
   stopFactory,
 } from "./factory-control.js";
+import { watchFactory } from "./factory-watch.js";
 
 export type CliArgs =
   | {
@@ -41,6 +42,11 @@ export type CliArgs =
       readonly command: "factory";
       readonly action: "start" | "stop" | "restart";
       readonly format: "human" | "json";
+    }
+  | {
+      readonly command: "factory";
+      readonly action: "watch";
+      readonly format: "human";
     }
   | {
       readonly command: "factory";
@@ -88,6 +94,18 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         format: args.includes("--json") ? "json" : "human",
       };
     }
+    if (action === "watch") {
+      if (args.includes("--json")) {
+        throw new Error(
+          "Usage: symphony factory watch",
+        );
+      }
+      return {
+        command: "factory",
+        action: "watch",
+        format: "human",
+      };
+    }
     if (action === "status") {
       return {
         command: "factory",
@@ -96,7 +114,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
       };
     }
     throw new Error(
-      "Usage: symphony factory <start|stop|restart|status> [--json]",
+      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
     );
   }
 
@@ -177,6 +195,10 @@ export async function runCli(argv: readonly string[]): Promise<void> {
           process.exitCode = snapshot.controlState === "degraded" ? 1 : 0;
           return;
         }
+
+        case "watch":
+          await watchFactory();
+          return;
       }
       return;
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,9 +96,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
     }
     if (action === "watch") {
       if (args.includes("--json")) {
-        throw new Error(
-          "Usage: symphony factory watch",
-        );
+        throw new Error("Usage: symphony factory watch");
       }
       return {
         command: "factory",

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -179,6 +179,15 @@ describe("parseArgs", () => {
     });
   });
 
+  it("parses the factory watch command", () => {
+    const args = parseArgs(["node", "symphony", "factory", "watch"]);
+    expect(args).toEqual({
+      command: "factory",
+      action: "watch",
+      format: "human",
+    });
+  });
+
   it("parses the factory start and stop commands", () => {
     expect(parseArgs(["node", "symphony", "factory", "start"])).toEqual({
       command: "factory",
@@ -218,13 +227,19 @@ describe("parseArgs", () => {
 
   it("shows factory-specific usage for missing or unknown factory actions", () => {
     expect(() => parseArgs(["node", "symphony", "factory"])).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json]",
+      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
     );
     expect(() =>
       parseArgs(["node", "symphony", "factory", "deploy"]),
     ).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json]",
+      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
     );
+  });
+
+  it("rejects --json for factory watch", () => {
+    expect(() =>
+      parseArgs(["node", "symphony", "factory", "watch", "--json"]),
+    ).toThrowError("Usage: symphony factory watch");
   });
 });
 
@@ -699,5 +714,26 @@ describe("runCli factory", () => {
     await mockedRunCli(["node", "symphony", "factory", "status", "--json"]);
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it("dispatches the factory watch command", async () => {
+    vi.resetModules();
+    const watchFactory = vi.fn(async () => {});
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(),
+      renderFactoryControlStatus: vi.fn(),
+      startFactory: vi.fn(),
+      stopFactory: vi.fn(),
+    }));
+    vi.doMock("../../src/cli/factory-watch.js", () => ({
+      watchFactory,
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    await mockedRunCli(["node", "symphony", "factory", "watch"]);
+
+    expect(watchFactory).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/factory-watch.test.ts
+++ b/tests/unit/factory-watch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { FactoryControlStatusSnapshot } from "../../src/cli/factory-control.js";
-import { renderWatchFrame, watchFactory } from "../../src/cli/factory-watch.js";
+import {
+  renderWatchError,
+  renderWatchFrame,
+  watchFactory,
+} from "../../src/cli/factory-watch.js";
 
 function createSnapshot(): FactoryControlStatusSnapshot {
   return {
@@ -34,6 +38,16 @@ describe("renderWatchFrame", () => {
     expect(output).toContain("Detached factory watch");
     expect(output).toContain("Ctrl-C stops this watch client only.");
     expect(output).toContain("Factory control: running");
+  });
+});
+
+describe("renderWatchError", () => {
+  it("renders a retrying degraded watch message", () => {
+    const output = renderWatchError(new Error("runtime missing"));
+
+    expect(output).toContain("Factory control: degraded");
+    expect(output).toContain("Watch error: runtime missing");
+    expect(output).toContain("watch will retry on the next poll");
   });
 });
 
@@ -99,5 +113,39 @@ describe("watchFactory", () => {
     expect(onSignal).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
     expect(offSignal).toHaveBeenCalledWith("SIGINT", expect.any(Function));
     expect(offSignal).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+  });
+
+  it("renders inspect failures and keeps polling until interrupted", async () => {
+    const writes: string[] = [];
+    const listeners = new Map<NodeJS.Signals, () => void>();
+    let iterations = 0;
+
+    await watchFactory({
+      inspectFactoryControl: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("runtime missing"))
+        .mockResolvedValue(createSnapshot()),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
+      writeStdout: (chunk) => {
+        writes.push(chunk);
+      },
+      isStdoutTTY: () => false,
+      onSignal: (signal, listener) => {
+        listeners.set(signal, listener);
+      },
+      offSignal: (signal) => {
+        listeners.delete(signal);
+      },
+      sleep: async () => {
+        iterations += 1;
+        if (iterations === 2) {
+          listeners.get("SIGINT")?.();
+        }
+      },
+    });
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toContain("Watch error: runtime missing");
+    expect(writes[1]).toContain("Factory control: running");
   });
 });

--- a/tests/unit/factory-watch.test.ts
+++ b/tests/unit/factory-watch.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FactoryControlStatusSnapshot } from "../../src/cli/factory-control.js";
+import { renderWatchFrame, watchFactory } from "../../src/cli/factory-watch.js";
+
+function createSnapshot(): FactoryControlStatusSnapshot {
+  return {
+    controlState: "running",
+    paths: {
+      repoRoot: "/repo",
+      runtimeRoot: "/repo/.tmp/factory-main",
+      workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+      statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+    },
+    sessionName: "symphony-factory",
+    sessions: [
+      {
+        id: "1001.symphony-factory",
+        pid: 1001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ],
+    workerAlive: true,
+    statusSnapshot: null,
+    processIds: [1001, 1002],
+    problems: [],
+  };
+}
+
+describe("renderWatchFrame", () => {
+  it("adds watch framing without mutating the control body", () => {
+    const output = renderWatchFrame("Factory control: running\n", false);
+
+    expect(output).toContain("Detached factory watch");
+    expect(output).toContain("Ctrl-C stops this watch client only.");
+    expect(output).toContain("Factory control: running");
+  });
+});
+
+describe("watchFactory", () => {
+  it("renders snapshots repeatedly until interrupted", async () => {
+    const writes: string[] = [];
+    const listeners = new Map<NodeJS.Signals, () => void>();
+    let iterations = 0;
+
+    await watchFactory({
+      inspectFactoryControl: vi.fn(async () => createSnapshot()),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
+      writeStdout: (chunk) => {
+        writes.push(chunk);
+      },
+      isStdoutTTY: () => false,
+      onSignal: (signal, listener) => {
+        listeners.set(signal, listener);
+      },
+      offSignal: (signal) => {
+        listeners.delete(signal);
+      },
+      sleep: async () => {
+        iterations += 1;
+        if (iterations === 2) {
+          listeners.get("SIGINT")?.();
+        }
+      },
+    });
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toContain("Detached factory watch");
+    expect(writes[1]).toContain("Factory control: running");
+    expect(listeners.size).toBe(0);
+  });
+
+  it("removes its own signal handlers when interrupted", async () => {
+    const onSignal = vi.fn<
+      (signal: NodeJS.Signals, listener: () => void) => void
+    >();
+    const offSignal = vi.fn<
+      (signal: NodeJS.Signals, listener: () => void) => void
+    >();
+    let stop: (() => void) | undefined;
+
+    onSignal.mockImplementation((signal, listener) => {
+      if (signal === "SIGINT") {
+        stop = listener;
+      }
+    });
+
+    await watchFactory({
+      inspectFactoryControl: vi.fn(async () => createSnapshot()),
+      renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
+      writeStdout: vi.fn(),
+      isStdoutTTY: () => false,
+      onSignal,
+      offSignal,
+      sleep: async () => {
+        stop?.();
+      },
+    });
+
+    expect(onSignal).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(onSignal).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(offSignal).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(offSignal).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+  });
+});

--- a/tests/unit/factory-watch.test.ts
+++ b/tests/unit/factory-watch.test.ts
@@ -71,12 +71,10 @@ describe("watchFactory", () => {
   });
 
   it("removes its own signal handlers when interrupted", async () => {
-    const onSignal = vi.fn<
-      (signal: NodeJS.Signals, listener: () => void) => void
-    >();
-    const offSignal = vi.fn<
-      (signal: NodeJS.Signals, listener: () => void) => void
-    >();
+    const onSignal =
+      vi.fn<(signal: NodeJS.Signals, listener: () => void) => void>();
+    const offSignal =
+      vi.fn<(signal: NodeJS.Signals, listener: () => void) => void>();
     let stop: (() => void) | undefined;
 
     onSignal.mockImplementation((signal, listener) => {


### PR DESCRIPTION
## Summary
- add a read-only  command that polls the detached control/status surface instead of attaching to the worker terminal
- stop the watch client cleanly on  and  without calling any factory stop path
- document  as the supported detached monitoring path and warn against raw Must be connected to a terminal.

Closes #139.

## Testing
- 
> @sociotechnica/symphony-ts@0.1.0 typecheck /Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139
> tsc --noEmit
- 
> @sociotechnica/symphony-ts@0.1.0 lint /Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139
> eslint . --ext .ts
- 
> @sociotechnica/symphony-ts@0.1.0 test /Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139
> vitest run


 RUN  v3.2.4 /Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139

{"timestamp":"2026-03-13T19:36:26.251Z","level":"info","message":"Launching runner","command":"node -e \"process.stdin.destroy(); setTimeout(() => process.exit(0), 10)\"","workspacePath":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","turnNumber":1}
 ✓ tests/unit/workflow.test.ts (36 tests) 87ms
Generated issue report for #32
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/32/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/32/report.md
{"timestamp":"2026-03-13T19:36:26.286Z","level":"info","message":"Claimed GitHub issue","issueNumber":7}
Generated issue report for #43
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/43/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/43/report.md
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-issues-gxa4p9F58dpn/.var/reports/issues/44/report.md
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-failed-dT5qYtkclSD1/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-failed-dT5qYtkclSD1/.var/reports/issues/44/report.md
{"timestamp":"2026-03-13T19:36:26.299Z","level":"info","message":"Launching runner","command":"node -e \"process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)\"","workspacePath":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.305Z","level":"info","message":"Auto-detected GitHub merge method","repo":"sociotechnica-org/symphony-ts","mergeMethod":"merge","allowedMergeMethods":["merge","squash","rebase"]}
{"timestamp":"2026-03-13T19:36:26.308Z","level":"info","message":"Launching runner","command":"node -e \"setInterval(() => {}, 1000)\"","workspacePath":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.310Z","level":"info","message":"Launching runner","command":"node -e \"process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)\"","workspacePath":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","turnNumber":1}
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-codex-9GAc2bC3LFer/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-codex-9GAc2bC3LFer/.var/reports/issues/44/report.md
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-partial-qXMOMqlOyAQb/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-partial-qXMOMqlOyAQb/.var/reports/issues/44/report.md
Generated issue report for #32
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/32/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/32/report.md
Generated issue report for #43
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/43/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/43/report.md
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/issues/44/report.md
Generated campaign digest window-2026-03-01-to-2026-03-07
summary.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/campaigns/window-2026-03-01-to-2026-03-07/summary.md
timeline.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/campaigns/window-2026-03-01-to-2026-03-07/timeline.md
github-activity.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/campaigns/window-2026-03-01-to-2026-03-07/github-activity.md
token-usage.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/campaigns/window-2026-03-01-to-2026-03-07/token-usage.md
learnings.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-window-Om0IWUbILjCi/.var/reports/campaigns/window-2026-03-01-to-2026-03-07/learnings.md
{"timestamp":"2026-03-13T19:36:26.370Z","level":"info","message":"Auto-detected GitHub merge method","repo":"sociotechnica-org/symphony-ts","mergeMethod":"merge","allowedMergeMethods":["merge","squash","rebase"]}
{"timestamp":"2026-03-13T19:36:26.377Z","level":"info","message":"Auto-detected GitHub merge method","repo":"sociotechnica-org/symphony-ts","mergeMethod":"squash","allowedMergeMethods":["squash"]}
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-linear-CrTCZ0IjGQuo/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-report-cli-linear-CrTCZ0IjGQuo/.var/reports/issues/44/report.md
 ✓ tests/integration/report-cli.test.ts (6 tests) 161ms
Generated issue report for #32
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-missing-Pq4X7aO0Lu95/.var/reports/issues/32/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-missing-Pq4X7aO0Lu95/.var/reports/issues/32/report.md
 ✓ tests/unit/issue-report-enrichment.test.ts (10 tests) 210ms
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-stale-SiECQzbFFsvh/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-stale-SiECQzbFFsvh/.var/reports/issues/44/report.md
Generated issue report for #32
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/issues/32/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/issues/32/report.md
{"timestamp":"2026-03-13T19:36:26.440Z","level":"info","message":"Claimed GitHub issue","issueNumber":7}
 ✓ tests/unit/issue-report.test.ts (13 tests) 249ms
Generated issue report for #44
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/issues/44/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/issues/44/report.md
Generated campaign digest issues-32-44
summary.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/campaigns/issues-32-44/summary.md
timeline.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/campaigns/issues-32-44/timeline.md
github-activity.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/campaigns/issues-32-44/github-activity.md
token-usage.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/campaigns/issues-32-44/token-usage.md
learnings.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-campaign-cli-partial-nOKpqJ2RKxIM/.var/reports/campaigns/issues-32-44/learnings.md
{"timestamp":"2026-03-13T19:36:26.449Z","level":"info","message":"Claimed GitHub issue","issueNumber":7}
 ✓ tests/integration/github-bootstrap.test.ts (33 tests) 201ms
 ✓ tests/integration/campaign-report-cli.test.ts (5 tests) 229ms
{"timestamp":"2026-03-13T19:36:26.565Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:26.569Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:26.583Z","level":"info","message":"Claimed GitHub issue","issueNumber":1}
{"timestamp":"2026-03-13T19:36:26.596Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:26.603Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:26.611Z","level":"info","message":"Claimed Linear issue","issueNumber":1,"identifier":"SYM-1","nextState":"In Progress"}
 ✓ tests/integration/linear-client.test.ts (12 tests) 75ms
 ✓ tests/integration/linear-write.test.ts (6 tests) 81ms
{"timestamp":"2026-03-13T19:36:26.656Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/status.test.ts (12 tests) 25ms
{"timestamp":"2026-03-13T19:36:26.706Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/issue-artifacts.test.ts (5 tests) 45ms
 ✓ tests/unit/issue-lease.test.ts (7 tests) 309ms
{"timestamp":"2026-03-13T19:36:26.745Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
{"timestamp":"2026-03-13T19:36:26.758Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-8HdkObC8vK85/.tmp/workspaces/sociotechnica-org_symphony-ts_1","issueIdentifier":"sociotechnica-org/symphony-ts#1","branchName":"symphony/1","createdNow":true}
{"timestamp":"2026-03-13T19:36:26.768Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":1,"branchName":"symphony/1","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-a21dacf9-dcd2-4fbe-8b06-09425009f0b7","maxTurns":3}
{"timestamp":"2026-03-13T19:36:26.769Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success-unique.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-8HdkObC8vK85/.tmp/workspaces/sociotechnica-org_symphony-ts_1","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-a21dacf9-dcd2-4fbe-8b06-09425009f0b7","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.772Z","level":"info","message":"Runner process attached to active issue","issueNumber":1,"runnerPid":39613,"spawnedAt":"2026-03-13T19:36:26.772Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.799Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-linear-e2e-EreTIaKz9nsH/.tmp/workspaces/SYM-1","issueIdentifier":"SYM-1","branchName":"symphony/1","createdNow":true}
{"timestamp":"2026-03-13T19:36:26.808Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":1,"branchName":"symphony/1","runSessionId":"SYM-1/attempt-1-a747739a-b2c2-4870-99f6-ae25e92ff621","maxTurns":3}
{"timestamp":"2026-03-13T19:36:26.809Z","level":"info","message":"Launching runner","command":"bash /Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-linear-success.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-linear-e2e-EreTIaKz9nsH/.tmp/workspaces/SYM-1","issueIdentifier":"SYM-1","attempt":1,"runSessionId":"SYM-1/attempt-1-a747739a-b2c2-4870-99f6-ae25e92ff621","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.812Z","level":"info","message":"Runner process attached to active issue","issueNumber":1,"runnerPid":39654,"spawnedAt":"2026-03-13T19:36:26.811Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:26.853Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/github-client.test.ts (6 tests) 19ms
{"timestamp":"2026-03-13T19:36:26.909Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
{"timestamp":"2026-03-13T19:36:26.920Z","level":"info","message":"Claimed Linear issue","issueNumber":7,"identifier":"SYMPHONY-LINEAR-7","nextState":"In Progress"}
 ✓ tests/unit/tui.test.ts (61 tests) 76ms
 ✓ tests/integration/mock-gh-fixture.test.ts (1 test) 55ms
{"timestamp":"2026-03-13T19:36:26.949Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":1,"branchName":"symphony/1","runSessionId":"SYM-1/attempt-1-a747739a-b2c2-4870-99f6-ae25e92ff621","backendSessionId":null,"lifecycle":"awaiting-human-review","summary":"Linear issue SYM-1 is waiting for human review","turnNumber":1}
 ✓ tests/unit/factory-control.test.ts (21 tests) 25ms
Factory control: degraded
 ✓ tests/unit/cli.test.ts (25 tests) 91ms
{"timestamp":"2026-03-13T19:36:26.962Z","level":"info","message":"Claimed Linear issue","issueNumber":18,"identifier":"SYMPHONY-LINEAR-18","nextState":"In Progress"}
{"timestamp":"2026-03-13T19:36:26.962Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:26.966Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:26.974Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/integration/linear.test.ts (22 tests) 110ms
{"timestamp":"2026-03-13T19:36:26.978Z","level":"info","message":"Issue remains in handoff review","issueNumber":1,"summary":"Linear issue SYM-1 is waiting in 'Merging' for landing to be observed"}
{"timestamp":"2026-03-13T19:36:26.989Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:26.993Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:26.999Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":1,"branchName":"symphony/1","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-a21dacf9-dcd2-4fbe-8b06-09425009f0b7","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52406/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:27.001Z","level":"info","message":"Issue completed","issueNumber":1}
{"timestamp":"2026-03-13T19:36:27.015Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.017Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:27.029Z","level":"info","message":"Issue remains in handoff review","issueNumber":1,"summary":"Pull request http://127.0.0.1:52406/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:27.050Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.052Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
{"timestamp":"2026-03-13T19:36:27.052Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
 ✓ tests/unit/planning-contract.test.ts (5 tests) 10ms
{"timestamp":"2026-03-13T19:36:27.079Z","level":"info","message":"Auto-detected GitHub merge method","repo":"sociotechnica-org/symphony-ts","mergeMethod":"merge","allowedMergeMethods":["merge","squash","rebase"]}
{"timestamp":"2026-03-13T19:36:27.088Z","level":"info","message":"Issue completed","issueNumber":1}
{"timestamp":"2026-03-13T19:36:27.091Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-8HdkObC8vK85/.tmp/workspaces/sociotechnica-org_symphony-ts_1"}
 ✓ tests/unit/liveness-probe.test.ts (4 tests) 8ms
{"timestamp":"2026-03-13T19:36:27.121Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/linear-policy.test.ts (27 tests) 12ms
 ✓ tests/unit/campaign-report.test.ts (5 tests) 4ms
 ✓ tests/unit/linear-write.test.ts (4 tests) 10ms
 ✓ tests/unit/guarded-landing.test.ts (11 tests) 4ms
 ✓ tests/e2e/linear-factory.test.ts (1 test) 811ms
   ✓ Linear factory e2e > runs a complete Linear handoff loop against mocked Linear  810ms
{"timestamp":"2026-03-13T19:36:27.203Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/plan-review-policy.test.ts (9 tests) 3ms
 ✓ tests/unit/runner-contract.test.ts (4 tests) 3ms
{"timestamp":"2026-03-13T19:36:27.329Z","level":"warn","message":"Dropped unsupported Codex exec arguments while building app-server launch command","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1","droppedArgs":["-C","."]}
 ✓ tests/unit/logger.test.ts (1 test) 3ms
 ✓ tests/unit/stall-detector.test.ts (23 tests) 3ms
 ✓ tests/unit/linear-normalize.test.ts (13 tests) 5ms
 ✓ tests/unit/pull-request-snapshot.test.ts (7 tests) 4ms
{"timestamp":"2026-03-13T19:36:27.397Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.398Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:27.402Z","level":"info","message":"Claimed GitHub issue","issueNumber":80}
 ✓ tests/unit/factory-watch.test.ts (3 tests) 4ms
 ✓ tests/unit/plan-review-comment.test.ts (7 tests) 5ms
 ✓ tests/unit/follow-up-state.test.ts (4 tests) 2ms
 ✓ tests/unit/runner-factory.test.ts (3 tests) 2ms
 ✓ tests/unit/running-entry.test.ts (8 tests) 4ms
 ✓ tests/unit/pull-request-policy.test.ts (7 tests) 3ms
 ✓ tests/unit/report-cli.test.ts (9 tests) 4ms
 ✓ tests/unit/status-state.test.ts (2 tests) 3ms
 ✓ tests/unit/local-runner.test.ts (34 tests) 1342ms
{"timestamp":"2026-03-13T19:36:27.598Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-AfPY1KrEbeEF/.tmp/workspaces/sociotechnica-org_symphony-ts_80","issueIdentifier":"sociotechnica-org/symphony-ts#80","branchName":"symphony/80","createdNow":true}
{"timestamp":"2026-03-13T19:36:27.610Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":80,"branchName":"symphony/80","runSessionId":"sociotechnica-org/symphony-ts#80/attempt-1-6060e25c-385c-40bc-9923-385c2b1ece2c","maxTurns":3}
{"timestamp":"2026-03-13T19:36:27.611Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success-unique.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-AfPY1KrEbeEF/.tmp/workspaces/sociotechnica-org_symphony-ts_80","issueIdentifier":"sociotechnica-org/symphony-ts#80","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#80/attempt-1-6060e25c-385c-40bc-9923-385c2b1ece2c","turnNumber":1}
{"timestamp":"2026-03-13T19:36:27.630Z","level":"info","message":"Runner process attached to active issue","issueNumber":80,"runnerPid":40198,"spawnedAt":"2026-03-13T19:36:27.628Z","turnNumber":1}
 ✓ tests/unit/factory-runs.test.ts (2 tests) 2ms
 ✓ tests/unit/linear-workpad.test.ts (1 test) 2ms
{"timestamp":"2026-03-13T19:36:27.806Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":80,"branchName":"symphony/80","runSessionId":"sociotechnica-org/symphony-ts#80/attempt-1-6060e25c-385c-40bc-9923-385c2b1ece2c","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52512/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:27.809Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.810Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:27.813Z","level":"info","message":"Issue remains in handoff review","issueNumber":80,"summary":"Pull request http://127.0.0.1:52512/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:27.815Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.816Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
 ✓ tests/unit/orchestrator.test.ts (46 tests) 1551ms
{"timestamp":"2026-03-13T19:36:27.821Z","level":"info","message":"Landing blocked by guard","issueNumber":80,"branchName":"symphony/80","pullRequestNumber":1,"reason":"review-threads-unresolved","lifecycleKind":"awaiting-human-review","summary":"Landing blocked for pull request http://127.0.0.1:52512/pulls/1 because unresolved non-outdated review threads remain."}
{"timestamp":"2026-03-13T19:36:27.939Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:27.940Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:27.941Z","level":"info","message":"Claimed GitHub issue","issueNumber":53}
{"timestamp":"2026-03-13T19:36:28.024Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-z1YsKlCpgqTn/.tmp/workspaces/sociotechnica-org_symphony-ts_53","issueIdentifier":"sociotechnica-org/symphony-ts#53","branchName":"symphony/53","createdNow":true}
{"timestamp":"2026-03-13T19:36:28.027Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":53,"branchName":"symphony/53","runSessionId":"sociotechnica-org/symphony-ts#53/attempt-1-5f2d1882-0004-46d8-a87a-abe8cdc8797c","maxTurns":3}
{"timestamp":"2026-03-13T19:36:28.027Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-plan-review.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-z1YsKlCpgqTn/.tmp/workspaces/sociotechnica-org_symphony-ts_53","issueIdentifier":"sociotechnica-org/symphony-ts#53","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#53/attempt-1-5f2d1882-0004-46d8-a87a-abe8cdc8797c","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.028Z","level":"info","message":"Runner process attached to active issue","issueNumber":53,"runnerPid":40520,"spawnedAt":"2026-03-13T19:36:28.028Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.144Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":53,"branchName":"symphony/53","runSessionId":"sociotechnica-org/symphony-ts#53/attempt-1-5f2d1882-0004-46d8-a87a-abe8cdc8797c","backendSessionId":null,"lifecycle":"awaiting-human-handoff","summary":"Waiting for human plan review on http://127.0.0.1:52519/issues/53","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.341Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:28.342Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:28.344Z","level":"info","message":"Claimed GitHub issue","issueNumber":12}
{"timestamp":"2026-03-13T19:36:28.436Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-16giETC8gBbp/.tmp/workspaces/sociotechnica-org_symphony-ts_12","issueIdentifier":"sociotechnica-org/symphony-ts#12","branchName":"symphony/12","createdNow":true}
{"timestamp":"2026-03-13T19:36:28.439Z","level":"info","message":"Launching runner","command":"claude --add-dir . --file=WORKFLOW.md -p --output-format json --permission-mode bypassPermissions --model sonnet","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-16giETC8gBbp/.tmp/workspaces/sociotechnica-org_symphony-ts_12","issueIdentifier":"sociotechnica-org/symphony-ts#12","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#12/attempt-1-b3da8437-9ac9-487e-8b94-e6a300f72a97","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.440Z","level":"info","message":"Runner process attached to active issue","issueNumber":12,"runnerPid":41180,"spawnedAt":"2026-03-13T19:36:28.439Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.561Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":12,"branchName":"symphony/12","runSessionId":"sociotechnica-org/symphony-ts#12/attempt-1-b3da8437-9ac9-487e-8b94-e6a300f72a97","backendSessionId":"claude-session-12-1","lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52525/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.565Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:28.567Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:28.571Z","level":"info","message":"Auto-detected GitHub merge method","repo":"sociotechnica-org/symphony-ts","mergeMethod":"merge","allowedMergeMethods":["merge","squash","rebase"]}
{"timestamp":"2026-03-13T19:36:28.574Z","level":"info","message":"Issue completed","issueNumber":12}
{"timestamp":"2026-03-13T19:36:28.575Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-16giETC8gBbp/.tmp/workspaces/sociotechnica-org_symphony-ts_12"}
{"timestamp":"2026-03-13T19:36:28.740Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:28.741Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:28.744Z","level":"info","message":"Issue remains in handoff review","issueNumber":47,"summary":"Pull request http://127.0.0.1:52532/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:28.853Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:28.854Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:28.856Z","level":"info","message":"Claimed GitHub issue","issueNumber":48}
 ✓ tests/integration/factory-runs-cli.test.ts (11 tests) 2654ms
   ✓ factory-runs publication > publishes generated issue outputs and copied logs into the archive repo  354ms
   ✓ factory-runs publication > falls back to pointer manifests when a log is unreadable  319ms
   ✓ factory-runs publication > falls back to a pointer manifest when copying a readable log fails  341ms
   ✓ factory-runs publication > keeps publication paths inside the archive root when report repo names contain traversal segments  412ms
{"timestamp":"2026-03-13T19:36:28.969Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-xflNi8NTvkSl/.tmp/workspaces/sociotechnica-org_symphony-ts_48","issueIdentifier":"sociotechnica-org/symphony-ts#48","branchName":"symphony/48","createdNow":true}
{"timestamp":"2026-03-13T19:36:28.974Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":48,"branchName":"symphony/48","runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","maxTurns":3}
{"timestamp":"2026-03-13T19:36:28.975Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success-unique.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-xflNi8NTvkSl/.tmp/workspaces/sociotechnica-org_symphony-ts_48","issueIdentifier":"sociotechnica-org/symphony-ts#48","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","turnNumber":1}
{"timestamp":"2026-03-13T19:36:28.975Z","level":"info","message":"Runner process attached to active issue","issueNumber":48,"runnerPid":41681,"spawnedAt":"2026-03-13T19:36:28.975Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.111Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":48,"branchName":"symphony/48","runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52537/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.113Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.114Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.117Z","level":"info","message":"Issue remains in handoff review","issueNumber":48,"summary":"Pull request http://127.0.0.1:52537/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:29.118Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.119Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.122Z","level":"info","message":"Issue completed","issueNumber":48}
{"timestamp":"2026-03-13T19:36:29.124Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-xflNi8NTvkSl/.tmp/workspaces/sociotechnica-org_symphony-ts_48"}
{"timestamp":"2026-03-13T19:36:29.128Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.129Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.130Z","level":"info","message":"Claimed GitHub issue","issueNumber":48}
{"timestamp":"2026-03-13T19:36:29.226Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-xflNi8NTvkSl/.tmp/workspaces/sociotechnica-org_symphony-ts_48","issueIdentifier":"sociotechnica-org/symphony-ts#48","branchName":"symphony/48","createdNow":true}
{"timestamp":"2026-03-13T19:36:29.228Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":48,"branchName":"symphony/48","runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","maxTurns":3}
{"timestamp":"2026-03-13T19:36:29.229Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success-unique.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-xflNi8NTvkSl/.tmp/workspaces/sociotechnica-org_symphony-ts_48","issueIdentifier":"sociotechnica-org/symphony-ts#48","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.229Z","level":"info","message":"Runner process attached to active issue","issueNumber":48,"runnerPid":41757,"spawnedAt":"2026-03-13T19:36:29.229Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.374Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":48,"branchName":"symphony/48","runSessionId":"sociotechnica-org/symphony-ts#48/attempt-1-cc9b10fb-f3b5-4578-94a6-9986cb0f76bf","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52537/pulls/2","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.519Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.520Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.522Z","level":"info","message":"Claimed GitHub issue","issueNumber":11}
{"timestamp":"2026-03-13T19:36:29.633Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-XcnVNmECJxJE/.tmp/workspaces/sociotechnica-org_symphony-ts_11","issueIdentifier":"sociotechnica-org/symphony-ts#11","branchName":"symphony/11","createdNow":true}
{"timestamp":"2026-03-13T19:36:29.636Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":11,"branchName":"symphony/11","runSessionId":"sociotechnica-org/symphony-ts#11/attempt-1-b3640cc0-56ec-42a9-8fa1-cad9073ee94d","maxTurns":3}
{"timestamp":"2026-03-13T19:36:29.636Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-XcnVNmECJxJE/.tmp/workspaces/sociotechnica-org_symphony-ts_11","issueIdentifier":"sociotechnica-org/symphony-ts#11","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#11/attempt-1-b3640cc0-56ec-42a9-8fa1-cad9073ee94d","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.638Z","level":"info","message":"Runner process attached to active issue","issueNumber":11,"runnerPid":41894,"spawnedAt":"2026-03-13T19:36:29.637Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.759Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":11,"branchName":"symphony/11","runSessionId":"sociotechnica-org/symphony-ts#11/attempt-1-b3640cc0-56ec-42a9-8fa1-cad9073ee94d","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52546/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.763Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.764Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.766Z","level":"info","message":"Issue remains in handoff review","issueNumber":11,"summary":"Pull request http://127.0.0.1:52546/pulls/1 is awaiting a human /land command"}
Generated issue report for #11
report.json: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-XcnVNmECJxJE/.var/reports/issues/11/report.json
report.md: /var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-XcnVNmECJxJE/.var/reports/issues/11/report.md
{"timestamp":"2026-03-13T19:36:29.880Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:29.881Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:29.882Z","level":"info","message":"Claimed GitHub issue","issueNumber":2}
{"timestamp":"2026-03-13T19:36:29.963Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-lsCXESvmFGRb/.tmp/workspaces/sociotechnica-org_symphony-ts_2","issueIdentifier":"sociotechnica-org/symphony-ts#2","branchName":"symphony/2","createdNow":true}
{"timestamp":"2026-03-13T19:36:29.965Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":2,"branchName":"symphony/2","runSessionId":"sociotechnica-org/symphony-ts#2/attempt-1-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","maxTurns":3}
{"timestamp":"2026-03-13T19:36:29.965Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-pr-follow-up.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-lsCXESvmFGRb/.tmp/workspaces/sociotechnica-org_symphony-ts_2","issueIdentifier":"sociotechnica-org/symphony-ts#2","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#2/attempt-1-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","turnNumber":1}
{"timestamp":"2026-03-13T19:36:29.967Z","level":"info","message":"Runner process attached to active issue","issueNumber":2,"runnerPid":42030,"spawnedAt":"2026-03-13T19:36:29.966Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.073Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":2,"branchName":"symphony/2","runSessionId":"sociotechnica-org/symphony-ts#2/attempt-1-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52553/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.087Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.088Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.153Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-lsCXESvmFGRb/.tmp/workspaces/sociotechnica-org_symphony-ts_2","issueIdentifier":"sociotechnica-org/symphony-ts#2","branchName":"symphony/2","createdNow":false}
{"timestamp":"2026-03-13T19:36:30.155Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":2,"branchName":"symphony/2","runSessionId":"sociotechnica-org/symphony-ts#2/attempt-2-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","maxTurns":3}
{"timestamp":"2026-03-13T19:36:30.156Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-pr-follow-up.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-lsCXESvmFGRb/.tmp/workspaces/sociotechnica-org_symphony-ts_2","issueIdentifier":"sociotechnica-org/symphony-ts#2","attempt":2,"runSessionId":"sociotechnica-org/symphony-ts#2/attempt-2-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.157Z","level":"info","message":"Runner process attached to active issue","issueNumber":2,"runnerPid":42096,"spawnedAt":"2026-03-13T19:36:30.156Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.252Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":2,"branchName":"symphony/2","runSessionId":"sociotechnica-org/symphony-ts#2/attempt-2-04e01fdb-bbc4-4eb2-a1f8-97a16989dd9d","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting on checks for http://127.0.0.1:52553/pulls/1; pending checks: CI","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.343Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.344Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.347Z","level":"info","message":"Issue remains in handoff review","issueNumber":2,"summary":"Pull request http://127.0.0.1:52553/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:30.348Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.349Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.353Z","level":"info","message":"Issue completed","issueNumber":2}
{"timestamp":"2026-03-13T19:36:30.355Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-lsCXESvmFGRb/.tmp/workspaces/sociotechnica-org_symphony-ts_2"}
{"timestamp":"2026-03-13T19:36:30.464Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.465Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.466Z","level":"info","message":"Claimed GitHub issue","issueNumber":3}
{"timestamp":"2026-03-13T19:36:30.549Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-YtWquY3vBFay/.tmp/workspaces/sociotechnica-org_symphony-ts_3","issueIdentifier":"sociotechnica-org/symphony-ts#3","branchName":"symphony/3","createdNow":true}
{"timestamp":"2026-03-13T19:36:30.551Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":3,"branchName":"symphony/3","runSessionId":"sociotechnica-org/symphony-ts#3/attempt-1-30f691e5-33fd-4949-ae71-67db40b4c1ce","maxTurns":3}
{"timestamp":"2026-03-13T19:36:30.551Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-pr-follow-up.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-YtWquY3vBFay/.tmp/workspaces/sociotechnica-org_symphony-ts_3","issueIdentifier":"sociotechnica-org/symphony-ts#3","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#3/attempt-1-30f691e5-33fd-4949-ae71-67db40b4c1ce","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.552Z","level":"info","message":"Runner process attached to active issue","issueNumber":3,"runnerPid":42265,"spawnedAt":"2026-03-13T19:36:30.552Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.660Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":3,"branchName":"symphony/3","runSessionId":"sociotechnica-org/symphony-ts#3/attempt-1-30f691e5-33fd-4949-ae71-67db40b4c1ce","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52561/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.662Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.663Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.717Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-YtWquY3vBFay/.tmp/workspaces/sociotechnica-org_symphony-ts_3","issueIdentifier":"sociotechnica-org/symphony-ts#3","branchName":"symphony/3","createdNow":false}
{"timestamp":"2026-03-13T19:36:30.719Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":3,"branchName":"symphony/3","runSessionId":"sociotechnica-org/symphony-ts#3/attempt-2-30f691e5-33fd-4949-ae71-67db40b4c1ce","maxTurns":3}
{"timestamp":"2026-03-13T19:36:30.719Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-pr-follow-up.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-YtWquY3vBFay/.tmp/workspaces/sociotechnica-org_symphony-ts_3","issueIdentifier":"sociotechnica-org/symphony-ts#3","attempt":2,"runSessionId":"sociotechnica-org/symphony-ts#3/attempt-2-30f691e5-33fd-4949-ae71-67db40b4c1ce","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.720Z","level":"info","message":"Runner process attached to active issue","issueNumber":3,"runnerPid":42331,"spawnedAt":"2026-03-13T19:36:30.719Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.801Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":3,"branchName":"symphony/3","runSessionId":"sociotechnica-org/symphony-ts#3/attempt-2-30f691e5-33fd-4949-ae71-67db40b4c1ce","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting on checks for http://127.0.0.1:52561/pulls/1; pending checks: CI","turnNumber":1}
{"timestamp":"2026-03-13T19:36:30.885Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.886Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.888Z","level":"info","message":"Issue remains in handoff review","issueNumber":3,"summary":"Pull request http://127.0.0.1:52561/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:30.889Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:30.890Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:30.893Z","level":"info","message":"Issue completed","issueNumber":3}
{"timestamp":"2026-03-13T19:36:30.894Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-YtWquY3vBFay/.tmp/workspaces/sociotechnica-org_symphony-ts_3"}
{"timestamp":"2026-03-13T19:36:31.002Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:31.026Z","level":"warn","message":"Recovered stale local run ownership","issueNumber":4,"ownershipState":"stale-owner-runner","ownerPid":999999,"runnerPid":42449,"runSessionId":"sociotechnica-org/symphony-ts#4/attempt-1/orphaned"}
{"timestamp":"2026-03-13T19:36:31.027Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:31.132Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-cYgVXqOd1UtK/.tmp/workspaces/sociotechnica-org_symphony-ts_4","issueIdentifier":"sociotechnica-org/symphony-ts#4","branchName":"symphony/4","createdNow":true}
{"timestamp":"2026-03-13T19:36:31.136Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":4,"branchName":"symphony/4","runSessionId":"sociotechnica-org/symphony-ts#4/attempt-1-a0534e0f-49bc-45aa-b289-82eb0dbee184","maxTurns":3}
{"timestamp":"2026-03-13T19:36:31.137Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-cYgVXqOd1UtK/.tmp/workspaces/sociotechnica-org_symphony-ts_4","issueIdentifier":"sociotechnica-org/symphony-ts#4","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#4/attempt-1-a0534e0f-49bc-45aa-b289-82eb0dbee184","turnNumber":1}
{"timestamp":"2026-03-13T19:36:31.138Z","level":"info","message":"Runner process attached to active issue","issueNumber":4,"runnerPid":42543,"spawnedAt":"2026-03-13T19:36:31.138Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:31.265Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":4,"branchName":"symphony/4","runSessionId":"sociotechnica-org/symphony-ts#4/attempt-1-a0534e0f-49bc-45aa-b289-82eb0dbee184","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52569/pulls/1","turnNumber":1}
{"timestamp":"2026-03-13T19:36:31.268Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:31.269Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:31.273Z","level":"info","message":"Issue remains in handoff review","issueNumber":4,"summary":"Pull request http://127.0.0.1:52569/pulls/1 is awaiting a human /land command"}
{"timestamp":"2026-03-13T19:36:31.277Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:31.278Z","level":"info","message":"Poll candidates fetched","readyCount":0,"runningCount":1,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:31.281Z","level":"info","message":"Issue completed","issueNumber":4}
{"timestamp":"2026-03-13T19:36:31.282Z","level":"info","message":"Cleaning workspace","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-e2e-cYgVXqOd1UtK/.tmp/workspaces/sociotechnica-org_symphony-ts_4"}
{"timestamp":"2026-03-13T19:36:31.398Z","level":"info","message":"Poll started"}
{"timestamp":"2026-03-13T19:36:31.399Z","level":"info","message":"Poll candidates fetched","readyCount":1,"runningCount":0,"failedCount":0,"candidateCount":1,"availableSlots":1}
{"timestamp":"2026-03-13T19:36:31.400Z","level":"info","message":"Claimed GitHub issue","issueNumber":1}
{"timestamp":"2026-03-13T19:36:31.481Z","level":"info","message":"Workspace ready","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-tui-2iGn4JPmNWXg/.tmp/workspaces/sociotechnica-org_symphony-ts_1","issueIdentifier":"sociotechnica-org/symphony-ts#1","branchName":"symphony/1","createdNow":true}
{"timestamp":"2026-03-13T19:36:31.484Z","level":"warn","message":"Runner does not support live continuation sessions; continuation turns will cold-start new subprocesses","issueNumber":1,"branchName":"symphony/1","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-bd9183a2-84f2-4112-be23-ff212db0cd58","maxTurns":3}
{"timestamp":"2026-03-13T19:36:31.484Z","level":"info","message":"Launching runner","command":"/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_139/tests/fixtures/fake-agent-success.sh","workspacePath":"/var/folders/t9/nf9sjd7d7bgd13xkkd3s2s2r0000gn/T/symphony-tui-2iGn4JPmNWXg/.tmp/workspaces/sociotechnica-org_symphony-ts_1","issueIdentifier":"sociotechnica-org/symphony-ts#1","attempt":1,"runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-bd9183a2-84f2-4112-be23-ff212db0cd58","turnNumber":1}
{"timestamp":"2026-03-13T19:36:31.485Z","level":"info","message":"Runner process attached to active issue","issueNumber":1,"runnerPid":42679,"spawnedAt":"2026-03-13T19:36:31.485Z","turnNumber":1}
{"timestamp":"2026-03-13T19:36:31.591Z","level":"info","message":"Issue remains in handoff lifecycle","issueNumber":1,"branchName":"symphony/1","runSessionId":"sociotechnica-org/symphony-ts#1/attempt-1-bd9183a2-84f2-4112-be23-ff212db0cd58","backendSessionId":null,"lifecycle":"awaiting-system-checks","summary":"Waiting for PR checks to appear on http://127.0.0.1:52576/pulls/1","turnNumber":1}
 ✓ tests/e2e/bootstrap-factory.test.ts (11 tests) 5275ms
   ✓ Phase 1.2 PR lifecycle factory > keeps the issue running after PR open until the pull request is merged  842ms
   ✓ Phase 1.2 PR lifecycle factory > blocks landing when unresolved non-outdated review threads remain even if checks are green  666ms
   ✓ Phase 1.2 PR lifecycle factory > pushes the reviewed plan branch before plan-ready and keeps the plan recoverable from the remote  401ms
   ✓ Phase 1.2 PR lifecycle factory > runs a complete GitHub factory handoff loop through the Claude Code runner  388ms
   ✓ Phase 1.2 PR lifecycle factory > does not immediately re-close a reopened issue because of a previously merged PR  637ms
   ✓ Phase 1.2 PR lifecycle factory > generates a detached per-issue report from runtime artifacts without mutating raw artifacts  393ms
   ✓ Phase 1.2 PR lifecycle factory > reruns the same PR branch after CI failure and closes only after the rerun goes green  582ms
   ✓ Phase 1.2 PR lifecycle factory > resolves actionable review feedback after a follow-up push and waits for the PR to become clean  539ms
   ✓ Phase 1.2 PR lifecycle factory > recovers a stale running issue and clears orphaned local ownership on startup  389ms
   ✓ TUI dashboard integration > renders SYMPHONY STATUS frames during a factory run and terminates with an offline frame  309ms

 Test Files  44 passed (44)
      Tests  543 passed (543)
   Start at  15:36:25
   Duration  5.87s (transform 1.81s, setup 0ms, collect 4.37s, tests 13.78s, environment 5ms, prepare 2.67s)
- manual isolated validation: launched a dummy detached Must be connected to a terminal. worker in a temp runtime, ran , sent  to the watch process, and confirmed the worker PID stayed alive afterward
