### PR TITLE
Package operator loop as supported repo tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ dist/
 coverage/
 .tmp/
 .var/
+# Local/generated operator state only. Durable operator tooling lives under
+# skills/symphony-operator/.
 .ralph/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ Status surfaces now also distinguish snapshot freshness explicitly:
 `unavailable` while startup is still publishing a current snapshot or no
 readable snapshot exists.
 
+For the repo's operator-assisted self-hosting loop, use the versioned operator
+entry point instead of any local `.ralph/` script:
+
+```bash
+pnpm operator        # continuous wake-up loop
+pnpm operator:once   # single operator wake-up cycle
+```
+
+The checked-in loop lives under `skills/symphony-operator/`. `.ralph/` remains
+local/generated-only for scratch notes, loop status, logs, and lock files.
+The current entry point requires a Unix-like shell environment such as macOS,
+Linux, or WSL/Git Bash on Windows.
+
 Generate a per-issue report from local artifacts:
 
 ```bash

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -75,6 +75,23 @@ In continuous mode, Symphony will keep polling for additional ready issues. The
 factory-control commands are the normal operator surface for the detached
 runtime under `.tmp/factory-main`.
 
+To run the higher-level repo-owned operator wake-up loop from a clean clone,
+use the versioned entry point under `skills/symphony-operator/` through the
+package scripts:
+
+```bash
+pnpm operator
+pnpm operator:once
+```
+
+`pnpm operator` runs the continuous wake-up loop. `pnpm operator:once` runs one
+operator cycle and exits. The loop writes only local/generated artifacts under
+`.ralph/` such as `operator-scratchpad.md`, `status.json`, `status.md`,
+`logs/`, and lock files; the durable tooling and prompt live in
+`skills/symphony-operator/`.
+This entry point currently expects a Unix-like shell environment such as macOS,
+Linux, or WSL/Git Bash on Windows.
+
 Symphony now has two status surfaces:
 
 - `pnpm tsx bin/symphony.ts status` reads the workflow-derived status snapshot
@@ -92,6 +109,10 @@ usable UTF-8 locale.
 Do not use raw `screen -r symphony-factory` as the normal watch path. That
 attach path gives your terminal direct foreground ownership of the worker, so
 an accidental `Ctrl-C` can stop the detached factory.
+
+The operator loop sits above those factory-control commands; it should inspect
+and supervise the detached runtime through `factory status` / `factory watch`
+rather than reimplementing scheduler or runner logic.
 
 ### 5. Watch the issue lifecycle
 
@@ -146,3 +167,5 @@ That is the self-hosting loop:
 - Use `--once` when you want tight control over one issue at a time.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart|status|watch` over ad hoc `screen` and
   process cleanup when operating the detached runtime.
+- Prefer `pnpm operator` / `pnpm operator:once` over any ad hoc local `.ralph/`
+  script; `.ralph/` is reserved for generated operator state only.

--- a/docs/plans/136-package-operator-loop-tooling/plan.md
+++ b/docs/plans/136-package-operator-loop-tooling/plan.md
@@ -167,14 +167,14 @@ Notes:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected decision |
-| --- | --- | --- |
-| packaged loop entry point missing or not executable | clean clone, repo files present or validation fails | fail clearly during setup and document the supported invocation |
-| second loop start attempted while local lock is held | lockfile exists and owner appears live | exit with a clear "already running" message rather than racing |
-| stale loop lock found | lockfile exists but owner is dead/unreadable | clear or replace the stale lock using repo-owned rules; do not require manual `.ralph/` archaeology |
-| operator cycle command fails | repo commands or `gh` step exits non-zero | record failure in local status/log artifacts and continue or exit according to the existing loop contract; do not mutate factory policy in this issue |
-| detached factory is stopped or degraded | `symphony factory status --json` reports stopped/degraded | surface the state in the loop's local status output; do not invent new runtime control logic |
-| `.ralph/` does not exist yet | clean clone or new machine | create only the local/generated directories/files needed at runtime; durable tooling must remain elsewhere |
+| Observed condition                                   | Local facts available                                     | Expected decision                                                                                                                                     |
+| ---------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| packaged loop entry point missing or not executable  | clean clone, repo files present or validation fails       | fail clearly during setup and document the supported invocation                                                                                       |
+| second loop start attempted while local lock is held | lockfile exists and owner appears live                    | exit with a clear "already running" message rather than racing                                                                                        |
+| stale loop lock found                                | lockfile exists but owner is dead/unreadable              | clear or replace the stale lock using repo-owned rules; do not require manual `.ralph/` archaeology                                                   |
+| operator cycle command fails                         | repo commands or `gh` step exits non-zero                 | record failure in local status/log artifacts and continue or exit according to the existing loop contract; do not mutate factory policy in this issue |
+| detached factory is stopped or degraded              | `symphony factory status --json` reports stopped/degraded | surface the state in the loop's local status output; do not invent new runtime control logic                                                          |
+| `.ralph/` does not exist yet                         | clean clone or new machine                                | create only the local/generated directories/files needed at runtime; durable tooling must remain elsewhere                                            |
 
 ## Storage And Persistence Contract
 

