### PR TITLE
Fix watchdog startup liveness accounting

### DIFF
--- a/docs/plans/128-watchdog-startup-liveness/plan.md
+++ b/docs/plans/128-watchdog-startup-liveness/plan.md
@@ -1,0 +1,219 @@
+# Issue 128 Plan: Watchdog Startup Liveness Revalidation And Narrow Fix
+
+Status: plan-ready
+
+## Goal
+
+Revalidate the March 13 `#81` false-positive shutdown shape on current `main` and, if it still reproduces, close the remaining watchdog gap with one explicit control-plane concept of `last observable activity` that keeps live startup and low-output runs from being aborted as `Runner cancelled by shutdown`.
+
+## Scope
+
+- reproduce or disprove the archived `#81` overnight failure shape against current `main`
+- keep the PR seam limited to watchdog stall classification, runner startup activity plumbing, and the minimum observability needed to explain the decision
+- cover the reproduced startup / pre-turn / low-output path in unit, orchestrator, and bootstrap-factory regression tests
+- preserve existing genuine stalled-run recovery behavior
+
+## Non-goals
+
+- redesigning the detached factory control surface
+- changing retry budgeting outside watchdog stall handling
+- changing tracker transport, tracker normalization, or tracker lifecycle policy
+- broad status-surface redesign beyond exposing the normalized last-activity facts needed for diagnosis
+- remote execution or multi-host supervision work
+
+## Current Gaps
+
+- the archived `#81` artifacts show repeated six-minute aborts with `Runner cancelled by shutdown`, no recorded `latestTurnNumber`, no `backendSessionId`, and no session log pointers, which indicates the run died in a startup or pre-turn phase before the usual turn-level observability became durable
+- current watchdog policy still compares multiple raw probe fields (`logSizeBytes`, workspace diff hash, PR head SHA, runner heartbeat, runner action) instead of using one named authoritative last-activity concept the way the spec and Elixir reference do
+- current `main` already includes more startup visibility than the March 13 runtime, but the issue comment requires fresh validation before assuming the failure is gone
+- if the runtime still reproduces, the remaining bug is likely a missing or misclassified startup activity source rather than another tracker or retry-policy problem
+
+## Spec Alignment By Abstraction Level
+
+### Policy Layer
+
+- belongs here: define the intended liveness rule as "a run is live when any normalized observable activity source advances, including startup-phase runner activity"
+- does not belong here: provider-specific parsing, tracker quirks, or ad hoc timeout exceptions
+
+### Configuration Layer
+
+- belongs here: reuse the existing watchdog timing contract
+- does not belong here: new issue-specific stall knobs unless fresh validation proves the current threshold model cannot express the fix
+- expected change: none unless validation proves a real config gap
+
+### Coordination Layer
+
+- belongs here: watchdog state, last-activity derivation, stall classification, and the distinction between recoverable stall versus terminal stall
+- does not belong here: runner protocol parsing details or tracker lifecycle writes
+- this is the primary implementation layer for the issue
+
+### Execution Layer
+
+- belongs here: emitting provider-neutral startup activity facts from the local runner path before a turn has produced durable output or writes
+- does not belong here: retry transitions or watchdog policy branching
+- this layer is touched only to expose the missing startup signal cleanly
+
+### Integration Layer
+
+- untouched by this slice
+- tracker transport, normalization, and lifecycle policy stay unchanged
+- nothing in this issue should mix tracker facts with watchdog control logic beyond the already-normalized PR head / actionable-review snapshot
+
+### Observability Layer
+
+- belongs here: status and artifact fields that explain the latest observable activity source and why a run stayed live or was classified stalled
+- does not belong here: becoming the source of truth for stall policy
+- only the minimum needed operator-facing explanation should land in this PR
+
+## Architecture Boundaries
+
+- `src/orchestrator/stall-detector.ts` should own pure last-activity derivation and stall classification
+- `src/orchestrator/watchdog-state.ts` should continue to own watchdog runtime bookkeeping, not tracker or runner semantics
+- `src/orchestrator/service.ts` should own watchdog scheduling, recovery decisions, and the handoff from runner/status events into the normalized liveness snapshot
+- `src/runner/*` should emit provider-neutral startup activity facts but should not decide when a run is stalled
+- `src/observability/*` should render the normalized facts but should not infer stall policy
+
+What does not belong in this slice:
+
+- tracker API changes
+- detached-factory control refactors
+- queue fairness or retry scheduler redesign
+- provider-specific watchdog parsing of Codex payload content beyond normalized visibility/spawn facts
+
+## Slice Strategy And PR Seam
+
+This should stay one reviewable PR because the seam is narrow:
+
+- first, revalidate whether the archived `#81` shape still reproduces on current `main`
+- if it does, normalize startup-phase activity into one authoritative last-activity timestamp/source and keep the rest of the watchdog machinery intact
+- if it does not, limit the output of this issue to the validation evidence and close or narrow the issue instead of forcing speculative runtime edits
+
+What lands in the PR if reproduction still exists:
+
+- a named last-activity concept in watchdog coordination code
+- the minimum runner/startup plumbing needed so startup activity feeds that concept
+- regression coverage for the `#81` shape and a negative genuine-stall case
+- minimal status/artifact clarification for operators
+
+What is deferred:
+
+- separate thresholds per stall class
+- richer semantic parsing of runner output
+- broad status UI redesign
+- durable stall telemetry beyond the current per-issue artifacts
+
+## Runtime State Machine
+
+This issue changes long-running orchestration behavior, so the runtime states must stay explicit.
+
+1. `starting-without-observed-activity`
+   - the run has been claimed and the runner may be spawning, but no normalized activity has been observed yet
+   - stall timing uses `startedAt` as the fallback baseline, matching the spec
+2. `running-with-activity`
+   - at least one normalized activity source has advanced
+   - the authoritative `lastObservableActivityAt` is updated from the newest allowed source
+3. `idle-with-known-activity`
+   - the run has observable history, but no source has advanced on the latest sample
+   - the watchdog compares `capturedAt - lastObservableActivityAt`
+4. `stalled-recoverable`
+   - elapsed time exceeds the watchdog threshold and recovery budget remains
+5. `stalled-terminal`
+   - elapsed time exceeds the watchdog threshold and recovery budget is exhausted
+6. `aborting`
+   - the orchestrator aborts the runner because of a confirmed stall
+7. `runner-finished`
+   - the run exits through normal success/failure/cancellation handling and watchdog state is cleaned up
+
+Allowed last-activity sources in this slice:
+
+- run start time when nothing else has been observed yet
+- runner spawned/startup visibility
+- runner heartbeat/action timestamps
+- watchdog session log growth
+- workspace diff movement
+- PR head movement
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Runner is still in startup, no turn number or backend session id yet, but spawned/startup activity continues advancing | run start time, spawned timestamp, startup visibility or equivalent progress fact | none required | treat as live; do not abort |
+| Runner is still in startup, no filesystem writes, no PR movement, and no startup or visibility activity has advanced past threshold | run start time only, no later activity | none required | classify as genuine startup stall and recover/abort through the normal watchdog path |
+| Runner heartbeat/action advances while workspace stays clean | updated runner visibility timestamps | none required | treat as live pre-write progress |
+| Workspace diff or PR head moved recently even if runner visibility is quiet | diff hash or PR head changed | PR head and actionable review state when present | treat as live |
+| No source has advanced past threshold after prior activity and recovery budget remains | last observable activity timestamp/source, active watchdog entry | normalized current issue snapshot | classify stalled and abort for retry |
+| No source has advanced past threshold after prior activity and recovery budget is exhausted | same as above | normalized current issue snapshot | classify stalled-terminal, abort, and preserve the true watchdog reason |
+| Runner exits on its own before watchdog threshold | runner result path settled | tracker lifecycle continues normally | watchdog stops; no stall recovery |
+
+## Storage And Persistence Contract
+
+- watchdog runtime state remains process-local under `src/orchestrator/state.ts` / `src/orchestrator/watchdog-state.ts`
+- no new durable tracker writes are introduced by this issue
+- per-issue artifacts and status snapshots remain the inspectable record of watchdog decisions
+- if a new last-activity field is surfaced in status or artifacts, it should be derived from normalized runtime state rather than stored as a second independent source of truth
+
+## Observability Requirements
+
+- preserve the distinction between `watchdog-recovery`, `watchdog-recovery-exhausted`, and non-watchdog runner failures
+- make the latest observable activity source/time inspectable enough that operators can tell whether a run was in startup progress, active turn progress, or a genuine stall
+- keep the failure summary truthful when recovery is exhausted so `Runner cancelled by shutdown` is not the only visible explanation for a watchdog-driven abort
+
+## Implementation Steps
+
+1. Revalidate the archived `#81` shape on current `main` using the stored artifacts plus a focused regression harness for startup / pre-turn liveness.
+2. If current `main` no longer reproduces the failure, document that evidence on the issue and narrow or close the ticket instead of landing speculative code.
+3. If the failure still reproduces, extract or name the watchdog's authoritative `lastObservableActivityAt` / source concept in coordination code so stall timing follows one explicit baseline.
+4. Feed startup-phase runner activity into that concept using provider-neutral spawned / startup visibility facts rather than provider-specific output parsing.
+5. Keep the recovery path unchanged except for using the new authoritative last-activity classification and preserving the true stall reason in status/artifacts.
+6. Add regression coverage for the `#81` startup shape, a low-output visibility-only live case, and a genuine startup stall negative case.
+7. Update the issue thread if validation changes the scope materially.
+
+## Tests And Acceptance Scenarios
+
+Unit coverage:
+
+- `tests/unit/stall-detector.test.ts`
+  - stall timing uses run start as the fallback baseline before first observed activity
+  - startup/spawned activity advances the authoritative last-activity timestamp
+  - a run stalls only after the authoritative timestamp stops moving past threshold
+
+Orchestrator / integration coverage:
+
+- `tests/unit/orchestrator.test.ts`
+  - a startup-heavy run with no writes and delayed first turn is not aborted while startup activity keeps advancing
+  - a genuinely hung startup run with no advancing activity still triggers watchdog recovery
+  - exhausted recovery preserves the watchdog-specific terminal reason instead of collapsing to a generic shutdown summary
+
+Bootstrap-factory / end-to-end coverage:
+
+- add or extend a factory regression harness that reproduces the archived `#81` shape: alive runner, low/no writes, delayed durable turn metadata
+- add the negative case where startup activity stops and the watchdog must still abort
+
+Acceptance scenarios:
+
+1. Given a live runner that is still starting and has not yet recorded a turn number, when startup activity continues, then the watchdog keeps the run alive.
+2. Given a low-output run with runner visibility but no workspace writes, when visibility timestamps advance, then the run is not aborted as `Runner cancelled by shutdown`.
+3. Given a truly hung startup run, when no observable activity advances past threshold, then the watchdog aborts and retry behavior remains intact.
+4. Given a terminal watchdog abort, when operators inspect status/artifacts, then they can distinguish watchdog stall exhaustion from an unrelated shutdown.
+
+## Exit Criteria
+
+- current `main` has been revalidated against the archived `#81` shape
+- if a runtime bug still exists, it is fixed without broad watchdog redesign
+- the `#81`-style regression is covered in tests
+- genuine stalled-runner recovery still works
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Deferred To Later Issues Or PRs
+
+- multi-threshold stall policies for different phases
+- richer provider-neutral semantic progress events beyond timestamps/source labels
+- broader factory-control or status-TUI redesign around liveness
+- durable cross-restart stall forensics beyond the current local artifact set
+
+## Decision Notes
+
+- The spec and Elixir reference both point toward one authoritative last-activity concept. This issue should move toward that shape instead of adding more special cases to field-by-field watchdog comparisons.
+- Revalidation on current `main` is part of the plan, not an optional preamble, because the issue already has a human comment warning that recent runtime changes may have resolved the original failure.

