### PR TITLE
Fix live Codex token_count event extraction

### DIFF
--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -65,7 +65,12 @@ function extractTokenDelta(
   const inputRaw =
     getMapKey(payload, ["input_tokens", "inputTokens"]) ??
     mapPath(payload, ["payload", "total_token_usage", "input_tokens"]) ??
-    mapPath(payload, ["payload", "info", "total_token_usage", "input_tokens"]) ??
+    mapPath(payload, [
+      "payload",
+      "info",
+      "total_token_usage",
+      "input_tokens",
+    ]) ??
     mapPath(payload, [
       "params",
       "msg",
@@ -95,7 +100,12 @@ function extractTokenDelta(
   const outputRaw =
     getMapKey(payload, ["output_tokens", "outputTokens"]) ??
     mapPath(payload, ["payload", "total_token_usage", "output_tokens"]) ??
-    mapPath(payload, ["payload", "info", "total_token_usage", "output_tokens"]) ??
+    mapPath(payload, [
+      "payload",
+      "info",
+      "total_token_usage",
+      "output_tokens",
+    ]) ??
     mapPath(payload, [
       "params",
       "msg",
@@ -125,7 +135,12 @@ function extractTokenDelta(
   const totalRaw =
     getMapKey(payload, ["total_tokens", "totalTokens"]) ??
     mapPath(payload, ["payload", "total_token_usage", "total_tokens"]) ??
-    mapPath(payload, ["payload", "info", "total_token_usage", "total_tokens"]) ??
+    mapPath(payload, [
+      "payload",
+      "info",
+      "total_token_usage",
+      "total_tokens",
+    ]) ??
     mapPath(payload, [
       "params",
       "msg",

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -64,6 +64,8 @@ function extractTokenDelta(
 ): TokenDelta {
   const inputRaw =
     getMapKey(payload, ["input_tokens", "inputTokens"]) ??
+    mapPath(payload, ["payload", "total_token_usage", "input_tokens"]) ??
+    mapPath(payload, ["payload", "info", "total_token_usage", "input_tokens"]) ??
     mapPath(payload, [
       "params",
       "msg",
@@ -92,6 +94,8 @@ function extractTokenDelta(
     mapPath(payload, ["usage", "input_tokens"]);
   const outputRaw =
     getMapKey(payload, ["output_tokens", "outputTokens"]) ??
+    mapPath(payload, ["payload", "total_token_usage", "output_tokens"]) ??
+    mapPath(payload, ["payload", "info", "total_token_usage", "output_tokens"]) ??
     mapPath(payload, [
       "params",
       "msg",
@@ -120,6 +124,8 @@ function extractTokenDelta(
     mapPath(payload, ["usage", "output_tokens"]);
   const totalRaw =
     getMapKey(payload, ["total_tokens", "totalTokens"]) ??
+    mapPath(payload, ["payload", "total_token_usage", "total_tokens"]) ??
+    mapPath(payload, ["payload", "info", "total_token_usage", "total_tokens"]) ??
     mapPath(payload, [
       "params",
       "msg",
@@ -197,6 +203,8 @@ function extractSessionId(
 ): string | null {
   const raw =
     getMapKey(payload, ["session_id", "sessionId"]) ??
+    mapPath(payload, ["payload", "sessionId"]) ??
+    mapPath(payload, ["payload", "session_id"]) ??
     mapPath(payload, ["params", "sessionId"]) ??
     mapPath(payload, ["params", "session_id"]) ??
     mapPath(payload, ["params", "msg", "payload", "session_id"]) ??

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { RunnerAbortedError, RunnerError } from "../domain/errors.js";
-import type { RunSession, RunTurn } from "../domain/run.js";
+import type { RunSession, RunTurn, RunUpdateEvent } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { describeLocalRunnerSession } from "./local-session-description.js";
+import { parseRunUpdateEvent } from "./run-update-event.js";
 import {
   buildCodexAppServerCommand,
   type CodexAppServerCommand,
@@ -64,6 +65,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   #nextTurnStartRequestId = TURN_START_FIRST_REQUEST_ID;
   #startupStderr = "";
   #currentOnEvent: ((event: RunnerEvent) => void | Promise<void>) | null = null;
+  #currentOnUpdate: ((event: RunUpdateEvent) => void) | null = null;
 
   constructor(config: AgentConfig, logger: Logger, session: RunSession) {
     this.#config = config;
@@ -121,6 +123,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
 
     try {
       this.#currentOnEvent = options?.onEvent ?? null;
+      this.#currentOnUpdate = options?.onUpdate ?? null;
       options?.signal?.addEventListener("abort", handleAbort, { once: true });
       await this.#emitVisibility({
         state: "starting",
@@ -137,6 +140,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       return await Promise.race([runPromise, timeoutPromise, abortPromise]);
     } finally {
       this.#currentOnEvent = null;
+      this.#currentOnUpdate = null;
       clearTimeout(timeoutHandle);
       options?.signal?.removeEventListener("abort", handleAbort);
     }
@@ -548,6 +552,20 @@ export class CodexAppServerSession implements LiveRunnerSession {
     if (message === null) {
       return;
     }
+
+    const update = parseRunUpdateEvent(payload);
+    if (update !== undefined) {
+      try {
+        this.#currentOnUpdate?.(update);
+      } catch (error) {
+        this.#logger.warn("Codex app-server onUpdate handler failed", {
+          runSessionId: this.#runSession.id,
+          error: error instanceof Error ? error.message : String(error),
+          event: update.event,
+        });
+      }
+    }
+
     if (message["id"] !== undefined) {
       this.#handleResponse(message);
       return;

--- a/src/runner/local-execution.ts
+++ b/src/runner/local-execution.ts
@@ -4,13 +4,9 @@ import { RunnerAbortedError, RunnerError } from "../domain/errors.js";
 import type { RunSession, RunUpdateEvent } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import { parseRunUpdateEvent } from "./run-update-event.js";
 import type { RunnerExecutionResult, RunnerRunOptions } from "./service.js";
 
-/**
- * Try to parse a single stdout line as a JSON event object.
- * Returns a RunUpdateEvent if the line is valid JSON with an event/method key,
- * or undefined otherwise.
- */
 function tryParseStdoutEvent(line: string): RunUpdateEvent | undefined {
   const trimmed = line.trim();
   if (trimmed === "") return undefined;
@@ -20,37 +16,7 @@ function tryParseStdoutEvent(line: string): RunUpdateEvent | undefined {
   } catch {
     return undefined;
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return undefined;
-  }
-  const obj = parsed as Record<string, unknown>;
-  // Prefer explicit "event" field, then drill into Codex JSON-RPC payload type
-  // (prefixed with codex/event/ to match wrapper event convention), then fall
-  // back to the raw "method" field.
-  const payloadType = extractPayloadType(obj);
-  const event =
-    typeof obj["event"] === "string"
-      ? obj["event"]
-      : payloadType !== undefined
-        ? `codex/event/${payloadType}`
-        : typeof obj["method"] === "string"
-          ? (obj["method"] as string)
-          : "unknown";
-  return { event, payload: parsed, timestamp: new Date().toISOString() };
-}
-
-function extractPayloadType(obj: Record<string, unknown>): string | undefined {
-  const params = obj["params"];
-  if (params === null || typeof params !== "object" || Array.isArray(params))
-    return undefined;
-  const msg = (params as Record<string, unknown>)["msg"];
-  if (msg === null || typeof msg !== "object" || Array.isArray(msg))
-    return undefined;
-  const payload = (msg as Record<string, unknown>)["payload"];
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload))
-    return undefined;
-  const type = (payload as Record<string, unknown>)["type"];
-  return typeof type === "string" ? type : undefined;
+  return parseRunUpdateEvent(parsed);
 }
 
 export interface LocalCommandExecutionOptions {

--- a/src/runner/run-update-event.ts
+++ b/src/runner/run-update-event.ts
@@ -3,7 +3,11 @@ import type { RunUpdateEvent } from "../domain/run.js";
 export function parseRunUpdateEvent(
   payload: unknown,
 ): RunUpdateEvent | undefined {
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
     return undefined;
   }
 

--- a/src/runner/run-update-event.ts
+++ b/src/runner/run-update-event.ts
@@ -1,0 +1,43 @@
+import type { RunUpdateEvent } from "../domain/run.js";
+
+export function parseRunUpdateEvent(
+  payload: unknown,
+): RunUpdateEvent | undefined {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  const obj = payload as Record<string, unknown>;
+  const payloadType = extractPayloadType(obj);
+  const event =
+    typeof obj["event"] === "string"
+      ? obj["event"]
+      : payloadType !== undefined
+        ? `codex/event/${payloadType}`
+        : typeof obj["method"] === "string"
+          ? (obj["method"] as string)
+          : "unknown";
+
+  return { event, payload, timestamp: new Date().toISOString() };
+}
+
+function extractPayloadType(obj: Record<string, unknown>): string | undefined {
+  if (obj["type"] === "event_msg") {
+    const payload = asRecord(obj["payload"]);
+    const type = payload?.["type"];
+    return typeof type === "string" ? type : undefined;
+  }
+
+  const params = asRecord(obj["params"]);
+  const msg = asRecord(params?.["msg"]);
+  const payload = asRecord(msg?.["payload"]);
+  const type = payload?.["type"];
+  return typeof type === "string" ? type : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -5,6 +5,10 @@ import type { RunSession } from "../../src/domain/run.js";
 import type { AgentConfig } from "../../src/domain/workflow.js";
 import { RunnerAbortedError } from "../../src/domain/errors.js";
 import { JsonLogger } from "../../src/observability/logger.js";
+import {
+  createRunningEntry,
+  integrateCodexUpdate,
+} from "../../src/orchestrator/running-entry.js";
 import { ClaudeCodeRunner } from "../../src/runner/claude-code.js";
 import {
   buildClaudeResumeCommand,
@@ -107,6 +111,7 @@ function createClaudeCodeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
 type FakeCodexMode =
   | "success"
   | "hang"
+  | "token-count-event-msg"
   | "turn-failed"
   | "turn-failed-null-params"
   | "turn-failed-without-params"
@@ -171,6 +176,21 @@ function completeTurn(turnId) {
   }
   if (mode === "malformed-stream") {
     process.stdout.write("not-json\\n");
+  }
+  if (mode === "token-count-event-msg") {
+    send({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: {
+            input_tokens: 123,
+            output_tokens: 45,
+            total_tokens: 168,
+          },
+        },
+      },
+    });
   }
   if (mode === "completed-null-params") {
     send({
@@ -921,6 +941,52 @@ describe("runners", () => {
         line: "not-json",
       }),
     );
+  });
+
+  it("forwards top-level event_msg token_count updates from the Codex app-server", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const runner = createCodexRunnerForMode(fakeCodex, "token-count-event-msg");
+    const liveSession = await runner.startSession(createSession());
+    const updates: Array<{ event: string; payload: unknown }> = [];
+
+    try {
+      await liveSession.runTurn(
+        {
+          turnNumber: 1,
+          prompt: "first",
+        },
+        {
+          onUpdate(event) {
+            updates.push({ event: event.event, payload: event.payload });
+          },
+        },
+      );
+    } finally {
+      await liveSession.close();
+    }
+
+    expect(updates).toContainEqual(
+      expect.objectContaining({
+        event: "codex/event/token_count",
+      }),
+    );
+
+    const tokenUpdate = updates.find(
+      (event) => event.event === "codex/event/token_count",
+    );
+    expect(tokenUpdate).toBeDefined();
+
+    const entry = createRunningEntry(87, "sociotechnica-org/symphony-ts#87", "open", 1);
+    integrateCodexUpdate(entry, {
+      event: tokenUpdate?.event ?? "unknown",
+      payload: tokenUpdate?.payload ?? {},
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(entry.codexTokenState).toBe("observed");
+    expect(entry.codexInputTokens).toBe(123);
+    expect(entry.codexOutputTokens).toBe(45);
+    expect(entry.codexTotalTokens).toBe(168);
   });
 
   it("completes a Codex turn when turn/completed omits params", async () => {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -976,7 +976,12 @@ describe("runners", () => {
     );
     expect(tokenUpdate).toBeDefined();
 
-    const entry = createRunningEntry(87, "sociotechnica-org/symphony-ts#87", "open", 1);
+    const entry = createRunningEntry(
+      87,
+      "sociotechnica-org/symphony-ts#87",
+      "open",
+      1,
+    );
     integrateCodexUpdate(entry, {
       event: tokenUpdate?.event ?? "unknown",
       payload: tokenUpdate?.payload ?? {},

--- a/tests/unit/running-entry.test.ts
+++ b/tests/unit/running-entry.test.ts
@@ -94,6 +94,38 @@ describe("integrateCodexUpdate", () => {
     expect(entry.codexTokenState).toBe("observed");
   });
 
+  it("extracts tokens from top-level Codex event_msg payloads", () => {
+    const entry = createRunningEntry(99, "issue-99", "open", 1);
+
+    const result = integrateCodexUpdate(entry, {
+      event: "codex/event/token_count",
+      payload: {
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 123,
+              output_tokens: 45,
+              total_tokens: 168,
+            },
+          },
+        },
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(result.tokenDelta).toEqual({
+      inputTokens: 123,
+      outputTokens: 45,
+      totalTokens: 168,
+    });
+    expect(entry.codexInputTokens).toBe(123);
+    expect(entry.codexOutputTokens).toBe(45);
+    expect(entry.codexTotalTokens).toBe(168);
+    expect(entry.codexTokenState).toBe("observed");
+  });
+
   it("extracts session ID from nested Codex JSON-RPC payload", () => {
     const entry = createRunningEntry(99, "issue-99", "open", 1);
 


### PR DESCRIPTION
Closes #158

## Summary
- normalize live runner updates through a shared parser that recognizes top-level Codex `event_msg` payloads
- forward live app-server token_count events through `onUpdate` and teach running-entry extraction the current top-level payload shape
- add extraction-level regression coverage for live `event_msg/token_count` updates and their integration into token accounting

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test