### PR TITLE
Expose factory runtime version identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ foreground signal boundary, so an accidental `Ctrl-C` can stop the factory.
 The status snapshot includes normalized runner visibility for active issues,
 including worker state, current phase, session identity, heartbeat/action
 timestamps, waiting reason, and condensed output/error summaries.
+Status surfaces now also publish a runtime checkout identity for the live
+factory code, including the runtime checkout path, `HEAD` commit SHA, commit
+timestamp, and dirty-state summary when git metadata is available. This
+describes the running runtime checkout (for detached control, `.tmp/factory-main`),
+not whatever commit your operator checkout currently has checked out.
 Status surfaces now also distinguish snapshot freshness explicitly:
 `fresh` for the live worker, `stale` for leftover historical snapshots, and
 `unavailable` while startup is still publishing a current snapshot or no

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -98,6 +98,11 @@ Symphony now has two status surfaces:
 - `pnpm tsx bin/symphony.ts factory status` inspects the detached runtime and
   embeds the latest status snapshot when available
 
+Both surfaces now include the runtime checkout identity for the live factory
+code. Use that `HEAD` SHA and checkout path to answer "what version is running
+right now?"; for detached control it refers to `.tmp/factory-main`, not the
+operator checkout you are typing in.
+
 For self-hosting operations, prefer `factory status` first, then `factory watch`
 when you want a live read-only monitor.
 

--- a/docs/plans/037-factory-runtime-version-identity/plan.md
+++ b/docs/plans/037-factory-runtime-version-identity/plan.md
@@ -163,14 +163,14 @@ If identity collection fails:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected behavior |
-| --- | --- | --- |
-| Runtime checkout is a healthy git worktree | runtime root path, `HEAD` SHA, commit timestamp, diff status | publish full identity in startup/status snapshots and logs |
-| Runtime checkout is a git worktree but diff check fails | runtime root path, `HEAD` SHA, commit timestamp, dirty state unavailable | publish SHA/timestamp with `isDirty: null` and source detail explaining the partial result |
-| Runtime checkout is missing `.git` or git is unavailable | runtime root path only | publish identity with null git fields and a normalized unavailable source; status must say runtime identity unavailable, not crash |
-| Detached runtime starts, then operator checkout advances later | runtime snapshot already persisted from live runtime root | status continues to report the live runtime checkout identity, not the operator checkout `HEAD` |
-| Startup fails before orchestration reaches steady-state | startup snapshot exists | `factory status` still surfaces the runtime identity from `startup.json` for debugging |
-| Status snapshot write/log render fails | runtime remains alive | log a warning and continue; runtime identity collection must not add a fatal observability dependency |
+| Observed condition                                             | Local facts available                                                    | Expected behavior                                                                                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime checkout is a healthy git worktree                     | runtime root path, `HEAD` SHA, commit timestamp, diff status             | publish full identity in startup/status snapshots and logs                                                                         |
+| Runtime checkout is a git worktree but diff check fails        | runtime root path, `HEAD` SHA, commit timestamp, dirty state unavailable | publish SHA/timestamp with `isDirty: null` and source detail explaining the partial result                                         |
+| Runtime checkout is missing `.git` or git is unavailable       | runtime root path only                                                   | publish identity with null git fields and a normalized unavailable source; status must say runtime identity unavailable, not crash |
+| Detached runtime starts, then operator checkout advances later | runtime snapshot already persisted from live runtime root                | status continues to report the live runtime checkout identity, not the operator checkout `HEAD`                                    |
+| Startup fails before orchestration reaches steady-state        | startup snapshot exists                                                  | `factory status` still surfaces the runtime identity from `startup.json` for debugging                                             |
+| Status snapshot write/log render fails                         | runtime remains alive                                                    | log a warning and continue; runtime identity collection must not add a fatal observability dependency                              |
 
 ## Observability Requirements
 

