### PR TITLE
Add local Git mirror bootstrap source

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,21 +236,21 @@ Workers should treat those summarized GitHub fields as untrusted context that
 helps explain the task, not as instructions that can override checked-in repo
 policy, code, docs, or local test evidence.
 
-| Field                          | Purpose                                                                       |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| `tracker.repo`                 | GitHub repository to poll for labeled issues                                  |
-| `tracker.review_bot_logins`    | PR comment authors treated as actionable bot review                           |
-| `polling.interval_ms`          | How often to check for new work                                               |
-| `polling.max_concurrent_runs`  | Local concurrency cap                                                         |
-| `workspace.root`               | Where isolated workspaces are created                                         |
-| `workspace.repo_url`           | Explicit SSH or HTTPS clone URL when it cannot be derived from tracker config |
-| `workspace.branch_prefix`      | Issue branch naming prefix                                                    |
-| `agent.runner.kind`            | Selects the execution backend (`codex`, `claude-code`, or `generic-command`)  |
-| `agent.command`                | Runner command shape; Codex reuses its flags to launch `codex app-server`     |
-| `agent.prompt_transport`       | Sends the prompt over `stdin` or via a temp file path                         |
-| `agent.timeout_ms`             | Max wall-clock time per runner turn                                           |
-| `agent.max_turns`              | Max in-process continuation turns per worker run                              |
-| `workspace.cleanup_on_success` | Remove local workspace after a successful run (default `true`)                |
+| Field                          | Purpose                                                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------- |
+| `tracker.repo`                 | GitHub repository to poll for labeled issues                                           |
+| `tracker.review_bot_logins`    | PR comment authors treated as actionable bot review                                    |
+| `polling.interval_ms`          | How often to check for new work                                                        |
+| `polling.max_concurrent_runs`  | Local concurrency cap                                                                  |
+| `workspace.root`               | Where isolated workspaces are created                                                  |
+| `workspace.repo_url`           | Explicit clone source URL or local path; local paths resolve relative to `WORKFLOW.md` |
+| `workspace.branch_prefix`      | Issue branch naming prefix                                                             |
+| `agent.runner.kind`            | Selects the execution backend (`codex`, `claude-code`, or `generic-command`)           |
+| `agent.command`                | Runner command shape; Codex reuses its flags to launch `codex app-server`              |
+| `agent.prompt_transport`       | Sends the prompt over `stdin` or via a temp file path                                  |
+| `agent.timeout_ms`             | Max wall-clock time per runner turn                                                    |
+| `agent.max_turns`              | Max in-process continuation turns per worker run                                       |
+| `workspace.cleanup_on_success` | Remove local workspace after a successful run (default `true`)                         |
 
 `agent.timeout_ms` applies to each runner turn. If `agent.max_turns` is greater
 than `1`, a single worker run can consume multiple per-turn timeout windows
@@ -258,9 +258,13 @@ before it exits.
 
 For `tracker.kind: github-bootstrap`, Symphony can derive the workspace clone
 URL from `tracker.repo` (or `SYMPHONY_REPO`) for the normal bootstrap flow.
-Set `workspace.repo_url` explicitly when you want to override that derived URL
-or when using a tracker/config path that does not provide enough repository
-information on its own.
+On startup, that GitHub bootstrap path now creates or refreshes a local bare
+mirror under `.tmp/github/upstream` and clones per-issue workspaces from that
+mirror instead of hitting GitHub directly. Set `workspace.repo_url` explicitly
+when you want to override the derived source or when using a tracker/config
+path that does not provide enough repository information on its own. Explicit
+local-path `workspace.repo_url` values are resolved relative to the owning
+`WORKFLOW.md`.
 
 `agent.runner.kind` keeps backend selection in `WORKFLOW.md`. Use `codex` for
 the built-in long-lived Codex app-server path, `claude-code` for the first-class

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -41,7 +41,9 @@ For the bootstrap GitHub flow, Symphony can derive the workspace clone URL from
 
 That means the local orchestrator will poll the real `symphony-ts` GitHub repo
 and create issue branches inside local workspaces cloned from that same
-repository.
+repository. Startup now refreshes a local bare mirror under
+`.tmp/github/upstream` first, so those per-issue workspaces clone from the
+local mirror instead of directly from GitHub.
 
 ### 3. Create a real GitHub issue
 