--- a/docs/plans/136-package-operator-loop-tooling/plan.md
+++ b/docs/plans/136-package-operator-loop-tooling/plan.md
@@ -1,0 +1,249 @@
+# Issue 136 Plan
+
+## Summary
+
+Package the operator wake-up loop as a supported, versioned repo tool instead of a script living under ignored `.ralph/`, while keeping `.ralph/` reserved for local/generated operator state.
+
+Plan status: plan-ready
+
+## Goal
+
+Give contributors one discoverable, reviewable entry point for running the repo's operator loop from a clean clone without learning a force-add exception or treating `.ralph/` as partly-versioned scratch space.
+
+## Scope
+
+- choose and document the supported home for the operator loop
+- move or replace the current loop with a versioned entry point in that supported home
+- make the commit-vs-local boundary explicit between durable operator tooling, durable operator guidance, and local/generated operator state
+- keep the loop compatible with the current detached `symphony factory` control surface and multi-runner runtime model
+- update the operator skill, README, and self-hosting docs to point to the supported entry point
+
+## Non-Goals
+
+- changing factory runtime behavior in `src/orchestrator/`, `src/runner/`, `src/tracker/`, or `src/cli/`
+- redesigning the operator workflow beyond packaging/discovery of the existing wake-up loop
+- making the operator loop a general-purpose product CLI command for all Symphony repos
+- changing tracker lifecycle policy, retries, watchdog logic, or landing semantics
+- versioning `.ralph/` runtime notes, logs, or generated status artifacts
+
+## Current Gaps
+
+- the issue describes a durable loop script at `.ralph/ralph-loop.sh`, but `.ralph/` is ignored and not present in a clean clone, so the supported operator entry point is not discoverable from the checked-out repo
+- the current checked-in operator surface is split awkwardly between durable guidance in `skills/symphony-operator/SKILL.md` and implied local-only automation in `.ralph/`
+- `.gitignore` treats all of `.ralph/` as local-only, but repo policy/docs do not yet define a first-class checked-in home for operator-loop automation
+- the docs describe detached factory control and watch commands, but they do not expose one durable command for the higher-level operator wake-up loop itself
+
+## Option Evaluation
+
+### Option 1: version the loop under `skills/symphony-operator/`
+
+Pros:
+
+- colocates durable operator behavior and durable operator tooling
+- matches the existing repo split where `skills/` holds reusable operator guidance
+- keeps the tool obviously repo-local rather than implying it is part of the product CLI
+- lets docs and the skill point to one adjacent entry point
+
+Cons:
+
+- `skills/` is guidance-first, so a scripted entry point there needs clear documentation to avoid looking like hidden prompt state
+
+### Option 2: version the loop under `bin/`, `scripts/`, or `tools/operator/`
+
+Pros:
+
+- makes tooling look more conventional to contributors
+- can separate executable code from skill prose cleanly
+
+Cons:
+
+- weakens the existing adjacency between operator guidance and operator automation
+- introduces a new top-level surface for a repo-specific operator helper even though the repo already has a durable operator home
+
+### Option 3: replace the loop with a first-class CLI entry point
+
+Pros:
+
+- yields the cleanest command UX if the operator loop is promoted to a product-level contract
+
+Cons:
+
+- broadens the review surface into `src/cli/` and product command design
+- risks mixing repo-local operator automation with general runtime control
+- is unnecessary for this packaging/discovery slice if the current shell-based loop can be versioned cleanly
+
+### Proposed Direction
+
+Land the loop as a versioned script under `skills/symphony-operator/`, then expose a simple documented repo-root invocation for it, likely through a package script alias plus direct script path documentation.
+
+Rationale:
+
+- this keeps durable operator guidance and durable operator tooling adjacent
+- it avoids widening the seam into product CLI design
+- it keeps `.ralph/` purely local/generated
+- it satisfies the issue's requirement that the supported loop be reviewable and discoverable from a clean clone
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: the repo-owned rule that operator-loop guidance and entry points are versioned, discoverable, and separate from local-only runtime state
+  - does not belong: changing issue lifecycle, plan review policy, or landing policy
+- Configuration Layer
+  - belongs: any explicit environment variables or path contracts the loop needs to locate local-only state or tune cadence
+  - does not belong: hidden author-specific paths or shell-profile assumptions baked into the versioned tool
+- Coordination Layer
+  - belongs: the loop's wake-up cadence, lock/lease behavior for one local operator loop instance, and its interaction boundary with `symphony factory status|watch|start`
+  - does not belong: becoming a second scheduler or reimplementing orchestrator state transitions
+- Execution Layer
+  - belongs: the concrete wrapper that launches the operator session and invokes repo-owned commands
+  - does not belong: runner semantics, workspace orchestration, or tracker mutations that belong in the factory runtime
+- Integration Layer
+  - belongs: shell and `gh` interactions used by the loop, if any, behind a stable repo-owned contract
+  - does not belong: coupling the loop to a single agent/provider assumption when the factory runtime is multi-runner
+- Observability Layer
+  - belongs: clear placement of local/generated operator artifacts such as `.ralph/status.*`, loop logs, and scratch notes
+  - does not belong: mixing those generated artifacts into the same versioned directory as the durable tool
+
+## Architecture Boundaries
+
+- `skills/symphony-operator/SKILL.md` remains the durable guidance layer.
+- The packaged loop becomes durable tooling adjacent to that skill, not hidden under `.ralph/`.
+- `.ralph/` remains local/generated state only: operator notebook, generated status, logs, temp cycle files, and any per-run scratch artifacts.
+- The product CLI under `bin/` and `src/cli/` remains focused on factory/runtime control, not repo-specific operator wake-up automation.
+- The implementation should avoid new assumptions about `codex` as the only healthy runtime; the loop should continue to supervise the factory through repo-owned control surfaces and runner-neutral docs.
+
+## Slice Strategy And PR Seam
+
+Keep this as one packaging-and-discovery PR:
+
+1. add the plan for issue `#136`
+2. add the versioned operator-loop entry point in its supported repo-owned home
+3. update docs and skill guidance to point at that entry point
+4. make the `.ralph/` boundary explicit as local/generated-only
+
+Why this fits in one reviewable PR:
+
+- it stays in repo-local tooling, package metadata, ignore/docs, and operator guidance
+- it does not change factory runtime behavior or tracker/orchestrator contracts
+- it preserves the seam established by issue `#134`, which explicitly deferred this packaging follow-up
+
+## Runtime State Model
+
+This issue does not change the factory runtime state machine, but the packaged operator loop itself is stateful enough to name a minimal cycle model.
+
+States:
+
+1. `idle`: loop not running
+2. `acquiring-lock`: startup path attempting to claim the local loop lock
+3. `sleeping`: loop is healthy and waiting for the next wake-up time
+4. `inspecting`: loop is gathering repo/factory/issue status for one cycle
+5. `acting`: loop is invoking the operator command for that cycle
+6. `recording`: loop is writing local-only status artifacts or logs
+7. `failed`: loop cannot continue because setup, locking, or command execution failed
+8. `stopping`: loop received shutdown and is releasing local state cleanly
+
+Allowed transitions:
+
+- `idle -> acquiring-lock`
+- `acquiring-lock -> sleeping`
+- `acquiring-lock -> failed`
+- `sleeping -> inspecting`
+- `inspecting -> acting`
+- `acting -> recording`
+- `recording -> sleeping`
+- `inspecting -> failed`
+- `acting -> failed`
+- `recording -> failed`
+- `sleeping -> stopping`
+- `inspecting -> stopping`
+- `acting -> stopping`
+- `recording -> stopping`
+- `stopping -> idle`
+
+Notes:
+
+- the lock is local operator-loop coordination only; it must not be treated as factory ownership or tracker ownership
+- generated artifacts remain best-effort observability aids, not the system of record for runtime state
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected decision |
+| --- | --- | --- |
+| packaged loop entry point missing or not executable | clean clone, repo files present or validation fails | fail clearly during setup and document the supported invocation |
+| second loop start attempted while local lock is held | lockfile exists and owner appears live | exit with a clear "already running" message rather than racing |
+| stale loop lock found | lockfile exists but owner is dead/unreadable | clear or replace the stale lock using repo-owned rules; do not require manual `.ralph/` archaeology |
+| operator cycle command fails | repo commands or `gh` step exits non-zero | record failure in local status/log artifacts and continue or exit according to the existing loop contract; do not mutate factory policy in this issue |
+| detached factory is stopped or degraded | `symphony factory status --json` reports stopped/degraded | surface the state in the loop's local status output; do not invent new runtime control logic |
+| `.ralph/` does not exist yet | clean clone or new machine | create only the local/generated directories/files needed at runtime; durable tooling must remain elsewhere |
+
+## Storage And Persistence Contract
+
+- versioned:
+  - `skills/symphony-operator/` for durable guidance plus the packaged loop tool
+  - package metadata or docs pointing to the supported invocation
+- local/generated only:
+  - `.ralph/operator-scratchpad.md`
+  - `.ralph/status.json`
+  - `.ralph/status.md`
+  - `.ralph/logs/`
+  - temp cycle files and lock files used by the operator loop
+
+The plan should make this boundary explicit in docs and, if needed, in ignore comments or directory-level README guidance.
+
+## Observability Requirements
+
+- the supported operator entry point must be named in checked-in docs
+- local/generated status artifacts must still land under `.ralph/` or the documented equivalent local-only area
+- the packaged loop should emit actionable errors when setup, locking, or the cycle command fails
+- docs should explain that `factory status` / `factory watch` remain the canonical runtime-control surfaces and that the operator loop sits above them as repo-local automation
+
+## Implementation Steps
+
+1. Create `docs/plans/136-package-operator-loop-tooling/plan.md` with this scope and decision record.
+2. Add the packaged operator-loop script under `skills/symphony-operator/`.
+3. Add the minimal repo-root invocation surface for that script, likely a `package.json` script alias.
+4. Update `skills/symphony-operator/SKILL.md` so durable guidance points to the supported entry point and reserves `.ralph/` for local/generated state only.
+5. Update `README.md` and `docs/guides/self-hosting-loop.md` so a new contributor can discover and run the operator-assisted flow from a clean clone.
+6. Update `.gitignore` comments or adjacent docs only as needed to make the packaging boundary explicit without versioning `.ralph/`.
+7. Validate the packaged entry point from the repo root and manually exercise one operator wake-up cycle against the local factory.
+8. Run local QA gates for touched surfaces.
+9. Self-review the diff, fix findings, then open/update the PR for `#136`.
+
+## Tests
+
+- shell validation of the packaged entry point from the repo root
+- manual clean-clone-path validation that the documented command does not depend on `.ralph/ralph-loop.sh`
+- manual one-cycle validation that generated status/log artifacts still land in `.ralph/`
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. From a clean clone, a contributor can find the operator-loop command in checked-in docs and run the versioned entry point without learning a force-add exception.
+2. After the change, the repo layout makes it obvious that `skills/symphony-operator/` is versioned and `.ralph/` is local/generated only.
+3. The packaged loop still supervises the factory through the detached factory-control surface and does not assume one specific runner implementation.
+4. Running one wake-up cycle still produces local operator artifacts under `.ralph/` rather than mixing them into the versioned tooling directory.
+5. The final PR stays limited to operator-tooling packaging, docs, and supporting repo-owned invocation wiring.
+
+## Exit Criteria
+
+- one versioned, documented operator-loop entry point exists in a supported repo-owned location
+- `.ralph/` is documented and treated as local/generated-only state
+- operator docs and skill guidance point to the supported entry point
+- the packaged loop works from the repo root with the documented command
+- local QA gates pass
+- PR is opened or updated against `main` and references `#136`
+
+## Deferred
+
+- replacing the operator loop with a first-class product CLI command
+- changing factory runtime semantics, retries, reconciliation, or watchdog behavior
+- broader operator dashboard or control-surface redesign
+- generalizing this repo-local operator tool into a cross-repo framework
+
+## Decision Notes
+
+- Prefer adjacency over a new top-level tooling directory for this slice: the operator loop is a repo-local operator aid, and `skills/symphony-operator/` is already the durable home for that role.
+- Keep the product CLI boundary clean: `symphony factory ...` remains the runtime-control surface, while the packaged operator loop remains a repo-owned helper layered above it.

