### PR TITLE
Fix landing failure artifact semantics

### DIFF
--- a/docs/plans/132-landing-failure-artifact-semantics/plan.md
+++ b/docs/plans/132-landing-failure-artifact-semantics/plan.md
@@ -1,0 +1,165 @@
+# Issue 132 Plan
+
+## Goal
+
+Make landing execution exceptions produce an explicit failure artifact outcome instead of reusing `landing-requested`, so artifact consumers, reports, and metrics can distinguish:
+
+- landing request dispatched
+- landing blocked by guard/policy
+- landing execution or transport failure before dispatch completed
+
+## Scope
+
+- add one explicit landing failure event kind for thrown landing execution paths
+- update orchestrator landing artifact creation so exceptions do not emit `landing-requested`
+- keep issue artifact summary/outcome inference and markdown timeline rendering coherent with the new event kind
+- add regression coverage for unit, observability, and integration/e2e landing-exception paths
+
+## Non-Goals
+
+- changing guarded landing policy rules or `/land` authorization behavior
+- redesigning the broader issue artifact schema beyond the minimum taxonomy extension needed here
+- changing tracker landing transport behavior except where existing tests need a failure seam
+- reworking retry budgets, continuation state, reconciliation, or lease handling
+
+## Current Gaps
+
+- `src/orchestrator/service.ts` currently emits `landing-requested` for every non-blocked landing observation, including exceptions thrown before a request is successfully issued
+- `src/observability/issue-artifacts.ts` has no distinct event kind for landing execution failure
+- `src/observability/issue-report.ts` assumes every non-blocked landing event means a request was sent and maps `landing-requested` directly to `awaiting-landing`
+- existing coverage proves successful and blocked landing paths, but not the thrown-exception artifact semantics called out in the unresolved PR `#123` review thread
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: naming the top-level landing event taxonomy so requested, blocked, and failed outcomes are semantically distinct
+  - does not belong: changing merge authorization policy or retry policy
+- Configuration Layer
+  - belongs: none
+  - does not belong: workflow/config fields or parsing changes
+- Coordination Layer
+  - belongs: the orchestrator branch that converts landing results vs thrown exceptions into durable artifact observations
+  - does not belong: broader orchestration-state refactors, retries, or continuation budgeting
+- Execution Layer
+  - belongs: none beyond treating a thrown `executeLanding()` call as an execution failure signal
+  - does not belong: runner or workspace changes
+- Integration Layer
+  - belongs: preserving the existing tracker contract while testing a transport/execution throw from `executeLanding()`
+  - does not belong: mixing transport quirks or GitHub-specific policy into the orchestrator event taxonomy
+- Observability Layer
+  - belongs: issue artifact event kinds, summary text, report inference, and timeline/status wording
+  - does not belong: unrelated report redesign or dashboard changes
+
+## Architecture Boundaries
+
+- Keep the taxonomy change centered in the issue-artifact/issue-report contract, not in tracker-specific code.
+- Keep tracker transport, normalization, and policy unchanged for this slice; the orchestrator should react to the normalized `LandingExecutionResult` or thrown exception only.
+- Do not introduce a generic boolean-plus-summary bucket for landing outcomes; the top-level event kind must carry the semantic distinction.
+- If a shared helper for landing artifact creation is touched, keep it limited to event-kind/outcome selection rather than broad orchestrator restructuring.
+
+## Slice Strategy And PR Seam
+
+This issue should land as one narrow PR:
+
+1. extend the issue-artifact landing event taxonomy with one explicit failure kind
+2. update the orchestrator landing exception observation path to emit that kind
+3. update issue-report inference/rendering for the new semantics
+4. add focused regression coverage
+
+This remains reviewable because it stays inside the landing observability seam. It does not combine guarded-landing policy, transport hardening, or retry-state work.
+
+## Runtime State Model
+
+This issue does not add new runtime states, but it does tighten the mapping between the existing landing execution branch and durable observability outcomes.
+
+- `awaiting-landing-command`
+  - PR is clean and waiting for an explicit landing signal
+- `awaiting-landing`
+  - landing request was actually dispatched and merge observation is pending
+- `awaiting-human-review` / `awaiting-system-checks`
+  - landing was blocked by normalized policy/guard checks
+- `attempt-failed`
+  - landing execution threw before request dispatch completed, so the orchestrator records a failed execution path rather than a requested landing
+
+Allowed transitions for this slice:
+
+- `awaiting-landing-command` or `awaiting-landing` + blocked landing result -> artifact event `landing-blocked`, summary outcome matches the normalized lifecycle kind
+- `awaiting-landing` + requested landing result -> artifact event `landing-requested`, summary outcome `awaiting-landing`
+- `awaiting-landing` + thrown landing exception -> artifact event `landing-failed`, summary outcome `attempt-failed`
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected artifact semantics |
+| --- | --- | --- | --- |
+| `executeLanding()` returns `{ kind: "requested" }` | landing attempt started, PR handle present | tracker accepted landing request | event kind `landing-requested`; issue outcome `awaiting-landing` |
+| `executeLanding()` returns `{ kind: "blocked" }` | landing attempt started, PR handle present | normalized blocked reason and lifecycle kind | event kind `landing-blocked`; issue outcome matches blocked lifecycle kind |
+| `executeLanding()` throws before returning | landing attempt started, error string captured; request dispatch not confirmed | no successful landing result exists | event kind `landing-failed`; issue outcome `attempt-failed` |
+| landing branch starts without a PR handle | orchestrator throws locally before tracker dispatch | no landing result | event kind `landing-failed`; issue outcome `attempt-failed` |
+
+## Observability Requirements
+
+- top-level event kind must indicate whether landing was requested, blocked, or failed
+- landing failure summaries must say the request failed before/while dispatching, not imply a request was sent
+- report timeline titles and summaries must render the new event kind distinctly
+- event-to-outcome inference must not map landing failures to `awaiting-landing`
+- existing landing-requested consumers should continue to see only genuine request-dispatch cases
+
+## Implementation Steps
+
+1. Add `landing-failed` to the issue artifact event-kind union and update any parsing/ordering helpers that rely on the closed set.
+2. Update `#createLandingObservation()` in `src/orchestrator/service.ts` so:
+   - blocked results still emit `landing-blocked`
+   - requested results still emit `landing-requested`
+   - thrown exceptions emit `landing-failed` and set the issue outcome to `attempt-failed`
+3. Update `src/observability/issue-report.ts` to:
+   - render a distinct title/summary for `landing-failed`
+   - keep timeline ordering coherent
+   - infer `attempt-failed` from `landing-failed`
+4. Add or update focused tests for:
+   - landing observation creation around requested/blocked/failed outcomes
+   - issue-report inference/rendering for `landing-failed`
+   - a tracker/orchestrator failure path where landing transport throws
+5. Run repo validation and keep this branch as the single PR surface for `#132`.
+
+## Tests
+
+- unit coverage for landing observation creation with:
+  - requested landing
+  - blocked landing
+  - thrown landing exception
+- observability/report regression coverage proving:
+  - `landing-failed` renders distinct timeline copy
+  - report inference returns `attempt-failed` instead of `awaiting-landing`
+- integration or e2e coverage with a mocked tracker/GitHub failure during landing execution
+- standard repo gates:
+  - `pnpm typecheck`
+  - `pnpm lint`
+  - `pnpm test`
+
+## Acceptance Scenarios
+
+1. When landing dispatch succeeds, artifacts still record `landing-requested` and the issue remains `awaiting-landing`.
+2. When landing is blocked by guard logic, artifacts still record `landing-blocked` and the issue outcome matches the normalized blocked lifecycle kind.
+3. When landing execution throws before request dispatch completes, artifacts record `landing-failed` and the issue summary/outcome reflect a failed attempt rather than `awaiting-landing`.
+4. The issue report timeline and markdown summary describe landing failures as execution failures, not attempted requests.
+5. Artifact consumers querying `landing-requested` no longer include thrown landing exception cases.
+
+## Exit Criteria
+
+- landing exceptions never emit `landing-requested`
+- issue artifact summaries and report inference distinguish requested, blocked, and failed landing paths
+- regression coverage exists for the thrown-exception path
+- local validation passes
+- the resulting PR stays limited to the landing observability seam for `#132`
+
+## Deferred
+
+- guarded-landing policy changes
+- broader artifact-schema redesign beyond this one event-kind addition
+- retry/reconciliation behavior changes for landing failures
+- tracker transport hardening unrelated to the observability contract
+
+## Decision Notes
+
+- Introduce a dedicated `landing-failed` event kind rather than overloading `landing-requested` with `success: false`. The top-level kind is the durable contract consumed by reports and metrics, so the semantic distinction belongs there.
+- Keep the failure mapped to `attempt-failed` rather than inventing a new issue outcome in this issue. That preserves the narrow seam while still separating failed execution from a successful landing request.

