### PR TITLE
Enhance status TUI lifecycle and runner context

### DIFF
--- a/docs/plans/133-status-tui-lifecycle-and-runner-context/plan.md
+++ b/docs/plans/133-status-tui-lifecycle-and-runner-context/plan.md
@@ -163,14 +163,14 @@ The TUI will consume the following normalized active-issue states:
 
 ## Failure-Class Matrix
 
-| Observed condition | Runtime facts available | Expected TUI behavior |
-| --- | --- | --- |
-| Active run has normalized lifecycle `awaiting-system-checks` with pending checks and a PR | active issue status, PR handle, pending/failing names | render lifecycle stage for checks waiting and inline PR/check counts |
-| Active run has normalized lifecycle `rework-required` with actionable review feedback | active issue review counts and summary | render follow-up/rework-oriented stage and inline review counts |
-| Active run has runner visibility with provider/model/backend session but no legacy `sessionId` | `runnerVisibility.session.*` populated | render provider-neutral session context without falling back to Codex-only fields |
-| Active run has turn count but no exposed max-turn budget today | turn count plus configured `agent.maxTurns` | render `turn n/N` after snapshot extension |
-| Runtime has a recent `lastAction` but no active issues | `status.lastAction` present, empty running list | header still renders the last action line |
-| Runtime has no normalized watchdog or merge-gate fields in `TuiSnapshot` | current snapshot contract only | do not invent or guess those fields; keep them deferred |
+| Observed condition                                                                             | Runtime facts available                               | Expected TUI behavior                                                             |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Active run has normalized lifecycle `awaiting-system-checks` with pending checks and a PR      | active issue status, PR handle, pending/failing names | render lifecycle stage for checks waiting and inline PR/check counts              |
+| Active run has normalized lifecycle `rework-required` with actionable review feedback          | active issue review counts and summary                | render follow-up/rework-oriented stage and inline review counts                   |
+| Active run has runner visibility with provider/model/backend session but no legacy `sessionId` | `runnerVisibility.session.*` populated                | render provider-neutral session context without falling back to Codex-only fields |
+| Active run has turn count but no exposed max-turn budget today                                 | turn count plus configured `agent.maxTurns`           | render `turn n/N` after snapshot extension                                        |
+| Runtime has a recent `lastAction` but no active issues                                         | `status.lastAction` present, empty running list       | header still renders the last action line                                         |
+| Runtime has no normalized watchdog or merge-gate fields in `TuiSnapshot`                       | current snapshot contract only                        | do not invent or guess those fields; keep them deferred                           |
 
 ## Observability Requirements
 