--- a/docs/plans/136-package-operator-loop-tooling/plan.md
+++ b/docs/plans/136-package-operator-loop-tooling/plan.md
@@ -137,29 +137,25 @@ States:
 2. `acquiring-lock`: startup path attempting to claim the local loop lock
 3. `sleeping`: loop is healthy and waiting for the next wake-up time
 4. `retrying`: the last cycle failed and the loop is waiting for the next retry interval
-5. `inspecting`: loop is gathering repo/factory/issue status for one cycle
-6. `acting`: loop is invoking the operator command for that cycle
-7. `recording`: loop is writing local-only status artifacts or logs
-8. `failed`: loop cannot continue because setup, locking, or command execution failed
-9. `stopping`: loop received shutdown and is releasing local state cleanly
+5. `acting`: loop is invoking the operator command for one cycle
+6. `recording`: loop is writing local-only status artifacts or logs
+7. `failed`: loop cannot continue because setup, locking, or command execution failed
+8. `stopping`: loop received shutdown and is releasing local state cleanly
 
 Allowed transitions:
 
 - `idle -> acquiring-lock`
 - `acquiring-lock -> sleeping`
 - `acquiring-lock -> failed`
-- `sleeping -> inspecting`
-- `retrying -> inspecting`
-- `inspecting -> acting`
+- `sleeping -> acting`
+- `retrying -> acting`
 - `acting -> recording`
 - `recording -> sleeping`
 - `failed -> retrying`