--- a/docs/plans/037-factory-runtime-version-identity/plan.md
+++ b/docs/plans/037-factory-runtime-version-identity/plan.md
@@ -1,0 +1,245 @@
+# Issue 37 Plan: Factory Runtime Version Identity
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Expose a clear, immutable-enough runtime identity for the live local factory so an operator can answer "what version of the factory is running right now?" from the status surface and logs without inspecting git state by hand.
+
+## Scope
+
+This slice covers:
+
+1. defining the first local runtime identity contract for the detached factory runtime
+2. collecting that identity from the live runtime checkout under `.tmp/factory-main`
+3. persisting the identity into operator-facing runtime snapshots
+4. rendering the identity in `symphony status` and `symphony factory status`
+5. emitting the same identity in structured logs at startup / snapshot publication points
+6. tests and docs for the contract and operator usage
+
+## Non-goals
+
+This slice does not include:
+
+1. semantic versioning, release tags, or release engineering automation
+2. proving provenance beyond local git metadata
+3. branch-name-based runtime identity as the primary answer
+4. remote archive publication or report schema changes
+5. redesigning orchestrator state, retry behavior, or tracker policy
+6. comparing the live runtime against the operator checkout beyond surfacing each path distinctly when useful
+
+## Current Gaps
+
+Today the detached factory runtime does not expose a durable code identity:
+
+1. `status.json` and `startup.json` describe worker/process state but not the runtime checkout revision
+2. `factory status` can show the runtime root path, but the operator still has to run git commands manually to know which commit that checkout is on
+3. logs do not carry a normalized runtime identity field that can be correlated across startup, status snapshots, and debugging
+4. the status surface can be misread as describing the operator checkout on disk rather than the live runtime checkout under `.tmp/factory-main`
+5. the future report path has no reusable runtime-identity contract to consume yet
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_37/docs/architecture.md).
+
+- Policy Layer: define the repo-owned rule that local runtime identity is derived from immutable runtime checkout facts such as `HEAD` commit SHA and commit timestamp, not mutable branch names. This issue should not add tracker or landing policy.
+- Configuration Layer: no workflow schema change is required in the first slice. Runtime identity is derived from the live runtime checkout path already owned by factory control and runtime startup.
+- Coordination Layer: the orchestrator may publish identity into status snapshots it already owns, but it should not gain new dispatch or retry behavior.
+- Execution Layer: runtime identity collection may inspect the runtime checkout on disk and capture process-start context, but runner/workspace layers should not become responsible for status rendering or git policy.
+- Integration Layer: no tracker transport or normalization changes belong here. Git inspection is local runtime introspection, not tracker integration.
+- Observability Layer: owns the runtime identity contract, snapshot fields, rendering, and structured log fields. This is the primary layer touched by the issue.
+
+## Architecture Boundaries
+
+### Observability
+
+Belongs here:
+
+1. a small `FactoryRuntimeIdentity` contract that can be embedded in startup/status snapshots
+2. human-readable rendering for status surfaces
+3. structured-log fields and helper formatting
+4. read/write validation for the new snapshot fields
+
+Does not belong here:
+
+1. ad hoc shell parsing inside render functions
+2. tracker-specific status policy
+3. report-generation logic in this slice
+
+### CLI / Factory Control
+
+Belongs here:
+
+1. resolving the live runtime root already used by detached control commands
+2. surfacing runtime identity in `factory status` output
+3. clearly distinguishing runtime checkout information from the operator repo root when both are shown
+
+Does not belong here:
+
+1. direct git command formatting in the terminal renderer
+2. a second competing runtime identity model
+
+### Startup
+
+Belongs here:
+
+1. collecting runtime identity early enough that startup and later status surfaces agree on the same live checkout facts
+2. publishing identity in `startup.json` so early failures still report the running code version
+
+Does not belong here:
+
+1. release/version policy
+2. retry or supervision changes
+
+### Orchestrator
+
+Belongs here:
+
+1. carrying precomputed runtime identity into status snapshot publication
+2. logging snapshot publication with identity context
+
+Does not belong here:
+
+1. recomputing git state inline in hot orchestration branches
+2. deriving identity from issue/workspace branches
+
+### Workspace / Runner
+
+Belongs here:
+
+1. no contract ownership changes in this slice
+
+Does not belong here:
+
+1. defining factory runtime identity from issue workspaces or runner sessions
+
+### Tracker
+
+Belongs here:
+
+1. no changes
+
+Does not belong here:
+
+1. status-surface identity logic
+2. any transport, normalization, or policy changes for this issue
+
+## Proposed Runtime Identity Contract
+
+Introduce one normalized runtime identity object owned by observability and derived from the live factory runtime checkout:
+
+1. `checkoutPath`: absolute path to the live runtime checkout root
+2. `headSha`: resolved `git rev-parse HEAD` value, or `null` when unavailable
+3. `committedAt`: resolved `git show -s --format=%cI HEAD` value, or `null` when unavailable
+4. `isDirty`: boolean when local diff state can be determined, otherwise `null`
+5. `source`: a short normalized source/result summary such as `git`, `git-unavailable`, or `not-a-git-checkout`
+
+Decision notes:
+
+1. `headSha` is the primary operator answer because it is immutable for local debugging and does not depend on branch movement.
+2. `committedAt` helps humans compare two SHAs quickly and gives reports/logs a readable anchor without inventing semver.
+3. `isDirty` is useful for debugging local detached runtimes that have uncommitted changes, but it is secondary to `headSha`.
+4. branch name may be shown as supplementary context later, but it should not be required for the first contract and should not be treated as identity.
+
+## Runtime Publication Model
+
+This feature does not change orchestration state transitions, so it does not need a new runtime state machine for retries or handoff logic.
+
+It does need one explicit publication model:
+
+1. collect runtime identity from the live runtime checkout before or during startup preparation
+2. write the identity into `startup.json`
+3. reuse the same identity when building `status.json` for that runtime process
+4. render the identity in `status` / `factory status`
+5. emit structured logs that include the same identity fields on startup and status publication
+
+If identity collection fails:
+
+1. the runtime should stay operable
+2. snapshots should record the failure mode in normalized form
+3. the status surface should say identity is unavailable rather than silently omitting the field
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected behavior |
+| --- | --- | --- |
+| Runtime checkout is a healthy git worktree | runtime root path, `HEAD` SHA, commit timestamp, diff status | publish full identity in startup/status snapshots and logs |
+| Runtime checkout is a git worktree but diff check fails | runtime root path, `HEAD` SHA, commit timestamp, dirty state unavailable | publish SHA/timestamp with `isDirty: null` and source detail explaining the partial result |
+| Runtime checkout is missing `.git` or git is unavailable | runtime root path only | publish identity with null git fields and a normalized unavailable source; status must say runtime identity unavailable, not crash |
+| Detached runtime starts, then operator checkout advances later | runtime snapshot already persisted from live runtime root | status continues to report the live runtime checkout identity, not the operator checkout `HEAD` |
+| Startup fails before orchestration reaches steady-state | startup snapshot exists | `factory status` still surfaces the runtime identity from `startup.json` for debugging |
+| Status snapshot write/log render fails | runtime remains alive | log a warning and continue; runtime identity collection must not add a fatal observability dependency |
+
+## Observability Requirements
+
+Required operator-visible outcomes:
+
+1. `symphony status` prints the runtime identity near the worker/runtime summary
+2. `symphony factory status` prints the same identity alongside runtime root information
+3. JSON status/control snapshots include a stable machine-readable runtime identity object
+4. startup and status publication logs include runtime identity fields for grep/debugging
+5. docs explain that the detached runtime identity describes `.tmp/factory-main`, not the operator checkout
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR because it stays on one seam: local runtime observability for the detached factory checkout.
+
+The PR should include:
+
+1. a small runtime identity collector/helper
+2. snapshot contract updates for startup/status/control output
+3. render/log wiring and tests
+4. concise operator docs
+
+The PR should explicitly defer:
+
+1. issue report schema/rendering changes from future report-focused work
+2. release/version labels or build pipelines
+3. broader status-surface redesign beyond adding the new identity fields
+
+## Implementation Steps
+
+1. Add a small runtime-identity helper that inspects a checkout root and returns the normalized contract without throwing on expected git/environment failures.
+2. Extend the startup snapshot contract to carry runtime identity so early detached-runtime failures still report the live code version.
+3. Extend the factory status snapshot contract and builder to carry the same identity object.
+4. Thread runtime identity through detached factory control inspection so `factory status` can render it even when only startup data is available.
+5. Render the identity in human-readable `status` and `factory status` output with wording that distinguishes runtime checkout from operator repo root.
+6. Emit structured log fields for startup preparation and status snapshot publication that include runtime identity.
+7. Update docs for the detached-runtime operator flow and status interpretation.
+
+## Tests
+
+Add or update coverage for:
+
+1. unit tests for runtime identity collection across healthy git, partial git failure, and non-git checkout cases
+2. unit tests for startup snapshot parsing/rendering with runtime identity present and unavailable
+3. unit tests for status snapshot parsing/rendering with runtime identity present and unavailable
+4. unit tests for `factory status` rendering to confirm runtime root and runtime identity are both shown clearly
+5. integration or CLI contract coverage, if needed, to ensure `status --json` and `factory status --json` expose the new fields
+
+## Acceptance Scenarios
+
+1. Detached runtime healthy: after `factory start`, `factory status` answers with the runtime checkout path and `HEAD` SHA for `.tmp/factory-main` without any manual git command.
+2. Operator checkout diverged: if the operator repo root moves to a different commit after the runtime started, `factory status` still reports the live runtime SHA from the runtime checkout.
+3. Startup failure: when startup fails after publishing `startup.json`, `factory status` still shows the runtime identity for the failed live runtime.
+4. Identity unavailable: if the runtime checkout cannot provide git metadata, status surfaces say identity is unavailable in a normalized, non-crashing way.
+5. JSON consumers: machine-readable status output includes the runtime identity object needed by future status/report consumers.
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. the live detached runtime publishes a normalized runtime identity derived from its own checkout
+2. `status` and `factory status` surface that identity clearly
+3. startup/status logs carry the same identity fields
+4. tests cover healthy and unavailable identity cases
+5. docs explain how operators should interpret the runtime identity
+
+## Deferred To Later Issues Or PRs
+
+1. adding runtime identity to generated issue reports or archive publication metadata
+2. release-channel names, semantic versions, or signed build provenance
+3. cross-checks that compare operator checkout and runtime checkout automatically
+4. richer build metadata such as Node version, package version, or build host once a broader runtime-build contract exists

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -13,6 +13,10 @@ import {
   type FactoryStatusSnapshot,
 } from "../observability/status.js";
 import {
+  renderFactoryRuntimeIdentity,
+  type FactoryRuntimeIdentity,
+} from "../observability/runtime-identity.js";
+import {
   deriveStartupFilePath,
   parseStartupSnapshotContent,
   type StartupSnapshot,
@@ -60,6 +64,7 @@ export interface FactoryStartupAssessment {
   readonly workerPid: number;
   readonly workerAlive: boolean;
   readonly stale: boolean;
+  readonly runtimeIdentity: FactoryRuntimeIdentity | null;
 }
 
 export interface FactoryControlStatusSnapshot {
@@ -307,6 +312,13 @@ export function renderFactoryControlStatus(
       `Startup: ${snapshot.startup.state} provider=${snapshot.startup.provider} pid=${snapshot.startup.workerPid.toString()}`,
     );
     lines.push(`Startup detail: ${snapshot.startup.summary}`);
+    if (snapshot.statusSnapshot === null) {
+      lines.push(
+        `Runtime version: ${renderFactoryRuntimeIdentity(
+          snapshot.startup.runtimeIdentity,
+        )}`,
+      );
+    }
     if (snapshot.startup.stale) {
       lines.push("Startup freshness: stale");
     }
@@ -981,6 +993,7 @@ function assessStartupSnapshot(
     workerPid: snapshot.workerPid,
     workerAlive,
     stale,
+    runtimeIdentity: snapshot.runtimeIdentity ?? null,
   };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -379,6 +379,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     logger,
     undefined,
     livenessProbe,
+    startup.runtimeIdentity,
   );
 
   const logFile = path.join(workflow.config.workspace.root, "symphony.log");

--- a/src/observability/runtime-identity.ts
+++ b/src/observability/runtime-identity.ts
@@ -4,11 +4,15 @@ import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
 
+export const FACTORY_RUNTIME_IDENTITY_SOURCES = [
+  "git",
+  "git-unavailable",
+  "not-a-git-checkout",
+  "git-error",
+] as const;
+
 export type FactoryRuntimeIdentitySource =
-  | "git"
-  | "git-unavailable"
-  | "not-a-git-checkout"
-  | "git-error";
+  (typeof FACTORY_RUNTIME_IDENTITY_SOURCES)[number];
 
 export interface FactoryRuntimeIdentity {
   readonly checkoutPath: string;
@@ -60,6 +64,8 @@ export async function collectFactoryRuntimeIdentity(
   }
 
   try {
+    // Ignore untracked files so temp artifacts under the detached runtime root
+    // do not make the runtime checkout look dirty to operators.
     const result = await execGit(
       "git",
       ["status", "--porcelain", "--untracked-files=no"],
@@ -168,7 +174,7 @@ export function parseFactoryRuntimeIdentity(
     ),
     source: expectEnum(
       identity.source,
-      ["git", "git-unavailable", "not-a-git-checkout", "git-error"],
+      FACTORY_RUNTIME_IDENTITY_SOURCES,
       filePath,
       `${field}.source`,
     ),

--- a/src/observability/runtime-identity.ts
+++ b/src/observability/runtime-identity.ts
@@ -1,0 +1,297 @@
+import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export type FactoryRuntimeIdentitySource =
+  | "git"
+  | "git-unavailable"
+  | "not-a-git-checkout"
+  | "git-error";
+
+export interface FactoryRuntimeIdentity {
+  readonly checkoutPath: string;
+  readonly headSha: string | null;
+  readonly committedAt: string | null;
+  readonly isDirty: boolean | null;
+  readonly source: FactoryRuntimeIdentitySource;
+  readonly detail: string | null;
+}
+
+export interface RuntimeIdentityCollectorDeps {
+  readonly execFile?: typeof execFile;
+}
+
+export async function collectFactoryRuntimeIdentity(
+  checkoutPath: string,
+  deps: RuntimeIdentityCollectorDeps = {},
+): Promise<FactoryRuntimeIdentity> {
+  const resolvedCheckoutPath = path.resolve(checkoutPath);
+  const execGit = deps.execFile ?? execFile;
+
+  let headSha: string;
+  try {
+    const result = await execGit("git", ["rev-parse", "HEAD"], {
+      cwd: resolvedCheckoutPath,
+    });
+    headSha = result.stdout.trim();
+  } catch (error) {
+    return buildUnavailableIdentity(resolvedCheckoutPath, error);
+  }
+
+  let committedAt: string | null = null;
+  let isDirty: boolean | null = null;
+  const detailParts: string[] = [];
+
+  try {
+    const result = await execGit("git", ["show", "-s", "--format=%cI", "HEAD"], {
+      cwd: resolvedCheckoutPath,
+    });
+    committedAt = normalizeOptionalText(result.stdout);
+  } catch (error) {
+    detailParts.push(
+      `commit timestamp unavailable: ${normalizeGitErrorMessage(error)}`,
+    );
+  }
+
+  try {
+    const result = await execGit(
+      "git",
+      ["status", "--porcelain", "--untracked-files=no"],
+      {
+        cwd: resolvedCheckoutPath,
+      },
+    );
+    isDirty = result.stdout.trim().length > 0;
+  } catch (error) {
+    detailParts.push(`dirty state unavailable: ${normalizeGitErrorMessage(error)}`);
+  }
+
+  return {
+    checkoutPath: resolvedCheckoutPath,
+    headSha,
+    committedAt,
+    isDirty,
+    source: "git",
+    detail: detailParts.length === 0 ? null : detailParts.join("; "),
+  };
+}
+
+export function renderFactoryRuntimeIdentity(
+  identity: FactoryRuntimeIdentity | null | undefined,
+): string {
+  if (identity === null || identity === undefined) {
+    return "unavailable";
+  }
+  if (identity.headSha === null) {
+    const reason =
+      identity.detail === null
+        ? identity.source
+        : `${identity.source}: ${identity.detail}`;
+    return `unavailable (${reason})`;
+  }
+
+  const parts = [identity.headSha];
+  if (identity.committedAt !== null) {
+    parts.push(`committed ${identity.committedAt}`);
+  }
+  if (identity.isDirty === true) {
+    parts.push("dirty");
+  } else if (identity.isDirty === false) {
+    parts.push("clean");
+  }
+  if (identity.detail !== null) {
+    parts.push(identity.detail);
+  }
+  return parts.join(" | ");
+}
+
+export function factoryRuntimeIdentityLogFields(
+  identity: FactoryRuntimeIdentity | null | undefined,
+): Record<string, unknown> {
+  if (identity === null || identity === undefined) {
+    return {
+      runtimeCheckoutPath: null,
+      runtimeHeadSha: null,
+      runtimeCommittedAt: null,
+      runtimeIsDirty: null,
+      runtimeIdentitySource: null,
+      runtimeIdentityDetail: null,
+    };
+  }
+  return {
+    runtimeCheckoutPath: identity.checkoutPath,
+    runtimeHeadSha: identity.headSha,
+    runtimeCommittedAt: identity.committedAt,
+    runtimeIsDirty: identity.isDirty,
+    runtimeIdentitySource: identity.source,
+    runtimeIdentityDetail: identity.detail,
+  };
+}
+
+export function parseFactoryRuntimeIdentity(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryRuntimeIdentity | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const identity = expectObject(value, filePath, field);
+  return {
+    checkoutPath: expectString(
+      identity.checkoutPath,
+      filePath,
+      `${field}.checkoutPath`,
+    ),
+    headSha: expectNullableString(identity.headSha, filePath, `${field}.headSha`),
+    committedAt: expectNullableString(
+      identity.committedAt,
+      filePath,
+      `${field}.committedAt`,
+    ),
+    isDirty: expectNullableBoolean(
+      identity.isDirty,
+      filePath,
+      `${field}.isDirty`,
+    ),
+    source: expectEnum(
+      identity.source,
+      ["git", "git-unavailable", "not-a-git-checkout", "git-error"],
+      filePath,
+      `${field}.source`,
+    ),
+    detail: expectNullableString(identity.detail, filePath, `${field}.detail`),
+  };
+}
+
+function buildUnavailableIdentity(
+  checkoutPath: string,
+  error: unknown,
+): FactoryRuntimeIdentity {
+  const normalized = classifyGitError(error);
+  return {
+    checkoutPath,
+    headSha: null,
+    committedAt: null,
+    isDirty: null,
+    source: normalized.source,
+    detail: normalized.detail,
+  };
+}
+
+function classifyGitError(error: unknown): {
+  readonly source: FactoryRuntimeIdentitySource;
+  readonly detail: string;
+} {
+  const err = error as {
+    readonly code?: string;
+    readonly stderr?: string;
+    readonly stdout?: string;
+    readonly message?: string;
+  };
+  if (err.code === "ENOENT") {
+    return {
+      source: "git-unavailable",
+      detail: "git executable is not available",
+    };
+  }
+  const detail = normalizeGitErrorMessage(error);
+  if (/not a git repository/i.test(detail)) {
+    return {
+      source: "not-a-git-checkout",
+      detail,
+    };
+  }
+  return {
+    source: "git-error",
+    detail,
+  };
+}
+
+function normalizeGitErrorMessage(error: unknown): string {
+  const err = error as {
+    readonly stderr?: string;
+    readonly stdout?: string;
+    readonly message?: string;
+  };
+  const text =
+    normalizeOptionalText(err.stderr) ??
+    normalizeOptionalText(err.stdout) ??
+    (error instanceof Error ? error.message : String(error));
+  return text.length === 0 ? "unknown git error" : text;
+}
+
+function normalizeOptionalText(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function expectObject(
+  value: unknown,
+  filePath: string,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `Expected object for ${field} in runtime identity snapshot ${filePath}.`,
+    );
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function expectString(value: unknown, filePath: string, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Expected string for ${field} in runtime identity snapshot ${filePath}.`,
+    );
+  }
+  return value;
+}
+
+function expectNullableString(
+  value: unknown,
+  filePath: string,
+  field: string,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(
+      `Expected string or null for ${field} in runtime identity snapshot ${filePath}.`,
+    );
+  }
+  return value;
+}
+
+function expectNullableBoolean(
+  value: unknown,
+  filePath: string,
+  field: string,
+): boolean | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(
+      `Expected boolean or null for ${field} in runtime identity snapshot ${filePath}.`,
+    );
+  }
+  return value;
+}
+
+function expectEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  filePath: string,
+  field: string,
+): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new Error(
+      `Expected ${allowed.join(" | ")} for ${field} in runtime identity snapshot ${filePath}.`,
+    );
+  }
+  return value as T;
+}

--- a/src/observability/runtime-identity.ts
+++ b/src/observability/runtime-identity.ts
@@ -45,9 +45,13 @@ export async function collectFactoryRuntimeIdentity(
   const detailParts: string[] = [];
 
   try {
-    const result = await execGit("git", ["show", "-s", "--format=%cI", "HEAD"], {
-      cwd: resolvedCheckoutPath,
-    });
+    const result = await execGit(
+      "git",
+      ["show", "-s", "--format=%cI", "HEAD"],
+      {
+        cwd: resolvedCheckoutPath,
+      },
+    );
     committedAt = normalizeOptionalText(result.stdout);
   } catch (error) {
     detailParts.push(
@@ -65,7 +69,9 @@ export async function collectFactoryRuntimeIdentity(
     );
     isDirty = result.stdout.trim().length > 0;
   } catch (error) {
-    detailParts.push(`dirty state unavailable: ${normalizeGitErrorMessage(error)}`);
+    detailParts.push(
+      `dirty state unavailable: ${normalizeGitErrorMessage(error)}`,
+    );
   }
 
   return {
@@ -145,7 +151,11 @@ export function parseFactoryRuntimeIdentity(
       filePath,
       `${field}.checkoutPath`,
     ),
-    headSha: expectNullableString(identity.headSha, filePath, `${field}.headSha`),
+    headSha: expectNullableString(
+      identity.headSha,
+      filePath,
+      `${field}.headSha`,
+    ),
     committedAt: expectNullableString(
       identity.committedAt,
       filePath,

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
+import {
+  parseFactoryRuntimeIdentity,
+  renderFactoryRuntimeIdentity,
+  type FactoryRuntimeIdentity,
+} from "./runtime-identity.js";
 import type {
   RunnerSessionDescription,
   RunnerVisibilityPhase,
@@ -101,6 +106,7 @@ export interface FactoryRetrySnapshot {
 export interface FactoryStatusSnapshot {
   readonly version: 1;
   readonly generatedAt: string;
+  readonly runtimeIdentity?: FactoryRuntimeIdentity | null;
   readonly publication?: FactoryStatusPublication;
   readonly factoryState: FactoryState;
   readonly worker: FactoryWorkerSnapshot;
@@ -238,6 +244,12 @@ export function renderFactoryStatusSnapshot(
   );
   lines.push(
     `Polling: every ${snapshot.worker.pollIntervalMs.toString()}ms, max concurrency ${snapshot.worker.maxConcurrentRuns.toString()}`,
+  );
+  lines.push(
+    `Runtime checkout: ${snapshot.runtimeIdentity?.checkoutPath ?? "unavailable"}`,
+  );
+  lines.push(
+    `Runtime version: ${renderFactoryRuntimeIdentity(snapshot.runtimeIdentity)}`,
   );
   if (options?.statusFilePath) {
     lines.push(`Snapshot file: ${options.statusFilePath}`);
@@ -494,6 +506,11 @@ function parseFactoryStatusSnapshot(
   return {
     version: 1,
     generatedAt: expectString(snapshot.generatedAt, filePath, "generatedAt"),
+    runtimeIdentity: parseFactoryRuntimeIdentity(
+      snapshot.runtimeIdentity,
+      filePath,
+      "runtimeIdentity",
+    ),
     publication: parsePublication(snapshot.publication, filePath),
     factoryState: expectEnum(
       snapshot.factoryState,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { OrchestratorError, RunnerAbortedError } from "../domain/errors.js";
 import type { HandoffLifecycle } from "../domain/handoff.js";
@@ -27,6 +28,11 @@ import {
   LocalIssueArtifactStore,
 } from "../observability/issue-artifacts.js";
 import type { Logger } from "../observability/logger.js";
+import {
+  collectFactoryRuntimeIdentity,
+  factoryRuntimeIdentityLogFields,
+  type FactoryRuntimeIdentity,
+} from "../observability/runtime-identity.js";
 import {
   deriveStatusFilePath,
   writeFactoryStatusSnapshot,
@@ -186,6 +192,7 @@ export class BootstrapOrchestrator implements Orchestrator {
   readonly #livenessProbe: LivenessProbe | null;
   readonly #watchdogConfig: WatchdogConfig;
   readonly #factoryStartedAt: number = Date.now();
+  readonly #runtimeIdentity: Promise<FactoryRuntimeIdentity>;
   #shutdownSignal: AbortSignal | undefined;
   #dashboardNotify: (() => void) | null = null;
   // Guard startup placeholder publication so a later initializing write cannot
@@ -201,6 +208,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     logger: Logger,
     issueArtifactStore?: IssueArtifactStore,
     livenessProbe?: LivenessProbe,
+    runtimeIdentity?: FactoryRuntimeIdentity,
   ) {
     this.#config = config;
     this.#promptBuilder = promptBuilder;
@@ -218,6 +226,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#statusFilePath = deriveStatusFilePath(config.workspace.root);
     this.#watchdogConfig = config.polling.watchdog ?? DEFAULT_WATCHDOG_CONFIG;
     this.#livenessProbe = livenessProbe ?? null;
+    this.#runtimeIdentity = Promise.resolve(
+      runtimeIdentity ??
+        collectFactoryRuntimeIdentity(path.dirname(config.workflowPath)),
+    );
   }
 
   setDashboardNotify(notify: (() => void) | null): void {
@@ -2666,6 +2678,7 @@ export class BootstrapOrchestrator implements Orchestrator {
 
   async #persistStatusSnapshot(): Promise<void> {
     try {
+      const runtimeIdentity = await this.#runtimeIdentity;
       await writeFactoryStatusSnapshot(
         this.#statusFilePath,
         buildFactoryStatusSnapshot({
@@ -2676,8 +2689,13 @@ export class BootstrapOrchestrator implements Orchestrator {
           maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
           activeLocalRuns: this.#state.runningIssueNumbers.size,
           retries: this.#state.retries,
+          runtimeIdentity,
         }),
       );
+      this.#logger.info("Published current factory status snapshot", {
+        statusFilePath: this.#statusFilePath,
+        ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+      });
       // Prevent a later #publishStartupStatusSnapshot call from overwriting
       // this current snapshot with an initializing placeholder.
       this.#startupStatusPublished = true;
@@ -2705,6 +2723,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       return;
     }
     try {
+      const runtimeIdentity = await this.#runtimeIdentity;
       await writeFactoryStatusSnapshot(
         this.#statusFilePath,
         buildFactoryStatusSnapshot({
@@ -2715,11 +2734,16 @@ export class BootstrapOrchestrator implements Orchestrator {
           maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
           activeLocalRuns: this.#state.runningIssueNumbers.size,
           retries: this.#state.retries,
+          runtimeIdentity,
           publicationState: "initializing",
           publicationDetail:
             "Factory startup is in progress; no current runtime snapshot is available yet.",
         }),
       );
+      this.#logger.info("Published startup factory status snapshot", {
+        statusFilePath: this.#statusFilePath,
+        ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+      });
       this.#startupStatusPublished = true;
     } catch (error) {
       this.#logger.warn("Failed to write startup status snapshot", {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -228,6 +228,8 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#livenessProbe = livenessProbe ?? null;
     this.#runtimeIdentity = Promise.resolve(
       runtimeIdentity ??
+        // `workflowPath` resolves to `<runtime-checkout>/symphony.yml` in the
+        // detached factory layout, so its parent is the live runtime checkout root.
         collectFactoryRuntimeIdentity(path.dirname(config.workflowPath)),
     );
   }

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -8,6 +8,7 @@ import type {
   FactoryStatusAction,
   FactoryStatusSnapshot,
 } from "../observability/status.js";
+import type { FactoryRuntimeIdentity } from "../observability/runtime-identity.js";
 
 export interface TrackerIssueCounts {
   readonly ready: number;
@@ -213,6 +214,7 @@ export function buildFactoryStatusSnapshot(input: {
   readonly maxConcurrentRuns: number;
   readonly activeLocalRuns: number;
   readonly retries: ReadonlyMap<number, RetryState>;
+  readonly runtimeIdentity?: FactoryRuntimeIdentity | null;
   readonly publicationState?: "current" | "initializing";
   readonly publicationDetail?: string | null;
 }): FactoryStatusSnapshot {
@@ -233,6 +235,7 @@ export function buildFactoryStatusSnapshot(input: {
   return {
     version: 1,
     generatedAt: new Date().toISOString(),
+    runtimeIdentity: input.runtimeIdentity ?? null,
     publication: {
       state: input.publicationState ?? "current",
       detail: input.publicationDetail ?? null,

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -160,6 +160,8 @@ export async function runStartupPreparation(options: {
   const preparer = options.preparer ?? createStartupPreparer(options.config);
   const workerPid = options.workerPid ?? process.pid;
   const artifactPath = deriveStartupFilePath(options.config.workspace.root);
+  // `workflowPath` resolves to `<runtime-checkout>/symphony.yml` in the
+  // detached factory layout, so its parent is the live runtime checkout root.
   const runtimeIdentity = await collectFactoryRuntimeIdentity(
     path.dirname(options.config.workflowPath),
   );

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -2,6 +2,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import {
+  collectFactoryRuntimeIdentity,
+  factoryRuntimeIdentityLogFields,
+  parseFactoryRuntimeIdentity,
+  type FactoryRuntimeIdentity,
+} from "../observability/runtime-identity.js";
 import { isAbortError } from "../support/abort.js";
 
 let startupWriteSequence = 0;
@@ -15,6 +21,7 @@ export interface StartupSnapshot {
   readonly workerPid: number;
   readonly provider: string;
   readonly summary: string | null;
+  readonly runtimeIdentity?: FactoryRuntimeIdentity | null;
 }
 
 export interface StartupPreparationSuccess {
@@ -47,6 +54,7 @@ export interface StartupPreparationOutcomeReady {
   readonly summary: string | null;
   readonly workspaceRepoUrlOverride: string | null;
   readonly artifactPath: string;
+  readonly runtimeIdentity: FactoryRuntimeIdentity;
 }
 
 export interface StartupPreparationOutcomeFailed {
@@ -55,6 +63,7 @@ export interface StartupPreparationOutcomeFailed {
   readonly summary: string;
   readonly workspaceRepoUrlOverride: null;
   readonly artifactPath: string;
+  readonly runtimeIdentity: FactoryRuntimeIdentity;
 }
 
 export type StartupPreparationOutcome =
@@ -151,10 +160,14 @@ export async function runStartupPreparation(options: {
   const preparer = options.preparer ?? createStartupPreparer(options.config);
   const workerPid = options.workerPid ?? process.pid;
   const artifactPath = deriveStartupFilePath(options.config.workspace.root);
+  const runtimeIdentity = await collectFactoryRuntimeIdentity(
+    path.dirname(options.config.workflowPath),
+  );
 
   options.logger.info("Startup preparation started", {
     provider: preparer.id,
     startupFilePath: artifactPath,
+    ...factoryRuntimeIdentityLogFields(runtimeIdentity),
   });
   await writeStartupSnapshot(artifactPath, {
     version: 1,
@@ -163,6 +176,7 @@ export async function runStartupPreparation(options: {
     workerPid,
     provider: preparer.id,
     summary: "Startup preparation is in progress.",
+    runtimeIdentity,
   });
 
   try {
@@ -179,11 +193,13 @@ export async function runStartupPreparation(options: {
         workerPid,
         provider: preparer.id,
         summary: result.summary,
+        runtimeIdentity,
       });
       options.logger.error("Startup preparation failed", {
         provider: preparer.id,
         startupFilePath: artifactPath,
         summary: result.summary,
+        ...factoryRuntimeIdentityLogFields(runtimeIdentity),
       });
       return {
         kind: "failed",
@@ -191,6 +207,7 @@ export async function runStartupPreparation(options: {
         summary: result.summary,
         workspaceRepoUrlOverride: null,
         artifactPath,
+        runtimeIdentity,
       };
     }
 
@@ -201,12 +218,14 @@ export async function runStartupPreparation(options: {
       workerPid,
       provider: preparer.id,
       summary: result.summary ?? "Startup preparation completed.",
+      runtimeIdentity,
     });
     options.logger.info("Startup preparation completed", {
       provider: preparer.id,
       startupFilePath: artifactPath,
       summary: result.summary ?? null,
       workspaceRepoUrlOverride: result.workspaceRepoUrlOverride ?? null,
+      ...factoryRuntimeIdentityLogFields(runtimeIdentity),
     });
     return {
       kind: "ready",
@@ -214,6 +233,7 @@ export async function runStartupPreparation(options: {
       summary: result.summary ?? null,
       workspaceRepoUrlOverride: result.workspaceRepoUrlOverride ?? null,
       artifactPath,
+      runtimeIdentity,
     };
   } catch (error) {
     if (isAbortError(error)) {
@@ -228,11 +248,13 @@ export async function runStartupPreparation(options: {
       workerPid,
       provider: preparer.id,
       summary,
+      runtimeIdentity,
     });
     options.logger.error("Startup preparation failed", {
       provider: preparer.id,
       startupFilePath: artifactPath,
       summary,
+      ...factoryRuntimeIdentityLogFields(runtimeIdentity),
     });
     return {
       kind: "failed",
@@ -240,6 +262,7 @@ export async function runStartupPreparation(options: {
       summary,
       workspaceRepoUrlOverride: null,
       artifactPath,
+      runtimeIdentity,
     };
   }
 }
@@ -264,6 +287,11 @@ function parseStartupSnapshot(
     workerPid: expectInteger(snapshot["workerPid"], filePath, "workerPid"),
     provider: expectString(snapshot["provider"], filePath, "provider"),
     summary: expectOptionalString(snapshot["summary"], filePath, "summary"),
+    runtimeIdentity: parseFactoryRuntimeIdentity(
+      snapshot["runtimeIdentity"],
+      filePath,
+      "runtimeIdentity",
+    ),
   };
 }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -519,6 +519,14 @@ describe("runCli run", () => {
         summary: null,
         workspaceRepoUrlOverride: null,
         artifactPath: "/tmp/factory-root/.tmp/startup.json",
+        runtimeIdentity: {
+          checkoutPath: "/tmp/factory-root",
+          headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+          committedAt: "2026-03-14T12:00:00.000Z",
+          isDirty: false,
+          source: "git",
+          detail: null,
+        },
       })),
     }));
     vi.doMock("../../src/workspace/local.js", () => ({
@@ -566,6 +574,10 @@ describe("runCli run", () => {
     expect(probeRoots).toEqual(["/tmp/factory-root"]);
     expect(orchestratorArgs).not.toBeNull();
     expect(orchestratorArgs?.[7]).toBeDefined();
+    expect(orchestratorArgs?.[8]).toMatchObject({
+      checkoutPath: "/tmp/factory-root",
+      headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+    });
     expect(runOnce).toHaveBeenCalledOnce();
   });
 
@@ -595,6 +607,14 @@ describe("runCli run", () => {
         summary: "Mirror refresh failed.",
         workspaceRepoUrlOverride: null,
         artifactPath: "/tmp/factory-root/.tmp/startup.json",
+        runtimeIdentity: {
+          checkoutPath: "/tmp/factory-root",
+          headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+          committedAt: "2026-03-14T12:00:00.000Z",
+          isDirty: false,
+          source: "git",
+          detail: null,
+        },
       })),
     }));
     vi.doMock("../../src/tracker/factory.js", () => ({

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -31,6 +31,14 @@ function createStatusSnapshot(
   return {
     version: 1,
     generatedAt: "2026-03-13T12:00:00.000Z",
+    runtimeIdentity: {
+      checkoutPath: "/repo/.tmp/factory-main",
+      headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+      committedAt: "2026-03-13T11:57:00.000Z",
+      isDirty: false,
+      source: "git",
+      detail: null,
+    },
     factoryState: "idle",
     worker: {
       instanceId: "worker-1",
@@ -64,6 +72,14 @@ function createStartupSnapshot(
     workerPid,
     provider: "github-bootstrap/noop",
     summary: "Startup preparation is in progress.",
+    runtimeIdentity: {
+      checkoutPath: "/repo/.tmp/factory-main",
+      headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+      committedAt: "2026-03-13T11:57:00.000Z",
+      isDirty: false,
+      source: "git",
+      detail: null,
+    },
     ...overrides,
   };
 }
@@ -1653,7 +1669,23 @@ describe("renderFactoryControlStatus", () => {
       sessionName: "symphony-factory",
       sessions: [],
       workerAlive: false,
-      startup: null,
+      startup: {
+        state: "ready",
+        provider: "github-bootstrap/noop",
+        summary: "Startup preparation completed.",
+        updatedAt: "2026-03-13T11:58:30.000Z",
+        workerPid: 4321,
+        workerAlive: false,
+        stale: false,
+        runtimeIdentity: {
+          checkoutPath: "/repo/.tmp/factory-main",
+          headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+          committedAt: "2026-03-13T11:57:00.000Z",
+          isDirty: false,
+          source: "git",
+          detail: null,
+        },
+      },
       snapshotFreshness: {
         freshness: "unavailable",
         reason: "missing-snapshot",
@@ -1668,6 +1700,9 @@ describe("renderFactoryControlStatus", () => {
 
     expect(output).toContain("Factory control: stopped");
     expect(output).toContain("Runtime root: /repo/.tmp/factory-main");
+    expect(output).toContain(
+      "Runtime version: 4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26 | committed 2026-03-13T11:57:00.000Z | clean",
+    );
     expect(output).toContain("Snapshot freshness: unavailable");
     expect(output).toContain(
       "Status detail: No runtime snapshot is available.",

--- a/tests/unit/runtime-identity.test.ts
+++ b/tests/unit/runtime-identity.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  collectFactoryRuntimeIdentity,
+  renderFactoryRuntimeIdentity,
+} from "../../src/observability/runtime-identity.js";
+import {
+  commitAllFiles,
+  createTempDir,
+  initializeGitRepo,
+} from "../support/git.js";
+
+describe("factory runtime identity", () => {
+  it("collects commit metadata from a git checkout", async () => {
+    const tempDir = await createTempDir("symphony-runtime-identity-git-");
+
+    try {
+      await initializeGitRepo(tempDir);
+      await fs.writeFile(path.join(tempDir, "README.md"), "# test\n", "utf8");
+      const sha = await commitAllFiles(tempDir, "initial commit");
+
+      const identity = await collectFactoryRuntimeIdentity(tempDir);
+
+      expect(identity).toMatchObject({
+        checkoutPath: tempDir,
+        headSha: sha,
+        source: "git",
+        isDirty: false,
+      });
+      expect(identity.committedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks the checkout dirty when tracked files change", async () => {
+    const tempDir = await createTempDir("symphony-runtime-identity-dirty-");
+
+    try {
+      await initializeGitRepo(tempDir);
+      const readmePath = path.join(tempDir, "README.md");
+      await fs.writeFile(readmePath, "# test\n", "utf8");
+      await commitAllFiles(tempDir, "initial commit");
+      await fs.writeFile(readmePath, "# dirty\n", "utf8");
+
+      const identity = await collectFactoryRuntimeIdentity(tempDir);
+
+      expect(identity.isDirty).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a normalized unavailable identity outside a git checkout", async () => {
+    const tempDir = await createTempDir("symphony-runtime-identity-plain-");
+
+    try {
+      const identity = await collectFactoryRuntimeIdentity(tempDir);
+
+      expect(identity).toMatchObject({
+        checkoutPath: tempDir,
+        headSha: null,
+        committedAt: null,
+        isDirty: null,
+        source: "not-a-git-checkout",
+      });
+      expect(renderFactoryRuntimeIdentity(identity)).toContain("unavailable");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -85,6 +85,9 @@ describe("startup service", () => {
         state: "ready",
         workerPid: 3210,
         provider: "github-bootstrap/noop",
+        runtimeIdentity: {
+          checkoutPath: tempDir,
+        },
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -122,6 +125,9 @@ describe("startup service", () => {
         workerPid: 6543,
         provider: "github-bootstrap/test-failure",
         summary: "Mirror refresh failed.",
+        runtimeIdentity: {
+          checkoutPath: tempDir,
+        },
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -157,6 +163,9 @@ describe("startup service", () => {
         state: "preparing",
         workerPid: 9876,
         provider: "github-bootstrap/test-abort",
+        runtimeIdentity: {
+          checkoutPath: tempDir,
+        },
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -18,6 +18,14 @@ function createSnapshot(
   return {
     version: 1,
     generatedAt: "2026-03-06T12:00:00.000Z",
+    runtimeIdentity: {
+      checkoutPath: "/tmp/repo/.tmp/factory-main",
+      headSha: "4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26",
+      committedAt: "2026-03-06T11:57:00.000Z",
+      isDirty: false,
+      source: "git",
+      detail: null,
+    },
     publication: {
       state: "current",
       detail: null,
@@ -305,6 +313,10 @@ describe("factory status helpers", () => {
     expect(output).toContain(
       "Counts: ready=1 tracker_running=2 failed=0 local=0 retries=1",
     );
+    expect(output).toContain("Runtime checkout: /tmp/repo/.tmp/factory-main");
+    expect(output).toContain(
+      "Runtime version: 4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26 | committed 2026-03-06T11:57:00.000Z | clean",
+    );
     expect(output).toContain(
       "#12 Expose factory status [awaiting-system-checks]",
     );
@@ -331,6 +343,27 @@ describe("factory status helpers", () => {
     expect(output).toContain("Snapshot freshness: stale");
     expect(output).toContain(
       "The recorded worker PID is offline, so this snapshot is historical and not current.",
+    );
+  });
+
+  it("renders unavailable runtime identity cleanly", () => {
+    const output = renderFactoryStatusSnapshot(
+      createSnapshot({
+        runtimeIdentity: {
+          checkoutPath: "/tmp/repo/.tmp/factory-main",
+          headSha: null,
+          committedAt: null,
+          isDirty: null,
+          source: "not-a-git-checkout",
+          detail: "fatal: not a git repository",
+        },
+        activeIssues: [],
+        retries: [],
+      }),
+    );
+
+    expect(output).toContain(
+      "Runtime version: unavailable (not-a-git-checkout: fatal: not a git repository)",
     );
   });
 


### PR DESCRIPTION
Closes #37

## Summary
- add a normalized runtime identity contract for startup and status snapshots
- surface the live runtime checkout version in `status`, `factory status`, and startup/status logs
- cover git-backed and unavailable identity cases with unit tests and update operator docs

## Checks
- pnpm typecheck
- pnpm lint
- pnpm test