--- a/docs/plans/128-watchdog-startup-liveness/plan.md
+++ b/docs/plans/128-watchdog-startup-liveness/plan.md
@@ -135,15 +135,15 @@ Allowed last-activity sources in this slice:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Runner is still in startup, no turn number or backend session id yet, but spawned/startup activity continues advancing | run start time, spawned timestamp, startup visibility or equivalent progress fact | none required | treat as live; do not abort |
-| Runner is still in startup, no filesystem writes, no PR movement, and no startup or visibility activity has advanced past threshold | run start time only, no later activity | none required | classify as genuine startup stall and recover/abort through the normal watchdog path |
-| Runner heartbeat/action advances while workspace stays clean | updated runner visibility timestamps | none required | treat as live pre-write progress |
-| Workspace diff or PR head moved recently even if runner visibility is quiet | diff hash or PR head changed | PR head and actionable review state when present | treat as live |
-| No source has advanced past threshold after prior activity and recovery budget remains | last observable activity timestamp/source, active watchdog entry | normalized current issue snapshot | classify stalled and abort for retry |
-| No source has advanced past threshold after prior activity and recovery budget is exhausted | same as above | normalized current issue snapshot | classify stalled-terminal, abort, and preserve the true watchdog reason |
-| Runner exits on its own before watchdog threshold | runner result path settled | tracker lifecycle continues normally | watchdog stops; no stall recovery |
+| Observed condition                                                                                                                  | Local facts available                                                             | Normalized tracker facts available               | Expected decision                                                                    |
+| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Runner is still in startup, no turn number or backend session id yet, but spawned/startup activity continues advancing              | run start time, spawned timestamp, startup visibility or equivalent progress fact | none required                                    | treat as live; do not abort                                                          |
+| Runner is still in startup, no filesystem writes, no PR movement, and no startup or visibility activity has advanced past threshold | run start time only, no later activity                                            | none required                                    | classify as genuine startup stall and recover/abort through the normal watchdog path |
+| Runner heartbeat/action advances while workspace stays clean                                                                        | updated runner visibility timestamps                                              | none required                                    | treat as live pre-write progress                                                     |
+| Workspace diff or PR head moved recently even if runner visibility is quiet                                                         | diff hash or PR head changed                                                      | PR head and actionable review state when present | treat as live                                                                        |
+| No source has advanced past threshold after prior activity and recovery budget remains                                              | last observable activity timestamp/source, active watchdog entry                  | normalized current issue snapshot                | classify stalled and abort for retry                                                 |
+| No source has advanced past threshold after prior activity and recovery budget is exhausted                                         | same as above                                                                     | normalized current issue snapshot                | classify stalled-terminal, abort, and preserve the true watchdog reason              |
+| Runner exits on its own before watchdog threshold                                                                                   | runner result path settled                                                        | tracker lifecycle continues normally             | watchdog stops; no stall recovery                                                    |
 
 ## Storage And Persistence Contract
 

--- a/src/orchestrator/liveness-probe.ts
+++ b/src/orchestrator/liveness-probe.ts
@@ -1,4 +1,5 @@
 import type { LivenessSnapshot } from "./stall-detector.js";