-- `inspecting -> failed`
 - `acting -> failed`
 - `recording -> failed`
 - `sleeping -> stopping`
 - `retrying -> stopping`
-- `inspecting -> stopping`
 - `acting -> stopping`
 - `recording -> stopping`
 - `stopping -> idle`
@@ -168,6 +164,7 @@ Notes:
 
 - the lock is local operator-loop coordination only; it must not be treated as factory ownership or tracker ownership
 - generated artifacts remain best-effort observability aids, not the system of record for runtime state
+- repo/factory/issue inspection happens inside the launched operator session; `.ralph/status.json` surfaces the loop's coarse outer cycle states rather than an internal inspection subphase
 
 ## Failure-Class Matrix
 

--- a/docs/plans/136-package-operator-loop-tooling/plan.md
+++ b/docs/plans/136-package-operator-loop-tooling/plan.md
@@ -136,11 +136,12 @@ States:
 1. `idle`: loop not running
 2. `acquiring-lock`: startup path attempting to claim the local loop lock
 3. `sleeping`: loop is healthy and waiting for the next wake-up time
-4. `inspecting`: loop is gathering repo/factory/issue status for one cycle
-5. `acting`: loop is invoking the operator command for that cycle
-6. `recording`: loop is writing local-only status artifacts or logs
-7. `failed`: loop cannot continue because setup, locking, or command execution failed
-8. `stopping`: loop received shutdown and is releasing local state cleanly
+4. `retrying`: the last cycle failed and the loop is waiting for the next retry interval
+5. `inspecting`: loop is gathering repo/factory/issue status for one cycle
+6. `acting`: loop is invoking the operator command for that cycle
+7. `recording`: loop is writing local-only status artifacts or logs
+8. `failed`: loop cannot continue because setup, locking, or command execution failed
+9. `stopping`: loop received shutdown and is releasing local state cleanly
 
 Allowed transitions:
 
@@ -148,13 +149,16 @@ Allowed transitions:
 - `acquiring-lock -> sleeping`
 - `acquiring-lock -> failed`
 - `sleeping -> inspecting`
+- `retrying -> inspecting`
 - `inspecting -> acting`
 - `acting -> recording`
 - `recording -> sleeping`
+- `failed -> retrying`
 - `inspecting -> failed`
 - `acting -> failed`
 - `recording -> failed`
 - `sleeping -> stopping`
+- `retrying -> stopping`
 - `inspecting -> stopping`
 - `acting -> stopping`
 - `recording -> stopping`
@@ -167,14 +171,14 @@ Notes:
 
 ## Failure-Class Matrix
 