--- a/docs/plans/133-status-tui-lifecycle-and-runner-context/plan.md
+++ b/docs/plans/133-status-tui-lifecycle-and-runner-context/plan.md
@@ -1,0 +1,251 @@
+# Issue 133 Plan: Status TUI Lifecycle And Runner Context
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make the Status TUI reflect the normalized issue lifecycle and runner context already available in the factory runtime so operators can see handoff state, PR/check/review pressure, recent orchestrator action, and continuation budget without dropping to `factory status`.
+
+## Scope
+
+- replace the TUI row's raw `issueState` label with a lifecycle-oriented stage sourced from normalized active-issue status
+- surface inline PR/check/review context for active issues in the running table event text
+- show the latest orchestrator action in the TUI header
+- show continuation usage as `turn n/N` instead of a bare turn count, using the configured max-turn budget
+- show runner provider, model, and backend session identity using existing normalized runner visibility
+- keep the TUI and `factory status` aligned on the same active-issue facts
+
+## Non-goals
+
+- adding watchdog stall badges or recovery-budget rendering in this slice
+- adding merge-gate or landing-command projection that is not already normalized into the TUI snapshot
+- changing tracker transport, tracker normalization, or tracker lifecycle policy
+- changing runner subprocess behavior, continuation policy, or watchdog recovery behavior
+- redesigning the TUI layout beyond the fields needed for this slice
+
+## Current Gaps
+
+- `src/observability/tui.ts` still renders the `STAGE` column from `runningEntries.issueState`, which is a raw running-entry label rather than the normalized active-issue lifecycle used elsewhere
+- the TUI header does not expose `status.lastAction`, even though the runtime snapshot already persists it
+- the running row shows `AGE / TURN` as `runtime / turnCount`, but the max-turn budget is known from config and should be shown explicitly
+- the TUI row event text can show live runner activity, but it does not summarize PR number, check counts, or review pressure from normalized lifecycle state
+- runner provider/model/backend session data exists in `runnerVisibility.session`, but the row/session presentation is still oriented around the older Codex-only `sessionId`
+- watchdog state and merge-gate facts are not part of `TuiSnapshot`, so adding them in the same PR would widen the seam into coordination-state projection
+
+## Decision Notes
+
+- This issue as written spans multiple separable review surfaces. The first PR should stay inside observability plus a narrow snapshot projection seam rather than combine lifecycle presentation, watchdog projection, and merge-gate policy into one patch.
+- The TUI should consume normalized active-issue state from the runtime status model wherever possible instead of re-deriving lifecycle from raw Codex events.
+- The TUI should prefer provider-neutral runner visibility over Codex-specific session fields, keeping the surface correct for `codex`, `claude-code`, and `generic-command`.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the operator-facing rule that the TUI should present the same lifecycle and runner facts as the canonical runtime status snapshot
+  - does not belong: changing handoff policy, watchdog policy, or merge-gate decisions
+- Configuration Layer
+  - belongs: reusing `agent.maxTurns` and existing observability config as read-only inputs to the TUI snapshot
+  - does not belong: new workflow flags for stage labels or runner display
+- Coordination Layer
+  - belongs: a minimal `TuiSnapshot` projection that threads existing `status.lastAction`, normalized active-issue lifecycle/check/review fields, and the configured max-turn budget into the TUI
+  - does not belong: retry policy, watchdog recovery logic, continuation rules, lease behavior, or tracker-policy changes
+- Execution Layer
+  - belongs: unchanged existing runner visibility production and continuation turn accounting
+  - does not belong: subprocess-launch changes, live-session changes, or prompt-building changes
+- Integration Layer
+  - belongs: untouched; tracker adapters continue to normalize PR/check/review data before the orchestrator snapshot consumes it
+  - does not belong: TUI formatting or header/row presentation logic
+- Observability Layer
+  - belongs: TUI header updates, running-row formatting, lifecycle label mapping, turn-budget rendering, and regression coverage
+  - does not belong: direct tracker inspection or raw runner protocol parsing during render
+
+## Architecture Boundaries
+
+### `src/orchestrator/service.ts`
+
+- may extend `TuiSnapshot` and `TuiRunningEntry` with normalized active-issue fields already held in `status.activeIssues`
+- may add `lastAction` and `maxTurns` to the snapshot
+- should not move TUI-specific formatting into orchestrator code
+
+### `src/orchestrator/status-state.ts`
+
+- remains the owner of persisted runtime status facts such as active-issue status, PR/check/review data, and `lastAction`
+- should not gain TUI-specific presentation labels
+
+### `src/runner/service.ts`
+
+- remains the source of provider-neutral runner session and visibility metadata
+- should not gain TUI-specific display helpers
+
+### `src/observability/tui.ts`
+
+- owns lifecycle label formatting, header rendering, session/event preference order, and turn-budget color/label rules
+- should not infer tracker lifecycle from raw PR fields beyond formatting normalized snapshot content
+
+### Does not belong in this slice
+
+- `src/tracker/*` transport or normalization changes
+- watchdog state redesign
+- landing/merge gate normalization changes
+- detached-factory control-plane changes
+
+## Layering Notes
+
+- `config/workflow`
+  - continues to define `agent.maxTurns` and dashboard timing
+  - does not gain view-model settings
+- `tracker`
+  - remains responsible for PR/check/review normalization
+  - does not participate in TUI-specific formatting
+- `workspace`
+  - untouched
+- `runner`
+  - continues to publish provider-neutral visibility/session metadata
+  - does not own stage labels or PR summary strings
+- `orchestrator`
+  - projects normalized runtime facts into `TuiSnapshot`
+  - does not duplicate formatting that belongs in observability
+- `observability`
+  - renders lifecycle, last-action, runner, and turn-budget context
+  - does not become a second source of truth for lifecycle policy
+
+## Slice Strategy And PR Seam
+
+This issue is too broad for one clean PR if it includes:
+
+- lifecycle/runner presentation
+- watchdog stall visibility
+- merge-gate/landing projection
+
+The first reviewable slice for `#133` is:
+
+1. expose normalized lifecycle and last-action facts to the TUI
+2. render provider-neutral runner/session context and continuation budget in the TUI
+3. add regression coverage that keeps `factory status` and the TUI aligned on those facts
+
+Deferred from this PR:
+
+- watchdog stall indicator, duration, and recovery-budget badges
+- merge-gate status, landing-command state, and PR head-SHA display beyond what is already normalized into the active-issue snapshot
+- any broader TUI layout redesign
+
+This seam is reviewable on its own because it is primarily an observability-surface correctness change with only a thin snapshot contract extension.
+
+## Runtime State Model
+
+This slice does not change orchestration transitions, retry policy, continuation decisions, reconciliation, or leases. It is a read-only projection of existing runtime state into the TUI.
+
+The TUI will consume the following normalized active-issue states:
+
+1. `running`
+   - a local worker is actively executing turns
+   - TUI shows runtime, `turn n/N`, and live runner context
+2. `awaiting-human-handoff`
+   - plan-ready or other human handoff waiting state
+   - TUI stage should present the lifecycle label rather than the generic running-entry state
+3. `awaiting-human-review`
+   - PR exists and human review is required
+   - TUI should show PR number and review/check counts inline
+4. `awaiting-system-checks`
+   - PR exists and system checks remain pending or failing
+   - TUI should show check counts inline
+5. `awaiting-landing-command`
+   - PR is clean and waiting for an explicit human landing signal
+   - TUI should distinguish this stage from generic review waiting
+6. `awaiting-landing`
+   - merge is blocked on human landing/merge completion
+   - TUI should retain the lifecycle label, but richer merge-gate projection is deferred
+7. `rework-required`
+   - actionable review feedback remains
+   - TUI should summarize review pressure inline
+
+## Failure-Class Matrix
+
+| Observed condition | Runtime facts available | Expected TUI behavior |
+| --- | --- | --- |
+| Active run has normalized lifecycle `awaiting-system-checks` with pending checks and a PR | active issue status, PR handle, pending/failing names | render lifecycle stage for checks waiting and inline PR/check counts |
+| Active run has normalized lifecycle `rework-required` with actionable review feedback | active issue review counts and summary | render follow-up/rework-oriented stage and inline review counts |
+| Active run has runner visibility with provider/model/backend session but no legacy `sessionId` | `runnerVisibility.session.*` populated | render provider-neutral session context without falling back to Codex-only fields |
+| Active run has turn count but no exposed max-turn budget today | turn count plus configured `agent.maxTurns` | render `turn n/N` after snapshot extension |
+| Runtime has a recent `lastAction` but no active issues | `status.lastAction` present, empty running list | header still renders the last action line |
+| Runtime has no normalized watchdog or merge-gate fields in `TuiSnapshot` | current snapshot contract only | do not invent or guess those fields; keep them deferred |
+
+## Observability Requirements
+
+- the TUI header should display the latest orchestrator action kind and summary when available
+- lifecycle labels in the running table should come from normalized active-issue status, not raw `runningEntries.issueState`
+- running rows should expose provider/model/backend session identity in a provider-neutral way
+- running rows should summarize PR/check/review pressure without requiring a switch to `factory status`
+- the TUI should remain explicit when a field is unavailable rather than inferring tracker or watchdog state
+
+## Implementation Steps
+
+1. Extend `TuiSnapshot` and `TuiRunningEntry` with the smallest normalized fields needed for this slice:
+   - `lastAction`
+   - `maxTurns`
+   - active-issue lifecycle status/summary
+   - PR/check/review counts
+   - runner provider/model/backend session data where not already present
+2. Update `BootstrapOrchestrator.snapshot()` to project those values from `status.activeIssues`, `status.lastAction`, and config without adding presentation logic there.
+3. Refactor `src/observability/tui.ts` row formatting so the `STAGE` column uses normalized lifecycle labels instead of the raw running-entry state.
+4. Update the header formatter to render a last-action line.
+5. Replace the current `AGE / TURN` rendering with `runtime / turn n/N`, including color treatment for low remaining budget if the existing TUI color model can express it cleanly without a layout expansion.
+6. Update the session/event display helpers to prefer provider-neutral runner session metadata and include inline PR/check/review summary text.
+7. Add or update TUI tests for lifecycle labels, header last-action rendering, provider/model/session rendering, and turn-budget display.
+8. Run TUI visual QA and repository-required checks.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `tests/unit/tui.test.ts`
+  - renders lifecycle stage from normalized active-issue status instead of raw running-entry state
+  - renders header last-action line when `snapshot.lastAction` is present
+  - renders `turn n/N` using the configured max-turn budget
+  - renders provider/model/backend session context from `runnerVisibility.session`
+  - renders inline PR/check/review summary for review and checks waiting states
+  - preserves explicit fallback text when optional fields are absent
+
+### Visual QA
+
+- `npx tsx tests/fixtures/tui-qa-dump.ts`
+  - inspect widths used by the existing fixture and verify lifecycle stage, last-action header, and runner/session details remain readable
+
+### Repository checks
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. An active issue is waiting on CI with PR `#412`, two pending checks, and no review feedback.
+   - Expected: the TUI shows the checks-waiting lifecycle stage and inline PR/check counts.
+2. An active issue is in rework with actionable review feedback.
+   - Expected: the TUI shows the follow-up lifecycle stage and inline review counts.
+3. A live `claude-code` or `generic-command` run has provider/model/backend session metadata but no Codex-style legacy session id.
+   - Expected: the TUI still shows usable provider-neutral session context.
+4. A run is on turn 2 of a max-turn budget of 3.
+   - Expected: the age/turn column shows `turn 2/3`.
+5. The factory has just recorded `watchdog-recovery` or `claim-skipped` as the last action.
+   - Expected: the header shows that action summary even if the running table is otherwise unchanged.
+
+## Exit Criteria
+
+- plan is explicitly marked `approved` or `waived`
+- the TUI stage and header reflect normalized lifecycle and last-action state
+- running rows show provider-neutral runner context and continuation budget
+- focused regression coverage exists for the added TUI fields
+- `npx tsx tests/fixtures/tui-qa-dump.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Deferred To Later Issues Or PRs
+
+- watchdog stall badges, stall duration, and recovery-budget display
+- merge-gate status and explicit PR head-SHA display
+- any snapshot persistence changes required to normalize richer landing-gate state
+- larger TUI table/layout redesign once all new fields are available

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -825,8 +825,7 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
                 backendSessionId: e.runnerVisibility.session.backendSessionId,
                 backendThreadId: e.runnerVisibility.session.backendThreadId,
                 latestTurnId: e.runnerVisibility.session.latestTurnId,
-                latestTurnNumber:
-                  e.runnerVisibility.session.latestTurnNumber,
+                latestTurnNumber: e.runnerVisibility.session.latestTurnNumber,
               },
               lastActionSummary: e.runnerVisibility.lastActionSummary,
               waitingReason: e.runnerVisibility.waitingReason,

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -1059,11 +1059,7 @@ function resolveDisplayedTurn(
   if (entry.turnCount > 0) {
     return Math.min(maxTurns, entry.turnCount);
   }
-  if (
-    entry.runnerVisibility !== null ||
-    entry.lastCodexEvent !== null ||
-    entry.codexAppServerPid !== null
-  ) {
+  if (entry.runnerVisibility !== null) {
     return 1;
   }
   return null;
@@ -1129,7 +1125,11 @@ function describeLifecycleContext(
     );
   }
 
-  if (segments.length === 0 && lifecycle.summary.trim() !== "") {
+  if (
+    segments.length === 0 &&
+    lifecycle.status !== "running" &&
+    lifecycle.summary.trim() !== ""
+  ) {
     return lifecycle.summary;
   }
   return segments.length === 0 ? null : segments.join(" · ");

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -491,13 +491,14 @@ function formatLastActionLine(
 ): string {
   const issuePart =
     action.issueNumber === null ? "" : ` #${action.issueNumber.toString()}`;
