### PR TITLE
Recognize Devin review as bot feedback

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -12,6 +12,7 @@ tracker:
     - bugbot[bot]
     - greptile-apps
     - cursor
+    - devin-ai-integration
 polling:
   interval_ms: 30000
   max_concurrent_runs: 1

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -168,6 +168,47 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.unresolvedThreadIds).toEqual([]);
   });
 
+  it("treats configured top-level bot review comments as bot feedback", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              authorAssociation: "NONE",
+              author: { login: "devin-ai-integration" },
+              body: "Automated review found a shutdown edge case.",
+              createdAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#comment-1",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
+    });
+
+    expect(snapshot.actionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]?.authorLogin).toBe(
+      "devin-ai-integration",
+    );
+  });
+
   it("detects a human /land command on the current PR head", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",


### PR DESCRIPTION
## Summary
- recognize `devin-ai-integration` as a configured review bot in `WORKFLOW.md`
- add regression coverage proving top-level configured bot comments are classified as bot feedback
- unblock the factory so Devin comments route to automated rework instead of `awaiting-human-review`

## Testing
- pnpm test -- --run tests/unit/pull-request-snapshot.test.ts tests/unit/pull-request-policy.test.ts tests/unit/workflow.test.ts
- pnpm typecheck
- pre-push: pnpm typecheck && pnpm lint && pnpm format:check