-| Observed condition                                   | Local facts available                                     | Expected decision                                                                                                                                     |
-| ---------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| packaged loop entry point missing or not executable  | clean clone, repo files present or validation fails       | fail clearly during setup and document the supported invocation                                                                                       |
-| second loop start attempted while local lock is held | lockfile exists and owner appears live                    | exit with a clear "already running" message rather than racing                                                                                        |
-| stale loop lock found                                | lockfile exists but owner is dead/unreadable              | clear or replace the stale lock using repo-owned rules; do not require manual `.ralph/` archaeology                                                   |
-| operator cycle command fails                         | repo commands or `gh` step exits non-zero                 | record failure in local status/log artifacts and continue or exit according to the existing loop contract; do not mutate factory policy in this issue |
-| detached factory is stopped or degraded              | `symphony factory status --json` reports stopped/degraded | surface the state in the loop's local status output; do not invent new runtime control logic                                                          |
-| `.ralph/` does not exist yet                         | clean clone or new machine                                | create only the local/generated directories/files needed at runtime; durable tooling must remain elsewhere                                            |
+| Observed condition                                   | Local facts available                                     | Expected decision                                                                                                                                          |
+| ---------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| packaged loop entry point missing or not executable  | clean clone, repo files present or validation fails       | fail clearly during setup and document the supported invocation                                                                                            |
+| second loop start attempted while local lock is held | lockfile exists and owner appears live                    | exit with a clear "already running" message rather than racing                                                                                             |
+| stale loop lock found                                | lockfile exists but owner is dead/unreadable              | clear or replace the stale lock using repo-owned rules; do not require manual `.ralph/` archaeology                                                        |
+| operator cycle command fails                         | repo commands or `gh` step exits non-zero                 | record failure in local status/log artifacts, expose a visible `retrying` wait state before the next cycle, and do not mutate factory policy in this issue |
+| detached factory is stopped or degraded              | `symphony factory status --json` reports stopped/degraded | surface the state in the loop's local status output; do not invent new runtime control logic                                                               |
+| `.ralph/` does not exist yet                         | clean clone or new machine                                | create only the local/generated directories/files needed at runtime; durable tooling must remain elsewhere                                                 |
 
 ## Storage And Persistence Contract
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "symphony": "tsx bin/symphony.ts",
+    "operator": "bash skills/symphony-operator/operator-loop.sh",
+    "operator:once": "bash skills/symphony-operator/operator-loop.sh --once",
     "dev": "tsx watch bin/symphony.ts run",
     "prepare": "husky"
   },

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -7,6 +7,15 @@ description: Operate and maintain the local Symphony factory in this repository.
 
 Use this skill when acting as the operator for the local Symphony factory.
 
+Supported repo-owned entry point:
+
+- `pnpm operator` for the continuous wake-up loop
+- `pnpm operator:once` for one cycle
+
+The checked-in loop and prompt live next to this skill under
+`skills/symphony-operator/`. `.ralph/` is local/generated-only state for the
+scratchpad, status snapshots, logs, and loop lock files.
+
 ## Scope
 
 - Observe the live factory, not just the repository.

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -286,10 +286,11 @@ fi
 
 warn_default_command
 ensure_runtime_paths
-write_status "acquiring-lock" "Preparing operator loop runtime paths"
-trap on_signal INT TERM
 trap 'release_lock' EXIT
 acquire_lock