--- a/docs/plans/088-local-git-mirror-workspace-source/plan.md
+++ b/docs/plans/088-local-git-mirror-workspace-source/plan.md
@@ -1,0 +1,266 @@
+# Issue 88 Plan: Local Git Mirror Workspace Source For GitHub Bootstrap
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Land the local-mirror portion of closed PR `#75` as a repo-owned slice by teaching the GitHub bootstrap startup path to maintain a local mirror, then letting workspace creation clone from that mirror instead of cloning directly from GitHub.
+
+The slice should preserve the startup contract added in `#86`, keep GitHub-specific mirror behavior at the edge, and make workspace preparation default-branch aware instead of hardcoding `main`.
+
+## Scope
+
+- add a GitHub-bootstrap startup preparer that creates or refreshes a local bare mirror from the configured source remote
+- return a local-path workspace source override from startup preparation so workspaces can clone from the mirror
+- resolve local-path `workspace.repo_url` values relative to `WORKFLOW.md`
+- make workspace reset/branch creation default-branch aware by consulting the remote HEAD instead of assuming `main`
+- add tests for fresh mirror creation, incremental mirror refresh, local-path config resolution, and workspace reuse against non-`main` default branches
+- update operator-facing docs to describe the mirror-backed bootstrap path and local-path `workspace.repo_url` behavior
+
+## Non-goals
+
+- prompt-content changes from closed PR `#75`
+- new wrapper CLIs or alternate startup entrypoints
+- tracker trust-policy redesign
+- broader workspace-manager refactors unrelated to source selection / default-branch resolution
+- non-GitHub tracker mirror support in this issue
+
+## Current Gaps
+
+- `src/startup/service.ts` still selects a GitHub bootstrap no-op preparer, so startup preparation cannot harden or normalize the workspace clone source yet
+- `src/workspace/local.ts` clones and fetches directly from `workspace.repoUrl`, which means bootstrap runs still trust the configured GitHub remote directly
+- workspace preparation hardcodes `main` when resetting the base branch, so repos with `master` or any other default branch do not get a correct clean base checkout
+- `src/config/workflow.ts` trims `workspace.repo_url` as a string but does not resolve local filesystem paths relative to the owning `WORKFLOW.md`
+- existing tests cover derived GitHub clone URLs and direct local remotes, but not a startup-managed local mirror lifecycle or default-branch-aware reuse
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned rule that GitHub bootstrap may prepare a local mirror during startup and hand that mirror path to workspace creation
+  - belongs: the rule that workspace checkout follows the source repo default branch, not a hardcoded branch name
+  - does not belong: raw git subprocess wiring or filesystem path joins
+- Configuration Layer
+  - belongs: resolving `workspace.repo_url` as either a remote URL or a local path relative to `WORKFLOW.md`
+  - belongs: preserving the configured remote source URL separately from any startup-produced local override
+  - does not belong: mirror refresh commands or branch checkout logic
+- Coordination Layer
+  - belongs: unchanged startup orchestration contract from `#86`, which executes one startup preparer before the runtime starts
+  - does not belong: tracker API behavior, workspace git state, or prompt policy
+- Execution Layer
+  - belongs: git mirror creation/refresh, workspace clone source selection, default-branch-aware checkout/reset, and diagnosable workspace-prep failures
+  - does not belong: GitHub issue/PR policy or tracker comment parsing
+- Integration Layer
+  - belongs: GitHub-bootstrap-specific startup preparer selection and source-remote handling
+  - does not belong: generic workspace branch-reset policy that should remain tracker-agnostic once the source path is chosen
+- Observability Layer
+  - belongs: structured startup/workspace logs that show mirror create/refresh activity and explicit failure summaries
+  - does not belong: deciding whether the GitHub bootstrap path should use a mirror at all
+
+## Architecture Boundaries
+
+### Configuration
+
+Belongs here:
+
+- typed workflow resolution for `workspace.repo_url`
+- resolving local filesystem values relative to `path.dirname(workflowPath)`
+- keeping the configured source remote URL/path distinct from any startup-produced override
+
+Does not belong here:
+
+- `git clone --mirror` / `git remote update` subprocesses
+- startup artifact writing
+- workspace branch checkout decisions
+
+### Startup / GitHub bootstrap integration
+
+Belongs here:
+
+- a GitHub-bootstrap startup preparer that owns the local mirror lifecycle
+- deriving a stable mirror location under the runtime-owned temp area, matching the repo-owned `github/upstream` intent
+- returning `workspaceRepoUrlOverride` so the rest of the runtime can consume a local mirror path without duplicating GitHub logic
+
+Does not belong here:
+
+- issue polling or tracker review policy
+- per-issue workspace branch creation
+- prompt text changes
+
+### Workspace
+
+Belongs here:
+
+- clone/fetch/reset operations against the resolved source repo path
+- determining the source remote default branch from `origin/HEAD` with narrow fallbacks
+- reusing the existing branch-reset behavior while basing it on the resolved default branch
+
+Does not belong here:
+
+- deciding where the GitHub mirror lives
+- GitHub API calls or tracker-specific policy
+- startup status persistence
+
+### Tracker / orchestrator
+
+- tracker
+  - remains responsible for normalized GitHub issue/PR state only
+  - must not absorb mirror filesystem management
+- orchestrator
+  - continues to consume the startup outcome and invoke workspace preparation
+  - must not inline mirror refresh branches or GitHub-specific git policy
+
+### Observability
+
+Belongs here:
+
+- startup and workspace logs for mirror create/refresh, chosen source path, default branch, and failures
+
+Does not belong here:
+
+- retry policy or hidden fallback behavior that would mask git failures
+
+## Decision Notes
+
+- Reuse the startup-preparation seam from `#86` instead of adding another wrapper command. That keeps mirror setup on the canonical `run` path and keeps detached control behavior consistent.
+- Keep the GitHub mirror lifecycle in a focused startup module so the workspace layer only receives a resolved source path and default-branch facts.
+- Preserve one reviewable PR by limiting this slice to source preparation and workspace consumption. Prompt trust-surface changes from `#75` remain explicitly deferred.
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR with one narrow seam:
+
+1. replace the GitHub bootstrap startup no-op with a real local-mirror preparer
+2. thread the startup-produced local source override into workspace preparation
+3. make workflow repo-path resolution and workspace default-branch detection support that source cleanly
+4. add focused tests and docs
+
+Deferred from this PR:
+
+- prompt-content filtering or startup prompt-hardening changes from `#75`
+- alternate startup wrappers or operator CLI variants
+- tracker-side trust or repository-identity redesign
+- mirror reuse for non-GitHub trackers
+
+This seam is reviewable because it stays within startup/config/workspace behavior. It does not combine tracker transport changes, orchestrator retry-state changes, or prompt rewrites in the same patch.
+
+## Runtime State Model
+
+The startup lifecycle already exists from `#86`; this issue adds a concrete GitHub-bootstrap provider and a narrower workspace source contract.
+
+### Startup provider states
+
+1. `preparing`
+   - startup selected the GitHub mirror preparer and is inspecting or refreshing the mirror
+2. `ready`
+   - the mirror is usable and startup returns a local workspace source override
+3. `failed`
+   - mirror creation or refresh failed terminally and startup exits non-zero
+
+### Workspace source states
+
+1. `configured-source`
+   - config resolved the raw `workspace.repo_url` value, either derived from `tracker.repo` or explicitly configured
+2. `startup-override`
+   - startup returned a local mirror path that supersedes the configured source for workspace cloning
+3. `workspace-ready`
+   - the workspace cloned/fetched from the resolved source and reset to the source default branch before checking out the issue branch
+
+### Allowed transitions
+
+- `configured-source -> startup-override`
+- `configured-source -> failed`
+- `startup-override -> workspace-ready`
+- `startup-override -> failed`
+
+### Decision facts
+
+The startup/workspace seam should decide from:
+
+- resolved workflow config
+- filesystem existence/type of the mirror path
+- git facts from the configured source remote and the mirror clone
+- remote default-branch facts from `origin/HEAD` plus explicit `main` / `master` fallbacks only when `origin/HEAD` is absent
+
+The seam should not decide from:
+
+- tracker issue state
+- prompt contents
+- orchestrator retry counters
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized startup/workspace facts available | Expected decision |
+| --- | --- | --- | --- |
+| Mirror path absent on first startup | configured source URL/path, target mirror path | no existing mirror | create bare mirror, return local override path |
+| Mirror exists and source has new commits | existing mirror repo, configured source, `git remote update --prune` succeeds | remote HEAD resolves to current default branch | reuse mirror path, workspace later fetches new refs from mirror |
+| Mirror exists but configured source remote is unreachable | existing mirror repo, git error text | startup provider selected for GitHub bootstrap | fail startup loudly with provider/source/mirror path in the error summary; do not silently use stale data |
+| Configured `workspace.repo_url` is a relative local path | workflow path, raw config value | config resolves absolute repo path | use resolved absolute path as the source remote for mirror creation or direct workspace cloning |
+| Workspace clone source remote default branch is `master` | workspace git checkout, `refs/remotes/origin/HEAD` resolves to `origin/master` | default branch resolved as `master` | reset workspace to `origin/master` before issue-branch handling |
+| Source remote has no `origin/HEAD` symbolic ref but `origin/main` exists | workspace git checkout | `origin/HEAD` absent, `origin/main` exists | fall back to `main` and proceed |
+| Source remote has neither `origin/HEAD` nor known fallback refs | workspace git checkout, git verification failure | no default branch resolved | fail workspace preparation loudly with diagnosable error |
+
+## Storage / Persistence Contract
+
+- mirror state is stored as a local bare Git repository under the runtime-owned temp area, not under a per-issue workspace
+- the startup snapshot remains the transient status surface; it does not become the system of record for mirror refs
+- the mirror path should be deterministic from the workspace/runtime root so repeated runs reuse the same local cache
+- no new tracker-side persistence is introduced in this issue
+
+## Observability Requirements
+
+- startup logs must identify whether the mirror was created fresh or refreshed in place
+- startup failures must include enough context to diagnose the failing source remote and local mirror path
+- workspace logs should record the resolved source path and detected default branch when preparing a workspace
+- failures from local-path resolution, mirror setup, and default-branch detection should stay loud instead of silently falling back to a potentially wrong branch or stale source
+
+## Implementation Steps
+
+1. Add a focused GitHub-bootstrap mirror preparer under `src/startup/` that:
+   - derives the local mirror path from the runtime/workspace root
+   - creates the mirror with `git clone --mirror` on first use
+   - refreshes an existing mirror from the configured source remote before each run
+   - returns the mirror path as `workspaceRepoUrlOverride`
+2. Replace the GitHub bootstrap no-op startup provider selection with the new mirror preparer while leaving other trackers on the existing no-op path.
+3. Update workflow config resolution so explicit local-path `workspace.repo_url` values resolve relative to `WORKFLOW.md`; leave remote URLs and scp-style git URLs unchanged.
+4. Thread the startup-produced source override into workspace preparation and make `LocalWorkspaceManager` resolve the source default branch from `origin/HEAD` before resetting the base branch.
+5. Keep workspace error handling explicit and update logs so mirror/default-branch failures remain diagnosable.
+6. Update docs covering the self-hosting/bootstrap flow and any config reference text that describes `workspace.repo_url`.
+
+## Tests And Acceptance Scenarios
+
+### Unit / focused tests
+
+- workflow config: relative local `workspace.repo_url` resolves against `WORKFLOW.md`; remote URLs and scp-style git remotes are preserved unchanged
+- startup mirror preparer: creates a mirror on first run and returns a local override path
+- startup mirror preparer: refreshes an existing mirror and exposes new upstream commits on a later run
+- startup mirror preparer: reports a clear failure when mirror creation or refresh fails
+- workspace manager: resolves `origin/master` via `origin/HEAD` and resets the workspace against that branch instead of `main`
+- workspace manager: fails clearly when no default branch can be resolved
+
+### Integration / end-to-end scenarios
+
+1. Given a GitHub-bootstrap workflow and no existing mirror, when startup runs, then it creates `github/upstream`, returns that path, and the first workspace clone succeeds from the mirror.
+2. Given an existing mirror and a new upstream commit on the source remote, when a later startup runs, then the mirror refresh exposes the new commit and a reused workspace fetch/reset sees the update.
+3. Given a source remote whose default branch is `master`, when a workspace is prepared, then the issue branch starts from `origin/master` and not from a nonexistent `origin/main`.
+4. Given a relative local `workspace.repo_url`, when `WORKFLOW.md` is loaded from a temp repo, then the resolved source path is absolute and points at the sibling local repository.
+5. Given a broken source remote or corrupted mirror bootstrap setup, when startup runs, then the run fails before orchestration starts and reports a diagnosable mirror error.
+
+## Exit Criteria
+
+- GitHub bootstrap startup creates or refreshes a reusable local mirror and returns it as the workspace clone source
+- workspace preparation can clone from that local mirror path successfully
+- workspace default-branch handling is no longer hardcoded to `main`
+- relative local `workspace.repo_url` values resolve correctly against `WORKFLOW.md`
+- tests cover fresh mirror creation, incremental refresh, and non-`main` default branches
+- docs describe the repo-owned mirror behavior and local-path config rule
+
+## Deferred To Later Issues Or PRs
+
+- prompt hardening / injection-surface changes from closed PR `#75`
+- any richer mirror health policy such as stale-but-usable fallback or background sync
+- cross-tracker startup source normalization
+- operator controls for mirror inspection, pruning, or relocation