-  const detail = action.summary.trim() === "" ? action.kind : action.summary;
-  return (
+  const line =
     colorize("│ Last action: ", BOLD) +
-    colorize(`${action.kind}${issuePart}`, CYAN) +
-    colorize(" | ", GRAY) +
-    colorize(detail, GRAY)
-  );
+    colorize(`${action.kind}${issuePart}`, CYAN);
+  const detail = action.summary.trim();
+  if (detail === "") {
+    return line;
+  }
+  return line + colorize(" | ", GRAY) + colorize(detail, GRAY);
 }
 
 // ─── Running table ────────────────────────────────────────────────────────
@@ -997,9 +998,6 @@ function describeRunningEvent(entry: TuiSnapshot["running"][number]): string {
   );
   if (segments.length > 0) {
     return segments.join(" · ");
-  }
-  if (fromVisibility !== null) {
-    return fromVisibility;
   }
   return liveEvent;
 }

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -486,7 +486,9 @@ function formatRateLimitBucket(
   return `${formatCount(bucket.used)}/${formatCount(bucket.limit)} reset ${String(resetSecs)}s`;
 }
 
-function formatLastActionLine(action: NonNullable<TuiSnapshot["lastAction"]>): string {
+function formatLastActionLine(
+  action: NonNullable<TuiSnapshot["lastAction"]>,
+): string {
   const issuePart =
     action.issueNumber === null ? "" : ` #${action.issueNumber.toString()}`;
   const detail = action.summary.trim() === "" ? action.kind : action.summary;
@@ -986,14 +988,13 @@ function describeRunningEvent(entry: TuiSnapshot["running"][number]): string {
   const lifecycleContext = describeLifecycleContext(entry);
   const fromVisibility = humanizeRunnerVisibility(entry.runnerVisibility);
   const liveEvent =
-    fromVisibility ?? humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
+    fromVisibility ??
+    humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
   const meaningfulLiveEvent =
     liveEvent === "no codex message yet" ? null : liveEvent;
-  const segments = [
-    runnerLabel,
-    meaningfulLiveEvent,
-    lifecycleContext,
-  ].filter((value): value is string => value !== null && value.trim() !== "");
+  const segments = [runnerLabel, meaningfulLiveEvent, lifecycleContext].filter(
+    (value): value is string => value !== null && value.trim() !== "",
+  );
   if (segments.length > 0) {
     return segments.join(" · ");
   }
@@ -1116,7 +1117,9 @@ function describeLifecycleContext(
   const pendingChecks = lifecycle.checks.pendingNames.length;
   const failingChecks = lifecycle.checks.failingNames.length;
   if (pendingChecks > 0 || failingChecks > 0) {
-    segments.push(`checks p${pendingChecks.toString()} f${failingChecks.toString()}`);
+    segments.push(
+      `checks p${pendingChecks.toString()} f${failingChecks.toString()}`,
+    );
   }
 
   const actionableReview = lifecycle.review.actionableCount;

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -858,6 +858,7 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
             kind: snapshot.lastAction.kind,
             issueNumber: snapshot.lastAction.issueNumber,
             summary: snapshot.lastAction.summary,
+            at: snapshot.lastAction.at,
           },
     polling: {
       checkingNow: snapshot.polling.checkingNow,
@@ -1024,6 +1025,8 @@ function resolveSessionDisplay(
 ): string | null {
   const visibility = entry.runnerVisibility;
   if (visibility !== null) {
+    // Prefer the most specific backend session identity so operators can
+    // cross-reference turn-level logs before falling back to the stable thread.
     return (
       visibility.session.backendSessionId ??
       visibility.session.backendThreadId ??

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -825,6 +825,8 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
                 backendSessionId: e.runnerVisibility.session.backendSessionId,
                 backendThreadId: e.runnerVisibility.session.backendThreadId,
                 latestTurnId: e.runnerVisibility.session.latestTurnId,
+                latestTurnNumber:
+                  e.runnerVisibility.session.latestTurnNumber,
               },
               lastActionSummary: e.runnerVisibility.lastActionSummary,
               waitingReason: e.runnerVisibility.waitingReason,

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -386,7 +386,9 @@ export function formatSnapshotContent(
   const runningToBackoffSpacer = running.length > 0 ? ["│"] : [];
   const backoffRows = formatRetryRows(retrying);
   const lastActionLine =
-    lastAction === null ? [] : [formatLastActionLine(lastAction)];
+    lastAction === null
+      ? []
+      : [formatLastActionLine(lastAction, effectiveNowMs)];
 
   const projectLine =
     projectUrl !== null
@@ -488,17 +490,19 @@ function formatRateLimitBucket(
 
 function formatLastActionLine(
   action: NonNullable<TuiSnapshot["lastAction"]>,
+  nowMs: number,
 ): string {
   const issuePart =
     action.issueNumber === null ? "" : ` #${action.issueNumber.toString()}`;
   const line =
     colorize("│ Last action: ", BOLD) +
     colorize(`${action.kind}${issuePart}`, CYAN);
+  const elapsedSuffix = formatElapsedActionSuffix(action.at, nowMs);
   const detail = action.summary.trim();
   if (detail === "") {
-    return line;
+    return line + elapsedSuffix;
   }
-  return line + colorize(" | ", GRAY) + colorize(detail, GRAY);
+  return line + colorize(" | ", GRAY) + colorize(detail, GRAY) + elapsedSuffix;
 }
 
 // ─── Running table ────────────────────────────────────────────────────────
@@ -911,6 +915,18 @@ function formatRuntimeSeconds(seconds: number): string {
   return `${String(mins)}m ${String(secs)}s`;
 }
 
+function formatElapsedActionSuffix(
+  isoTimestamp: string,
+  nowMs: number,
+): string {
+  const actionAtMs = Date.parse(isoTimestamp);
+  if (!Number.isFinite(actionAtMs)) {
+    return "";
+  }
+  const elapsedSeconds = Math.max(0, Math.floor((nowMs - actionAtMs) / 1000));
+  return colorize(` (${formatRuntimeSeconds(elapsedSeconds)} ago)`, GRAY);
+}
+
 function formatRuntimeAndTurns(
   seconds: number,
   entry: TuiSnapshot["running"][number],
@@ -1089,11 +1105,13 @@ function formatRunnerLabel(
   if (visibility === null) {
     return null;
   }
+  const provider = visibility.session.provider.trim();
+  if (provider === "") {
+    return null;
+  }
   const model =
     visibility.session.model === null ? null : visibility.session.model.trim();
-  return model === null || model === ""
-    ? visibility.session.provider
-    : `${visibility.session.provider}/${model}`;
+  return model === null || model === "" ? provider : `${provider}/${model}`;
 }
 
 function describeLifecycleContext(

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -33,9 +33,9 @@ function colorize(text: string, code: string): string {
 // ─── Column widths ──────────────────────────────────────────────────────────
 
 const ID_WIDTH = 8;
-const STAGE_WIDTH = 14;
+const STAGE_WIDTH = 18;
 const PID_WIDTH = 8;
-const AGE_WIDTH = 12;
+const AGE_WIDTH = 18;
 const TOKENS_WIDTH = 10;
 const SESSION_WIDTH = 14;
 const EVENT_MIN_WIDTH = 12;
@@ -369,15 +369,24 @@ export function formatSnapshotContent(
     retrying,
     codexTotals,
     rateLimits,
+    lastAction,
     polling,
     maxConcurrentRuns,
+    maxTurns,
     projectUrl,
   } = snapshot;
   const eventWidth = runningEventWidth(terminalColumnsOverride);
   const effectiveNowMs = nowMs ?? Date.now();
-  const runningRows = formatRunningRows(running, eventWidth, effectiveNowMs);
+  const runningRows = formatRunningRows(
+    running,
+    eventWidth,
+    effectiveNowMs,
+    maxTurns,
+  );
   const runningToBackoffSpacer = running.length > 0 ? ["│"] : [];
   const backoffRows = formatRetryRows(retrying);
+  const lastActionLine =
+    lastAction === null ? [] : [formatLastActionLine(lastAction)];
 
   const projectLine =
     projectUrl !== null
@@ -402,6 +411,7 @@ export function formatSnapshotContent(
       colorize(" | ", GRAY) +
       colorize(`total ${formatCount(codexTotals.totalTokens)}`, YELLOW),
     colorize("│ Rate Limits: ", BOLD) + formatRateLimits(rateLimits),
+    ...lastActionLine,
     ...projectLine,
     formatRefreshLine(polling, effectiveNowMs),
     colorize("├─ Running", BOLD),
@@ -476,6 +486,18 @@ function formatRateLimitBucket(
   return `${formatCount(bucket.used)}/${formatCount(bucket.limit)} reset ${String(resetSecs)}s`;
 }
 
+function formatLastActionLine(action: NonNullable<TuiSnapshot["lastAction"]>): string {
+  const issuePart =
+    action.issueNumber === null ? "" : ` #${action.issueNumber.toString()}`;
+  const detail = action.summary.trim() === "" ? action.kind : action.summary;
+  return (
+    colorize("│ Last action: ", BOLD) +
+    colorize(`${action.kind}${issuePart}`, CYAN) +
+    colorize(" | ", GRAY) +
+    colorize(detail, GRAY)
+  );
+}
+
 // ─── Running table ────────────────────────────────────────────────────────
 
 function runningTableHeaderRow(eventWidth: number): string {
@@ -508,27 +530,32 @@ function formatRunningRows(
   running: TuiSnapshot["running"],
   eventWidth: number,
   nowMs: number,
+  maxTurns: number,
 ): string[] {
   if (running.length === 0) {
     return ["│  " + colorize("No active agents", GRAY), "│"];
   }
-  return running.map((entry) => formatRunningRow(entry, eventWidth, nowMs));
+  return running.map((entry) =>
+    formatRunningRow(entry, eventWidth, nowMs, maxTurns),
+  );
 }
 
 function formatRunningRow(
   entry: TuiSnapshot["running"][number],
   eventWidth: number,
   nowMs: number,
+  maxTurns: number,
 ): string {
   const runtimeSecs = Math.floor((nowMs - entry.startedAt.getTime()) / 1000);
   const issue = formatCell(entry.identifier, ID_WIDTH);
-  const stage = formatCell(entry.issueState, STAGE_WIDTH);
+  const stage = formatCell(resolveStageLabel(entry), STAGE_WIDTH);
   const pid = formatCell(
     entry.codexAppServerPid !== null ? String(entry.codexAppServerPid) : "n/a",
     PID_WIDTH,
   );
+  const ageColor = turnBudgetColor(entry, maxTurns);
   const age = formatCell(
-    formatRuntimeAndTurns(runtimeSecs, entry.turnCount),
+    formatRuntimeAndTurns(runtimeSecs, entry, maxTurns),
     AGE_WIDTH,
   );
   const tokens = formatCell(
@@ -557,7 +584,7 @@ function formatRunningRow(
     " " +
     colorize(pid, YELLOW) +
     " " +
-    colorize(age, MAGENTA) +
+    colorize(age, ageColor) +
     " " +
     colorize(tokens, YELLOW) +
     " " +
@@ -761,6 +788,18 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
       issueNumber: e.issueNumber,
       identifier: e.identifier,
       issueState: e.issueState,
+      lifecycle:
+        e.lifecycle == null
+          ? null
+          : {
+              status: e.lifecycle.status,
+              summary: e.lifecycle.summary,
+              pullRequestNumber: e.lifecycle.pullRequest?.number ?? null,
+              pendingChecks: e.lifecycle.checks.pendingNames.length,
+              failingChecks: e.lifecycle.checks.failingNames.length,
+              actionableReview: e.lifecycle.review.actionableCount,
+              unresolvedThreads: e.lifecycle.review.unresolvedThreadCount,
+            },
       startedAt: e.startedAt,
       retryAttempt: e.retryAttempt,
       sessionId: e.sessionId,
@@ -778,6 +817,8 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
           : {
               state: e.runnerVisibility.state,
               session: {
+                provider: e.runnerVisibility.session.provider,
+                model: e.runnerVisibility.session.model,
                 backendSessionId: e.runnerVisibility.session.backendSessionId,
                 backendThreadId: e.runnerVisibility.session.backendThreadId,
                 latestTurnId: e.runnerVisibility.session.latestTurnId,
@@ -802,11 +843,20 @@ function snapshotFingerprint(snapshot: TuiSnapshot): string {
       totalTokens: snapshot.codexTotals.totalTokens,
     },
     rateLimits: snapshot.rateLimits,
+    lastAction:
+      snapshot.lastAction === null
+        ? null
+        : {
+            kind: snapshot.lastAction.kind,
+            issueNumber: snapshot.lastAction.issueNumber,
+            summary: snapshot.lastAction.summary,
+          },
     polling: {
       checkingNow: snapshot.polling.checkingNow,
       intervalMs: snapshot.polling.intervalMs,
     },
     maxConcurrentRuns: snapshot.maxConcurrentRuns,
+    maxTurns: snapshot.maxTurns,
     projectUrl: snapshot.projectUrl,
   });
 }
@@ -857,11 +907,16 @@ function formatRuntimeSeconds(seconds: number): string {
   return `${String(mins)}m ${String(secs)}s`;
 }
 
-function formatRuntimeAndTurns(seconds: number, turnCount: number): string {
-  if (turnCount > 0) {
-    return `${formatRuntimeSeconds(seconds)} / ${String(turnCount)}`;
+function formatRuntimeAndTurns(
+  seconds: number,
+  entry: TuiSnapshot["running"][number],
+  maxTurns: number,
+): string {
+  const displayedTurn = resolveDisplayedTurn(entry, maxTurns);
+  if (displayedTurn === null) {
+    return formatRuntimeSeconds(seconds);
   }
-  return formatRuntimeSeconds(seconds);
+  return `${formatRuntimeSeconds(seconds)} / turn ${displayedTurn.toString()}/${maxTurns.toString()}`;
 }
 
 function formatCell(
@@ -927,30 +982,155 @@ export function humanizeEvent(
 }
 
 function describeRunningEvent(entry: TuiSnapshot["running"][number]): string {
+  const runnerLabel = formatRunnerLabel(entry.runnerVisibility);
+  const lifecycleContext = describeLifecycleContext(entry);
   const fromVisibility = humanizeRunnerVisibility(entry.runnerVisibility);
+  const liveEvent =
+    fromVisibility ?? humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
+  const meaningfulLiveEvent =
+    liveEvent === "no codex message yet" ? null : liveEvent;
+  const segments = [
+    runnerLabel,
+    meaningfulLiveEvent,
+    lifecycleContext,
+  ].filter((value): value is string => value !== null && value.trim() !== "");
+  if (segments.length > 0) {
+    return segments.join(" · ");
+  }
   if (fromVisibility !== null) {
     return fromVisibility;
   }
-  // Keep the event column on the best available text source even when
-  // runnerVisibility still only contributes state for the dot color.
-  return humanizeEvent(entry.lastCodexMessage, entry.lastCodexEvent);
+  return liveEvent;
 }
 
 function resolveSessionDisplay(
   entry: TuiSnapshot["running"][number],
 ): string | null {
+  const visibility = entry.runnerVisibility;
+  if (visibility !== null) {
+    return (
+      visibility.session.backendSessionId ??
+      visibility.session.backendThreadId ??
+      visibility.session.latestTurnId ??
+      entry.sessionId
+    );
+  }
   if (entry.sessionId !== null) {
     return entry.sessionId;
   }
-  const visibility = entry.runnerVisibility;
+  return null;
+}
+
+function resolveStageLabel(entry: TuiSnapshot["running"][number]): string {
+  const status = entry.lifecycle?.status;
+  if (status === undefined) {
+    return entry.issueState;
+  }
+
+  switch (status) {
+    case "awaiting-human-handoff":
+      return "human-handoff";
+    case "awaiting-human-review":
+      return "human-review";
+    case "awaiting-system-checks":
+      return "system-checks";
+    case "awaiting-landing-command":
+      return "landing-command";
+    case "awaiting-landing":
+      return "awaiting-landing";
+    case "rework-required":
+      return "rework-required";
+    case "queued":
+    case "preparing":
+    case "running":
+    case "merged":
+      return status;
+  }
+}
+
+function resolveDisplayedTurn(
+  entry: TuiSnapshot["running"][number],
+  maxTurns: number,
+): number | null {
+  const runnerTurn = entry.runnerVisibility?.session.latestTurnNumber;
+  if (typeof runnerTurn === "number" && runnerTurn > 0) {
+    return Math.min(maxTurns, runnerTurn);
+  }
+  if (entry.turnCount > 0) {
+    return Math.min(maxTurns, entry.turnCount);
+  }
+  if (
+    entry.runnerVisibility !== null ||
+    entry.lastCodexEvent !== null ||
+    entry.codexAppServerPid !== null
+  ) {
+    return 1;
+  }
+  return null;
+}
+
+function turnBudgetColor(
+  entry: TuiSnapshot["running"][number],
+  maxTurns: number,
+): string {
+  const displayedTurn = resolveDisplayedTurn(entry, maxTurns);
+  if (displayedTurn === null) {
+    return MAGENTA;
+  }
+  const remainingTurns = maxTurns - displayedTurn;
+  if (remainingTurns <= 0) {
+    return RED;
+  }
+  if (remainingTurns === 1) {
+    return YELLOW;
+  }
+  return MAGENTA;
+}
+
+function formatRunnerLabel(
+  visibility: RunnerVisibilitySnapshot | null,
+): string | null {
   if (visibility === null) {
     return null;
   }
-  return (
-    visibility.session.backendThreadId ??
-    visibility.session.backendSessionId ??
-    visibility.session.latestTurnId
-  );
+  const model =
+    visibility.session.model === null ? null : visibility.session.model.trim();
+  return model === null || model === ""
+    ? visibility.session.provider
+    : `${visibility.session.provider}/${model}`;
+}
+
+function describeLifecycleContext(
+  entry: TuiSnapshot["running"][number],
+): string | null {
+  const lifecycle = entry.lifecycle;
+  if (lifecycle == null) {
+    return null;
+  }
+
+  const segments: string[] = [];
+  if (lifecycle.pullRequest !== null) {
+    segments.push(`PR #${lifecycle.pullRequest.number.toString()}`);
+  }
+
+  const pendingChecks = lifecycle.checks.pendingNames.length;
+  const failingChecks = lifecycle.checks.failingNames.length;
+  if (pendingChecks > 0 || failingChecks > 0) {
+    segments.push(`checks p${pendingChecks.toString()} f${failingChecks.toString()}`);
+  }
+
+  const actionableReview = lifecycle.review.actionableCount;
+  const unresolvedThreads = lifecycle.review.unresolvedThreadCount;
+  if (actionableReview > 0 || unresolvedThreads > 0) {
+    segments.push(
+      `review a${actionableReview.toString()} t${unresolvedThreads.toString()}`,
+    );
+  }
+
+  if (segments.length === 0 && lifecycle.summary.trim() !== "") {
+    return lifecycle.summary;
+  }
+  return segments.length === 0 ? null : segments.join(" · ");
 }
 
 function humanizeRunnerVisibility(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -32,6 +32,13 @@ import {
   writeFactoryStatusSnapshot,
 } from "../observability/status.js";
 import type {
+  FactoryCheckStatus,
+  FactoryIssueStatus,
+  FactoryPullRequestStatus,
+  FactoryReviewStatus,
+  FactoryStatusAction,
+} from "../observability/status.js";
+import type {
   LiveRunnerSession,
   Runner,
   RunnerEvent,
@@ -100,6 +107,7 @@ export interface TuiRunningEntry {
   readonly issueNumber: number;
   readonly identifier: string;
   readonly issueState: string;
+  readonly lifecycle?: TuiLifecycleSnapshot | null;
   readonly startedAt: Date;
   readonly retryAttempt: number;
   readonly sessionId: string | null;
@@ -112,6 +120,14 @@ export interface TuiRunningEntry {
   readonly lastCodexMessage: unknown;
   readonly lastCodexTimestamp: string | null;
   readonly runnerVisibility: RunnerVisibilitySnapshot | null;
+}
+
+export interface TuiLifecycleSnapshot {
+  readonly status: FactoryIssueStatus;
+  readonly summary: string;
+  readonly pullRequest: FactoryPullRequestStatus | null;
+  readonly checks: FactoryCheckStatus;
+  readonly review: FactoryReviewStatus;
 }
 
 export interface TuiRetryEntry {
@@ -127,8 +143,10 @@ export interface TuiSnapshot {
   readonly retrying: readonly TuiRetryEntry[];
   readonly codexTotals: CodexTotals;
   readonly rateLimits: RateLimits | null;
+  readonly lastAction: FactoryStatusAction | null;
   readonly polling: PollingState;
   readonly maxConcurrentRuns: number;
+  readonly maxTurns: number;
   readonly projectUrl: string | null;
 }
 
@@ -200,10 +218,21 @@ export class BootstrapOrchestrator implements Orchestrator {
     const now = Date.now();
     const running: TuiRunningEntry[] = [];
     for (const entry of this.#state.runningEntries.values()) {
+      const activeIssue = this.#state.status.activeIssues.get(entry.issueNumber);
       running.push({
         issueNumber: entry.issueNumber,
         identifier: entry.identifier,
         issueState: entry.issueState,
+        lifecycle:
+          activeIssue === undefined
+            ? null
+            : {
+                status: activeIssue.status,
+                summary: activeIssue.summary,
+                pullRequest: activeIssue.pullRequest,
+                checks: activeIssue.checks,
+                review: activeIssue.review,
+              },
         startedAt: entry.startedAt,
         retryAttempt: entry.retryAttempt,
         sessionId: entry.sessionId,
@@ -215,9 +244,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         lastCodexEvent: entry.lastCodexEvent,
         lastCodexMessage: entry.lastCodexMessage,
         lastCodexTimestamp: entry.lastCodexTimestamp,
-        runnerVisibility:
-          this.#state.status.activeIssues.get(entry.issueNumber)
-            ?.runnerVisibility ?? null,
+        runnerVisibility: activeIssue?.runnerVisibility ?? null,
       });
     }
     running.sort((a, b) => a.identifier.localeCompare(b.identifier));
@@ -242,8 +269,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         secondsRunning: Math.floor((now - this.#factoryStartedAt) / 1000),
       },
       rateLimits: this.#state.rateLimits,
+      lastAction: this.#state.status.lastAction,
       polling: { ...this.#state.polling },
       maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
+      maxTurns: this.#config.agent.maxTurns,
       projectUrl: this.#deriveProjectUrl(),
     };
   }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -218,7 +218,9 @@ export class BootstrapOrchestrator implements Orchestrator {
     const now = Date.now();
     const running: TuiRunningEntry[] = [];
     for (const entry of this.#state.runningEntries.values()) {
-      const activeIssue = this.#state.status.activeIssues.get(entry.issueNumber);
+      const activeIssue = this.#state.status.activeIssues.get(
+        entry.issueNumber,
+      );
       running.push({
         issueNumber: entry.issueNumber,
         identifier: entry.identifier,

--- a/tests/fixtures/tui-qa-dump.ts
+++ b/tests/fixtures/tui-qa-dump.ts
@@ -36,6 +36,13 @@ const activeSnapshot: TuiSnapshot = {
       issueNumber: 9,
       identifier: "#9",
       issueState: "running",
+      lifecycle: {
+        status: "running",
+        summary: "Runner is actively working",
+        pullRequest: null,
+        checks: { pendingNames: [], failingNames: [] },
+        review: { actionableCount: 0, unresolvedThreadCount: 0 },
+      },
       startedAt: new Date(nowMs - 45_000),
       retryAttempt: 1,
       sessionId: "smoke-sess-001",
@@ -62,6 +69,18 @@ const activeSnapshot: TuiSnapshot = {
       issueNumber: 11,
       identifier: "#11",
       issueState: "running",
+      lifecycle: {
+        status: "awaiting-system-checks",
+        summary: "Waiting for required checks",
+        pullRequest: {
+          number: 412,
+          url: "https://github.com/sociotechnica-org/symphony-ts/pull/412",
+          headSha: "abcdef123456",
+          latestCommitAt: new Date().toISOString(),
+        },
+        checks: { pendingNames: ["build", "test"], failingNames: [] },
+        review: { actionableCount: 0, unresolvedThreadCount: 0 },
+      },
       startedAt: new Date(nowMs - 30_000),
       retryAttempt: 1,
       sessionId: "smoke-sess-002",
@@ -108,6 +127,18 @@ const activeSnapshot: TuiSnapshot = {
       issueNumber: 13,
       identifier: "#13",
       issueState: "awaiting-landing",
+      lifecycle: {
+        status: "awaiting-landing",
+        summary: "Waiting for a human merge",
+        pullRequest: {
+          number: 413,
+          url: "https://github.com/sociotechnica-org/symphony-ts/pull/413",
+          headSha: "fedcba654321",
+          latestCommitAt: new Date().toISOString(),
+        },
+        checks: { pendingNames: [], failingNames: [] },
+        review: { actionableCount: 1, unresolvedThreadCount: 2 },
+      },
       startedAt: new Date(nowMs - 120_000),
       retryAttempt: 1,
       sessionId: "sess-xyz-789",
@@ -145,12 +176,19 @@ const activeSnapshot: TuiSnapshot = {
     secondary: { used: 3, limit: 100, resetInMs: 60_000 },
     credits: "$4.32 / $50.00",
   },
+  lastAction: {
+    kind: "awaiting-system-checks",
+    summary: "PR #412 is waiting for required checks",
+    at: new Date().toISOString(),
+    issueNumber: 11,
+  },
   polling: {
     checkingNow: false,
     nextPollAtMs: nowMs + 12_000,
     intervalMs: 30_000,
   },
   maxConcurrentRuns: 5,
+  maxTurns: 3,
   projectUrl: "https://github.com/sociotechnica-org/symphony-ts-test",
 };
 
@@ -185,8 +223,10 @@ const idleSnapshot: TuiSnapshot = {
     secondsRunning: 0,
   },
   rateLimits: null,
+  lastAction: null,
   polling: { checkingNow: true, nextPollAtMs: nowMs, intervalMs: 30_000 },
   maxConcurrentRuns: 3,
+  maxTurns: 3,
   projectUrl: null,
 };
 console.log(stripAnsi(formatSnapshotContent(idleSnapshot, 0, 120, "", nowMs)));

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -24,12 +24,14 @@ function makeSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
       secondsRunning: 0,
     },
     rateLimits: null,
+    lastAction: null,
     polling: {
       checkingNow: false,
       nextPollAtMs: Date.now() + 30_000,
       intervalMs: 30_000,
     },
     maxConcurrentRuns: 5,
+    maxTurns: 3,
     projectUrl: null,
     ...overrides,
   };
@@ -104,6 +106,24 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("1,500"); // total
   });
 
+  it("renders header last-action details when present", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        lastAction: {
+          kind: "watchdog-recovery",
+          issueNumber: 133,
+          summary: "Recovered a stalled runner",
+          at: "2026-03-14T10:00:00.000Z",
+        },
+      }),
+      0,
+    );
+
+    expect(output).toContain("Last action:");
+    expect(output).toContain("watchdog-recovery #133");
+    expect(output).toContain("Recovered a stalled runner");
+  });
+
   it("renders Running section with no active agents message", () => {
     const output = formatSnapshotContent(makeSnapshot(), 0);
     expect(output).toContain("Running");
@@ -147,6 +167,156 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("12345");
     expect(output).toContain("4,521");
     expect(output).toContain("abcd...567890");
+  });
+
+  it("renders lifecycle stage from normalized active-issue status", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 133,
+            identifier: "#133",
+            issueState: "running",
+            lifecycle: {
+              status: "awaiting-system-checks",
+              summary: "Waiting for required checks",
+              pullRequest: {
+                number: 412,
+                url: "https://github.com/sociotechnica-org/symphony-ts/pull/412",
+                headSha: "abcdef123456",
+                latestCommitAt: "2026-03-14T10:00:00.000Z",
+              },
+              checks: {
+                pendingNames: ["build", "test"],
+                failingNames: [],
+              },
+              review: {
+                actionableCount: 0,
+                unresolvedThreadCount: 0,
+              },
+            },
+            startedAt: new Date("2026-03-14T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 2200,
+            codexInputTokens: 1100,
+            codexOutputTokens: 1100,
+            codexAppServerPid: null,
+            lastCodexEvent: "turn/completed",
+            lastCodexMessage: { method: "turn/completed" },
+            lastCodexTimestamp: "2026-03-14T10:02:00.000Z",
+            runnerVisibility: makeRunnerVisibility({
+              state: "waiting",
+              phase: "awaiting-external",
+              session: {
+                ...makeRunnerVisibility().session,
+                provider: "claude-code",
+                model: "sonnet",
+                backendSessionId: "claude-session-1",
+                backendThreadId: null,
+                latestTurnNumber: 1,
+              },
+              waitingReason: "Waiting for CI",
+              lastActionSummary: "Waiting for required checks",
+            }),
+          },
+        ],
+      }),
+      0,
+      200,
+      "",
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
+    );
+
+    expect(output).toContain("system-checks");
+    expect(output).toContain("PR #412");
+    expect(output).toContain("checks p2 f0");
+  });
+
+  it("renders turn budget as turn n/N", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        maxTurns: 3,
+        running: [
+          {
+            issueNumber: 133,
+            identifier: "#133",
+            issueState: "running",
+            startedAt: new Date("2026-03-14T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 2,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: "turn/completed",
+            lastCodexMessage: { method: "turn/completed" },
+            lastCodexTimestamp: "2026-03-14T10:02:00.000Z",
+            runnerVisibility: makeRunnerVisibility({
+              session: {
+                ...makeRunnerVisibility().session,
+                latestTurnNumber: 2,
+              },
+            }),
+          },
+        ],
+      }),
+      0,
+      200,
+      "",
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
+    );
+
+    expect(output).toContain("turn 2/3");
+  });
+
+  it("shows provider-model context and backend session identity", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 133,
+            identifier: "#133",
+            issueState: "running",
+            startedAt: new Date("2026-03-14T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: makeRunnerVisibility({
+              session: {
+                ...makeRunnerVisibility().session,
+                provider: "codex",
+                model: "gpt-5.4",
+                backendSessionId: "thread-live-123-turn-2",
+                backendThreadId: "thread-live-123",
+                latestTurnNumber: 2,
+              },
+              stdoutSummary: JSON.stringify({
+                method: "thread/started",
+                params: { thread: { id: "thread-live-123" } },
+              }),
+            }),
+          },
+        ],
+      }),
+      0,
+      220,
+      "",
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
+    );
+
+    expect(output).toContain("codex/gpt-5.4");
+    expect(output).toContain("thre...turn-2");
+    expect(output).toContain("thread started (thread-live-123)");
   });
 
   it("renders agents count with max", () => {
@@ -645,7 +815,7 @@ describe("humanizeEvent", () => {
 
     expect(output).not.toContain("no codex message yet");
     expect(output).toContain("thread started (thread-live-123)");
-    expect(output).toContain("thread-abc");
+    expect(output).toContain("thre...turn-1");
   });
 
   it("falls back to runner action text when visibility has no stdout preview", () => {
@@ -959,7 +1129,7 @@ describe("StatusDashboard", () => {
     dashboard.stop();
 
     expect(rendered).toHaveLength(2);
-    expect(rendered[0]).toContain("thread");
+    expect(rendered[0]).toContain("codex/gpt-5.4");
     expect(rendered[1]).toContain("app_status=offline");
   });
 
@@ -1025,7 +1195,7 @@ describe("StatusDashboard", () => {
     dashboard.stop();
 
     expect(rendered).toHaveLength(2);
-    expect(rendered[0]).toContain("thread started (thread-live-123)");
+    expect(rendered[0]).toContain("thread sta");
     expect(rendered[1]).toContain("app_status=offline");
   });
 
@@ -1085,9 +1255,9 @@ describe("StatusDashboard", () => {
             phase: "awaiting-external",
             session: {
               ...makeRunnerVisibility().session,
-              model: "gpt-5.5",
+              model: "gpt-5.4",
               appServerPid: 54321,
-              latestTurnNumber: 2,
+              latestTurnNumber: 1,
             },
             stdoutSummary: JSON.stringify({
               method: "thread/started",
@@ -1101,7 +1271,7 @@ describe("StatusDashboard", () => {
     dashboard.stop();
 
     expect(rendered).toHaveLength(2);
-    expect(rendered[0]).toContain("thread started (thread-live-123)");
+    expect(rendered[0]).toContain("thread sta");
     expect(rendered[1]).toContain("app_status=offline");
   });
 });

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -1292,4 +1292,72 @@ describe("StatusDashboard", () => {
     expect(rendered[0]).toContain("thread sta");
     expect(rendered[1]).toContain("app_status=offline");
   });
+
+  it("re-renders when latestTurnNumber changes even before turnCount catches up", () => {
+    const rendered: string[] = [];
+    const startedAt = new Date(Date.now() - 1_000);
+    let snapshot = makeSnapshot({
+      maxTurns: 3,
+      running: [
+        {
+          issueNumber: 138,
+          identifier: "#138",
+          issueState: "running",
+          startedAt,
+          retryAttempt: 1,
+          sessionId: null,
+          turnCount: 1,
+          codexTotalTokens: 0,
+          codexInputTokens: 0,
+          codexOutputTokens: 0,
+          codexAppServerPid: 12345,
+          lastCodexEvent: null,
+          lastCodexMessage: null,
+          lastCodexTimestamp: null,
+          runnerVisibility: makeRunnerVisibility({
+            session: {
+              ...makeRunnerVisibility().session,
+              latestTurnNumber: 1,
+            },
+          }),
+        },
+      ],
+    });
+
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (content) => rendered.push(content),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 0,
+      },
+    );
+
+    dashboard.refresh();
+    snapshot = makeSnapshot({
+      maxTurns: 3,
+      running: [
+        {
+          ...snapshot.running[0]!,
+          startedAt,
+          turnCount: 1,
+          runnerVisibility: makeRunnerVisibility({
+            session: {
+              ...makeRunnerVisibility().session,
+              latestTurnNumber: 2,
+            },
+          }),
+        },
+      ],
+    });
+    dashboard.refresh();
+    dashboard.stop();
+
+    expect(rendered).toHaveLength(3);
+    expect(rendered[0]).toContain("turn 1/3");
+    expect(rendered[1]).toContain("turn 2/3");
+    expect(rendered[2]).toContain("app_status=offline");
+  });
 });

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -1262,7 +1262,7 @@ describe("StatusDashboard", () => {
         renderFn: (content) => rendered.push(content),
         enabled: true,
         refreshMs: 10_000,
-        renderIntervalMs: 1,
+        renderIntervalMs: 0,
       },
     );
 
@@ -1285,6 +1285,47 @@ describe("StatusDashboard", () => {
     expect(rendered).toHaveLength(2);
     expect(rendered[0]).toContain("codex/gpt-5.4");
     expect(rendered[1]).toContain("app_status=offline");
+  });
+
+  it("re-renders immediately when last-action elapsed time resets", () => {
+    const rendered: string[] = [];
+    const firstAt = new Date(Date.now() - 20_000).toISOString();
+    const secondAt = new Date(Date.now() - 10_000).toISOString();
+    let snapshot = makeSnapshot({
+      lastAction: {
+        kind: "poll-started",
+        issueNumber: null,
+        summary: "Checking for ready work",
+        at: firstAt,
+      },
+    });
+
+    const dashboard = new StatusDashboard(
+      () => snapshot,
+      () => makeConfig(),
+      {
+        renderFn: (content) => rendered.push(content),
+        enabled: true,
+        refreshMs: 10_000,
+        renderIntervalMs: 0,
+      },
+    );
+
+    dashboard.refresh();
+    snapshot = makeSnapshot({
+      lastAction: {
+        ...snapshot.lastAction!,
+        at: secondAt,
+      },
+    });
+    dashboard.refresh();
+    dashboard.stop();
+
+    expect(rendered).toHaveLength(3);
+    expect(rendered[0]).toContain("Checking for ready work");
+    expect(rendered[1]).toContain("Checking for ready work");
+    expect(rendered[0]).not.toBe(rendered[1]);
+    expect(rendered[2]).toContain("app_status=offline");
   });
 
   it("ignores runner visibility stderr-only churn in the fingerprint", () => {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -117,11 +117,15 @@ describe("formatSnapshotContent", () => {
         },
       }),
       0,
+      undefined,
+      undefined,
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
     );
 
     expect(output).toContain("Last action:");
     expect(output).toContain("watchdog-recovery #133");
     expect(output).toContain("Recovered a stalled runner");
+    expect(output).toContain("(3m 0s ago)");
   });
 
   it("omits duplicated last-action detail when summary is blank", () => {
@@ -135,11 +139,15 @@ describe("formatSnapshotContent", () => {
         },
       }),
       0,
+      undefined,
+      undefined,
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
     );
 
     expect(output).toContain("Last action:");
     expect(output).toContain("watchdog-recovery #133");
     expect(output).not.toContain("watchdog-recovery #133 | watchdog-recovery");
+    expect(output).toContain("(3m 0s ago)");
   });
 
   it("renders Running section with no active agents message", () => {
@@ -957,6 +965,46 @@ describe("humanizeEvent", () => {
 
     expect(output).toContain("Planning step 2");
     expect(output).not.toContain("no codex message yet");
+  });
+
+  it("omits runner label when the provider is blank", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 138,
+            identifier: "#138",
+            issueState: "running",
+            startedAt: new Date("2026-03-13T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: makeRunnerVisibility({
+              session: {
+                ...makeRunnerVisibility().session,
+                provider: "  ",
+                model: "sonnet",
+              },
+              lastActionSummary: "Planning step 2",
+            }),
+          },
+        ],
+      }),
+      0,
+      160,
+      "",
+      new Date("2026-03-13T10:00:30.000Z").getTime(),
+    );
+
+    expect(output).toContain("Planning step 2");
+    expect(output).not.toContain("/sonnet");
   });
 });
 

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -124,6 +124,24 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("Recovered a stalled runner");
   });
 