+import type { RunnerVisibilityPhase } from "../runner/service.js";
 
 /**
  * Collects liveness signals for an active runner issue.
@@ -12,6 +13,8 @@ export interface LivenessProbe {
     readonly workspacePath: string | null;
     readonly runSessionId: string | null;
     readonly prHeadSha: string | null;
+    readonly runStartedAt: string | null;
+    readonly runnerPhase: RunnerVisibilityPhase | null;
     readonly runnerHeartbeatAt: string | null;
     readonly runnerActionAt: string | null;
     readonly hasActionableFeedback: boolean;
@@ -37,6 +40,8 @@ export class NullLivenessProbe implements LivenessProbe {
     readonly runSessionId: string | null;
     readonly hasActionableFeedback: boolean;
     readonly prHeadSha: string | null;
+    readonly runStartedAt: string | null;
+    readonly runnerPhase: RunnerVisibilityPhase | null;
     readonly runnerHeartbeatAt: string | null;
     readonly runnerActionAt: string | null;
   }): Promise<LivenessSnapshot> {
@@ -44,6 +49,8 @@ export class NullLivenessProbe implements LivenessProbe {
       logSizeBytes: null,
       workspaceDiffHash: null,
       prHeadSha: options.prHeadSha,
+      runStartedAt: options.runStartedAt,
+      runnerPhase: options.runnerPhase,
       runnerHeartbeatAt: options.runnerHeartbeatAt,
       runnerActionAt: options.runnerActionAt,
       hasActionableFeedback: options.hasActionableFeedback,
@@ -70,6 +77,8 @@ export class FsLivenessProbe implements LivenessProbe {
     readonly workspacePath: string | null;
     readonly runSessionId: string | null;
     readonly prHeadSha: string | null;
+    readonly runStartedAt: string | null;
+    readonly runnerPhase: RunnerVisibilityPhase | null;
     readonly runnerHeartbeatAt: string | null;
     readonly runnerActionAt: string | null;
     readonly hasActionableFeedback: boolean;
@@ -83,6 +92,8 @@ export class FsLivenessProbe implements LivenessProbe {
       logSizeBytes: logSize,
       workspaceDiffHash: diffHash,
       prHeadSha: options.prHeadSha,
+      runStartedAt: options.runStartedAt,
+      runnerPhase: options.runnerPhase,
       runnerHeartbeatAt: options.runnerHeartbeatAt,
       runnerActionAt: options.runnerActionAt,
       hasActionableFeedback: options.hasActionableFeedback,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -64,6 +64,7 @@ import { LocalIssueLeaseManager } from "./issue-lease.js";
 import type { LivenessProbe } from "./liveness-probe.js";
 import { createRunningEntry, integrateCodexUpdate } from "./running-entry.js";
 import {
+  type LivenessSource,
   type StallReason,
   checkStall,
   canRecover,
@@ -86,8 +87,11 @@ import {
 } from "./status-state.js";
 import {
   clearActiveWatchdogEntry,
+  clearWatchdogAbortReason,
   clearWatchdogIssueState,
   initWatchdogEntry,
+  noteWatchdogAbortReason,
+  readWatchdogAbortReason,
   recordWatchdogRecovery,
 } from "./watchdog-state.js";
 import { summarizeRunnerText } from "../runner/service.js";
@@ -928,6 +932,15 @@ export class BootstrapOrchestrator implements Orchestrator {
       issue.number,
       watchdogStop.signal,
     );
+    let watchdogStopped = false;
+    const stopWatchdog = async (): Promise<void> => {
+      if (watchdogStopped) {
+        return;
+      }
+      watchdogStopped = true;
+      watchdogStop.abort();
+      await watchdogPromise;
+    };
     const runEntry = createRunningEntry(
       issue.number,
       issue.identifier,
@@ -981,6 +994,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         };
 
         if (result.exitCode !== 0) {
+          await stopWatchdog();
           this.#setIssueRunnerVisibility(
             issue.number,
             this.#buildRunnerVisibility(result.session, {
@@ -1039,6 +1053,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         );
 
         if (nextLifecycle.kind === "handoff-ready") {
+          await stopWatchdog();
           await this.#completeIssue(issue, {
             attemptNumber: attempt,
             branchName: workspace.branchName,
@@ -1070,6 +1085,7 @@ export class BootstrapOrchestrator implements Orchestrator {
           continue;
         }
 
+        await stopWatchdog();
         await this.#handleTurnLifecycleExit(
           issue,
           attempt,
@@ -1082,15 +1098,21 @@ export class BootstrapOrchestrator implements Orchestrator {
         return;
       }
     } catch (error) {
+      await stopWatchdog();
+      const normalizedFailure = this.#resolveRunFailureMessage(
+        sessionState.runSession.issue.number,
+        error as Error,
+      );
       this.#setIssueFailureVisibility(
         sessionState.runSession.issue.number,
         sessionState.description,
         error as Error,
+        normalizedFailure,
       );
       await this.#handleFailure(
         sessionState,
         attempt,
-        this.#normalizeFailure(error as Error),
+        normalizedFailure,
         new Date().toISOString(),
       );
     } finally {
@@ -1102,8 +1124,7 @@ export class BootstrapOrchestrator implements Orchestrator {
           error: error instanceof Error ? error.message : String(error),
         });
       });
-      watchdogStop.abort();
-      await watchdogPromise;
+      await stopWatchdog();
       shutdownSignal?.removeEventListener("abort", handleShutdown);
       this.#state.runAbortControllers.delete(issue.number);
       clearActiveWatchdogEntry(this.#state.watchdog, issue.number);
@@ -2486,9 +2507,9 @@ export class BootstrapOrchestrator implements Orchestrator {
     issueNumber: number,
     session: RunSessionArtifactsState["description"],
     error: Error,
+    normalizedError = this.#normalizeFailure(error),
   ): void {
     const observedAt = new Date().toISOString();
-    const normalized = this.#normalizeFailure(error);
     if (error instanceof RunnerAbortedError) {
       this.#setIssueRunnerVisibility(
         issueNumber,
@@ -2498,14 +2519,14 @@ export class BootstrapOrchestrator implements Orchestrator {
           lastHeartbeatAt: observedAt,
           lastActionAt: observedAt,
           lastActionSummary: "Runner cancelled",
-          errorSummary: normalized,
+          errorSummary: normalizedError,
           cancelledAt: observedAt,
         }),
         observedAt,
       );
       return;
     }
-    const timedOut = normalized.includes("timed out");
+    const timedOut = normalizedError.includes("timed out");
     this.#setIssueRunnerVisibility(
       issueNumber,
       this.#buildRunnerVisibility(session, {
@@ -2514,11 +2535,43 @@ export class BootstrapOrchestrator implements Orchestrator {
         lastHeartbeatAt: observedAt,
         lastActionAt: observedAt,
         lastActionSummary: timedOut ? "Runner timed out" : "Runner failed",
-        errorSummary: normalized,
+        errorSummary: normalizedError,
         ...(timedOut ? { timedOutAt: observedAt } : {}),
       }),
       observedAt,
     );
+  }
+
+  #resolveRunFailureMessage(issueNumber: number, error: Error): string {
+    if (error instanceof RunnerAbortedError) {
+      const watchdogAbort = readWatchdogAbortReason(
+        this.#state.watchdog,
+        issueNumber,
+      );
+      if (watchdogAbort !== null) {
+        return watchdogAbort.summary;
+      }
+    }
+    return this.#normalizeFailure(error);
+  }
+
+  #formatWatchdogAbortSummary(
+    issueNumber: number,
+    reason: StallReason,
+    stalledForMs: number,
+    lastObservableActivityAt: number,
+    lastObservableActivitySource: LivenessSource | null,
+    recoveryExhausted: boolean,
+  ): string {
+    const lastObservedAt = new Date(lastObservableActivityAt).toISOString();
+    const source =
+      lastObservableActivitySource === null
+        ? "unknown"
+        : lastObservableActivitySource;
+    const recoveryText = recoveryExhausted
+      ? "recovery limit reached, aborting"
+      : "aborting runner for retry";
+    return `Stall detected (${reason}) for issue #${issueNumber.toString()} after ${stalledForMs.toString()}ms since ${source} at ${lastObservedAt}; ${recoveryText}`;
   }
 
   #buildRunnerVisibility(
@@ -2620,14 +2673,18 @@ export class BootstrapOrchestrator implements Orchestrator {
     ) {
       return;
     }
+    clearWatchdogAbortReason(this.#state.watchdog, issueNumber);
+    const activeIssue = this.#state.status.activeIssues.get(issueNumber);
     const now = Date.now();
     initWatchdogEntry(this.#state.watchdog, issueNumber, {
       logSizeBytes: null,
       workspaceDiffHash: null,
       prHeadSha: null,
-      runnerHeartbeatAt: null,
-      runnerActionAt: null,
-      hasActionableFeedback: false,
+      runStartedAt: activeIssue?.startedAt ?? null,
+      runnerPhase: activeIssue?.runnerVisibility?.phase ?? null,
+      runnerHeartbeatAt: activeIssue?.runnerVisibility?.lastHeartbeatAt ?? null,
+      runnerActionAt: activeIssue?.runnerVisibility?.lastActionAt ?? null,
+      hasActionableFeedback: (activeIssue?.review.actionableCount ?? 0) > 0,
       capturedAt: now,
     });
   }
@@ -2666,6 +2723,8 @@ export class BootstrapOrchestrator implements Orchestrator {
           workspacePath: activeIssue?.workspacePath ?? null,
           runSessionId: activeIssue?.runSessionId ?? null,
           prHeadSha: activeIssue?.pullRequest?.headSha ?? null,
+          runStartedAt: activeIssue?.startedAt ?? null,
+          runnerPhase: activeIssue?.runnerVisibility?.phase ?? null,
           runnerHeartbeatAt:
             activeIssue?.runnerVisibility?.lastHeartbeatAt ?? null,
           runnerActionAt: activeIssue?.runnerVisibility?.lastActionAt ?? null,
@@ -2674,18 +2733,45 @@ export class BootstrapOrchestrator implements Orchestrator {
         const result = checkStall(entry, snapshot, this.#watchdogConfig);
         if (result.stalled && result.reason !== null) {
           if (canRecover(entry, this.#watchdogConfig)) {
-            await this.#recoverStalledRunner(issueNumber, result.reason);
+            await this.#recoverStalledRunner(issueNumber, {
+              reason: result.reason,
+              stalledForMs: result.stalledForMs,
+              lastObservableActivityAt: result.lastObservableActivityAt,
+              lastObservableActivitySource: result.lastObservableActivitySource,
+            });
             break;
           }
+          const observedAt = new Date().toISOString();
+          const summary = this.#formatWatchdogAbortSummary(
+            issueNumber,
+            result.reason,
+            result.stalledForMs,
+            result.lastObservableActivityAt,
+            result.lastObservableActivitySource,
+            true,
+          );
           this.#logger.warn("Stalled runner exceeded recovery limit", {
             issueNumber,
             reason: result.reason,
             recoveryCount: entry.recoveryCount,
+            lastObservableActivityAt: new Date(
+              result.lastObservableActivityAt,
+            ).toISOString(),
+            lastObservableActivitySource: result.lastObservableActivitySource,
           });
           noteStatusAction(this.#state.status, {
             kind: "watchdog-recovery-exhausted",
-            summary: `Stall detected (${result.reason}) for issue #${issueNumber.toString()}; recovery limit reached, aborting`,
+            summary,
             issueNumber,
+            at: observedAt,
+          });
+          noteWatchdogAbortReason(this.#state.watchdog, issueNumber, {
+            reason: result.reason,
+            summary,
+            observedAt,
+            recoveryExhausted: true,
+            lastObservableActivityAt: result.lastObservableActivityAt,
+            lastObservableActivitySource: result.lastObservableActivitySource,
           });
           await this.#persistStatusSnapshot();
           const controller = this.#state.runAbortControllers.get(issueNumber);
@@ -2705,22 +2791,49 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   async #recoverStalledRunner(
     issueNumber: number,
-    reason: StallReason,
+    result: {
+      readonly reason: StallReason;
+      readonly stalledForMs: number;
+      readonly lastObservableActivityAt: number;
+      readonly lastObservableActivitySource: LivenessSource | null;
+    },
   ): Promise<void> {
     const entry = this.#state.watchdog.activeEntries.get(issueNumber);
     if (!entry) {
       return;
     }
     recordWatchdogRecovery(this.#state.watchdog, entry);
+    const observedAt = new Date().toISOString();
+    const summary = this.#formatWatchdogAbortSummary(
+      issueNumber,
+      result.reason,
+      result.stalledForMs,
+      result.lastObservableActivityAt,
+      result.lastObservableActivitySource,
+      false,
+    );
     this.#logger.warn("Recovering stalled runner", {
       issueNumber,
-      reason,
+      reason: result.reason,
       recoveryCount: entry.recoveryCount,
+      lastObservableActivityAt: new Date(
+        result.lastObservableActivityAt,
+      ).toISOString(),
+      lastObservableActivitySource: result.lastObservableActivitySource,
     });
     noteStatusAction(this.#state.status, {
       kind: "watchdog-recovery",
-      summary: `Stall detected (${reason}) for issue #${issueNumber.toString()}; aborting runner`,
+      summary,
       issueNumber,
+      at: observedAt,
+    });
+    noteWatchdogAbortReason(this.#state.watchdog, issueNumber, {
+      reason: result.reason,
+      summary,
+      observedAt,
+      recoveryExhausted: false,
+      lastObservableActivityAt: result.lastObservableActivityAt,
+      lastObservableActivitySource: result.lastObservableActivitySource,
     });
     await this.#persistStatusSnapshot();
     const controller = this.#state.runAbortControllers.get(issueNumber);

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -91,7 +91,9 @@ export function checkStall(
   if (activity !== null && activity.at >= entry.lastObservableActivityAt) {
     // Clamp runner-reported timestamps to the probe wall clock so a fast
     // runner clock cannot push the baseline into the future and disable stall
-    // detection with negative idle durations.
+    // detection with negative idle durations. An exact tie still updates the
+    // source to the freshest signal, but it does not advance the baseline or
+    // reset the stall timer.
     const creditedAt = Math.min(activity.at, current.capturedAt);
     entry.lastLiveness = current;
     entry.lastObservableActivityAt = creditedAt;

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -43,6 +43,9 @@ export interface StallCheckResult {
   readonly issueNumber: number;
   readonly stalled: boolean;
   readonly reason: StallReason | null;
+  // When stalled, this is the idle duration since the credited last observable
+  // activity. On the non-stalled activity-detected path it is only the lag
+  // between the current probe wall clock and the credited activity timestamp.
   readonly stalledForMs: number;
   readonly lastObservableActivityAt: number;
   readonly lastObservableActivitySource: LivenessSource | null;
@@ -177,7 +180,7 @@ function deriveInitialObservableActivity(
   const runStartedAt = parseTimestamp(snapshot.runStartedAt);
   if (runStartedAt !== null) {
     candidates.push({
-      at: runStartedAt,
+      at: Math.min(runStartedAt, snapshot.capturedAt),
       source: "run-start",
     });
   }

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -93,7 +93,7 @@ export function checkStall(
       issueNumber: entry.issueNumber,
       stalled: false,
       reason: null,
-      stalledForMs: 0,
+      stalledForMs: current.capturedAt - activity.at,
       lastObservableActivityAt: entry.lastObservableActivityAt,
       lastObservableActivitySource: entry.lastObservableActivitySource,
     };

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -1,13 +1,25 @@
 import type { WatchdogConfig } from "../domain/workflow.js";
+import type { RunnerVisibilityPhase } from "../runner/service.js";
 
 /** Reason a runner was classified as stalled. */
 export type StallReason = "log-stall" | "workspace-stall" | "pr-stall";