--- a/docs/plans/132-landing-failure-artifact-semantics/plan.md
+++ b/docs/plans/132-landing-failure-artifact-semantics/plan.md
@@ -89,12 +89,12 @@ Allowed transitions for this slice:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected artifact semantics |
-| --- | --- | --- | --- |
-| `executeLanding()` returns `{ kind: "requested" }` | landing attempt started, PR handle present | tracker accepted landing request | event kind `landing-requested`; issue outcome `awaiting-landing` |
-| `executeLanding()` returns `{ kind: "blocked" }` | landing attempt started, PR handle present | normalized blocked reason and lifecycle kind | event kind `landing-blocked`; issue outcome matches blocked lifecycle kind |
-| `executeLanding()` throws before returning | landing attempt started, error string captured; request dispatch not confirmed | no successful landing result exists | event kind `landing-failed`; issue outcome `attempt-failed` |
-| landing branch starts without a PR handle | orchestrator throws locally before tracker dispatch | no landing result | event kind `landing-failed`; issue outcome `attempt-failed` |
+| Observed condition                                 | Local facts available                                                          | Normalized tracker facts available           | Expected artifact semantics                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------- |
+| `executeLanding()` returns `{ kind: "requested" }` | landing attempt started, PR handle present                                     | tracker accepted landing request             | event kind `landing-requested`; issue outcome `awaiting-landing`           |
+| `executeLanding()` returns `{ kind: "blocked" }`   | landing attempt started, PR handle present                                     | normalized blocked reason and lifecycle kind | event kind `landing-blocked`; issue outcome matches blocked lifecycle kind |
+| `executeLanding()` throws before returning         | landing attempt started, error string captured; request dispatch not confirmed | no successful landing result exists          | event kind `landing-failed`; issue outcome `attempt-failed`                |
+| landing branch starts without a PR handle          | orchestrator throws locally before tracker dispatch                            | no landing result                            | event kind `landing-failed`; issue outcome `attempt-failed`                |
 
 ## Observability Requirements
 

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -13,6 +13,7 @@ export type IssueArtifactEventKind =
   | "runner-spawned"
   | "pr-opened"
   | "landing-blocked"