--- a/docs/plans/088-local-git-mirror-workspace-source/plan.md
+++ b/docs/plans/088-local-git-mirror-workspace-source/plan.md
@@ -193,15 +193,15 @@ The seam should not decide from:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized startup/workspace facts available | Expected decision |
-| --- | --- | --- | --- |
-| Mirror path absent on first startup | configured source URL/path, target mirror path | no existing mirror | create bare mirror, return local override path |
-| Mirror exists and source has new commits | existing mirror repo, configured source, `git remote update --prune` succeeds | remote HEAD resolves to current default branch | reuse mirror path, workspace later fetches new refs from mirror |
-| Mirror exists but configured source remote is unreachable | existing mirror repo, git error text | startup provider selected for GitHub bootstrap | fail startup loudly with provider/source/mirror path in the error summary; do not silently use stale data |
-| Configured `workspace.repo_url` is a relative local path | workflow path, raw config value | config resolves absolute repo path | use resolved absolute path as the source remote for mirror creation or direct workspace cloning |
-| Workspace clone source remote default branch is `master` | workspace git checkout, `refs/remotes/origin/HEAD` resolves to `origin/master` | default branch resolved as `master` | reset workspace to `origin/master` before issue-branch handling |
-| Source remote has no `origin/HEAD` symbolic ref but `origin/main` exists | workspace git checkout | `origin/HEAD` absent, `origin/main` exists | fall back to `main` and proceed |
-| Source remote has neither `origin/HEAD` nor known fallback refs | workspace git checkout, git verification failure | no default branch resolved | fail workspace preparation loudly with diagnosable error |
+| Observed condition                                                       | Local facts available                                                          | Normalized startup/workspace facts available   | Expected decision                                                                                         |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Mirror path absent on first startup                                      | configured source URL/path, target mirror path                                 | no existing mirror                             | create bare mirror, return local override path                                                            |
+| Mirror exists and source has new commits                                 | existing mirror repo, configured source, `git remote update --prune` succeeds  | remote HEAD resolves to current default branch | reuse mirror path, workspace later fetches new refs from mirror                                           |
+| Mirror exists but configured source remote is unreachable                | existing mirror repo, git error text                                           | startup provider selected for GitHub bootstrap | fail startup loudly with provider/source/mirror path in the error summary; do not silently use stale data |
+| Configured `workspace.repo_url` is a relative local path                 | workflow path, raw config value                                                | config resolves absolute repo path             | use resolved absolute path as the source remote for mirror creation or direct workspace cloning           |
+| Workspace clone source remote default branch is `master`                 | workspace git checkout, `refs/remotes/origin/HEAD` resolves to `origin/master` | default branch resolved as `master`            | reset workspace to `origin/master` before issue-branch handling                                           |
+| Source remote has no `origin/HEAD` symbolic ref but `origin/main` exists | workspace git checkout                                                         | `origin/HEAD` absent, `origin/main` exists     | fall back to `main` and proceed                                                                           |
+| Source remote has neither `origin/HEAD` nor known fallback refs          | workspace git checkout, git verification failure                               | no default branch resolved                     | fail workspace preparation loudly with diagnosable error                                                  |
 
 ## Storage / Persistence Contract
 

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -304,6 +304,7 @@ function resolveRepoUrl(
   explicitRepoUrl: unknown,
   derivedRepoUrl: string | undefined,
   envOverrideActive: boolean,
+  workflowPath: string,
 ): string {
   // When SYMPHONY_REPO is set, the derived URL always wins so the factory
   // polls, clones, and pushes to the same repo.
@@ -328,7 +329,27 @@ function resolveRepoUrl(
     );
   }
 