+
+export type LivenessSource =
+  | "run-start"
+  | "runner-startup"
+  | "runner-heartbeat"
+  | "runner-action"
+  | "watchdog-log"
+  | "workspace-diff"
+  | "pr-head";
 
 /** Liveness snapshot captured per active issue. */
 export interface LivenessSnapshot {
   readonly logSizeBytes: number | null;
   readonly workspaceDiffHash: string | null;
   readonly prHeadSha: string | null;
+  readonly runStartedAt: string | null;
+  readonly runnerPhase: RunnerVisibilityPhase | null;
   readonly runnerHeartbeatAt: string | null;
   readonly runnerActionAt: string | null;
   readonly hasActionableFeedback: boolean;
@@ -18,7 +30,8 @@ export interface LivenessSnapshot {
 export interface WatchdogEntry {
   readonly issueNumber: number;
   lastLiveness: LivenessSnapshot;
-  lastChangeAt: number;
+  lastObservableActivityAt: number;
+  lastObservableActivitySource: LivenessSource | null;
   recoveryCount: number;
 }
 
@@ -28,6 +41,8 @@ export interface StallCheckResult {
   readonly stalled: boolean;
   readonly reason: StallReason | null;
   readonly stalledForMs: number;
+  readonly lastObservableActivityAt: number;
+  readonly lastObservableActivitySource: LivenessSource | null;
 }
 
 /**
@@ -38,10 +53,12 @@ export function createWatchdogEntry(
   snapshot: LivenessSnapshot,
   recoveryCount = 0,
 ): WatchdogEntry {
+  const initialActivity = deriveInitialObservableActivity(snapshot);
   return {
     issueNumber,
     lastLiveness: snapshot,
-    lastChangeAt: snapshot.capturedAt,
+    lastObservableActivityAt: initialActivity.at,
+    lastObservableActivitySource: initialActivity.source,
     recoveryCount,
   };
 }
@@ -53,6 +70,7 @@ export function hasObservableLivenessSignal(
     snapshot.logSizeBytes !== null ||
     snapshot.workspaceDiffHash !== null ||
     snapshot.prHeadSha !== null ||
+    snapshot.runStartedAt !== null ||
     snapshot.runnerHeartbeatAt !== null ||
     snapshot.runnerActionAt !== null
   );
@@ -61,7 +79,8 @@ export function hasObservableLivenessSignal(
 /**
  * Check whether an issue's runner has stalled based on liveness signals.
  *
- * Updates `entry.lastLiveness` and `entry.lastChangeAt` as a side effect.
+ * Updates `entry.lastLiveness` and the authoritative last observable activity
+ * as a side effect.
  * Returns whether the issue is stalled and why.
  */
 export function checkStall(
@@ -71,75 +90,33 @@ export function checkStall(
 ): StallCheckResult {
   const previous = entry.lastLiveness;
 
-  if (!hasObservableLivenessSignal(current)) {
+  const activity = detectObservableActivity(previous, current);
+  if (activity !== null && activity.at >= entry.lastObservableActivityAt) {
     entry.lastLiveness = current;
-    entry.lastChangeAt = current.capturedAt;
+    entry.lastObservableActivityAt = activity.at;
+    entry.lastObservableActivitySource = activity.source;
     return {
       issueNumber: entry.issueNumber,
       stalled: false,
       reason: null,
       stalledForMs: 0,
-    };
-  }
-
-  let changed = false;
-
-  // Check log growth
-  if (
-    current.logSizeBytes !== null &&
-    current.logSizeBytes !== previous.logSizeBytes
-  ) {
-    changed = true;
-  }
-
-  // Check workspace diff changes
-  if (
-    current.workspaceDiffHash !== null &&
-    current.workspaceDiffHash !== previous.workspaceDiffHash
-  ) {
-    changed = true;
-  }
-
-  // Check PR head movement
-  if (current.prHeadSha !== null && current.prHeadSha !== previous.prHeadSha) {
-    changed = true;
-  }
-
-  // Check runner heartbeat and action progress
-  if (
-    current.runnerHeartbeatAt !== null &&
-    current.runnerHeartbeatAt !== previous.runnerHeartbeatAt
-  ) {
-    changed = true;
-  }
-  if (
-    current.runnerActionAt !== null &&
-    current.runnerActionAt !== previous.runnerActionAt
-  ) {
-    changed = true;
-  }
-
-  if (changed) {
-    entry.lastLiveness = current;
-    entry.lastChangeAt = current.capturedAt;
-    return {
-      issueNumber: entry.issueNumber,
-      stalled: false,
-      reason: null,
-      stalledForMs: 0,
+      lastObservableActivityAt: entry.lastObservableActivityAt,
+      lastObservableActivitySource: entry.lastObservableActivitySource,
     };
   }
 
   // Update snapshot even if no change detected
   entry.lastLiveness = current;
 
-  const stalledForMs = current.capturedAt - entry.lastChangeAt;
+  const stalledForMs = current.capturedAt - entry.lastObservableActivityAt;
   if (stalledForMs < config.stallThresholdMs) {
     return {
       issueNumber: entry.issueNumber,
       stalled: false,
       reason: null,
       stalledForMs,
+      lastObservableActivityAt: entry.lastObservableActivityAt,
+      lastObservableActivitySource: entry.lastObservableActivitySource,
     };
   }
 
@@ -150,6 +127,8 @@ export function checkStall(
     stalled: true,
     reason,
     stalledForMs,
+    lastObservableActivityAt: entry.lastObservableActivityAt,
+    lastObservableActivitySource: entry.lastObservableActivitySource,
   };
 }
 
@@ -186,3 +165,137 @@ export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
   stallThresholdMs: 300_000,
   maxRecoveryAttempts: 2,
 };
+
+interface ObservableActivity {
+  readonly at: number;
+  readonly source: LivenessSource | null;
+}
+
+function deriveInitialObservableActivity(
+  snapshot: LivenessSnapshot,
+): ObservableActivity {
+  const candidates: ObservableActivity[] = [];
+
+  const runStartedAt = parseTimestamp(snapshot.runStartedAt);
+  if (runStartedAt !== null) {
+    candidates.push({
+      at: runStartedAt,
+      source: "run-start",
+    });
+  }
+
+  const runnerHeartbeatAt = parseTimestamp(snapshot.runnerHeartbeatAt);
+  if (runnerHeartbeatAt !== null) {
+    candidates.push({
+      at: runnerHeartbeatAt,
+      source: "runner-heartbeat",
+    });
+  }
+
+  const runnerActionAt = parseTimestamp(snapshot.runnerActionAt);
+  if (runnerActionAt !== null) {
+    candidates.push({
+      at: runnerActionAt,
+      source: isStartupPhase(snapshot.runnerPhase)
+        ? "runner-startup"
+        : "runner-action",
+    });
+  }
+
+  return (
+    latestObservableActivity(candidates) ?? {
+      at: snapshot.capturedAt,
+      source: null,
+    }
+  );
+}
+
+function detectObservableActivity(
+  previous: LivenessSnapshot,
+  current: LivenessSnapshot,
+): ObservableActivity | null {
+  const candidates: ObservableActivity[] = [];
+
+  if (
+    current.logSizeBytes !== null &&
+    current.logSizeBytes !== previous.logSizeBytes
+  ) {
+    candidates.push({
+      at: current.capturedAt,
+      source: "watchdog-log",
+    });
+  }
+
+  if (
+    current.workspaceDiffHash !== null &&
+    current.workspaceDiffHash !== previous.workspaceDiffHash
+  ) {
+    candidates.push({
+      at: current.capturedAt,
+      source: "workspace-diff",
+    });
+  }
+
+  if (current.prHeadSha !== null && current.prHeadSha !== previous.prHeadSha) {
+    candidates.push({
+      at: current.capturedAt,
+      source: "pr-head",
+    });
+  }
+
+  if (
+    current.runnerHeartbeatAt !== null &&
+    current.runnerHeartbeatAt !== previous.runnerHeartbeatAt
+  ) {
+    const runnerHeartbeatAt = parseTimestamp(current.runnerHeartbeatAt);
+    if (runnerHeartbeatAt !== null) {
+      candidates.push({
+        at: runnerHeartbeatAt,
+        source: "runner-heartbeat",
+      });
+    }
+  }
+
+  if (
+    current.runnerActionAt !== null &&
+    current.runnerActionAt !== previous.runnerActionAt
+  ) {
+    const runnerActionAt = parseTimestamp(current.runnerActionAt);
+    if (runnerActionAt !== null) {
+      candidates.push({
+        at: runnerActionAt,
+        source: isStartupPhase(current.runnerPhase)
+          ? "runner-startup"
+          : "runner-action",
+      });
+    }
+  }
+
+  return latestObservableActivity(candidates);
+}
+
+function latestObservableActivity(
+  candidates: readonly ObservableActivity[],
+): ObservableActivity | null {
+  let latest: ObservableActivity | null = null;
+  for (const candidate of candidates) {
+    if (latest === null || candidate.at >= latest.at) {
+      latest = candidate;
+    }
+  }
+  return latest;
+}
+
+function parseTimestamp(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isStartupPhase(
+  phase: RunnerVisibilityPhase | null,
+): phase is "boot" | "session-start" {
+  return phase === "boot" || phase === "session-start";
+}

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -63,19 +63,6 @@ export function createWatchdogEntry(
   };
 }
 
-export function hasObservableLivenessSignal(
-  snapshot: LivenessSnapshot,
-): boolean {
-  return (
-    snapshot.logSizeBytes !== null ||
-    snapshot.workspaceDiffHash !== null ||
-    snapshot.prHeadSha !== null ||
-    snapshot.runStartedAt !== null ||
-    snapshot.runnerHeartbeatAt !== null ||
-    snapshot.runnerActionAt !== null
-  );
-}
-
 /**
  * Check whether an issue's runner has stalled based on liveness signals.
  *

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -86,14 +86,18 @@ export function checkStall(
   // run-start anchor because of clock skew or delayed propagation; that still
   // updates visibility, but it must not reset the watchdog deadline.
   if (activity !== null && activity.at >= entry.lastObservableActivityAt) {
+    // Clamp runner-reported timestamps to the probe wall clock so a fast
+    // runner clock cannot push the baseline into the future and disable stall
+    // detection with negative idle durations.
+    const creditedAt = Math.min(activity.at, current.capturedAt);
     entry.lastLiveness = current;
-    entry.lastObservableActivityAt = activity.at;
+    entry.lastObservableActivityAt = creditedAt;
     entry.lastObservableActivitySource = activity.source;
     return {
       issueNumber: entry.issueNumber,
       stalled: false,
       reason: null,
-      stalledForMs: current.capturedAt - activity.at,
+      stalledForMs: current.capturedAt - creditedAt,
       lastObservableActivityAt: entry.lastObservableActivityAt,
       lastObservableActivitySource: entry.lastObservableActivitySource,
     };

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -255,6 +255,10 @@ function detectObservableActivity(
         source: "runner-heartbeat",
       });
     }
+    // If the raw heartbeat string changed but is unparseable, this update
+    // cannot advance the authoritative timestamp. We still replace
+    // entry.lastLiveness below so a later valid heartbeat string is detected as
+    // a new change instead of being masked by the malformed value.
   }
 
   if (
@@ -270,6 +274,9 @@ function detectObservableActivity(
           : "runner-action",
       });
     }
+    // Same as runnerHeartbeatAt above: a malformed action timestamp is visible
+    // in lastLiveness for future comparisons, but it cannot be credited as
+    // observable activity until the runner reports a parseable timestamp.
   }
 
   return latestObservableActivity(candidates);

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -29,6 +29,9 @@ export interface LivenessSnapshot {
 /** Per-issue watchdog tracking entry. */
 export interface WatchdogEntry {
   readonly issueNumber: number;
+  // These fields are intentionally mutated in place by checkStall() and
+  // recordWatchdogRecovery() so the watchdog loop can update per-issue state
+  // without allocating a replacement entry every poll.
   lastLiveness: LivenessSnapshot;
   lastObservableActivityAt: number;
   lastObservableActivitySource: LivenessSource | null;
@@ -78,6 +81,10 @@ export function checkStall(
   const previous = entry.lastLiveness;
 
   const activity = detectObservableActivity(previous, current);
+  // Only credit activity that is at-or-after the last known baseline.
+  // A runner may report heartbeat/action timestamps that are older than the
+  // run-start anchor because of clock skew or delayed propagation; that still
+  // updates visibility, but it must not reset the watchdog deadline.
   if (activity !== null && activity.at >= entry.lastObservableActivityAt) {
     entry.lastLiveness = current;
     entry.lastObservableActivityAt = activity.at;
@@ -266,7 +273,12 @@ function latestObservableActivity(
 ): ObservableActivity | null {
   let latest: ObservableActivity | null = null;
   for (const candidate of candidates) {
-    if (latest === null || candidate.at >= latest.at) {
+    // Candidate push order is the priority order for tied timestamps:
+    // run-start > runner-heartbeat > runner-startup/action during startup
+    // derivation, and watchdog-log > workspace-diff > pr-head >
+    // runner-heartbeat > runner-startup/action during incremental detection.
+    // Strict greater-than preserves the first (highest-priority) candidate.
+    if (latest === null || candidate.at > latest.at) {
       latest = candidate;
     }
   }

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -185,7 +185,7 @@ function deriveInitialObservableActivity(
   const runnerHeartbeatAt = parseTimestamp(snapshot.runnerHeartbeatAt);
   if (runnerHeartbeatAt !== null) {
     candidates.push({
-      at: runnerHeartbeatAt,
+      at: Math.min(runnerHeartbeatAt, snapshot.capturedAt),
       source: "runner-heartbeat",
     });
   }
@@ -193,7 +193,7 @@ function deriveInitialObservableActivity(
   const runnerActionAt = parseTimestamp(snapshot.runnerActionAt);
   if (runnerActionAt !== null) {
     candidates.push({
-      at: runnerActionAt,
+      at: Math.min(runnerActionAt, snapshot.capturedAt),
       source: isStartupPhase(snapshot.runnerPhase)
         ? "runner-startup"
         : "runner-action",

--- a/src/orchestrator/watchdog-state.ts
+++ b/src/orchestrator/watchdog-state.ts
@@ -1,15 +1,31 @@
-import type { LivenessSnapshot, WatchdogEntry } from "./stall-detector.js";
+import type {
+  LivenessSnapshot,
+  LivenessSource,
+  StallReason,
+  WatchdogEntry,
+} from "./stall-detector.js";
 import { createWatchdogEntry } from "./stall-detector.js";
+
+export interface WatchdogAbortReason {
+  readonly reason: StallReason;
+  readonly summary: string;
+  readonly observedAt: string;
+  readonly recoveryExhausted: boolean;
+  readonly lastObservableActivityAt: number;
+  readonly lastObservableActivitySource: LivenessSource | null;
+}
 
 export interface WatchdogRuntimeState {
   readonly activeEntries: Map<number, WatchdogEntry>;
   readonly recoveryCounts: Map<number, number>;
+  readonly abortReasons: Map<number, WatchdogAbortReason>;
 }
 
 export function createWatchdogRuntimeState(): WatchdogRuntimeState {
   return {
     activeEntries: new Map<number, WatchdogEntry>(),
     recoveryCounts: new Map<number, number>(),
+    abortReasons: new Map<number, WatchdogAbortReason>(),
   };
 }
 
@@ -44,6 +60,7 @@ export function clearWatchdogIssueState(
 ): void {
   state.activeEntries.delete(issueNumber);
   state.recoveryCounts.delete(issueNumber);
+  state.abortReasons.delete(issueNumber);
 }
 
 export function recordWatchdogRecovery(
@@ -53,4 +70,26 @@ export function recordWatchdogRecovery(
   entry.recoveryCount += 1;
   state.recoveryCounts.set(entry.issueNumber, entry.recoveryCount);
   return entry.recoveryCount;
+}
+
+export function noteWatchdogAbortReason(
+  state: WatchdogRuntimeState,
+  issueNumber: number,
+  reason: WatchdogAbortReason,
+): void {
+  state.abortReasons.set(issueNumber, reason);
+}
+
+export function clearWatchdogAbortReason(
+  state: WatchdogRuntimeState,
+  issueNumber: number,
+): void {
+  state.abortReasons.delete(issueNumber);
+}
+
+export function readWatchdogAbortReason(
+  state: WatchdogRuntimeState,
+  issueNumber: number,
+): WatchdogAbortReason | null {
+  return state.abortReasons.get(issueNumber) ?? null;
 }

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -17,6 +17,7 @@ import { runReportCli } from "../../src/cli/report.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
+import { FsLivenessProbe } from "../../src/orchestrator/liveness-probe.js";
 import { createRunner } from "../../src/runner/factory.js";
 import { GitHubBootstrapTracker } from "../../src/tracker/github-bootstrap.js";
 import { parsePlanReadyCommentMetadata } from "../../src/tracker/plan-review-comment.js";
@@ -42,6 +43,14 @@ async function writeWorkflow(options: {
   retryBackoffMs?: number;
   maxAttempts?: number;
   maxTurns?: number;
+  watchdog?:
+    | {
+        readonly enabled: boolean;
+        readonly checkIntervalMs: number;
+        readonly stallThresholdMs: number;
+        readonly maxRecoveryAttempts: number;
+      }
+    | undefined;
 }): Promise<string> {
   const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
   await fs.writeFile(
@@ -64,6 +73,16 @@ polling:
   retry:
     max_attempts: ${options.maxAttempts ?? 2}
     backoff_ms: ${options.retryBackoffMs ?? 0}
+${
+  options.watchdog === undefined
+    ? ""
+    : `  watchdog:
+    enabled: ${options.watchdog.enabled ? "true" : "false"}
+    check_interval_ms: ${options.watchdog.checkIntervalMs}
+    stall_threshold_ms: ${options.watchdog.stallThresholdMs}
+    max_recovery_attempts: ${options.watchdog.maxRecoveryAttempts}
+`
+}
 workspace:
   root: ./.tmp/workspaces
   repo_url: ${options.remotePath}
@@ -118,6 +137,10 @@ async function createOrchestrator(
     workspace,
     runner,
     logger,
+    undefined,
+    workflow.config.polling.watchdog?.enabled
+      ? new FsLivenessProbe(workflow.config.workspace.root)
+      : undefined,
   );
 }
 
@@ -384,6 +407,63 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       expect.objectContaining({
         kind: "failed",
       }),
+    );
+  });
+
+  it("preserves the watchdog stall reason instead of flattening it to shutdown", async () => {
+    server.seedIssue({
+      number: 83,
+      title: "Preserve watchdog reason",
+      body: "Do not collapse genuine stalls into generic shutdown summaries.",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand:
+        'node -e "process.stdin.resume(); setInterval(() => {}, 1000)"',
+      maxAttempts: 1,
+      watchdog: {
+        enabled: true,
+        checkIntervalMs: 5,
+        stallThresholdMs: 20,
+        maxRecoveryAttempts: 0,
+      },
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(83);
+    expect(issue.labels.map((label) => label.name)).toContain(
+      "symphony:failed",
+    );
+    expect(
+      issue.comments.some((comment) =>
+        comment.includes(
+          "Symphony failed this run: Stall detected (workspace-stall)",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      issue.comments.some((comment) =>
+        comment.includes("Runner cancelled by shutdown"),
+      ),
+    ).toBe(false);
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      83,
+    );
+    expect(artifactSummary.currentOutcome).toBe("failed");
+    expect(artifactSummary.currentSummary).toContain(
+      "Stall detected (workspace-stall)",
+    );
+    expect(artifactSummary.currentSummary).not.toContain(
+      "Runner cancelled by shutdown",
     );
   });
 

--- a/tests/unit/liveness-probe.test.ts
+++ b/tests/unit/liveness-probe.test.ts
@@ -33,6 +33,8 @@ describe("NullLivenessProbe", () => {
       workspacePath: "/tmp/workspaces/42",
       runSessionId: "session-42",
       prHeadSha: "abc123",
+      runStartedAt: "2026-03-13T08:45:59.000Z",
+      runnerPhase: "turn-execution",
       runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
       runnerActionAt: "2026-03-13T08:46:01.000Z",
       hasActionableFeedback: true,
@@ -40,6 +42,8 @@ describe("NullLivenessProbe", () => {
     expect(result.logSizeBytes).toBeNull();
     expect(result.workspaceDiffHash).toBeNull();
     expect(result.prHeadSha).toBe("abc123");
+    expect(result.runStartedAt).toBe("2026-03-13T08:45:59.000Z");
+    expect(result.runnerPhase).toBe("turn-execution");
     expect(result.runnerHeartbeatAt).toBe("2026-03-13T08:46:00.000Z");
     expect(result.runnerActionAt).toBe("2026-03-13T08:46:01.000Z");
     expect(result.hasActionableFeedback).toBe(true);
@@ -74,12 +78,16 @@ describe("FsLivenessProbe", () => {
       workspacePath: null,
       runSessionId,
       prHeadSha: null,
+      runStartedAt: "2026-03-13T08:45:59.000Z",
+      runnerPhase: "session-start",
       runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
       runnerActionAt: "2026-03-13T08:46:01.000Z",
       hasActionableFeedback: false,
     });
 
     expect(result.logSizeBytes).toBe("runner-a".length);
+    expect(result.runStartedAt).toBe("2026-03-13T08:45:59.000Z");
+    expect(result.runnerPhase).toBe("session-start");
     expect(result.runnerHeartbeatAt).toBe("2026-03-13T08:46:00.000Z");
     expect(result.runnerActionAt).toBe("2026-03-13T08:46:01.000Z");
   });
@@ -104,6 +112,8 @@ describe("FsLivenessProbe", () => {
       workspacePath: null,
       runSessionId: null,
       prHeadSha: null,
+      runStartedAt: null,
+      runnerPhase: null,
       runnerHeartbeatAt: null,
       runnerActionAt: null,
       hasActionableFeedback: false,

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -3347,7 +3347,13 @@ describe("BootstrapOrchestrator watchdog", () => {
 
     expect(abortCount).toBe(1);
     expect(tracker.retried).toHaveLength(1);
-    expect(tracker.retried[0]?.reason).toContain("since runner-heartbeat at");
+    // Startup stalls can summarize against the initial run-start anchor or a
+    // runner-heartbeat timestamp, depending on which startup-side signal wins
+    // the first baseline sample. The regression we care about is preserving the
+    // watchdog-specific source label instead of collapsing to shutdown.
+    expect(tracker.retried[0]?.reason).toMatch(
+      /since (run-start|runner-heartbeat) at/,
+    );
   });
 
   it("does not recover beyond maxRecoveryAttempts across retries", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -3431,7 +3431,9 @@ describe("BootstrapOrchestrator watchdog", () => {
       deriveStatusFilePath(tmpDir),
     );
     expect(snapshot.lastAction?.kind).toBe("issue-failed");
-    expect(snapshot.lastAction?.summary).toContain("Stall detected (log-stall)");
+    expect(snapshot.lastAction?.summary).toContain(
+      "Stall detected (log-stall)",
+    );
     expect(snapshot.lastAction?.summary).toContain("since ");
   });
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -72,6 +72,9 @@ function createDeferred<T>(): {
 function createObservableStalledProbe(): LivenessProbe {
   return {
     async capture(options) {
+      // Keep logSizeBytes fixed at 1 so the first watchdog poll observes a
+      // null -> 1 log transition, then all later polls stall on unchanged
+      // liveness. That exercises recovery paths without runner-side progress.
       return {
         logSizeBytes: 1,
         workspaceDiffHash: null,

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -3431,7 +3431,8 @@ describe("BootstrapOrchestrator watchdog", () => {
       deriveStatusFilePath(tmpDir),
     );
     expect(snapshot.lastAction?.kind).toBe("issue-failed");
-    expect(snapshot.lastAction?.summary).toContain("since watchdog-log at");
+    expect(snapshot.lastAction?.summary).toContain("Stall detected (log-stall)");
+    expect(snapshot.lastAction?.summary).toContain("since ");
   });
 
   it("aborts a stalled runner even when recovery is exhausted", async () => {

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -3347,12 +3347,9 @@ describe("BootstrapOrchestrator watchdog", () => {
 
     expect(abortCount).toBe(1);
     expect(tracker.retried).toHaveLength(1);
-    // Startup stalls can summarize against the initial run-start anchor or a
-    // runner-heartbeat timestamp, depending on which startup-side signal wins
-    // the first baseline sample. The regression we care about is preserving the
-    // watchdog-specific source label instead of collapsing to shutdown.
-    expect(tracker.retried[0]?.reason).toMatch(
-      /since (run-start|runner-heartbeat) at/,
+    expect(tracker.retried[0]?.reason).toContain("Stall detected (log-stall)");
+    expect(tracker.retried[0]?.reason).not.toContain(
+      "Runner cancelled by shutdown",
     );
   });
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -9,7 +9,10 @@ import type {
   ResolvedConfig,
 } from "../../src/domain/workflow.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
-import type { LivenessProbe } from "../../src/orchestrator/liveness-probe.js";
+import {
+  NullLivenessProbe,
+  type LivenessProbe,
+} from "../../src/orchestrator/liveness-probe.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import {
   deriveFactoryRuntimeRoot,
@@ -73,6 +76,8 @@ function createObservableStalledProbe(): LivenessProbe {
         logSizeBytes: 1,
         workspaceDiffHash: null,
         prHeadSha: options.prHeadSha,
+        runStartedAt: options.runStartedAt,
+        runnerPhase: options.runnerPhase,
         runnerHeartbeatAt: options.runnerHeartbeatAt,
         runnerActionAt: options.runnerActionAt,
         hasActionableFeedback: options.hasActionableFeedback,
@@ -89,6 +94,8 @@ function createRunnerVisibilityProbe(): LivenessProbe {
         logSizeBytes: null,
         workspaceDiffHash: null,
         prHeadSha: options.prHeadSha,
+        runStartedAt: options.runStartedAt,
+        runnerPhase: options.runnerPhase,
         runnerHeartbeatAt: options.runnerHeartbeatAt,
         runnerActionAt: options.runnerActionAt,
         hasActionableFeedback: options.hasActionableFeedback,
@@ -3281,6 +3288,68 @@ describe("BootstrapOrchestrator watchdog", () => {
     expect(tracker.completed).toEqual([91]);
   });
 
+  it("recovers a startup run that never advances beyond its start time", async () => {
+    const issue = createIssue(92);
+    const tracker = new SequencedTracker({ ready: [issue] });
+    tracker.setLifecycleSequence(92, [
+      lifecycle("missing-target", "symphony/92"),
+    ]);
+
+    let abortCount = 0;
+
+    const stalledRunner: Runner = {
+      describeSession() {
+        return createRunnerSessionDescription();
+      },
+      async run(_session, options) {
+        return await new Promise<RunnerExecutionResult>((_resolve, reject) => {
+          const handleAbort = (): void => {
+            abortCount += 1;
+            reject(new RunnerAbortedError("Aborted"));
+          };
+          if (options?.signal?.aborted) {
+            handleAbort();
+            return;
+          }
+          options?.signal?.addEventListener("abort", handleAbort, {
+            once: true,
+          });
+        });
+      },
+    };
+
+    const watchdogConfig = {
+      ...baseConfig,
+      workspace: { ...baseConfig.workspace, root: tmpDir },
+      polling: {
+        ...baseConfig.polling,
+        watchdog: {
+          enabled: true,
+          checkIntervalMs: 0,
+          stallThresholdMs: 0,
+          maxRecoveryAttempts: 1,
+        },
+      },
+    };
+
+    const orchestrator = new BootstrapOrchestrator(
+      watchdogConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      stalledRunner,
+      new NullLogger(),
+      undefined,
+      new NullLivenessProbe(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(abortCount).toBe(1);
+    expect(tracker.retried).toHaveLength(1);
+    expect(tracker.retried[0]?.reason).toContain("since runner-action at");
+  });
+
   it("does not recover beyond maxRecoveryAttempts across retries", async () => {
     const issue = createIssue(88);
     const tracker = new SequencedTracker({ ready: [issue] });
@@ -3355,13 +3424,14 @@ describe("BootstrapOrchestrator watchdog", () => {
     expect(tracker.failed).toEqual([
       {
         issueNumber: 88,
-        reason: "Aborted",
+        reason: expect.stringContaining("Stall detected (log-stall)"),
       },
     ]);
     const snapshot = await readFactoryStatusSnapshot(
       deriveStatusFilePath(tmpDir),
     );
     expect(snapshot.lastAction?.kind).toBe("issue-failed");
+    expect(snapshot.lastAction?.summary).toContain("since watchdog-log at");
   });
 
   it("aborts a stalled runner even when recovery is exhausted", async () => {
@@ -3466,7 +3536,7 @@ describe("BootstrapOrchestrator watchdog", () => {
         ...baseConfig.polling,
         watchdog: {
           enabled: true,
-          checkIntervalMs: 0,
+          checkIntervalMs: 50,
           stallThresholdMs: 0,
           maxRecoveryAttempts: 1,
         },

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -3347,7 +3347,7 @@ describe("BootstrapOrchestrator watchdog", () => {
 
     expect(abortCount).toBe(1);
     expect(tracker.retried).toHaveLength(1);
-    expect(tracker.retried[0]?.reason).toContain("since runner-action at");
+    expect(tracker.retried[0]?.reason).toContain("since runner-heartbeat at");
   });
 
   it("does not recover beyond maxRecoveryAttempts across retries", async () => {

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -58,6 +58,30 @@ describe("createWatchdogEntry", () => {
     expect(entry.lastObservableActivityAt).toBe(Date.parse(HEARTBEAT_AT));
     expect(entry.lastObservableActivitySource).toBe("run-start");
   });
+
+  it("clamps future-dated initial runner heartbeat activity to capturedAt", () => {
+    const capturedAt = Date.parse(CAPTURED_AT);
+    const entry = createWatchdogEntry(
+      42,
+      snapshot({
+        capturedAt,
+        runnerHeartbeatAt: "2026-03-13T08:46:30.000Z",
+      }),
+    );
+    expect(entry.lastObservableActivityAt).toBe(capturedAt);
+    expect(entry.lastObservableActivitySource).toBe("runner-heartbeat");
+
+    const result = checkStall(
+      entry,
+      snapshot({
+        capturedAt: capturedAt + config.stallThresholdMs + 1,
+        runnerHeartbeatAt: "2026-03-13T08:46:30.000Z",
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(true);
+    expect(result.reason).toBe("log-stall");
+  });
 });
 
 describe("checkStall", () => {
@@ -276,7 +300,7 @@ describe("checkStall", () => {
       snapshot({
         runnerHeartbeatAt: HEARTBEAT_AT,
         runnerActionAt: ACTION_AT,
-        capturedAt: 1000,
+        capturedAt: Date.parse(ACTION_AT),
       }),
     );
     const result = checkStall(

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -16,6 +16,12 @@ const config: WatchdogConfig = {
   maxRecoveryAttempts: 2,
 };
 
+const HEARTBEAT_AT = "2026-03-13T08:46:00.000Z";
+const HEARTBEAT_ADVANCED_AT = "2026-03-13T08:46:03.000Z";
+const ACTION_AT = "2026-03-13T08:46:01.000Z";
+const ACTION_ADVANCED_AT = "2026-03-13T08:46:04.000Z";
+const CAPTURED_AT = "2026-03-13T08:46:07.000Z";
+
 function snapshot(overrides: Partial<LivenessSnapshot> = {}): LivenessSnapshot {
   return {
     logSizeBytes: null,
@@ -46,12 +52,10 @@ describe("createWatchdogEntry", () => {
       42,
       snapshot({
         capturedAt: 7000,
-        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runStartedAt: HEARTBEAT_AT,
       }),
     );
-    expect(entry.lastObservableActivityAt).toBe(
-      Date.parse("2026-03-13T08:46:00.000Z"),
-    );
+    expect(entry.lastObservableActivityAt).toBe(Date.parse(HEARTBEAT_AT));
     expect(entry.lastObservableActivitySource).toBe("run-start");
   });
 });
@@ -102,19 +106,17 @@ describe("checkStall", () => {
     const result = checkStall(
       entry,
       snapshot({
-        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
-        capturedAt: 7000,
+        runnerHeartbeatAt: HEARTBEAT_AT,
+        capturedAt: Date.parse(CAPTURED_AT),
       }),
       config,
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
     expect(result.stalledForMs).toBe(
-      7000 - Date.parse("2026-03-13T08:46:00.000Z"),
+      Date.parse(CAPTURED_AT) - Date.parse(HEARTBEAT_AT),
     );
-    expect(entry.lastObservableActivityAt).toBe(
-      Date.parse("2026-03-13T08:46:00.000Z"),
-    );
+    expect(entry.lastObservableActivityAt).toBe(Date.parse(HEARTBEAT_AT));
     expect(entry.lastObservableActivitySource).toBe("runner-heartbeat");
   });
 
@@ -122,26 +124,41 @@ describe("checkStall", () => {
     const entry = createWatchdogEntry(
       1,
       snapshot({
-        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
-        runnerActionAt: "2026-03-13T08:46:00.000Z",
+        runnerHeartbeatAt: HEARTBEAT_AT,
+        runnerActionAt: HEARTBEAT_AT,
         capturedAt: 1000,
       }),
     );
     const result = checkStall(
       entry,
       snapshot({
-        runnerHeartbeatAt: "2026-03-13T08:46:03.000Z",
-        runnerActionAt: "2026-03-13T08:46:04.000Z",
-        capturedAt: 7000,
+        runnerHeartbeatAt: HEARTBEAT_ADVANCED_AT,
+        runnerActionAt: ACTION_ADVANCED_AT,
+        capturedAt: Date.parse(CAPTURED_AT),
       }),
       config,
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
-    expect(entry.lastObservableActivityAt).toBe(
-      Date.parse("2026-03-13T08:46:04.000Z"),
-    );
+    expect(entry.lastObservableActivityAt).toBe(Date.parse(ACTION_ADVANCED_AT));
     expect(entry.lastObservableActivitySource).toBe("runner-action");
+  });
+
+  it("clamps future-dated runner activity to the probe wall clock", () => {
+    const entry = createWatchdogEntry(1, snapshot({ capturedAt: 1000 }));
+    const result = checkStall(
+      entry,
+      snapshot({
+        runnerHeartbeatAt: "2026-03-13T08:46:30.000Z",
+        capturedAt: Date.parse(CAPTURED_AT),
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(false);
+    expect(result.stalledForMs).toBe(0);
+    expect(result.lastObservableActivityAt).toBe(Date.parse(CAPTURED_AT));
+    expect(entry.lastObservableActivityAt).toBe(Date.parse(CAPTURED_AT));
+    expect(entry.lastObservableActivitySource).toBe("runner-heartbeat");
   });
 
   it("reports not stalled within threshold window", () => {
@@ -163,14 +180,14 @@ describe("checkStall", () => {
       1,
       snapshot({
         capturedAt: 1000,
-        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runStartedAt: HEARTBEAT_AT,
       }),
     );
     const result = checkStall(
       entry,
       snapshot({
         capturedAt: Date.parse("2026-03-13T08:46:06.000Z"),
-        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runStartedAt: HEARTBEAT_AT,
       }),
       config,
     );
@@ -198,25 +215,25 @@ describe("checkStall", () => {
       1,
       snapshot({
         capturedAt: 1000,
-        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runStartedAt: HEARTBEAT_AT,
         runnerPhase: "boot",
-        runnerActionAt: "2026-03-13T08:46:00.000Z",
+        runnerActionAt: HEARTBEAT_AT,
       }),
     );
     const result = checkStall(
       entry,
       snapshot({
-        capturedAt: 7000,
-        runStartedAt: "2026-03-13T08:46:00.000Z",
+        capturedAt: Date.parse(CAPTURED_AT),
+        runStartedAt: HEARTBEAT_AT,
         runnerPhase: "session-start",
-        runnerActionAt: "2026-03-13T08:46:03.000Z",
+        runnerActionAt: HEARTBEAT_ADVANCED_AT,
       }),
       config,
     );
     expect(result.stalled).toBe(false);
     expect(result.lastObservableActivitySource).toBe("runner-startup");
     expect(result.lastObservableActivityAt).toBe(
-      Date.parse("2026-03-13T08:46:03.000Z"),
+      Date.parse(HEARTBEAT_ADVANCED_AT),
     );
   });
 
@@ -257,17 +274,17 @@ describe("checkStall", () => {
     const entry = createWatchdogEntry(
       1,
       snapshot({
-        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
-        runnerActionAt: "2026-03-13T08:46:01.000Z",
+        runnerHeartbeatAt: HEARTBEAT_AT,
+        runnerActionAt: ACTION_AT,
         capturedAt: 1000,
       }),
     );
     const result = checkStall(
       entry,
       snapshot({
-        runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
-        runnerActionAt: "2026-03-13T08:46:01.000Z",
-        capturedAt: Date.parse("2026-03-13T08:46:07.000Z"),
+        runnerHeartbeatAt: HEARTBEAT_AT,
+        runnerActionAt: ACTION_AT,
+        capturedAt: Date.parse(CAPTURED_AT),
       }),
       config,
     );

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -217,6 +217,24 @@ describe("checkStall", () => {
     );
   });
 
+  it("preserves the first activity source when timestamps tie", () => {
+    const entry = createWatchdogEntry(
+      1,
+      snapshot({ logSizeBytes: 100, capturedAt: 1000 }),
+    );
+    const result = checkStall(
+      entry,
+      snapshot({
+        logSizeBytes: 200,
+        runnerActionAt: "2026-03-13T08:46:07.000Z",
+        capturedAt: Date.parse("2026-03-13T08:46:07.000Z"),
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(false);
+    expect(result.lastObservableActivitySource).toBe("watchdog-log");
+  });
+
   it("reports stalled after threshold with no changes", () => {
     const entry = createWatchdogEntry(
       1,

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -6,7 +6,6 @@ import {
   canRecover,
   createWatchdogEntry,
   DEFAULT_WATCHDOG_CONFIG,
-  hasObservableLivenessSignal,
 } from "../../src/orchestrator/stall-detector.js";
 import type { WatchdogConfig } from "../../src/domain/workflow.js";
 
@@ -333,23 +332,6 @@ describe("classifyStallReason", () => {
 
   it("returns log-stall as default", () => {
     expect(classifyStallReason(snapshot())).toBe("log-stall");
-  });
-});
-
-describe("hasObservableLivenessSignal", () => {
-  it("returns false when every signal is null", () => {
-    expect(hasObservableLivenessSignal(snapshot())).toBe(false);
-  });
-
-  it("returns true when any concrete signal is present", () => {
-    expect(hasObservableLivenessSignal(snapshot({ logSizeBytes: 1 }))).toBe(
-      true,
-    );
-    expect(
-      hasObservableLivenessSignal(
-        snapshot({ runnerHeartbeatAt: "2026-03-13T08:46:00.000Z" }),
-      ),
-    ).toBe(true);
   });
 });
 

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -48,15 +48,40 @@ describe("createWatchdogEntry", () => {
   });
 
   it("uses run start as the initial observable activity baseline", () => {
+    const capturedAt = Date.parse(CAPTURED_AT);
     const entry = createWatchdogEntry(
       42,
       snapshot({
-        capturedAt: 7000,
+        capturedAt,
         runStartedAt: HEARTBEAT_AT,
       }),
     );
     expect(entry.lastObservableActivityAt).toBe(Date.parse(HEARTBEAT_AT));
     expect(entry.lastObservableActivitySource).toBe("run-start");
+  });
+
+  it("clamps future-dated run start activity to capturedAt", () => {
+    const capturedAt = Date.parse(CAPTURED_AT);
+    const entry = createWatchdogEntry(
+      42,
+      snapshot({
+        capturedAt,
+        runStartedAt: "2026-03-13T08:46:30.000Z",
+      }),
+    );
+    expect(entry.lastObservableActivityAt).toBe(capturedAt);
+    expect(entry.lastObservableActivitySource).toBe("run-start");
+
+    const result = checkStall(
+      entry,
+      snapshot({
+        capturedAt: capturedAt + config.stallThresholdMs + 1,
+        runStartedAt: "2026-03-13T08:46:30.000Z",
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(true);
+    expect(result.reason).toBe("log-stall");
   });
 
   it("clamps future-dated initial runner heartbeat activity to capturedAt", () => {
@@ -200,10 +225,11 @@ describe("checkStall", () => {
   });
 
   it("uses run start as the stall baseline before later activity appears", () => {
+    const runStartedAt = Date.parse(HEARTBEAT_AT);
     const entry = createWatchdogEntry(
       1,
       snapshot({
-        capturedAt: 1000,
+        capturedAt: runStartedAt,
         runStartedAt: HEARTBEAT_AT,
       }),
     );

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -109,6 +109,9 @@ describe("checkStall", () => {
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
+    expect(result.stalledForMs).toBe(
+      7000 - Date.parse("2026-03-13T08:46:00.000Z"),
+    );
     expect(entry.lastObservableActivityAt).toBe(
       Date.parse("2026-03-13T08:46:00.000Z"),
     );

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -22,6 +22,8 @@ function snapshot(overrides: Partial<LivenessSnapshot> = {}): LivenessSnapshot {
     logSizeBytes: null,
     workspaceDiffHash: null,
     prHeadSha: null,
+    runStartedAt: null,
+    runnerPhase: null,
     runnerHeartbeatAt: null,
     runnerActionAt: null,
     hasActionableFeedback: false,
@@ -35,8 +37,23 @@ describe("createWatchdogEntry", () => {
     const snap = snapshot({ capturedAt: 1000 });
     const entry = createWatchdogEntry(42, snap);
     expect(entry.issueNumber).toBe(42);
-    expect(entry.lastChangeAt).toBe(1000);
+    expect(entry.lastObservableActivityAt).toBe(1000);
+    expect(entry.lastObservableActivitySource).toBeNull();
     expect(entry.recoveryCount).toBe(0);
+  });
+
+  it("uses run start as the initial observable activity baseline", () => {
+    const entry = createWatchdogEntry(
+      42,
+      snapshot({
+        capturedAt: 7000,
+        runStartedAt: "2026-03-13T08:46:00.000Z",
+      }),
+    );
+    expect(entry.lastObservableActivityAt).toBe(
+      Date.parse("2026-03-13T08:46:00.000Z"),
+    );
+    expect(entry.lastObservableActivitySource).toBe("run-start");
   });
 });
 
@@ -93,7 +110,10 @@ describe("checkStall", () => {
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
-    expect(entry.lastChangeAt).toBe(7000);
+    expect(entry.lastObservableActivityAt).toBe(
+      Date.parse("2026-03-13T08:46:00.000Z"),
+    );
+    expect(entry.lastObservableActivitySource).toBe("runner-heartbeat");
   });
 
   it("resets idle time when runner progress timestamps advance", () => {
@@ -116,7 +136,10 @@ describe("checkStall", () => {
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
-    expect(entry.lastChangeAt).toBe(7000);
+    expect(entry.lastObservableActivityAt).toBe(
+      Date.parse("2026-03-13T08:46:04.000Z"),
+    );
+    expect(entry.lastObservableActivitySource).toBe("runner-action");
   });
 
   it("reports not stalled within threshold window", () => {
@@ -133,13 +156,26 @@ describe("checkStall", () => {
     expect(result.stalledForMs).toBe(3000);
   });
 
-  it("does not stall when all liveness signals remain unobserved", () => {
-    const entry = createWatchdogEntry(1, snapshot({ capturedAt: 1000 }));
-    const result = checkStall(entry, snapshot({ capturedAt: 7000 }), config);
-    expect(result.stalled).toBe(false);
-    expect(result.reason).toBeNull();
-    expect(result.stalledForMs).toBe(0);
-    expect(entry.lastChangeAt).toBe(7000);
+  it("uses run start as the stall baseline before later activity appears", () => {
+    const entry = createWatchdogEntry(
+      1,
+      snapshot({
+        capturedAt: 1000,
+        runStartedAt: "2026-03-13T08:46:00.000Z",
+      }),
+    );
+    const result = checkStall(
+      entry,
+      snapshot({
+        capturedAt: Date.parse("2026-03-13T08:46:06.000Z"),
+        runStartedAt: "2026-03-13T08:46:00.000Z",
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(true);
+    expect(result.reason).toBe("log-stall");
+    expect(result.stalledForMs).toBe(6000);
+    expect(result.lastObservableActivitySource).toBe("run-start");
   });
 
   it("treats the first observable signal as progress", () => {
@@ -151,7 +187,35 @@ describe("checkStall", () => {
     );
     expect(result.stalled).toBe(false);
     expect(result.reason).toBeNull();
-    expect(entry.lastChangeAt).toBe(7000);
+    expect(entry.lastObservableActivityAt).toBe(7000);
+    expect(entry.lastObservableActivitySource).toBe("watchdog-log");
+  });
+
+  it("classifies startup-phase action timestamps as runner-startup activity", () => {
+    const entry = createWatchdogEntry(
+      1,
+      snapshot({
+        capturedAt: 1000,
+        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runnerPhase: "boot",
+        runnerActionAt: "2026-03-13T08:46:00.000Z",
+      }),
+    );
+    const result = checkStall(
+      entry,
+      snapshot({
+        capturedAt: 7000,
+        runStartedAt: "2026-03-13T08:46:00.000Z",
+        runnerPhase: "session-start",
+        runnerActionAt: "2026-03-13T08:46:03.000Z",
+      }),
+      config,
+    );
+    expect(result.stalled).toBe(false);
+    expect(result.lastObservableActivitySource).toBe("runner-startup");
+    expect(result.lastObservableActivityAt).toBe(
+      Date.parse("2026-03-13T08:46:03.000Z"),
+    );
   });
 
   it("reports stalled after threshold with no changes", () => {
@@ -183,7 +247,7 @@ describe("checkStall", () => {
       snapshot({
         runnerHeartbeatAt: "2026-03-13T08:46:00.000Z",
         runnerActionAt: "2026-03-13T08:46:01.000Z",
-        capturedAt: 7000,
+        capturedAt: Date.parse("2026-03-13T08:46:07.000Z"),
       }),
       config,
     );
@@ -228,7 +292,7 @@ describe("checkStall", () => {
     expect(result.reason).toBe("workspace-stall");
   });
 
-  it("resets lastChangeAt when change detected", () => {
+  it("resets the authoritative last observable activity when change detected", () => {
     const entry = createWatchdogEntry(
       1,
       snapshot({ logSizeBytes: 100, capturedAt: 1000 }),
@@ -238,7 +302,8 @@ describe("checkStall", () => {
       snapshot({ logSizeBytes: 200, capturedAt: 5000 }),
       config,
     );
-    expect(entry.lastChangeAt).toBe(5000);
+    expect(entry.lastObservableActivityAt).toBe(5000);
+    expect(entry.lastObservableActivitySource).toBe("watchdog-log");
 
     // Now no change for another period but within threshold
     const result = checkStall(


### PR DESCRIPTION
Closes #128

## Summary
- replace raw field-by-field watchdog stall timing with one authoritative last-observable-activity record
- preserve watchdog stall reasons through retry/failure handling instead of collapsing them to `Runner cancelled by shutdown`
- add unit and bootstrap-factory regression coverage for startup stalls and watchdog-specific terminal summaries

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test