+  | "landing-failed"
   | "landing-requested"
   | "review-feedback"
   | "retry-scheduled"

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -988,6 +988,19 @@ function buildTimelineEntry(
         sessionId: event.sessionId,
         details: formatEventDetails(event.details),
       };
+    case "landing-failed":
+      return {
+        kind: event.kind,
+        at: event.observedAt,
+        title: "Landing failed",
+        summary: readEventSummary(
+          event.details,
+          "Symphony failed before it could dispatch the landing request.",
+        ),
+        attemptNumber: event.attemptNumber,
+        sessionId: event.sessionId,
+        details: formatEventDetails(event.details),
+      };
     case "landing-requested":
       return {
         kind: event.kind,
@@ -1403,16 +1416,18 @@ function timelineKindOrder(kind: string): number {
       return 5;
     case "landing-blocked":
       return 6;
-    case "landing-requested":
+    case "landing-failed":
       return 7;
-    case "review-feedback":
+    case "landing-requested":
       return 8;
-    case "retry-scheduled":
+    case "review-feedback":
       return 9;
+    case "retry-scheduled":
+      return 10;
     case "succeeded":
     case "failed":
     case "terminal-outcome":
-      return 10;
+      return 11;
     default:
       return 99;
   }
@@ -1444,6 +1459,8 @@ function inferOutcomeFromEvents(
         return (
           readLifecycleKindFromDetails(event.details) ?? "awaiting-landing"
         );
+      case "landing-failed":
+        return "attempt-failed";
       case "landing-requested":
         return "awaiting-landing";
       case "runner-spawned":

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -790,24 +790,30 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
     noteStatusAction(this.#state.status, {
       kind:
-        landingResult?.kind === "blocked"
+        landingError !== null
+          ? "landing-failed"
+          : landingResult?.kind === "blocked"
           ? "landing-blocked"
           : refreshedLifecycle.kind,
       summary:
-        landingResult?.kind === "blocked"
+        landingError !== null
+          ? `Landing request failed for ${issue.identifier}: ${landingError}`
+          : landingResult?.kind === "blocked"
           ? landingResult.summary
           : refreshedLifecycle.summary,
       issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
-    await this.#recordIssueArtifact(
-      this.#createLifecycleObservation(
-        issue,
-        attempt,
-        branchName,
-        refreshedLifecycle,
-      ),
-    );
+    if (landingError === null) {
+      await this.#recordIssueArtifact(
+        this.#createLifecycleObservation(
+          issue,
+          attempt,
+          branchName,
+          refreshedLifecycle,
+        ),
+      );
+    }
   }
 
   async #runIssue(