+trap on_signal INT TERM
+# Only the lock owner should publish operator-loop status snapshots.
+write_status "acquiring-lock" "Operator loop lock acquired; preparing runtime status"
 
 if [ "$RUN_ONCE" -eq 1 ]; then
   if run_cycle; then

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROMPT_FILE="$SCRIPT_DIR/operator-prompt.md"
+RALPH_DIR="$REPO_ROOT/.ralph"
+LOG_DIR="$RALPH_DIR/logs"
+LOCK_DIR="$RALPH_DIR/operator-loop.lock"
+LOCK_INFO_FILE="$LOCK_DIR/owner"
+STATUS_JSON="$RALPH_DIR/status.json"
+STATUS_MD="$RALPH_DIR/status.md"
+SCRATCHPAD="$RALPH_DIR/operator-scratchpad.md"
+
+INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
+OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-codex exec --dangerously-bypass-approvals-and-sandbox -C . -}"
+
+RUN_ONCE=0
+STOPPING=0
+LAST_STATE="idle"
+LAST_MESSAGE="Not started"
+LAST_LOG_FILE=""
+LAST_CYCLE_STARTED_AT=""
+LAST_CYCLE_FINISHED_AT=""
+LAST_CYCLE_EXIT_CODE=""
+NEXT_WAKE_AT=""
+
+usage() {
+  cat <<'EOF'
+Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--help]
+
+Environment:
+  SYMPHONY_OPERATOR_COMMAND           Command that reads the operator prompt from stdin.
+                                      Default: codex exec --dangerously-bypass-approvals-and-sandbox -C . -
+  SYMPHONY_OPERATOR_INTERVAL_SECONDS  Sleep interval for continuous mode. Default: 300
+
+Examples:
+  pnpm operator
+  pnpm operator:once
+  SYMPHONY_OPERATOR_INTERVAL_SECONDS=60 pnpm operator
+EOF
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '%s' "$value"
+}
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+future_utc() {
+  node -e 'const interval = Number(process.argv[1]); if (!Number.isInteger(interval) || interval <= 0) process.exit(1); console.log(new Date(Date.now() + interval * 1000).toISOString().replace(/\.\d{3}Z$/, "Z"));' "$1"
+}
+
+pid_is_live() {
+  local pid="${1:-}"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+write_status() {
+  local state="$1"
+  local message="$2"
+  local updated_at
+  updated_at="$(now_utc)"
+  LAST_STATE="$state"
+  LAST_MESSAGE="$message"
+
+  cat >"$STATUS_JSON" <<EOF
+{
+  "version": 1,
+  "state": "$(json_escape "$state")",
+  "message": "$(json_escape "$message")",
+  "updatedAt": "$(json_escape "$updated_at")",
+  "repoRoot": "$(json_escape "$REPO_ROOT")",
+  "pid": $$,
+  "runOnce": $RUN_ONCE,
+  "intervalSeconds": $INTERVAL_SECONDS,
+  "command": "$(json_escape "$OPERATOR_COMMAND")",
+  "promptFile": "$(json_escape "$PROMPT_FILE")",
+  "scratchpad": "$(json_escape "$SCRATCHPAD")",
+  "lastCycle": {
+    "startedAt": $(if [ -n "$LAST_CYCLE_STARTED_AT" ]; then printf '"%s"' "$(json_escape "$LAST_CYCLE_STARTED_AT")"; else printf 'null'; fi),
+    "finishedAt": $(if [ -n "$LAST_CYCLE_FINISHED_AT" ]; then printf '"%s"' "$(json_escape "$LAST_CYCLE_FINISHED_AT")"; else printf 'null'; fi),
+    "exitCode": $(if [ -n "$LAST_CYCLE_EXIT_CODE" ]; then printf '%s' "$LAST_CYCLE_EXIT_CODE"; else printf 'null'; fi),
+    "logFile": $(if [ -n "$LAST_LOG_FILE" ]; then printf '"%s"' "$(json_escape "$LAST_LOG_FILE")"; else printf 'null'; fi)
+  },
+  "nextWakeAt": $(if [ -n "$NEXT_WAKE_AT" ]; then printf '"%s"' "$(json_escape "$NEXT_WAKE_AT")"; else printf 'null'; fi)
+}
+EOF
+
+  cat >"$STATUS_MD" <<EOF
+# Symphony Operator Loop
+
+- State: $state
+- Message: $message
+- Updated: $updated_at
+- Repo root: $REPO_ROOT
+- Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
+- Interval seconds: $INTERVAL_SECONDS
+- Scratchpad: $SCRATCHPAD
+- Prompt: $PROMPT_FILE
+- Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
+- Last cycle finished: ${LAST_CYCLE_FINISHED_AT:-n/a}
+- Last cycle exit code: ${LAST_CYCLE_EXIT_CODE:-n/a}
+- Last cycle log: ${LAST_LOG_FILE:-n/a}
+- Next wake: ${NEXT_WAKE_AT:-n/a}
+EOF
+}
+
+ensure_runtime_paths() {
+  mkdir -p "$LOG_DIR"
+
+  if [ ! -f "$SCRATCHPAD" ]; then
+    cat >"$SCRATCHPAD" <<'EOF'
+# Operator Scratchpad
+
+Local-only operator notes. Durable process changes belong in tracked docs,
+skills, code, and plans instead of this file.
+EOF
+  fi
+}
+
+acquire_lock() {
+  while true; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      cat >"$LOCK_INFO_FILE" <<EOF
+pid=$$
+started_at=$(now_utc)
+repo_root=$REPO_ROOT
+EOF
+      return 0
+    fi
+
+    local existing_pid
+    existing_pid="$(sed -n 's/^pid=//p' "$LOCK_INFO_FILE" 2>/dev/null | head -n 1)"
+    if pid_is_live "$existing_pid"; then
+      echo "operator-loop: another loop is already running with pid $existing_pid" >&2
+      exit 1
+    fi
+
+    echo "operator-loop: clearing stale lock for pid ${existing_pid:-unknown}" >&2
+    rm -rf "$LOCK_DIR"
+  done
+}
+
+release_lock() {
+  if [ -d "$LOCK_DIR" ]; then
+    local existing_pid
+    existing_pid="$(sed -n 's/^pid=//p' "$LOCK_INFO_FILE" 2>/dev/null | head -n 1)"
+    if [ "$existing_pid" = "$$" ]; then
+      rm -rf "$LOCK_DIR"
+    fi
+  fi
+}
+
+on_signal() {
+  STOPPING=1
+  write_status "stopping" "Signal received; stopping operator loop"
+}
+
+run_cycle() {
+  local timestamp log_file exit_code cycle_message
+  timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+  log_file="$LOG_DIR/operator-cycle-$timestamp.log"
+
+  LAST_LOG_FILE="$log_file"
+  LAST_CYCLE_STARTED_AT="$(now_utc)"
+  LAST_CYCLE_FINISHED_AT=""
+  LAST_CYCLE_EXIT_CODE=""
+  NEXT_WAKE_AT=""
+  write_status "acting" "Running operator wake-up cycle"
+
+  {
+    printf '== Symphony operator cycle ==\n'
+    printf 'started_at=%s\n' "$LAST_CYCLE_STARTED_AT"
+    printf 'repo_root=%s\n' "$REPO_ROOT"
+    printf 'command=%s\n' "$OPERATOR_COMMAND"
+    printf 'prompt=%s\n' "$PROMPT_FILE"
+    printf '\n'
+  } >>"$log_file"
+
+  set +e
+  (
+    cd "$REPO_ROOT"
+    export SYMPHONY_OPERATOR_REPO_ROOT="$REPO_ROOT"
+    export SYMPHONY_OPERATOR_SCRATCHPAD="$SCRATCHPAD"
+    export SYMPHONY_OPERATOR_STATUS_JSON="$STATUS_JSON"
+    export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
+    export SYMPHONY_OPERATOR_LOG_DIR="$LOG_DIR"
+    export SYMPHONY_OPERATOR_PROMPT_FILE="$PROMPT_FILE"
+    bash -lc "$OPERATOR_COMMAND" <"$PROMPT_FILE"
+  ) >>"$log_file" 2>&1
+  exit_code=$?
+  set -e
+
+  LAST_CYCLE_FINISHED_AT="$(now_utc)"
+  LAST_CYCLE_EXIT_CODE="$exit_code"
+
+  if [ "$exit_code" -eq 0 ]; then
+    cycle_message="Operator cycle completed successfully"
+    write_status "recording" "$cycle_message"
+  else
+    cycle_message="Operator cycle failed with exit code $exit_code"
+    write_status "failed" "$cycle_message"
+  fi
+
+  return "$exit_code"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --)
+      shift
+      ;;
+    --once)
+      RUN_ONCE=1
+      shift
+      ;;
+    --interval-seconds)
+      if [ $# -lt 2 ]; then
+        echo "operator-loop: --interval-seconds requires a value" >&2
+        exit 1
+      fi
+      INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "operator-loop: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || [ "$INTERVAL_SECONDS" -le 0 ]; then
+  echo "operator-loop: interval must be a positive integer" >&2
+  exit 1
+fi
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "operator-loop: prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+ensure_runtime_paths
+acquire_lock
+write_status "acquiring-lock" "Preparing operator loop runtime paths"
+trap on_signal INT TERM
+trap 'release_lock' EXIT
+
+if [ "$RUN_ONCE" -eq 1 ]; then
+  if run_cycle; then
+    write_status "idle" "Operator loop finished one cycle"
+    exit 0
+  fi
+
+  write_status "idle" "Operator loop finished one cycle with a failure"
+  exit "$LAST_CYCLE_EXIT_CODE"
+fi
+
+write_status "sleeping" "Operator loop started"
+
+while [ "$STOPPING" -eq 0 ]; do
+  if run_cycle; then
+    NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
+    write_status "sleeping" "Sleeping until next operator wake-up cycle"
+  else
+    NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
+    write_status "sleeping" "Cycle failed; sleeping before retrying operator loop"
+  fi
+
+  sleep "$INTERVAL_SECONDS" || true
+done
+
+write_status "idle" "Operator loop stopped"

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -199,7 +199,9 @@ run_cycle() {
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
     export SYMPHONY_OPERATOR_LOG_DIR="$LOG_DIR"
     export SYMPHONY_OPERATOR_PROMPT_FILE="$PROMPT_FILE"
-    bash -lc "$OPERATOR_COMMAND" <"$PROMPT_FILE"
+    # Intentionally use a login shell so PATH-managed runner installs such as
+    # codex or claude remain discoverable during unattended operator cycles.
+    bash -l -c "$OPERATOR_COMMAND" <"$PROMPT_FILE"
   ) >>"$log_file" 2>&1
   exit_code=$?
   set -e

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -15,6 +15,7 @@ SCRATCHPAD="$RALPH_DIR/operator-scratchpad.md"
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
 OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-codex exec --dangerously-bypass-approvals-and-sandbox -C . -}"