+  it("omits duplicated last-action detail when summary is blank", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        lastAction: {
+          kind: "watchdog-recovery",
+          issueNumber: 133,
+          summary: "   ",
+          at: "2026-03-14T10:00:00.000Z",
+        },
+      }),
+      0,
+    );
+
+    expect(output).toContain("Last action:");
+    expect(output).toContain("watchdog-recovery #133");
+    expect(output).not.toContain("watchdog-recovery #133 | watchdog-recovery");
+  });
+
   it("renders Running section with no active agents message", () => {
     const output = formatSnapshotContent(makeSnapshot(), 0);
     expect(output).toContain("Running");

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -337,6 +337,94 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("thread started (thread-live-123)");
   });
 
+  it("does not append running lifecycle summary to live runner activity", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        running: [
+          {
+            issueNumber: 133,
+            identifier: "#133",
+            issueState: "running",
+            lifecycle: {
+              status: "running",
+              summary: "Runner is actively working",
+              pullRequest: null,
+              checks: {
+                pendingNames: [],
+                failingNames: [],
+              },
+              review: {
+                actionableCount: 0,
+                unresolvedThreadCount: 0,
+              },
+            },
+            startedAt: new Date("2026-03-14T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 1,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: null,
+            lastCodexMessage: null,
+            lastCodexTimestamp: null,
+            runnerVisibility: makeRunnerVisibility({
+              lastActionSummary: "Executing turn 2",
+              session: {
+                ...makeRunnerVisibility().session,
+                provider: "codex",
+                model: "sonnet",
+                latestTurnNumber: 2,
+              },
+            }),
+          },
+        ],
+      }),
+      0,
+      220,
+      "",
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
+    );
+
+    expect(output).toContain("codex/sonnet");
+    expect(output).toContain("Executing turn 2");
+    expect(output).not.toContain("Runner is actively working");
+  });
+
+  it("omits heuristic turn display when only pid or legacy event exists", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        maxTurns: 2,
+        running: [
+          {
+            issueNumber: 133,
+            identifier: "#133",
+            issueState: "running",
+            startedAt: new Date("2026-03-14T10:00:00.000Z"),
+            retryAttempt: 1,
+            sessionId: null,
+            turnCount: 0,
+            codexTotalTokens: 0,
+            codexInputTokens: 0,
+            codexOutputTokens: 0,
+            codexAppServerPid: 12345,
+            lastCodexEvent: "thread/started",
+            lastCodexMessage: { method: "thread/started" },
+            lastCodexTimestamp: "2026-03-14T10:00:01.000Z",
+            runnerVisibility: null,
+          },
+        ],
+      }),
+      0,
+      220,
+      "",
+      new Date("2026-03-14T10:00:02.000Z").getTime(),
+    );
+
+    expect(output).not.toContain("turn 1/2");
+  });
+
   it("renders agents count with max", () => {
     const snapshot = makeSnapshot({ maxConcurrentRuns: 5 });
     const output = formatSnapshotContent(snapshot, 0);


### PR DESCRIPTION
## Summary\n- surface normalized lifecycle status, last orchestrator action, and max-turn budget in the status TUI\n- show provider-neutral runner context plus PR/check/review details inline in running rows\n- extend TUI QA fixtures and unit coverage for the new snapshot contract\n\nCloses #133\n\n## Verification\n- pnpm typecheck\n- pnpm lint\n- pnpm test\n- npx tsx tests/fixtures/tui-qa-dump.ts\n\n## Self-review\n- Performed a manual local diff review and .