@@ -2131,12 +2137,17 @@ export class BootstrapOrchestrator implements Orchestrator {
     error: string | null,
   ): IssueArtifactObservation {
     const isBlocked = result?.kind === "blocked";
+    const isFailed = error !== null;
     return {
       issue: this.#createIssueArtifactUpdate(issue, {
         observedAt,
-        outcome: isBlocked ? result.lifecycleKind : "awaiting-landing",
+        outcome: isFailed
+          ? "attempt-failed"
+          : isBlocked
+            ? result.lifecycleKind
+            : "awaiting-landing",
         summary:
-          error !== null
+          isFailed
             ? `Landing request failed for ${issue.identifier}: ${error}`
             : isBlocked
               ? result.summary
@@ -2146,7 +2157,11 @@ export class BootstrapOrchestrator implements Orchestrator {
       }),
       events: [
         this.#createIssueEvent(
-          isBlocked ? "landing-blocked" : "landing-requested",
+          isFailed
+            ? "landing-failed"
+            : isBlocked
+              ? "landing-blocked"
+              : "landing-requested",
           issue,
           {
             observedAt,
@@ -2165,9 +2180,11 @@ export class BootstrapOrchestrator implements Orchestrator {
               error,
               reason: isBlocked ? result.reason : null,
               summary: isBlocked ? result.summary : null,
-              lifecycleKind: isBlocked
-                ? result.lifecycleKind
-                : "awaiting-landing",
+              lifecycleKind: isFailed
+                ? "attempt-failed"
+                : isBlocked
+                  ? result.lifecycleKind
+                  : "awaiting-landing",
             },
           },
         ),

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -793,14 +793,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         landingError !== null
           ? "landing-failed"
           : landingResult?.kind === "blocked"
-          ? "landing-blocked"
-          : refreshedLifecycle.kind,
+            ? "landing-blocked"
+            : refreshedLifecycle.kind,
       summary:
         landingError !== null
           ? `Landing request failed for ${issue.identifier}: ${landingError}`
           : landingResult?.kind === "blocked"
-          ? landingResult.summary
-          : refreshedLifecycle.summary,
+            ? landingResult.summary
+            : refreshedLifecycle.summary,
       issueNumber: issue.number,
     });
     await this.#persistStatusSnapshot();
@@ -2146,12 +2146,11 @@ export class BootstrapOrchestrator implements Orchestrator {
           : isBlocked
             ? result.lifecycleKind
             : "awaiting-landing",
-        summary:
-          isFailed
-            ? `Landing request failed for ${issue.identifier}: ${error}`
-            : isBlocked
-              ? result.summary
-              : `Landing requested for ${issue.identifier}`,
+        summary: isFailed
+          ? `Landing request failed for ${issue.identifier}: ${error}`
+          : isBlocked
+            ? result.summary
+            : `Landing requested for ${issue.identifier}`,
         branchName,
         latestAttemptNumber: attempt,
       }),

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -2178,7 +2178,11 @@ export class BootstrapOrchestrator implements Orchestrator {
               success: error === null && !isBlocked,
               error,
               reason: isBlocked ? result.reason : null,
-              summary: isBlocked ? result.summary : null,
+              summary: isFailed
+                ? `Landing request failed for ${issue.identifier}: ${error}`
+                : isBlocked
+                  ? result.summary
+                  : null,
               lifecycleKind: isFailed
                 ? "attempt-failed"
                 : isBlocked

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -431,6 +431,9 @@ describe("Phase 1.2 PR lifecycle factory", () => {
         details: expect.objectContaining({
           success: false,
           lifecycleKind: "attempt-failed",
+          summary: expect.stringContaining(
+            "Landing request failed for sociotechnica-org/symphony-ts#81",
+          ),
           error: expect.stringContaining("merge temporarily blocked"),
         }),
       }),

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -373,6 +373,76 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     );
   });
 