+RECORDING_SETTLE_SECONDS=1
 
 RUN_ONCE=0
 STOPPING=0
@@ -149,6 +150,7 @@ EOF
 
     echo "operator-loop: clearing stale lock for pid ${existing_pid:-unknown}" >&2
     rm -rf "$LOCK_DIR"
+    sleep 0.1
   done
 }
 
@@ -208,6 +210,9 @@ run_cycle() {
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"
     write_status "recording" "$cycle_message"
+    # Leave the post-cycle recording state visible briefly before callers
+    # transition to the next wait state.
+    sleep "$RECORDING_SETTLE_SECONDS"
   else
     cycle_message="Operator cycle failed with exit code $exit_code"
     write_status "failed" "$cycle_message"

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -309,9 +309,15 @@ write_status "sleeping" "Operator loop started"
 
 while [ "$STOPPING" -eq 0 ]; do
   if run_cycle; then
+    if [ "$STOPPING" -eq 1 ]; then
+      break
+    fi
     NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
     write_status "sleeping" "Sleeping until next operator wake-up cycle"
   else
+    if [ "$STOPPING" -eq 1 ]; then
+      break
+    fi
     NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
     write_status "retrying" "Cycle failed; sleeping before retrying operator loop"
   fi

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -83,7 +83,7 @@ write_status() {
   "updatedAt": "$(json_escape "$updated_at")",
   "repoRoot": "$(json_escape "$REPO_ROOT")",
   "pid": $$,
-  "runOnce": $RUN_ONCE,
+  "runOnce": $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'true'; else printf 'false'; fi),
   "intervalSeconds": $INTERVAL_SECONDS,
   "command": "$(json_escape "$OPERATOR_COMMAND")",
   "promptFile": "$(json_escape "$PROMPT_FILE")",

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -14,7 +14,8 @@ STATUS_MD="$RALPH_DIR/status.md"
 SCRATCHPAD="$RALPH_DIR/operator-scratchpad.md"
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
-OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-codex exec --dangerously-bypass-approvals-and-sandbox -C . -}"
+DEFAULT_OPERATOR_COMMAND="codex exec --dangerously-bypass-approvals-and-sandbox -C . -"
+OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-$DEFAULT_OPERATOR_COMMAND}"
 RECORDING_SETTLE_SECONDS=1
 
 RUN_ONCE=0
@@ -35,6 +36,7 @@ Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--help]
 Environment:
   SYMPHONY_OPERATOR_COMMAND           Command that reads the operator prompt from stdin.
                                       Default: codex exec --dangerously-bypass-approvals-and-sandbox -C . -
+                                      Warning: the default bypasses Codex approvals and sandboxing.
   SYMPHONY_OPERATOR_INTERVAL_SECONDS  Sleep interval for continuous mode. Default: 300
 
 Examples:
@@ -48,6 +50,8 @@ json_escape() {
   local value="$1"
   value="${value//\\/\\\\}"
   value="${value//\"/\\\"}"
+  value="${value//$'\b'/\\b}"
+  value="${value//$'\f'/\\f}"
   value="${value//$'\n'/\\n}"
   value="${value//$'\r'/\\r}"
   value="${value//$'\t'/\\t}"
@@ -180,6 +184,12 @@ sleep_until_next_cycle() {
   SLEEP_PID=""
 }
 
+warn_default_command() {
+  if [ "$OPERATOR_COMMAND" = "$DEFAULT_OPERATOR_COMMAND" ]; then
+    echo "operator-loop: using the default Codex command with approvals and sandbox bypass enabled" >&2
+  fi
+}
+
 run_cycle() {
   local timestamp log_file exit_code cycle_message
   timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
@@ -278,6 +288,7 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
+warn_default_command
 ensure_runtime_paths
 write_status "acquiring-lock" "Preparing operator loop runtime paths"
 trap on_signal INT TERM

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -19,6 +19,7 @@ RECORDING_SETTLE_SECONDS=1
 
 RUN_ONCE=0
 STOPPING=0
+SLEEP_PID=""
 LAST_STATE="idle"
 LAST_MESSAGE="Not started"
 LAST_LOG_FILE=""
@@ -166,7 +167,17 @@ release_lock() {
 
 on_signal() {
   STOPPING=1
+  if [ -n "$SLEEP_PID" ] && pid_is_live "$SLEEP_PID"; then
+    kill "$SLEEP_PID" 2>/dev/null || true
+  fi
   write_status "stopping" "Signal received; stopping operator loop"
+}
+
+sleep_until_next_cycle() {
+  sleep "$INTERVAL_SECONDS" &
+  SLEEP_PID=$!
+  wait "$SLEEP_PID" 2>/dev/null || true
+  SLEEP_PID=""
 }
 
 run_cycle() {
@@ -262,6 +273,11 @@ if [ ! -f "$PROMPT_FILE" ]; then
   exit 1
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "operator-loop: node not found in PATH; required for timestamp calculation" >&2
+  exit 1
+fi
+
 ensure_runtime_paths
 write_status "acquiring-lock" "Preparing operator loop runtime paths"
 trap on_signal INT TERM
@@ -275,7 +291,7 @@ if [ "$RUN_ONCE" -eq 1 ]; then
   fi
 
   write_status "idle" "Operator loop finished one cycle with a failure"
-  exit "$LAST_CYCLE_EXIT_CODE"
+  exit "${LAST_CYCLE_EXIT_CODE:-1}"
 fi
 
 write_status "sleeping" "Operator loop started"
@@ -289,7 +305,7 @@ while [ "$STOPPING" -eq 0 ]; do
     write_status "retrying" "Cycle failed; sleeping before retrying operator loop"
   fi
 
-  sleep "$INTERVAL_SECONDS" || true
+  sleep_until_next_cycle
 done
 
 write_status "idle" "Operator loop stopped"

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -21,8 +21,6 @@ RECORDING_SETTLE_SECONDS=1
 RUN_ONCE=0
 STOPPING=0
 SLEEP_PID=""
-LAST_STATE="idle"
-LAST_MESSAGE="Not started"
 LAST_LOG_FILE=""
 LAST_CYCLE_STARTED_AT=""
 LAST_CYCLE_FINISHED_AT=""
@@ -77,8 +75,6 @@ write_status() {
   local message="$2"
   local updated_at
   updated_at="$(now_utc)"
-  LAST_STATE="$state"
-  LAST_MESSAGE="$message"
 
   cat >"$STATUS_JSON" <<EOF
 {

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -256,10 +256,10 @@ if [ ! -f "$PROMPT_FILE" ]; then
 fi
 
 ensure_runtime_paths
-acquire_lock
 write_status "acquiring-lock" "Preparing operator loop runtime paths"
 trap on_signal INT TERM
 trap 'release_lock' EXIT
+acquire_lock
 
 if [ "$RUN_ONCE" -eq 1 ]; then
   if run_cycle; then
@@ -279,7 +279,7 @@ while [ "$STOPPING" -eq 0 ]; do
     write_status "sleeping" "Sleeping until next operator wake-up cycle"
   else
     NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
-    write_status "sleeping" "Cycle failed; sleeping before retrying operator loop"
+    write_status "retrying" "Cycle failed; sleeping before retrying operator loop"
   fi
 
   sleep "$INTERVAL_SECONDS" || true

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -1,0 +1,20 @@
+You are the operator for the local Symphony factory in this repository.
+
+Run exactly one wake-up cycle, then stop.
+
+Required workflow:
+
+1. Read `skills/symphony-operator/SKILL.md`.
+2. Read `.ralph/operator-scratchpad.md` if it exists.
+3. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
+4. Inspect the live watch surface when useful, but treat `factory status --json` as canonical.
+5. Review active issues, PRs, CI, and automated review feedback.
+6. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+7. Update `.ralph/operator-scratchpad.md` before finishing the cycle.
+
+Constraints:
+
+- Do not act as a second scheduler.
+- Do not replace the product factory-control commands with ad hoc process management unless the control surface is unavailable or inconsistent.
+- Keep runner assumptions provider-neutral; the factory may use `codex`, `claude-code`, or `generic-command`.
+- If durable repo changes are required, make them through the normal branch/PR flow instead of leaving the fix only in local notes.


### PR DESCRIPTION
## Summary
- package the operator loop as versioned repo tooling under `skills/symphony-operator/`
- add repo-root `pnpm operator` and `pnpm operator:once` entry points
- keep `.ralph/` local/generated-only and update docs to make that boundary explicit

## Testing
- `bash -n skills/symphony-operator/operator-loop.sh`
- `pnpm operator -- --help`
- `SYMPHONY_OPERATOR_COMMAND='cat >/dev/null; pnpm -s tsx bin/symphony.ts factory status --json >/dev/null 2>&1 || true' pnpm operator:once`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #136.