-  return requireString(explicitRepoUrl, "workspace.repo_url");
+  return resolveWorkspaceRepoUrl(
+    requireString(explicitRepoUrl, "workspace.repo_url"),
+    workflowPath,
+  );
+}
+
+function resolveWorkspaceRepoUrl(
+  repoUrl: string,
+  workflowPath: string,
+): string {
+  if (isRemoteRepoUrl(repoUrl)) {
+    return repoUrl;
+  }
+  return path.resolve(path.dirname(workflowPath), repoUrl);
+}
+
+function isRemoteRepoUrl(repoUrl: string): boolean {
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(repoUrl)) {
+    return true;
+  }
+  return /^[^/\\\s]+@[^:/\\\s]+:.+$/.test(repoUrl);
 }
 
 function resolveObservabilityConfig(
@@ -445,6 +466,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         workspace["repo_url"],
         derivedRepoUrl,
         repoOverride !== undefined,
+        workflowPath,
       ),
       branchPrefix: requireString(
         workspace["branch_prefix"],

--- a/src/startup/github-mirror.ts
+++ b/src/startup/github-mirror.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { ResolvedConfig } from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import type { StartupPreparationResult, StartupPreparer } from "./service.js";
+
+const execFile = promisify(execFileCallback);
+
+function formatExecError(error: unknown): string {
+  const err = error as NodeJS.ErrnoException & {
+    readonly stderr?: string;
+    readonly stdout?: string;
+  };
+  const details = [err.stderr, err.stdout, err.message]
+    .map((value) => value?.trim())
+    .find((value) => value !== undefined && value.length > 0);
+  return details ?? "git command failed";
+}
+
+async function execGit(
+  args: readonly string[],
+  options: {
+    readonly cwd?: string | undefined;
+    readonly signal?: AbortSignal | undefined;
+  } = {},
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await execFile("git", [...args], {
+    cwd: options.cwd,
+    signal: options.signal,
+  });
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.stat(targetPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function ensureBareMirror(
+  mirrorPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const result = await execGit(["rev-parse", "--is-bare-repository"], {
+    cwd: mirrorPath,
+    signal,
+  });
+  if (result.stdout.trim() !== "true") {
+    throw new Error(`${mirrorPath} is not a bare git repository.`);
+  }
+}
+
+async function resolveSourceDefaultBranch(
+  sourceRepoUrl: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const result = await execGit(
+    ["ls-remote", "--symref", sourceRepoUrl, "HEAD"],
+    {
+      signal,
+    },
+  );
+  const match = result.stdout.match(/^ref:\s+refs\/heads\/([^\t\n]+)\tHEAD$/m);
+  if (match?.[1] === undefined || match[1].trim() === "") {
+    throw new Error(
+      `Could not resolve the source default branch from HEAD for ${sourceRepoUrl}.`,
+    );
+  }
+  return match[1].trim();
+}
+
+export function deriveGitHubMirrorPath(workspaceRoot: string): string {
+  return path.join(path.dirname(workspaceRoot), "github", "upstream");
+}
+
+export class GitHubMirrorStartupPreparer implements StartupPreparer {
+  readonly id = "github-bootstrap/local-mirror";
+
+  async prepare(context: {
+    readonly config: ResolvedConfig;
+    readonly logger: Logger;
+    readonly signal?: AbortSignal | undefined;
+  }): Promise<StartupPreparationResult> {
+    const sourceRepoUrl = context.config.workspace.repoUrl;
+    const mirrorPath = deriveGitHubMirrorPath(context.config.workspace.root);
+    const mirrorParent = path.dirname(mirrorPath);
+
+    try {
+      const defaultBranch = await resolveSourceDefaultBranch(
+        sourceRepoUrl,
+        context.signal,
+      );
+      const exists = await pathExists(mirrorPath);
+
+      await fs.mkdir(mirrorParent, { recursive: true });
+
+      if (!exists) {
+        context.logger.info("Creating GitHub bootstrap mirror", {
+          sourceRepoUrl,
+          mirrorPath,
+          defaultBranch,
+        });
+        await execGit(["clone", "--mirror", sourceRepoUrl, mirrorPath], {
+          signal: context.signal,
+        });
+      } else {
+        await ensureBareMirror(mirrorPath, context.signal);
+        context.logger.info("Refreshing GitHub bootstrap mirror", {
+          sourceRepoUrl,
+          mirrorPath,
+          defaultBranch,
+        });
+        await execGit(["remote", "set-url", "origin", sourceRepoUrl], {
+          cwd: mirrorPath,
+          signal: context.signal,
+        });
+        await execGit(["remote", "update", "--prune", "origin"], {
+          cwd: mirrorPath,
+          signal: context.signal,
+        });
+      }
+
+      await execGit(["symbolic-ref", "HEAD", `refs/heads/${defaultBranch}`], {
+        cwd: mirrorPath,
+        signal: context.signal,
+      });
+
+      const action = exists ? "refreshed" : "created";
+      context.logger.info("GitHub bootstrap mirror ready", {
+        sourceRepoUrl,
+        mirrorPath,
+        defaultBranch,
+        action,
+      });
+      return {
+        kind: "ready",
+        summary: `GitHub bootstrap mirror ${action} at ${mirrorPath}.`,
+        workspaceRepoUrlOverride: mirrorPath,
+      };
+    } catch (error) {
+      const summary = `GitHub bootstrap mirror setup failed for source ${sourceRepoUrl} at ${mirrorPath}: ${formatExecError(
+        error,
+      )}`;
+      context.logger.error("GitHub bootstrap mirror setup failed", {
+        sourceRepoUrl,
+        mirrorPath,
+        error: formatExecError(error),
+      });
+      return {
+        kind: "failed",
+        summary,
+      };
+    }
+  }
+}

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -9,6 +9,7 @@ import {
   type FactoryRuntimeIdentity,
 } from "../observability/runtime-identity.js";
 import { isAbortError } from "../support/abort.js";
+import { GitHubMirrorStartupPreparer } from "./github-mirror.js";
 
 let startupWriteSequence = 0;
 
@@ -142,7 +143,7 @@ export function parseStartupSnapshotContent(
 export function createStartupPreparer(config: ResolvedConfig): StartupPreparer {
   switch (config.tracker.kind) {
     case "github-bootstrap":
-      return new NoOpStartupPreparer("github-bootstrap/noop");
+      return new GitHubMirrorStartupPreparer();
     case "linear":
       return new NoOpStartupPreparer("linear/noop");
     default:

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -59,6 +59,54 @@ async function branchAheadCount(
   return Number(result.stdout.trim() || "0");
 }
 
+async function syncOriginHead(cwd: string): Promise<void> {
+  try {
+    await execFileAsync("git", ["remote", "set-head", "origin", "--auto"], {
+      cwd,
+    });
+  } catch {
+    // Some remotes do not advertise HEAD; default-branch resolution handles
+    // the explicit fallback/error path after fetch.
+  }
+}
+
+async function remoteRefExists(cwd: string, refName: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["show-ref", "--verify", "--quiet", refName], {
+      cwd,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveDefaultBranch(cwd: string): Promise<string> {
+  try {
+    const result = await execFileAsync(
+      "git",
+      ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+      { cwd },
+    );
+    const branchRef = result.stdout.trim();
+    if (branchRef.startsWith("origin/")) {
+      return branchRef.slice("origin/".length);
+    }
+  } catch {
+    // Fall through to explicit fallback refs below.
+  }
+
+  for (const branchName of ["main", "master"]) {
+    if (await remoteRefExists(cwd, `refs/remotes/origin/${branchName}`)) {
+      return branchName;
+    }
+  }
+
+  throw new WorkspaceError(
+    `Could not resolve the default branch for origin in ${cwd}. Expected refs/remotes/origin/HEAD or a known fallback branch.`,
+  );
+}
+
 export class LocalWorkspaceManager implements WorkspaceManager {
   readonly #config: WorkspaceConfig;
   readonly #afterCreate: readonly string[];
@@ -99,6 +147,9 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     }
 
     await execFileAsync("git", ["fetch", "origin"], { cwd: workspacePath });
+    await syncOriginHead(workspacePath);
+    const defaultBranch = await resolveDefaultBranch(workspacePath);
+    const defaultBranchRef = `origin/${defaultBranch}`;
     const hasBranch = await branchExists(workspacePath, branchName);
     const hasRemoteTrackingBranch = await remoteTrackingBranchExists(
       workspacePath,
@@ -113,15 +164,21 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         cwd: workspacePath,
       });
     } else {
-      await execFileAsync("git", ["checkout", "main"], { cwd: workspacePath });
-      await execFileAsync("git", ["reset", "--hard", "origin/main"], {
+      await execFileAsync(
+        "git",
+        ["checkout", "-B", defaultBranch, defaultBranchRef],
+        {
+          cwd: workspacePath,
+        },
+      );
+      await execFileAsync("git", ["reset", "--hard", defaultBranchRef], {
         cwd: workspacePath,
       });
 
       if (hasBranch) {
         const aheadCount = await branchAheadCount(
           workspacePath,
-          "origin/main",
+          defaultBranchRef,
           branchName,
         );
         if (aheadCount > 0) {
@@ -134,7 +191,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         await execFileAsync("git", ["checkout", branchName], {
           cwd: workspacePath,
         });
-        await execFileAsync("git", ["reset", "--hard", "origin/main"], {
+        await execFileAsync("git", ["reset", "--hard", defaultBranchRef], {
           cwd: workspacePath,
         });
       } else {
@@ -148,6 +205,8 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       workspacePath,
       issueIdentifier: issue.identifier,
       branchName,
+      repoUrl: this.#config.repoUrl,
+      defaultBranch,
       createdNow: !exists,
     });
 

--- a/tests/support/git.ts
+++ b/tests/support/git.ts
@@ -48,16 +48,20 @@ export async function commitAllFiles(
   return result.stdout.trim();
 }
 
-export async function createSeedRemote(): Promise<{
+export async function createSeedRemote(options?: {
+  readonly branch?: string;
+}): Promise<{
   readonly rootDir: string;
   readonly remotePath: string;
+  readonly seedPath: string;
 }> {
   const rootDir = await createTempDir("symphony-git-");
   const seedPath = path.join(rootDir, "seed");
   const remotePath = path.join(rootDir, "remote.git");
+  const branchName = options?.branch ?? "main";
   await fs.mkdir(seedPath, { recursive: true });
   await execFileAsync("git", ["init", "--bare", remotePath]);
-  await execFileAsync("git", ["init", "-b", "main"], { cwd: seedPath });
+  await execFileAsync("git", ["init", "-b", branchName], { cwd: seedPath });
   await execFileAsync("git", ["config", "user.name", "Symphony Test"], {
     cwd: seedPath,
   });
@@ -74,10 +78,15 @@ export async function createSeedRemote(): Promise<{
   await execFileAsync("git", ["remote", "add", "origin", remotePath], {
     cwd: seedPath,
   });
-  await execFileAsync("git", ["push", "-u", "origin", "main"], {
+  await execFileAsync("git", ["push", "-u", "origin", branchName], {
     cwd: seedPath,
   });
-  return { rootDir, remotePath };
+  await execFileAsync(
+    "git",
+    ["symbolic-ref", "HEAD", `refs/heads/${branchName}`],
+    { cwd: remotePath },
+  );
+  return { rootDir, remotePath, seedPath };
 }
 
 export async function readRemoteBranchFile(

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { JsonLogger } from "../../src/observability/logger.js";
+import {
+  GitHubMirrorStartupPreparer,
+  deriveGitHubMirrorPath,
+} from "../../src/startup/github-mirror.js";
 import {
   createStartupPreparer,
   deriveStartupFilePath,
@@ -9,15 +16,21 @@ import {
   runStartupPreparation,
   type StartupPreparer,
 } from "../../src/startup/service.js";
-import { JsonLogger } from "../../src/observability/logger.js";
+import { LocalWorkspaceManager } from "../../src/workspace/local.js";
 import { isAbortError } from "../../src/support/abort.js";
-import { createTempDir } from "../support/git.js";
+import {
+  commitAllFiles,
+  createSeedRemote,
+  createTempDir,
+} from "../support/git.js";
+
+const execFile = promisify(execFileCallback);
 
 afterEach(() => {
   process.exitCode = undefined;
 });
 
-function createConfig(root: string) {
+function createConfig(root: string, repoUrl: string) {
   return {
     workflowPath: path.join(root, "WORKFLOW.md"),
     tracker: {
@@ -37,7 +50,7 @@ function createConfig(root: string) {
     },
     workspace: {
       root: path.join(root, ".tmp", "workspaces"),
-      repoUrl: "/tmp/repo.git",
+      repoUrl,
       branchPrefix: "symphony/",
       cleanupOnSuccess: false,
     },
@@ -60,15 +73,45 @@ function createConfig(root: string) {
   };
 }
 
+async function readFileAtRef(
+  repoPath: string,
+  ref: string,
+  filePath: string,
+): Promise<string> {
+  const result = await execFile("git", ["show", `${ref}:${filePath}`], {
+    cwd: repoPath,
+  });
+  return result.stdout;
+}
+
+function createIssue(number: number) {
+  return {
+    id: String(number),
+    identifier: `sociotechnica-org/symphony-ts#${number.toString()}`,
+    number,
+    title: `Issue ${number.toString()}`,
+    description: "desc",
+    labels: [],
+    state: "open" as const,
+    url: `https://example.test/issues/${number.toString()}`,
+    createdAt: "2026-03-14T12:00:00.000Z",
+    updatedAt: "2026-03-14T12:00:00.000Z",
+  };
+}
+
 describe("startup service", () => {
-  it("creates tracker-specific no-op preparers", () => {
-    const preparer = createStartupPreparer(createConfig("/tmp/repo"));
-    expect(preparer.id).toBe("github-bootstrap/noop");
+  it("creates a GitHub bootstrap mirror preparer", () => {
+    const preparer = createStartupPreparer(
+      createConfig("/tmp/repo", "/tmp/repo.git"),
+    );
+    expect(preparer).toBeInstanceOf(GitHubMirrorStartupPreparer);
+    expect(preparer.id).toBe("github-bootstrap/local-mirror");
   });
 
-  it("writes a ready startup snapshot for successful startup preparation", async () => {
-    const tempDir = await createTempDir("symphony-startup-ready-");
-    const config = createConfig(tempDir);
+  it("creates a local mirror and writes a ready startup snapshot", async () => {
+    const runtimeRoot = await createTempDir("symphony-startup-ready-");
+    const remote = await createSeedRemote();
+    const config = createConfig(runtimeRoot, remote.remotePath);
 
     try {
       const outcome = await runStartupPreparation({
@@ -78,25 +121,135 @@ describe("startup service", () => {
       });
 
       expect(outcome.kind).toBe("ready");
+      expect(outcome.provider).toBe("github-bootstrap/local-mirror");
+      expect(outcome.workspaceRepoUrlOverride).toBe(
+        deriveGitHubMirrorPath(config.workspace.root),
+      );
+
+      const mirrorResult = await execFile(
+        "git",
+        ["rev-parse", "--is-bare-repository"],
+        { cwd: deriveGitHubMirrorPath(config.workspace.root) },
+      );
+      expect(mirrorResult.stdout.trim()).toBe("true");
+
       const snapshot = await readStartupSnapshot(
         deriveStartupFilePath(config.workspace.root),
       );
       expect(snapshot).toMatchObject({
         state: "ready",
         workerPid: 3210,
-        provider: "github-bootstrap/noop",
+        provider: "github-bootstrap/local-mirror",
         runtimeIdentity: {
-          checkoutPath: tempDir,
+          checkoutPath: runtimeRoot,
         },
       });
     } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(runtimeRoot, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes an existing mirror and lets the workspace reuse it for newer upstream commits", async () => {
+    const runtimeRoot = await createTempDir("symphony-startup-refresh-");
+    const remote = await createSeedRemote();
+    const config = createConfig(runtimeRoot, remote.remotePath);
+    const logger = new JsonLogger();
+
+    try {
+      const firstStartup = await runStartupPreparation({
+        config,
+        logger,
+      });
+      expect(firstStartup.kind).toBe("ready");
+      if (firstStartup.kind !== "ready") {
+        throw new Error("expected startup success");
+      }
+
+      const workspace = new LocalWorkspaceManager(
+        {
+          ...config.workspace,
+          repoUrl:
+            firstStartup.workspaceRepoUrlOverride ?? config.workspace.repoUrl,
+        },
+        [],
+        logger,
+      );
+
+      const firstPrepared = await workspace.prepareWorkspace({
+        issue: createIssue(88),
+      });
+      expect(
+        await readFileAtRef(firstPrepared.path, "HEAD", "README.md"),
+      ).toContain("# mock repo");
+
+      await fs.writeFile(
+        path.join(remote.seedPath, "README.md"),
+        "# refreshed repo\n",
+        "utf8",
+      );
+      await commitAllFiles(remote.seedPath, "refresh upstream");
+      await execFile("git", ["push", "origin", "HEAD"], {
+        cwd: remote.seedPath,
+      });
+
+      const secondStartup = await runStartupPreparation({
+        config,
+        logger,
+      });
+      expect(secondStartup.kind).toBe("ready");
+
+      const secondPrepared = await workspace.prepareWorkspace({
+        issue: createIssue(88),
+      });
+      expect(secondPrepared.createdNow).toBe(false);
+      expect(
+        await readFileAtRef(secondPrepared.path, "HEAD", "README.md"),
+      ).toContain("# refreshed repo");
+
+      const remoteUrl = await execFile(
+        "git",
+        ["config", "--get", "remote.origin.url"],
+        { cwd: secondPrepared.path },
+      );
+      expect(remoteUrl.stdout.trim()).toBe(
+        deriveGitHubMirrorPath(config.workspace.root),
+      );
+    } finally {
+      await fs.rm(runtimeRoot, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a clear startup failure when mirror setup cannot reach the source", async () => {
+    const runtimeRoot = await createTempDir("symphony-startup-mirror-fail-");
+    const config = createConfig(
+      runtimeRoot,
+      path.join(runtimeRoot, "missing", "remote.git"),
+    );
+
+    try {
+      const outcome = await runStartupPreparation({
+        config,
+        logger: new JsonLogger(),
+        workerPid: 6543,
+      });
+
+      expect(outcome.kind).toBe("failed");
+      expect(outcome.provider).toBe("github-bootstrap/local-mirror");
+      expect(outcome.summary).toContain("GitHub bootstrap mirror setup failed");
+      expect(outcome.summary).toContain(config.workspace.repoUrl);
+      expect(outcome.summary).toContain(
+        deriveGitHubMirrorPath(config.workspace.root),
+      );
+    } finally {
+      await fs.rm(runtimeRoot, { recursive: true, force: true });
     }
   });
 
   it("persists an explicit failed startup snapshot when the preparer fails", async () => {
     const tempDir = await createTempDir("symphony-startup-failed-");
-    const config = createConfig(tempDir);
+    const config = createConfig(tempDir, "/tmp/repo.git");
     const preparer: StartupPreparer = {
       id: "github-bootstrap/test-failure",
       async prepare() {
@@ -136,7 +289,7 @@ describe("startup service", () => {
 
   it("rethrows AbortError without overwriting the preparing snapshot", async () => {
     const tempDir = await createTempDir("symphony-startup-abort-");
-    const config = createConfig(tempDir);
+    const config = createConfig(tempDir, "/tmp/repo.git");
     const preparer: StartupPreparer = {
       id: "github-bootstrap/test-abort",
       async prepare() {

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -1071,6 +1071,97 @@ agent:
     expect(workflow.config.agent.env["GITHUB_REPO"]).toBe("my-org/my-repo");
   });
 
+  it("resolves relative local workspace.repo_url values against WORKFLOW.md", async () => {
+    const dir = await createTempDir("workflow-local-repo-url-");
+    const workflowPath = path.join(dir, "nested", "WORKFLOW.md");
+    await fs.mkdir(path.dirname(workflowPath), { recursive: true });
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  endpoint: https://linear.example.test
+  api_key: linear-token
+  project_slug: symphony
+  assignee: worker@example.test
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: ../repos/local.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: generic-command
+  command: echo test
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.workspace.repoUrl).toBe(
+      path.resolve(path.dirname(workflowPath), "../repos/local.git"),
+    );
+  });
+
+  it("preserves scp-style workspace.repo_url values", async () => {
+    const dir = await createTempDir("workflow-scp-repo-url-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: linear
+  endpoint: https://linear.example.test
+  api_key: linear-token
+  project_slug: symphony
+  assignee: worker@example.test
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: generic-command
+  command: echo test
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.workspace.repoUrl).toBe("git@example.com:repo.git");
+  });
+
   it("SYMPHONY_REPO overrides tracker.repo and derives repoUrl and GITHUB_REPO", async () => {
     process.env["SYMPHONY_REPO"] = "my-org/my-test-repo";
 

--- a/tests/unit/workspace-local.test.ts
+++ b/tests/unit/workspace-local.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { WorkspaceError } from "../../src/domain/errors.js";
+import { JsonLogger } from "../../src/observability/logger.js";
+import { LocalWorkspaceManager } from "../../src/workspace/local.js";
+import {
+  commitAllFiles,
+  createSeedRemote,
+  createTempDir,
+} from "../support/git.js";
+
+const execFile = promisify(execFileCallback);
+
+function createIssue(number: number) {
+  return {
+    id: String(number),
+    identifier: `repo#${number.toString()}`,
+    number,
+    title: `Issue ${number.toString()}`,
+    description: "desc",
+    labels: [],
+    state: "open" as const,
+    url: `https://example.test/issues/${number.toString()}`,
+    createdAt: "2026-03-14T12:00:00.000Z",
+    updatedAt: "2026-03-14T12:00:00.000Z",
+  };
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("LocalWorkspaceManager", () => {
+  it("resets reused workspaces against the remote default branch from origin/HEAD", async () => {
+    const tempDir = await createTempDir("workspace-master-");
+    const remote = await createSeedRemote({ branch: "master" });
+    const logger = new JsonLogger();
+    const manager = new LocalWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remote.remotePath,
+        branchPrefix: "symphony/",
+        cleanupOnSuccess: false,
+      },
+      [],
+      logger,
+    );
+
+    try {
+      const firstPrepared = await manager.prepareWorkspace({
+        issue: createIssue(7),
+      });
+      const firstHead = await execFile("git", ["rev-parse", "HEAD"], {
+        cwd: firstPrepared.path,
+      });
+
+      await fs.writeFile(
+        path.join(remote.seedPath, "README.md"),
+        "# master update\n",
+        "utf8",
+      );
+      await commitAllFiles(remote.seedPath, "update master");
+      await execFile("git", ["push", "origin", "HEAD"], {
+        cwd: remote.seedPath,
+      });
+
+      const secondPrepared = await manager.prepareWorkspace({
+        issue: createIssue(7),
+      });
+      const secondHead = await execFile("git", ["rev-parse", "HEAD"], {
+        cwd: secondPrepared.path,
+      });
+      const currentBranch = await execFile(
+        "git",
+        ["symbolic-ref", "--short", "HEAD"],
+        { cwd: secondPrepared.path },
+      );
+
+      expect(firstHead.stdout.trim()).not.toBe(secondHead.stdout.trim());
+      expect(secondPrepared.createdNow).toBe(false);
+      expect(currentBranch.stdout.trim()).toBe("symphony/7");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails clearly when the source remote has no resolvable default branch", async () => {
+    const tempDir = await createTempDir("workspace-no-default-");
+    const remotePath = path.join(tempDir, "remote.git");
+    const logger = new JsonLogger();
+
+    await execFile("git", ["init", "--bare", remotePath]);
+
+    const manager = new LocalWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remotePath,
+        branchPrefix: "symphony/",
+        cleanupOnSuccess: false,
+      },
+      [],
+      logger,
+    );
+
+    try {
+      let thrown: unknown;
+      try {
+        await manager.prepareWorkspace({
+          issue: createIssue(8),
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(WorkspaceError);
+      expect((thrown as Error).message).toMatch(
+        /Could not resolve the default branch/,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #88.

## Summary
- add a GitHub bootstrap startup preparer that creates or refreshes a local `.tmp/github/upstream` bare mirror and hands that path to workspace cloning
- resolve explicit local `workspace.repo_url` values relative to `WORKFLOW.md` and make workspace reset logic follow the remote default branch instead of hardcoding `main`
- cover mirror creation, incremental refresh, local-path resolution, and non-`main` default-branch reuse in tests

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Review
- Manual local self-review via `git diff`; no separate local review bot/tool is available in this checkout.