+  it("records landing-failed when the merge request throws before dispatch completes", async () => {
+    server.seedIssue({
+      number: 81,
+      title: "Landing failure semantics",
+      body: "Record thrown landing failures distinctly",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success-unique.sh"),
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/81", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+
+    await orchestrator.runOnce();
+    server.addPullRequestComment({
+      head: "symphony/81",
+      authorLogin: "jessmartin",
+      body: "/land",
+    });
+    server.setPullRequestLandingBehavior("symphony/81", {
+      failureStatus: 500,
+      failureMessage: "merge temporarily blocked",
+    });
+
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(81);
+    expect(issue.state).toBe("open");
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.lastAction?.kind).toBe("landing-failed");
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      81,
+    );
+    expect(artifactSummary.currentOutcome).toBe("attempt-failed");
+
+    const artifactEvents = await readIssueArtifactEvents(
+      path.join(tempDir, ".tmp", "workspaces"),
+      81,
+    );
+    expect(artifactEvents).toContainEqual(
+      expect.objectContaining({
+        kind: "landing-failed",
+        details: expect.objectContaining({
+          success: false,
+          lifecycleKind: "attempt-failed",
+          error: expect.stringContaining("merge temporarily blocked"),
+        }),
+      }),
+    );
+    expect(artifactEvents).not.toContainEqual(
+      expect.objectContaining({
+        kind: "landing-requested",
+        attemptNumber: 2,
+      }),
+    );
+  });
+
   it("pushes the reviewed plan branch before plan-ready and keeps the plan recoverable from the remote", async () => {
     server.seedIssue({
       number: 53,

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -364,6 +364,62 @@ describe("issue report generation", () => {
     expect(generated.report.summary.outcome).toBe("awaiting-human-review");
   });
 
+  it("treats landing-failed as an attempt failure in report summaries and timeline copy", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-landing-failed-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const artifactPaths = deriveIssueArtifactPaths(workspaceRoot, 44);
+    await fs.mkdir(artifactPaths.issueRoot, { recursive: true });
+    await fs.writeFile(
+      artifactPaths.eventsFile,
+      [
+        {
+          version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+          kind: "claimed",
+          issueNumber: 44,
+          observedAt: "2026-03-09T10:00:00.000Z",
+          attemptNumber: null,
+          sessionId: null,
+          details: {},
+        },
+        {
+          version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+          kind: "landing-failed",
+          issueNumber: 44,
+          observedAt: "2026-03-09T10:10:00.000Z",
+          attemptNumber: 2,
+          sessionId: null,
+          details: {
+            summary:
+              "Landing request failed for sociotechnica-org/symphony-ts#44: Error: merge temporarily blocked",
+            branch: "symphony/44",
+            error: "Error: merge temporarily blocked",
+            success: false,
+            lifecycleKind: "attempt-failed",
+          },
+        },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n"),
+      "utf8",
+    );
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T14:10:00.000Z",
+    });
+
+    expect(generated.report.summary.outcome).toBe("attempt-failed");
+    expect(generated.report.timeline).toContainEqual(
+      expect.objectContaining({
+        kind: "landing-failed",
+        title: "Landing failed",
+        summary:
+          "Landing request failed for sociotechnica-org/symphony-ts#44: Error: merge temporarily blocked",
+      }),
+    );
+    expect(generated.markdown).toContain("Landing failed");
+  });
+
   it.each([
     {
       fileName: "report.json",

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -365,7 +365,9 @@ describe("issue report generation", () => {
   });
 
   it("treats landing-failed as an attempt failure in report summaries and timeline copy", async () => {
-    const tempDir = await createTempDir("symphony-issue-report-landing-failed-");
+    const tempDir = await createTempDir(
+      "symphony-issue-report-landing-failed-",
+    );
     tempRoots.push(tempDir);
     const workspaceRoot = deriveWorkspaceRoot(tempDir);
     const artifactPaths = deriveIssueArtifactPaths(workspaceRoot, 44);

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1407,6 +1407,8 @@ describe("BootstrapOrchestrator", () => {
             error:
               "Error: Cannot execute landing without a pull request handle",
             pullRequest: null,
+            summary:
+              "Landing request failed for sociotechnica-org/symphony-ts#74: Error: Cannot execute landing without a pull request handle",
             lifecycleKind: "attempt-failed",
           }),
         }),
@@ -1606,6 +1608,8 @@ describe("BootstrapOrchestrator", () => {
           details: expect.objectContaining({
             success: false,
             error: "Error: merge temporarily blocked",
+            summary:
+              "Landing request failed for sociotechnica-org/symphony-ts#73: Error: merge temporarily blocked",
             lifecycleKind: "attempt-failed",
           }),
         }),

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1384,7 +1384,6 @@ describe("BootstrapOrchestrator", () => {
 
     try {
       await orchestrator.runOnce();
-      await orchestrator.runOnce();
 
       expect(tracker.landingRequests).toEqual([]);
       expect(tracker.completed).toEqual([]);
@@ -1398,19 +1397,29 @@ describe("BootstrapOrchestrator", () => {
       });
 
       const summary = await readIssueArtifactSummary(tempRoot, 74);
-      expect(summary.currentOutcome).toBe("awaiting-landing");
+      expect(summary.currentOutcome).toBe("attempt-failed");
       const events = await readIssueArtifactEvents(tempRoot, 74);
       expect(events).toContainEqual(
         expect.objectContaining({
-          kind: "landing-requested",
+          kind: "landing-failed",
           details: expect.objectContaining({
             success: false,
             error:
               "Error: Cannot execute landing without a pull request handle",
             pullRequest: null,
+            lifecycleKind: "attempt-failed",
           }),
         }),
       );
+
+      const status = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(status.lastAction?.kind).toBe("landing-failed");
+
+      await orchestrator.runOnce();
+      expect(tracker.landingRequests).toEqual([]);
+      expect(tracker.completed).toEqual([]);
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
@@ -1552,6 +1561,7 @@ describe("BootstrapOrchestrator", () => {
   });
 
   it("does not retry landing on the same head after a failed merge request", async () => {
+    const tempRoot = await createTempDir("symphony-failed-landing-test-");
     const tracker = new FailOnceLandingTracker({
       running: [createIssue(73, "symphony:running")],
     });
@@ -1561,7 +1571,13 @@ describe("BootstrapOrchestrator", () => {
       lifecycle("awaiting-landing", "symphony/73"),
     ]);
     const orchestrator = new BootstrapOrchestrator(
-      baseConfig,
+      {
+        ...baseConfig,
+        workspace: {
+          ...baseConfig.workspace,
+          root: tempRoot,
+        },
+      },
       staticPromptBuilder,
       tracker,
       new StaticWorkspaceManager(),
@@ -1576,17 +1592,35 @@ describe("BootstrapOrchestrator", () => {
       new NullLogger(),
     );
 
-    await orchestrator.runOnce();
-    expect(tracker.landingRequests).toEqual([1]);
-    expect(tracker.completed).toEqual([]);
+    try {
+      await orchestrator.runOnce();
+      expect(tracker.landingRequests).toEqual([1]);
+      expect(tracker.completed).toEqual([]);
 
-    await orchestrator.runOnce();
-    expect(tracker.landingRequests).toEqual([1]);
-    expect(tracker.completed).toEqual([]);
+      const summary = await readIssueArtifactSummary(tempRoot, 73);
+      expect(summary.currentOutcome).toBe("attempt-failed");
+      const events = await readIssueArtifactEvents(tempRoot, 73);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          kind: "landing-failed",
+          details: expect.objectContaining({
+            success: false,
+            error: "Error: merge temporarily blocked",
+            lifecycleKind: "attempt-failed",
+          }),
+        }),
+      );
 
-    await orchestrator.runOnce();
-    expect(tracker.landingRequests).toEqual([1]);
-    expect(tracker.completed).toEqual([]);
+      await orchestrator.runOnce();
+      expect(tracker.landingRequests).toEqual([1]);
+      expect(tracker.completed).toEqual([]);
+
+      await orchestrator.runOnce();
+      expect(tracker.landingRequests).toEqual([1]);
+      expect(tracker.completed).toEqual([]);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("reruns a running PR when CI or review feedback is actionable and resolves review threads", async () => {


### PR DESCRIPTION
Closes #132.

## Summary
- add a dedicated `landing-failed` artifact event kind for thrown landing execution paths
- keep landing exceptions from being recorded as `landing-requested` and preserve `attempt-failed` report inference
- add unit and e2e regression coverage for landing execution failures

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- Local self-review was performed via `git diff --check` and manual diff review; no separate automated review tool is configured in this workspace.
