### PR TITLE
Project runner accounting into status and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ Missing, malformed, or ambiguous runner logs do not block report generation;
 the report stays partial and keeps the canonical local artifacts as the source
 of truth.
 
+Canonical session artifacts now persist any backend-provided runner-event token
+and cost facts that Symphony observed live. Reports and status surfaces project
+those canonical facts first and stay explicit about partial or unavailable
+accounting when a backend does not emit them.
+
 Publish one generated issue report into a checked-out `factory-runs` archive
 worktree:
 

--- a/docs/plans/167-token-and-cost-accounting-projection/plan.md
+++ b/docs/plans/167-token-and-cost-accounting-projection/plan.md
@@ -168,14 +168,14 @@ Aggregate runtime/report views should derive their status from session-level ava
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected decision |
-| --- | --- | --- |
-| Backend emits no accounting-bearing event for a session | runner session exists, no accounting snapshot observed | persist session/report accounting as `unavailable`; do not estimate tokens or cost |
-| Backend emits token totals but no cost fact | normalized token totals observed, cost absent | persist session/report accounting as `partial`; show observed tokens and explicit cost gap |
-| Backend emits token and cost totals | normalized accounting snapshot observed | persist session/report accounting as `complete`; aggregate into runtime/report totals |
-| Backend emits decreasing cumulative token totals | previous high-water accounting plus lower later payload | clamp deltas/high-water marks to avoid double counting; keep prior observed totals |
-| Multiple accounting-bearing events arrive for one session | normalized cumulative snapshots over time | update session high-water marks and aggregate totals deterministically |
-| Canonical session artifact has accounting, optional log enrichment disagrees or is missing | canonical artifact plus optional enrichment inputs | canonical runner-event accounting remains the source of truth; enrichment may add metadata notes only |
+| Observed condition                                                                         | Local facts available                                   | Expected decision                                                                                     |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Backend emits no accounting-bearing event for a session                                    | runner session exists, no accounting snapshot observed  | persist session/report accounting as `unavailable`; do not estimate tokens or cost                    |
+| Backend emits token totals but no cost fact                                                | normalized token totals observed, cost absent           | persist session/report accounting as `partial`; show observed tokens and explicit cost gap            |
+| Backend emits token and cost totals                                                        | normalized accounting snapshot observed                 | persist session/report accounting as `complete`; aggregate into runtime/report totals                 |
+| Backend emits decreasing cumulative token totals                                           | previous high-water accounting plus lower later payload | clamp deltas/high-water marks to avoid double counting; keep prior observed totals                    |
+| Multiple accounting-bearing events arrive for one session                                  | normalized cumulative snapshots over time               | update session high-water marks and aggregate totals deterministically                                |
+| Canonical session artifact has accounting, optional log enrichment disagrees or is missing | canonical artifact plus optional enrichment inputs      | canonical runner-event accounting remains the source of truth; enrichment may add metadata notes only |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/167-token-and-cost-accounting-projection/plan.md
+++ b/docs/plans/167-token-and-cost-accounting-projection/plan.md
@@ -1,0 +1,262 @@
+# Issue 167 Plan: Token And Cost Accounting Projection From Runner Events
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Project backend-provided token and cost facts from runner events into stable runtime and reporting contracts so operators can see what was observed during execution, while reports and status surfaces stay explicit when a backend does not provide those facts.
+
+## Scope
+
+- define a provider-neutral runner accounting snapshot for token and cost facts observed during a session
+- normalize backend event payloads into that snapshot at the runner/orchestrator boundary without making the orchestrator depend on Codex-specific payload shapes
+- persist per-session accounting into canonical local issue artifacts so reports can use runner-event observations directly
+- project aggregate and per-run accounting availability into operator-facing runtime/status surfaces
+- update issue and campaign reporting to use canonical runner-event accounting first and keep explicit gap reporting when accounting is partial or unavailable
+- add focused unit, integration, and end-to-end coverage for observed, partial, and unavailable accounting cases
+
+## Non-goals
+
+- tracker transport, normalization, or policy changes
+- new `WORKFLOW.md` knobs for accounting behavior or pricing configuration
+- heuristic token or cost estimation when the backend did not provide those facts
+- redesigning the TUI layout beyond the minimum needed to consume the new normalized accounting snapshot
+- replacing optional runner-log enrichment; that remains a supplemental path for richer metadata when canonical artifacts are incomplete
+- rate-limit policy, retry policy, or review-loop behavior changes
+
+## Current Gaps
+
+- `src/orchestrator/running-entry.ts` extracts only Codex-shaped input/output/total token deltas into mutable in-memory counters
+- `src/orchestrator/state.ts` stores only one global `codexTotals` aggregate, so runtime accounting is not provider-neutral and is not attached to canonical session artifacts
+- `src/observability/issue-artifacts.ts` session snapshots persist runner/session identity and log pointers but no token or cost accounting facts
+- `src/observability/issue-report.ts` still treats canonical token/cost accounting as unavailable and relies on optional read-side enrichment for Codex logs
+- operator-facing runtime/status surfaces can show live token totals in limited places, but they cannot distinguish “observed complete”, “observed partial”, and “backend did not provide accounting” as a stable contract
+
+## Decision Notes
+
+- The canonical contract for this slice should be event-derived session accounting, not provider-specific raw payload retention and not report-only enrichment.
+- The narrow seam is a provider-neutral accounting snapshot owned by runner/orchestrator normalization, then persisted into canonical session artifacts and consumed by observability.
+- Costs should only be recorded when the backend emitted an explicit cost fact. This issue should not infer pricing from tokens.
+- Optional log enrichment remains useful for auxiliary metadata, but canonical reports should stop depending on log matching for basic token accounting when the live runner already emitted those facts.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in [docs/architecture.md](/Users/jessmartin/Documents/code/symphony-ts/.tmp/factory-main/.tmp/workspaces/sociotechnica-org_symphony-ts_167/docs/architecture.md).
+
+- Policy Layer
+  - belongs: the rule that runtime and reports must distinguish observed accounting from unavailable accounting and must not fabricate missing totals
+  - does not belong: provider-specific JSON parsing details or pricing heuristics
+- Configuration Layer
+  - belongs: unchanged existing workflow/config loading
+  - does not belong: new accounting toggles, provider pricing tables, or report-only flags
+- Coordination Layer
+  - belongs: projecting normalized per-run accounting into runtime state and status snapshots
+  - does not belong: provider payload traversal or markdown/report formatting
+- Execution Layer
+  - belongs: runner-side identification of backend-provided accounting facts and session-level normalized event emission
+  - does not belong: tracker mutation, issue-report aggregation policy, or TUI formatting
+- Integration Layer
+  - belongs: untouched tracker adapters
+  - does not belong: runner accounting normalization or observability presentation
+- Observability Layer
+  - belongs: canonical artifact persistence, status/report aggregation, explicit availability wording, and operator-facing rendering
+  - does not belong: direct parsing of live backend payloads once runner/orchestrator normalization has produced the snapshot
+
+## Architecture Boundaries
+
+### Runner
+
+Belongs here:
+
+- provider-neutral `RunnerAccountingSnapshot` / event payload types shared across backends
+- backend-specific parsing from raw runner updates into normalized accounting facts at the edge
+- emitting accounting updates only when a backend actually provides them
+
+Does not belong here:
+
+- issue-report composition policy
+- tracker or orchestrator retry decisions
+- provider pricing inference when the backend emitted no cost data
+
+### Orchestrator
+
+Belongs here:
+
+- integrating normalized accounting updates into active run state
+- maintaining per-run and aggregate accounting projection for live status surfaces
+- persisting accounting into canonical session snapshots/artifacts
+
+Does not belong here:
+
+- raw backend payload traversal after the runner edge has normalized facts
+- tracker lifecycle compensation
+- markdown rendering or campaign-report wording
+
+### Observability
+
+Belongs here:
+
+- extending canonical session artifact and report contracts to store accounting availability and totals
+- aggregating session accounting into issue- and campaign-level summaries
+- rendering explicit observed/partial/unavailable accounting states in status and report surfaces
+
+Does not belong here:
+
+- runner protocol parsing
+- second-source-of-truth reconstruction from raw logs when canonical accounting is present
+
+### Tracker / Workspace / Config
+
+- untouched in this slice except for any minimal fixture wiring required by tests
+- must not gain accounting policy, storage, or provider-specific parsing logic
+
+## Layering Notes
+
+- `src/config/`
+  - stays unchanged; accounting availability is derived from runner facts, not configured policy
+- `src/tracker/`
+  - remains out of scope; no tracker label or lifecycle behavior changes
+- `src/workspace/`
+  - remains out of scope beyond existing session/workspace metadata already used by artifacts
+- `src/runner/`
+  - owns provider-edge accounting normalization and provider-neutral event contracts
+  - should not write artifacts or reports directly
+- `src/orchestrator/`
+  - owns active-run accounting state and artifact/status projection
+  - should not keep Codex-only accounting semantics as the public runtime contract
+- `src/observability/`
+  - owns durable artifact/report/status schemas and operator wording
+  - should not re-parse raw runner payloads to recover accounting
+
+## Slice Strategy And PR Seam
+
+One reviewable PR with one seam:
+
+1. introduce a provider-neutral runner accounting projection contract
+2. thread that contract through live runtime state and canonical session artifacts
+3. update reports and status surfaces to consume the canonical accounting contract and report gaps explicitly
+
+Why this stays reviewable:
+
+- it does not combine tracker changes, retry/recovery redesign, or workspace policy
+- it narrows the work to one cross-layer contract centered on runner accounting
+- optional log enrichment remains in place, so the PR does not need to redesign the entire reporting pipeline
+
+Deferred from this PR:
+
+- provider pricing catalogs or cost estimation
+- non-canonical analytics/history storage beyond current session and report artifacts
+- broader TUI redesign or additional dashboard drill-downs
+- richer runner-log enrichment changes not required to coexist with the new canonical accounting contract
+
+## Runtime State Model
+
+This issue does not change retries, continuations, reconciliation, leases, or handoff states, so no orchestration state-machine change is required.
+
+It does require one explicit accounting-availability model shared across runtime and reports:
+
+1. `unavailable`
+   - no normalized accounting snapshot has been observed for the session
+2. `partial`
+   - at least one accounting fact was observed, but required totals are missing or incomplete
+3. `complete`
+   - the backend provided the full normalized accounting snapshot expected for that session
+
+Aggregate runtime/report views should derive their status from session-level availability instead of assuming that numeric zero means “no usage”.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected decision |
+| --- | --- | --- |
+| Backend emits no accounting-bearing event for a session | runner session exists, no accounting snapshot observed | persist session/report accounting as `unavailable`; do not estimate tokens or cost |
+| Backend emits token totals but no cost fact | normalized token totals observed, cost absent | persist session/report accounting as `partial`; show observed tokens and explicit cost gap |
+| Backend emits token and cost totals | normalized accounting snapshot observed | persist session/report accounting as `complete`; aggregate into runtime/report totals |
+| Backend emits decreasing cumulative token totals | previous high-water accounting plus lower later payload | clamp deltas/high-water marks to avoid double counting; keep prior observed totals |
+| Multiple accounting-bearing events arrive for one session | normalized cumulative snapshots over time | update session high-water marks and aggregate totals deterministically |
+| Canonical session artifact has accounting, optional log enrichment disagrees or is missing | canonical artifact plus optional enrichment inputs | canonical runner-event accounting remains the source of truth; enrichment may add metadata notes only |
+
+## Storage / Persistence Contract
+
+This issue extends the canonical local artifact contract.
+
+Contract rules:
+
+1. per-session accounting must be stored on canonical session snapshots under `.var/factory/issues/...`
+2. stored accounting must be provider-neutral and nullable, with explicit availability/status fields rather than magic numbers
+3. session artifacts remain the canonical source for report generation; report enrichment becomes additive, not foundational, for runner-event accounting
+4. generated reports and campaign digests may aggregate only from canonical session accounting plus optional additive metadata
+5. if the artifact/report schema version changes, stored-report compatibility handling must remain explicit and test-covered
+
+## Observability Requirements
+
+- live status surfaces must show aggregate accounting derived from normalized session facts, including explicit pending/unavailable gaps
+- per-issue reports must explain whether token/cost totals came from canonical runner events and whether any fields remain unavailable
+- campaign digests must preserve the distinction between complete, partial, estimated, and unavailable accounting after canonical projection lands
+- when a backend provides no accounting data, the operator-facing wording must say that clearly instead of implying a zero total
+
+## Implementation Steps
+
+1. Introduce provider-neutral accounting types near the runner contract, including per-session availability and nullable token/cost fields.
+2. Refactor raw accounting extraction out of `src/orchestrator/running-entry.ts` into a normalization seam that can consume backend payloads and update per-session accounting state without exposing Codex-specific shapes downstream.
+3. Extend active run state and status snapshot projection to carry normalized per-run and aggregate accounting totals/availability.
+4. Extend `IssueArtifactSessionSnapshot` and artifact-writing paths so canonical session snapshots persist observed accounting facts.
+5. Update issue-report generation to build token/cost sections from canonical session accounting first, with optional enrichers limited to supplemental metadata or backfill only when canonical accounting is missing.
+6. Update campaign-report aggregation and any touched status/TUI helpers to consume the new canonical availability model.
+7. Add focused test builders/fixtures for runner-event accounting snapshots so unit, integration, and e2e coverage do not duplicate ad hoc setup.
+8. Update README or observability docs where needed to describe canonical runner-event accounting and explicit gap semantics.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `tests/unit/running-entry.test.ts`
+  - token-only event yields `partial` accounting with observed token totals and missing cost
+  - token-plus-cost event yields `complete` accounting
+  - decreasing cumulative totals do not double count
+- `tests/unit/issue-artifacts.test.ts`
+  - canonical session snapshots persist normalized accounting fields
+- `tests/unit/issue-report.test.ts`
+  - report token usage becomes complete/partial from canonical session accounting without requiring enrichment
+  - explicit unavailable wording remains when canonical sessions provide no accounting
+- `tests/unit/campaign-report.test.ts`
+  - campaign aggregation uses canonical session accounting and preserves partial/unavailable counts
+- `tests/unit/status.test.ts` and/or `tests/unit/tui.test.ts`
+  - live status surfaces distinguish pending/unavailable from observed zero/complete totals
+
+### Integration
+
+- `tests/integration/report-cli.test.ts`
+  - `symphony-report issue` emits canonical token usage from stored session accounting without any enricher
+  - optional Codex enrichment still coexists without replacing canonical totals
+
+### End-to-End
+
+- extend a realistic runner-driven fixture or e2e scenario so a backend emitting accounting-bearing events produces canonical session artifacts and an issue report with the expected availability state
+
+## Acceptance Scenarios
+
+1. A backend emits token totals but no cost information during a run.
+   - Expected: runtime and reports show observed token totals, mark cost unavailable, and classify accounting as partial.
+2. A backend emits both token and cost facts during a run.
+   - Expected: canonical session artifacts, live status surfaces, and reports all project complete accounting consistently.
+3. A backend emits no accounting facts.
+   - Expected: status and reports say accounting is unavailable rather than showing an implied zero.
+4. Optional Codex log enrichment is present alongside canonical runner-event accounting.
+   - Expected: canonical totals remain authoritative while enrichment adds only supplemental metadata or fills gaps explicitly allowed by policy.
+
+## Exit Criteria
+
+- provider-neutral runner accounting is normalized into a stable runtime contract
+- canonical session artifacts persist observed accounting facts and explicit availability state
+- issue and campaign reports consume canonical accounting instead of defaulting to unavailable when runner events already provided the facts
+- operator-facing runtime surfaces no longer blur unavailable accounting with zero totals
+- local typecheck, lint, unit/integration/e2e tests for touched seams pass
+
+## Deferred To Later Issues Or PRs
+
+- provider-specific pricing/estimation policy when backends provide only tokens
+- additional runner adapters beyond the minimal contract changes needed here
+- archival analytics beyond existing session/report artifacts
+- deeper dashboard/report UX work beyond the canonical accounting projection seam

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ObservabilityError } from "../domain/errors.js";
+import type { RunnerAccountingSnapshot } from "../runner/accounting.js";
 import { writeJsonFileAtomic } from "./atomic-file.js";
 
 export const ISSUE_ARTIFACT_SCHEMA_VERSION = 1 as const;
@@ -131,6 +132,7 @@ export interface IssueArtifactSessionSnapshot {
   readonly finishedAt: string | null;
   readonly workspacePath: string | null;
   readonly branch: string | null;
+  readonly accounting?: RunnerAccountingSnapshot | undefined;
   readonly logPointers: readonly IssueArtifactLogPointer[];
 }
 

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -152,32 +152,48 @@ function rebuildTokenUsage(
   sessions: readonly IssueReportTokenUsageSession[],
   notes: readonly string[],
 ): IssueReportTokenUsage {
+  const baseSessionsById = new Map(
+    base.sessions.map((session) => [session.sessionId, session]),
+  );
   const enrichedSessionCount = sessions.filter(
     (session) => session.status !== "unavailable",
   ).length;
   const completeSessionCount = sessions.filter(
+    (session) => session.status === "complete",
+  ).length;
+  const tokenTotalSessionCount = sessions.filter(
     (session) => session.totalTokens !== null,
   ).length;
+  const newlyFilledTokenTotals = sessions.filter((session) => {
+    const previous = baseSessionsById.get(session.sessionId);
+    return previous?.totalTokens === null && session.totalTokens !== null;
+  }).length;
   const anySessionDetail = enrichedSessionCount > 0;
   const allSessionTotalsAvailable =
-    sessions.length > 0 && completeSessionCount === sessions.length;
+    sessions.length > 0 && tokenTotalSessionCount === sessions.length;
   const someSessionTotalsAvailable =
-    completeSessionCount > 0 && !allSessionTotalsAvailable;
+    tokenTotalSessionCount > 0 && !allSessionTotalsAvailable;
 
-  const status = allSessionTotalsAvailable
-    ? "complete"
-    : someSessionTotalsAvailable
-      ? "partial"
-      : anySessionDetail
-        ? "partial"
-        : base.status;
-  const explanation = allSessionTotalsAvailable
-    ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
-    : someSessionTotalsAvailable
-      ? `Runner log enrichment supplied token totals for ${completeSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
-      : anySessionDetail
-        ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
-        : base.explanation;
+  const status =
+    newlyFilledTokenTotals === 0 && base.status !== "unavailable"
+      ? base.status
+      : completeSessionCount === sessions.length && sessions.length > 0
+        ? "complete"
+        : someSessionTotalsAvailable
+          ? "partial"
+          : anySessionDetail
+            ? "partial"
+            : base.status;
+  const explanation =
+    newlyFilledTokenTotals === 0 && base.status !== "unavailable"
+      ? base.explanation
+      : allSessionTotalsAvailable
+        ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
+        : someSessionTotalsAvailable
+          ? `Runner log enrichment supplied token totals for ${tokenTotalSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
+          : anySessionDetail
+            ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
+            : base.explanation;
 
   const attempts = base.attempts.map((attempt) => {
     const attemptSessions = sessions.filter((session) =>
@@ -194,7 +210,14 @@ function rebuildTokenUsage(
     return {
       ...attempt,
       totalTokens,
-      costUsd: null,
+      costUsd:
+        attemptSessions.length > 0 &&
+        attemptSessions.every((session) => session.costUsd !== null)
+          ? attemptSessions.reduce(
+              (total, session) => total + (session.costUsd ?? 0),
+              0,
+            )
+          : null,
     };
   });
 
@@ -232,7 +255,9 @@ function rebuildTokenUsage(
       agent,
       sessionCount: value.sessionCount,
       totalTokens: value.hasMissingTokens ? null : value.totalTokens,
-      costUsd: null,
+      costUsd:
+        base.agents.find((candidate) => candidate.agent === agent)?.costUsd ??
+        null,
     }))
     .sort((left, right) => left.agent.localeCompare(right.agent));
 
@@ -250,7 +275,7 @@ function rebuildTokenUsage(
     status,
     explanation,
     totalTokens,
-    costUsd: null,
+    costUsd: base.costUsd,
     sessions,
     attempts,
     agents,
@@ -265,10 +290,14 @@ function rebuildTokenUsage(
 function deriveSessionStatus(
   session: IssueReportTokenUsageSession,
 ): IssueReportTokenUsageSession["status"] {
-  if (session.totalTokens !== null) {
+  if (session.totalTokens !== null && session.costUsd !== null) {
     return "complete";
   }
   if (
+    session.inputTokens !== null ||
+    session.outputTokens !== null ||
+    session.totalTokens !== null ||
+    session.costUsd !== null ||
     session.originator !== null ||
     session.sessionSource !== null ||
     session.finalSummary !== null ||

--- a/src/observability/issue-report-enrichment.ts
+++ b/src/observability/issue-report-enrichment.ts
@@ -173,6 +173,18 @@ function rebuildTokenUsage(
     sessions.length > 0 && tokenTotalSessionCount === sessions.length;
   const someSessionTotalsAvailable =
     tokenTotalSessionCount > 0 && !allSessionTotalsAvailable;
+  const costAvailableSessionCount = sessions.filter(
+    (session) => session.costUsd !== null,
+  ).length;
+  const allSessionCostsAvailable =
+    sessions.length > 0 && costAvailableSessionCount === sessions.length;
+  const someSessionCostsAvailable =
+    costAvailableSessionCount > 0 && !allSessionCostsAvailable;
+  const costExplanation = allSessionCostsAvailable
+    ? `Canonical runner-event accounting already supplied cost totals for all ${sessions.length.toString()} session(s).`
+    : someSessionCostsAvailable
+      ? `Canonical runner-event accounting supplied cost totals for ${costAvailableSessionCount.toString()} of ${sessions.length.toString()} session(s); aggregate cost remained partial or unavailable.`
+      : "Estimated cost remains unavailable because report generation does not apply provider pricing.";
 
   const status =
     newlyFilledTokenTotals === 0 && base.status !== "unavailable"
@@ -188,9 +200,9 @@ function rebuildTokenUsage(
     newlyFilledTokenTotals === 0 && base.status !== "unavailable"
       ? base.explanation
       : allSessionTotalsAvailable
-        ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). Estimated cost remains unavailable because report generation does not apply provider pricing.`
+        ? `Runner log enrichment supplied token totals for all ${sessions.length.toString()} session(s). ${costExplanation}`
         : someSessionTotalsAvailable
-          ? `Runner log enrichment supplied token totals for ${tokenTotalSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable, and estimated cost remains unavailable because report generation does not apply provider pricing.`
+          ? `Runner log enrichment supplied token totals for ${tokenTotalSessionCount.toString()} of ${sessions.length.toString()} session(s). Remaining sessions stayed partial or unavailable. ${costExplanation}`
           : anySessionDetail
             ? "Runner log enrichment supplied optional session detail, but token totals remained partial or unavailable."
             : base.explanation;

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -710,11 +710,15 @@ function buildTokenUsage(
       totalTokens: sumIfAllPresent(
         attemptSessions.map((session) => session.totalTokens),
       ),
-      costUsd: sumIfAllPresent(attemptSessions.map((session) => session.costUsd)),
+      costUsd: sumIfAllPresent(
+        attemptSessions.map((session) => session.costUsd),
+      ),
     };
   });
   const agents = aggregateAgents(sessions);
-  const totalTokens = sumIfAllPresent(sessions.map((session) => session.totalTokens));
+  const totalTokens = sumIfAllPresent(
+    sessions.map((session) => session.totalTokens),
+  );
   const costUsd = sumIfAllPresent(sessions.map((session) => session.costUsd));
   const completeCount = sessions.filter(
     (session) => session.status === "complete",
@@ -1333,7 +1337,11 @@ function aggregateAgents(
 ): readonly IssueReportTokenUsageAgent[] {
   const grouped = new Map<
     string,
-    { readonly sessionCount: number; readonly totalTokens: number | null; readonly costUsd: number | null }
+    {
+      readonly sessionCount: number;
+      readonly totalTokens: number | null;
+      readonly costUsd: number | null;
+    }
   >();
   for (const session of sessions) {
     const label =

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -739,15 +739,15 @@ function buildTokenUsage(
         ? "partial"
         : estimatedCount > 0
           ? "estimated"
-        : "complete";
+          : "complete";
   const explanation =
     status === "complete"
       ? `Canonical runner-event accounting supplied complete token and cost totals for all ${sessions.length.toString()} session(s).`
       : status === "estimated"
         ? `All ${sessions.length.toString()} session(s) supplied token totals, but ${estimatedCount.toString()} session(s) remained estimated.`
-      : status === "partial"
-        ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${estimatedCount.toString()} remained estimated, ${partialCount.toString()} remained partial, and ${unavailableCount.toString()} remained unavailable.`
-        : "Canonical runner-event accounting was unavailable for all recorded sessions.";
+        : status === "partial"
+          ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${estimatedCount.toString()} remained estimated, ${partialCount.toString()} remained partial, and ${unavailableCount.toString()} remained unavailable.`
+          : "Canonical runner-event accounting was unavailable for all recorded sessions.";
   const notes = [
     ...(sessions.some((session) => session.costUsd === null)
       ? [

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -19,6 +19,7 @@ import {
   deriveFactoryRuntimeRoot,
   deriveIssueArtifactPaths,
 } from "./issue-artifacts.js";
+import { createRunnerAccountingSnapshot } from "../runner/accounting.js";
 import { renderIssueReportMarkdown } from "./issue-report-markdown.js";
 
 export const ISSUE_REPORT_SCHEMA_VERSION = 2 as const;
@@ -693,49 +694,64 @@ function buildTokenUsage(
   loaded: LoadedIssueArtifacts,
   attemptNumbers: readonly number[],
 ): IssueReportTokenUsage {
-  const sessions = loaded.sessions.map((session) => ({
-    sessionId: session.sessionId,
-    attemptNumber: session.attemptNumber,
-    provider: session.provider,
-    model: session.model,
-    status: "unavailable" as const,
-    inputTokens: null,
-    cachedInputTokens: null,
-    outputTokens: null,
-    reasoningOutputTokens: null,
-    totalTokens: null,
-    costUsd: null,
-    originator: null,
-    sessionSource: null,
-    cliVersion: null,
-    modelProvider: null,
-    gitBranch: null,
-    gitCommit: null,
-    finalSummary: null,
-    notes: [],
-    sourceArtifacts: [
-      path.join(
-        loaded.paths.sessionsDir,
-        `${encodeURIComponent(session.sessionId)}.json`,
+  const sessions = loaded.sessions.map((session) =>
+    buildTokenUsageSession(loaded, session),
+  );
+  const attempts = attemptNumbers.map((attemptNumber) => {
+    const attemptSessions = sessions.filter(
+      (session) => session.attemptNumber === attemptNumber,
+    );
+    return {
+      attemptNumber,
+      sessionIds: attemptSessions.map((session) => session.sessionId),
+      totalTokens: sumIfAllPresent(
+        attemptSessions.map((session) => session.totalTokens),
       ),
-    ],
-  }));
-  const attempts = attemptNumbers.map((attemptNumber) => ({
-    attemptNumber,
-    sessionIds: loaded.sessions
-      .filter((session) => session.attemptNumber === attemptNumber)
-      .map((session) => session.sessionId),
-    totalTokens: null,
-    costUsd: null,
-  }));
-  const agents = aggregateAgents(loaded.sessions);
+      costUsd: sumIfAllPresent(attemptSessions.map((session) => session.costUsd)),
+    };
+  });
+  const agents = aggregateAgents(sessions);
+  const totalTokens = sumIfAllPresent(sessions.map((session) => session.totalTokens));
+  const costUsd = sumIfAllPresent(sessions.map((session) => session.costUsd));
+  const completeCount = sessions.filter(
+    (session) => session.status === "complete",
+  ).length;
+  const partialCount = sessions.filter(
+    (session) => session.status === "partial",
+  ).length;
+  const unavailableCount = sessions.filter(
+    (session) => session.status === "unavailable",
+  ).length;
+  const status =
+    sessions.length === 0 || unavailableCount === sessions.length
+      ? "unavailable"
+      : partialCount > 0 || unavailableCount > 0
+        ? "partial"
+        : "complete";
+  const explanation =
+    status === "complete"
+      ? `Canonical runner-event accounting supplied complete token and cost totals for all ${sessions.length.toString()} session(s).`
+      : status === "partial"
+        ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${partialCount.toString()} remained partial and ${unavailableCount.toString()} remained unavailable.`
+        : "Canonical runner-event accounting was unavailable for all recorded sessions.";
+  const notes = [
+    ...(sessions.some((session) => session.costUsd === null)
+      ? [
+          "At least one recorded session lacked an explicit backend-provided cost fact, so aggregate cost remained partial or unavailable.",
+        ]
+      : []),
+    ...(sessions.some((session) => session.totalTokens === null)
+      ? [
+          "At least one recorded session lacked complete backend-provided token totals, so aggregate token usage remained partial or unavailable.",
+        ]
+      : []),
+  ];
 
   return {
-    status: "unavailable",
-    explanation:
-      "Canonical local artifacts include session metadata and raw log pointers, but they do not yet store provider token totals or cost data. Later enrichment is deferred to issue #46.",
-    totalTokens: null,
-    costUsd: null,
+    status,
+    explanation,
+    totalTokens,
+    costUsd,
     sessions,
     attempts,
     agents,
@@ -743,7 +759,7 @@ function buildTokenUsage(
       ...sessions.flatMap((session) => session.sourceArtifacts),
       ...(loaded.logPointers === null ? [] : [loaded.paths.logPointersFile]),
     ],
-    notes: [],
+    notes,
   };
 }
 
@@ -1267,25 +1283,92 @@ function buildReviewLoopSummary(
   return `Observed ${reviewFeedbackRounds.toString()} recorded review-feedback round(s) across ${pullRequests.length.toString()} pull request(s).`;
 }
 
+function buildTokenUsageSession(
+  loaded: LoadedIssueArtifacts,
+  session: IssueArtifactSessionSnapshot,
+): IssueReportTokenUsageSession {
+  const accounting =
+    session.accounting ??
+    createRunnerAccountingSnapshot({
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: null,
+      costUsd: null,
+    });
+
+  return {
+    sessionId: session.sessionId,
+    attemptNumber: session.attemptNumber,
+    provider: session.provider,
+    model: session.model,
+    status: accounting.status,
+    inputTokens: accounting.inputTokens,
+    cachedInputTokens: null,
+    outputTokens: accounting.outputTokens,
+    reasoningOutputTokens: null,
+    totalTokens: accounting.totalTokens,
+    costUsd: accounting.costUsd,
+    originator: null,
+    sessionSource: null,
+    cliVersion: null,
+    modelProvider: null,
+    gitBranch: null,
+    gitCommit: null,
+    finalSummary: null,
+    notes: [],
+    sourceArtifacts: [
+      path.join(
+        loaded.paths.sessionsDir,
+        `${encodeURIComponent(session.sessionId)}.json`,
+      ),
+    ],
+  };
+}
+
 function aggregateAgents(
-  sessions: readonly IssueArtifactSessionSnapshot[],
+  sessions: readonly IssueReportTokenUsageSession[],
 ): readonly IssueReportTokenUsageAgent[] {
-  const grouped = new Map<string, number>();
+  const grouped = new Map<
+    string,
+    { readonly sessionCount: number; readonly totalTokens: number | null; readonly costUsd: number | null }
+  >();
   for (const session of sessions) {
     const label =
       session.model === null
         ? session.provider
         : `${session.provider} (${session.model})`;
-    grouped.set(label, (grouped.get(label) ?? 0) + 1);
+    const existing = grouped.get(label) ?? {
+      sessionCount: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    };
+    grouped.set(label, {
+      sessionCount: existing.sessionCount + 1,
+      totalTokens:
+        existing.totalTokens === null || session.totalTokens === null
+          ? null
+          : existing.totalTokens + session.totalTokens,
+      costUsd:
+        existing.costUsd === null || session.costUsd === null
+          ? null
+          : existing.costUsd + session.costUsd,
+    });
   }
   return [...grouped.entries()]
-    .map(([agent, sessionCount]) => ({
+    .map(([agent, value]) => ({
       agent,
-      sessionCount,
-      totalTokens: null,
-      costUsd: null,
+      sessionCount: value.sessionCount,
+      totalTokens: value.totalTokens,
+      costUsd: value.costUsd,
     }))
     .sort((left, right) => left.agent.localeCompare(right.agent));
+}
+
+function sumIfAllPresent(values: readonly (number | null)[]): number | null {
+  const observed = values.filter((value): value is number => value !== null);
+  return observed.length === values.length && observed.length > 0
+    ? observed.reduce((sum, value) => sum + value, 0)
+    : null;
 }
 
 function readPullRequestFromDetails(

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -19,7 +19,10 @@ import {
   deriveFactoryRuntimeRoot,
   deriveIssueArtifactPaths,
 } from "./issue-artifacts.js";
-import { createRunnerAccountingSnapshot } from "../runner/accounting.js";
+import {
+  createRunnerAccountingSnapshot,
+  sumIfAllPresent,
+} from "../runner/accounting.js";
 import { renderIssueReportMarkdown } from "./issue-report-markdown.js";
 
 export const ISSUE_REPORT_SCHEMA_VERSION = 2 as const;
@@ -1362,13 +1365,6 @@ function aggregateAgents(
       costUsd: value.costUsd,
     }))
     .sort((left, right) => left.agent.localeCompare(right.agent));
-}
-
-function sumIfAllPresent(values: readonly (number | null)[]): number | null {
-  const observed = values.filter((value): value is number => value !== null);
-  return observed.length === values.length && observed.length > 0
-    ? observed.reduce((sum, value) => sum + value, 0)
-    : null;
 }
 
 function readPullRequestFromDetails(

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -723,6 +723,9 @@ function buildTokenUsage(
   const completeCount = sessions.filter(
     (session) => session.status === "complete",
   ).length;
+  const estimatedCount = sessions.filter(
+    (session) => session.status === "estimated",
+  ).length;
   const partialCount = sessions.filter(
     (session) => session.status === "partial",
   ).length;
@@ -734,12 +737,16 @@ function buildTokenUsage(
       ? "unavailable"
       : partialCount > 0 || unavailableCount > 0
         ? "partial"
+        : estimatedCount > 0
+          ? "estimated"
         : "complete";
   const explanation =
     status === "complete"
       ? `Canonical runner-event accounting supplied complete token and cost totals for all ${sessions.length.toString()} session(s).`
+      : status === "estimated"
+        ? `All ${sessions.length.toString()} session(s) supplied token totals, but ${estimatedCount.toString()} session(s) remained estimated.`
       : status === "partial"
-        ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${partialCount.toString()} remained partial and ${unavailableCount.toString()} remained unavailable.`
+        ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${estimatedCount.toString()} remained estimated, ${partialCount.toString()} remained partial, and ${unavailableCount.toString()} remained unavailable.`
         : "Canonical runner-event accounting was unavailable for all recorded sessions.";
   const notes = [
     ...(sessions.some((session) => session.costUsd === null)

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -746,7 +746,19 @@ function buildTokenUsage(
       : status === "estimated"
         ? `All ${sessions.length.toString()} session(s) supplied token totals, but ${estimatedCount.toString()} session(s) remained estimated.`
         : status === "partial"
-          ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${estimatedCount.toString()} remained estimated, ${partialCount.toString()} remained partial, and ${unavailableCount.toString()} remained unavailable.`
+          ? `Canonical runner-event accounting was complete for ${completeCount.toString()} of ${sessions.length.toString()} session(s); ${[
+              estimatedCount > 0
+                ? `${estimatedCount.toString()} remained estimated`
+                : null,
+              partialCount > 0
+                ? `${partialCount.toString()} remained partial`
+                : null,
+              unavailableCount > 0
+                ? `${unavailableCount.toString()} remained unavailable`
+                : null,
+            ]
+              .filter((value): value is string => value !== null)
+              .join(", ")}.`
           : "Canonical runner-event accounting was unavailable for all recorded sessions.";
   const notes = [
     ...(sessions.some((session) => session.costUsd === null)

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -1247,7 +1247,7 @@ function parseRunnerAccounting(
   filePath: string,
   field: string,
 ): RunnerAccountingSnapshot | undefined {
-  if (value === undefined) {
+  if (value === null || value === undefined) {
     return undefined;
   }
   const accounting = expectObject(value, filePath, field);

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -13,6 +13,7 @@ import type {
   RunnerVisibilitySnapshot,
   RunnerVisibilityState,
 } from "../runner/service.js";
+import type { RunnerAccountingSnapshot } from "../runner/accounting.js";
 
 let snapshotWriteSequence = 0;
 
@@ -144,6 +145,7 @@ export interface FactoryActiveIssueSnapshot {
   readonly checks: FactoryCheckStatus;
   readonly review: FactoryReviewStatus;
   readonly blockedReason: string | null;
+  readonly runnerAccounting?: RunnerAccountingSnapshot | undefined;
   readonly runnerVisibility: RunnerVisibilitySnapshot | null;
 }
 
@@ -459,6 +461,11 @@ export function renderFactoryStatusSnapshot(
       lines.push(
         `    Review: actionable=${issue.review.actionableCount.toString()} unresolved_threads=${issue.review.unresolvedThreadCount.toString()}`,
       );
+      if (issue.runnerAccounting !== undefined) {
+        lines.push(
+          `    Accounting: ${issue.runnerAccounting.status} total_tokens=${renderNullableNumber(issue.runnerAccounting.totalTokens)} cost_usd=${renderNullableNumber(issue.runnerAccounting.costUsd)}`,
+        );
+      }
       if (issue.blockedReason !== null) {
         lines.push(`    Blocked: ${issue.blockedReason}`);
       }
@@ -667,6 +674,10 @@ export function assessFactoryStatusSnapshot(
     workerAlive,
     publicationState: publication.state,
   };
+}
+
+function renderNullableNumber(value: number | null): string {
+  return value === null ? "n/a" : value.toString();
 }
 
 function parseFactoryStatusSnapshot(
@@ -1126,6 +1137,11 @@ function parseActiveIssue(
       filePath,
       `${field}.blockedReason`,
     ),
+    runnerAccounting: parseRunnerAccounting(
+      issue.runnerAccounting,
+      filePath,
+      `${field}.runnerAccounting`,
+    ),
     runnerVisibility: parseRunnerVisibility(
       issue.runnerVisibility,
       filePath,
@@ -1222,6 +1238,45 @@ function parseRunnerVisibility(
       visibility.timedOutAt,
       filePath,
       `${field}.timedOutAt`,
+    ),
+  };
+}
+
+function parseRunnerAccounting(
+  value: unknown,
+  filePath: string,
+  field: string,
+): RunnerAccountingSnapshot | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const accounting = expectObject(value, filePath, field);
+  return {
+    status: expectEnum(
+      accounting.status,
+      ["unavailable", "partial", "complete"],
+      filePath,
+      `${field}.status`,
+    ),
+    inputTokens: expectNullableNumber(
+      accounting.inputTokens,
+      filePath,
+      `${field}.inputTokens`,
+    ),
+    outputTokens: expectNullableNumber(
+      accounting.outputTokens,
+      filePath,
+      `${field}.outputTokens`,
+    ),
+    totalTokens: expectNullableNumber(
+      accounting.totalTokens,
+      filePath,
+      `${field}.totalTokens`,
+    ),
+    costUsd: expectNullableNumber(
+      accounting.costUsd,
+      filePath,
+      `${field}.costUsd`,
     ),
   };
 }
@@ -1502,6 +1557,22 @@ function expectNullableInteger(
     return null;
   }
   return expectInteger(value, filePath, field);
+}
+
+function expectNullableNumber(
+  value: unknown,
+  filePath: string,
+  field: string,
+): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new ObservabilityError(
+      `Expected ${field} in ${filePath} to be a finite number or null`,
+    );
+  }
+  return value;
 }
 
 function expectNullableBoolean(

--- a/src/orchestrator/continuation-turns.ts
+++ b/src/orchestrator/continuation-turns.ts
@@ -2,12 +2,14 @@ import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type { RunSession, RunTurn } from "../domain/run.js";
 import type { PromptBuilder } from "../domain/workflow.js";
+import type { RunnerAccountingSnapshot } from "../runner/accounting.js";
 import type { RunnerSessionDescription } from "../runner/service.js";
 
 export interface RunSessionArtifactsState {
   readonly runSession: RunSession;
   readonly description: RunnerSessionDescription;
   readonly latestTurnNumber: number | null;
+  readonly accounting: RunnerAccountingSnapshot;
 }
 
 export async function createContinuationRunTurn(input: {

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -1,5 +1,9 @@
 import type { RunUpdateEvent } from "../domain/run.js";
 import { getMapKey, mapPath } from "../domain/codex-payload.js";
+import {
+  createRunnerAccountingSnapshot,
+  type RunnerAccountingSnapshot,
+} from "../runner/accounting.js";
 
 export type CodexTokenState = "pending" | "observed";
 
@@ -11,13 +15,16 @@ export interface RunningEntry {
   readonly retryAttempt: number;
   sessionId: string | null;
   turnCount: number;
+  accounting: RunnerAccountingSnapshot;
   codexTokenState: CodexTokenState;
   codexInputTokens: number;
   codexOutputTokens: number;
   codexTotalTokens: number;
+  accountingCostUsd: number | null;
   codexLastReportedInputTokens: number;
   codexLastReportedOutputTokens: number;
   codexLastReportedTotalTokens: number;
+  accountingLastReportedCostUsd: number | null;
   codexAppServerPid: number | null;
   lastCodexEvent: string | null;
   lastCodexMessage: unknown;
@@ -38,13 +45,16 @@ export function createRunningEntry(
     retryAttempt,
     sessionId: null,
     turnCount: 0,
+    accounting: createRunnerAccountingSnapshot(),
     codexTokenState: "pending",
     codexInputTokens: 0,
     codexOutputTokens: 0,
     codexTotalTokens: 0,
+    accountingCostUsd: null,
     codexLastReportedInputTokens: 0,
     codexLastReportedOutputTokens: 0,
     codexLastReportedTotalTokens: 0,
+    accountingLastReportedCostUsd: null,
     codexAppServerPid: null,
     lastCodexEvent: null,
     lastCodexMessage: null,
@@ -56,6 +66,7 @@ interface TokenDelta {
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly totalTokens: number;
+  readonly costUsd: number;
 }
 
 function extractTokenDelta(
@@ -167,47 +178,81 @@ function extractTokenDelta(
     mapPath(payload, ["params", "usage", "total_tokens"]) ??
     mapPath(payload, ["usage", "totalTokens"]) ??
     mapPath(payload, ["usage", "total_tokens"]);
+  const costRaw =
+    getMapKey(payload, ["cost_usd", "costUsd", "total_cost_usd", "totalCostUsd"]) ??
+    mapPath(payload, ["payload", "cost_usd"]) ??
+    mapPath(payload, ["payload", "costUsd"]) ??
+    mapPath(payload, ["payload", "info", "cost_usd"]) ??
+    mapPath(payload, ["payload", "info", "costUsd"]) ??
+    mapPath(payload, ["params", "msg", "payload", "cost_usd"]) ??
+    mapPath(payload, ["params", "msg", "payload", "costUsd"]) ??
+    mapPath(payload, ["params", "msg", "payload", "info", "cost_usd"]) ??
+    mapPath(payload, ["params", "msg", "payload", "info", "costUsd"]) ??
+    mapPath(payload, ["params", "usage", "costUsd"]) ??
+    mapPath(payload, ["params", "usage", "cost_usd"]) ??
+    mapPath(payload, ["usage", "costUsd"]) ??
+    mapPath(payload, ["usage", "cost_usd"]);
 
-  const reported = {
-    input: typeof inputRaw === "number" ? inputRaw : 0,
-    output: typeof outputRaw === "number" ? outputRaw : 0,
-    total: typeof totalRaw === "number" ? totalRaw : 0,
-  };
+  const reportedInput = typeof inputRaw === "number" ? inputRaw : null;
+  const reportedOutput = typeof outputRaw === "number" ? outputRaw : null;
+  const reportedTotal = typeof totalRaw === "number" ? totalRaw : null;
+  const reportedCost = typeof costRaw === "number" ? costRaw : null;
 
-  if (reported.input === 0 && reported.output === 0 && reported.total === 0) {
-    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  if (
+    reportedInput === null &&
+    reportedOutput === null &&
+    reportedTotal === null &&
+    reportedCost === null
+  ) {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
   }
 
   const delta = {
-    inputTokens: Math.max(
-      0,
-      reported.input - entry.codexLastReportedInputTokens,
-    ),
-    outputTokens: Math.max(
-      0,
-      reported.output - entry.codexLastReportedOutputTokens,
-    ),
-    totalTokens: Math.max(
-      0,
-      reported.total - entry.codexLastReportedTotalTokens,
-    ),
+    inputTokens:
+      reportedInput === null
+        ? 0
+        : Math.max(0, reportedInput - entry.codexLastReportedInputTokens),
+    outputTokens:
+      reportedOutput === null
+        ? 0
+        : Math.max(0, reportedOutput - entry.codexLastReportedOutputTokens),
+    totalTokens:
+      reportedTotal === null
+        ? 0
+        : Math.max(0, reportedTotal - entry.codexLastReportedTotalTokens),
+    costUsd:
+      reportedCost === null
+        ? 0
+        : Math.max(0, reportedCost - (entry.accountingLastReportedCostUsd ?? 0)),
   };
 
   // Update high-water marks using Math.max so they never decrease.
   // A decrease (API quirk, race) would otherwise lower the baseline and
   // cause the next increase to double-count the difference.
-  entry.codexLastReportedInputTokens = Math.max(
-    entry.codexLastReportedInputTokens,
-    reported.input,
-  );
-  entry.codexLastReportedOutputTokens = Math.max(
-    entry.codexLastReportedOutputTokens,
-    reported.output,
-  );
-  entry.codexLastReportedTotalTokens = Math.max(
-    entry.codexLastReportedTotalTokens,
-    reported.total,
-  );
+  if (reportedInput !== null) {
+    entry.codexLastReportedInputTokens = Math.max(
+      entry.codexLastReportedInputTokens,
+      reportedInput,
+    );
+  }
+  if (reportedOutput !== null) {
+    entry.codexLastReportedOutputTokens = Math.max(
+      entry.codexLastReportedOutputTokens,
+      reportedOutput,
+    );
+  }
+  if (reportedTotal !== null) {
+    entry.codexLastReportedTotalTokens = Math.max(
+      entry.codexLastReportedTotalTokens,
+      reportedTotal,
+    );
+  }
+  if (reportedCost !== null) {
+    entry.accountingLastReportedCostUsd = Math.max(
+      entry.accountingLastReportedCostUsd ?? 0,
+      reportedCost,
+    );
+  }
 
   return delta;
 }
@@ -242,6 +287,7 @@ function extractPid(payload: Record<string, unknown>): number | null {
 
 export interface IntegrateResult {
   readonly tokenDelta: TokenDelta;
+  readonly accounting: RunnerAccountingSnapshot;
 }
 
 /**
@@ -284,6 +330,7 @@ export function integrateCodexUpdate(
     entry.codexLastReportedInputTokens = 0;
     entry.codexLastReportedOutputTokens = 0;
     entry.codexLastReportedTotalTokens = 0;
+    entry.accountingLastReportedCostUsd = null;
   }
 
   const tokenDelta = extractTokenDelta(entry, payload);
@@ -302,10 +349,31 @@ export function integrateCodexUpdate(
   entry.codexInputTokens += tokenDelta.inputTokens;
   entry.codexOutputTokens += tokenDelta.outputTokens;
   entry.codexTotalTokens += tokenDelta.totalTokens;
+  entry.accountingCostUsd =
+    tokenDelta.costUsd > 0 || entry.accountingCostUsd !== null
+      ? (entry.accountingCostUsd ?? 0) + tokenDelta.costUsd
+      : null;
+  entry.accounting = createRunnerAccountingSnapshot({
+    inputTokens:
+      entry.codexTokenState === "observed" || tokenDelta.inputTokens > 0
+        ? entry.codexInputTokens
+        : entry.accounting.inputTokens,
+    outputTokens:
+      entry.codexTokenState === "observed" || tokenDelta.outputTokens > 0
+        ? entry.codexOutputTokens
+        : entry.accounting.outputTokens,
+    totalTokens:
+      entry.codexTokenState === "observed" || tokenDelta.totalTokens > 0
+        ? entry.codexTotalTokens
+        : entry.accounting.totalTokens,
+    costUsd: entry.accountingCostUsd,
+  });
   if (
     tokenDelta.inputTokens > 0 ||
     tokenDelta.outputTokens > 0 ||
-    tokenDelta.totalTokens > 0
+    tokenDelta.totalTokens > 0 ||
+    tokenDelta.costUsd > 0 ||
+    entry.accounting.status !== "unavailable"
   ) {
     entry.codexTokenState = "observed";
   }
@@ -314,5 +382,8 @@ export function integrateCodexUpdate(
     entry.turnCount += 1;
   }
 
-  return { tokenDelta };
+  return {
+    tokenDelta,
+    accounting: entry.accounting,
+  };
 }

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -179,7 +179,12 @@ function extractTokenDelta(
     mapPath(payload, ["usage", "totalTokens"]) ??
     mapPath(payload, ["usage", "total_tokens"]);
   const costRaw =
-    getMapKey(payload, ["cost_usd", "costUsd", "total_cost_usd", "totalCostUsd"]) ??
+    getMapKey(payload, [
+      "cost_usd",
+      "costUsd",
+      "total_cost_usd",
+      "totalCostUsd",
+    ]) ??
     mapPath(payload, ["payload", "cost_usd"]) ??
     mapPath(payload, ["payload", "costUsd"]) ??
     mapPath(payload, ["payload", "info", "cost_usd"]) ??
@@ -223,7 +228,10 @@ function extractTokenDelta(
     costUsd:
       reportedCost === null
         ? 0
-        : Math.max(0, reportedCost - (entry.accountingLastReportedCostUsd ?? 0)),
+        : Math.max(
+            0,
+            reportedCost - (entry.accountingLastReportedCostUsd ?? 0),
+          ),
   };
 
   // Update high-water marks using Math.max so they never decrease.

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -373,17 +373,17 @@ export function integrateCodexUpdate(
       : null;
   entry.accounting = createRunnerAccountingSnapshot({
     inputTokens:
-      entry.codexTokenState === "observed" || tokenDelta.inputTokens > 0
+      entry.accounting.inputTokens !== null || tokenDelta.inputTokens > 0
         ? entry.codexInputTokens
-        : entry.accounting.inputTokens,
+        : null,
     outputTokens:
-      entry.codexTokenState === "observed" || tokenDelta.outputTokens > 0
+      entry.accounting.outputTokens !== null || tokenDelta.outputTokens > 0
         ? entry.codexOutputTokens
-        : entry.accounting.outputTokens,
+        : null,
     totalTokens:
-      entry.codexTokenState === "observed" || tokenDelta.totalTokens > 0
+      entry.accounting.totalTokens !== null || tokenDelta.totalTokens > 0
         ? entry.codexTotalTokens
-        : entry.accounting.totalTokens,
+        : null,
     costUsd: entry.accountingCostUsd,
   });
   if (

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -290,6 +290,16 @@ export interface IntegrateResult {
   readonly accounting: RunnerAccountingSnapshot;
 }
 
+function hasObservedTokenAccounting(
+  accounting: RunnerAccountingSnapshot,
+): boolean {
+  return (
+    accounting.inputTokens !== null ||
+    accounting.outputTokens !== null ||
+    accounting.totalTokens !== null
+  );
+}
+
 /**
  * Normalize Codex event names to a canonical slash form.
  *
@@ -372,8 +382,7 @@ export function integrateCodexUpdate(
     tokenDelta.inputTokens > 0 ||
     tokenDelta.outputTokens > 0 ||
     tokenDelta.totalTokens > 0 ||
-    tokenDelta.costUsd > 0 ||
-    entry.accounting.status !== "unavailable"
+    hasObservedTokenAccounting(entry.accounting)
   ) {
     entry.codexTokenState = "observed";
   }

--- a/src/orchestrator/running-entry.ts
+++ b/src/orchestrator/running-entry.ts
@@ -67,6 +67,7 @@ interface TokenDelta {
   readonly outputTokens: number;
   readonly totalTokens: number;
   readonly costUsd: number;
+  readonly costObserved: boolean;
 }
 
 function extractTokenDelta(
@@ -209,7 +210,13 @@ function extractTokenDelta(
     reportedTotal === null &&
     reportedCost === null
   ) {
-    return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      costObserved: false,
+    };
   }
 
   const delta = {
@@ -232,6 +239,7 @@ function extractTokenDelta(
             0,
             reportedCost - (entry.accountingLastReportedCostUsd ?? 0),
           ),
+    costObserved: reportedCost !== null,
   };
 
   // Update high-water marks using Math.max so they never decrease.
@@ -368,7 +376,7 @@ export function integrateCodexUpdate(
   entry.codexOutputTokens += tokenDelta.outputTokens;
   entry.codexTotalTokens += tokenDelta.totalTokens;
   entry.accountingCostUsd =
-    tokenDelta.costUsd > 0 || entry.accountingCostUsd !== null
+    tokenDelta.costObserved || entry.accountingCostUsd !== null
       ? (entry.accountingCostUsd ?? 0) + tokenDelta.costUsd
       : null;
   entry.accounting = createRunnerAccountingSnapshot({

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1181,7 +1181,9 @@ export class BootstrapOrchestrator implements Orchestrator {
           runSession: session,
           description: result.session,
           latestTurnNumber: turn.turnNumber,
-          accounting: sessionState.accounting,
+          accounting:
+            this.#state.runningEntries.get(issue.number)?.accounting ??
+            sessionState.accounting,
         };
 
         if (result.exitCode !== 0) {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -60,6 +60,11 @@ import {
   type RunnerVisibilitySnapshot,
   type RunnerTurnResult,
 } from "../runner/service.js";
+import {
+  aggregateRunnerAccountingSnapshots,
+  createRunnerAccountingSnapshot,
+  type RunnerAccountingSnapshot,
+} from "../runner/accounting.js";
 import type { Tracker } from "../tracker/service.js";
 import type { LandingExecutionResult } from "../tracker/service.js";
 import type { WorkspaceManager } from "../workspace/service.js";
@@ -155,6 +160,7 @@ export interface TuiRunningEntry {
   readonly retryAttempt: number;
   readonly sessionId: string | null;
   readonly turnCount: number;
+  readonly accounting?: RunnerAccountingSnapshot | undefined;
   readonly codexTokenState: CodexTokenState;
   readonly codexTotalTokens: number;
   readonly codexInputTokens: number;
@@ -192,6 +198,7 @@ export interface TuiSnapshot {
   readonly running: readonly TuiRunningEntry[];
   readonly retrying: readonly TuiRetryEntry[];
   readonly codexTotals: TuiCodexTotals;
+  readonly runnerAccounting?: RunnerAccountingSnapshot | undefined;
   readonly rateLimits: RateLimits | null;
   readonly recoveryPosture: ReturnType<typeof projectRecoveryPosture>;
   readonly lastAction: FactoryStatusAction | null;
@@ -320,6 +327,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         retryAttempt: entry.retryAttempt,
         sessionId: entry.sessionId,
         turnCount: entry.turnCount,
+        accounting: entry.accounting,
         codexTokenState: entry.codexTokenState,
         codexTotalTokens: entry.codexTotalTokens,
         codexInputTokens: entry.codexInputTokens,
@@ -355,6 +363,11 @@ export class BootstrapOrchestrator implements Orchestrator {
         pendingRunCount,
         secondsRunning: Math.floor((now - this.#factoryStartedAt) / 1000),
       },
+      runnerAccounting: aggregateRunnerAccountingSnapshots(
+        running
+          .map((entry) => entry.accounting)
+          .filter((entry): entry is RunnerAccountingSnapshot => entry !== undefined),
+      ),
       rateLimits: this.#state.rateLimits,
       recoveryPosture: projectRecoveryPosture({
         publication: this.#snapshotPublicationState(),
@@ -1019,6 +1032,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       runSession: session,
       description: this.#runner.describeSession(session),
       latestTurnNumber: null,
+      accounting: createRunnerAccountingSnapshot(),
     };
     upsertActiveIssue(this.#state.status, issue, {
       source,
@@ -1050,6 +1064,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         unresolvedThreadCount: pullRequest?.unresolvedThreadIds.length ?? 0,
       },
       blockedReason: null,
+      runnerAccounting: sessionState.accounting,
       runnerVisibility: this.#buildRunnerVisibility(sessionState.description, {
         state: "starting",
         phase: "boot",
@@ -1166,6 +1181,7 @@ export class BootstrapOrchestrator implements Orchestrator {
           runSession: session,
           description: result.session,
           latestTurnNumber: turn.turnNumber,
+          accounting: sessionState.accounting,
         };
 
         if (result.exitCode !== 0) {
@@ -1381,6 +1397,9 @@ export class BootstrapOrchestrator implements Orchestrator {
                 liveRunnerSession?.describe() ??
                 this.#runner.describeSession(session),
               latestTurnNumber: turn.turnNumber,
+              accounting:
+                this.#state.runningEntries.get(session.issue.number)
+                  ?.accounting ?? createRunnerAccountingSnapshot(),
             },
             lockDir,
             event,
@@ -1896,6 +1915,7 @@ export class BootstrapOrchestrator implements Orchestrator {
             runSession,
             description: this.#runner.describeSession(runSession),
             latestTurnNumber: null,
+            accounting: createRunnerAccountingSnapshot(),
           };
     this.#logger.error("Issue run failed", {
       issueNumber: runSession.issue.number,
@@ -2958,6 +2978,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       finishedAt: finishedAt ?? null,
       workspacePath: session.runSession.workspace.path,
       branch: session.runSession.workspace.branchName,
+      accounting: session.accounting,
       logPointers: session.description.logPointers.map((pointer) =>
         this.#createLogPointer(pointer),
       ),
@@ -3034,12 +3055,15 @@ export class BootstrapOrchestrator implements Orchestrator {
     session: RunSessionArtifactsState,
     liveRunnerSession?: LiveRunnerSession,
   ): RunSessionArtifactsState {
-    if (liveRunnerSession === undefined) {
-      return session;
-    }
     return {
       ...session,
-      description: liveRunnerSession.describe(),
+      description:
+        liveRunnerSession === undefined
+          ? session.description
+          : liveRunnerSession.describe(),
+      accounting:
+        this.#state.runningEntries.get(session.runSession.issue.number)
+          ?.accounting ?? session.accounting,
     };
   }
 
@@ -3254,6 +3278,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         ...entry,
         runnerPid: event.pid,
         updatedAt: event.spawnedAt,
+        runnerAccounting: session.accounting,
         runnerVisibility: this.#buildRunnerVisibility(
           {
             ...(entry.runnerVisibility?.session ?? session.description),
@@ -3313,6 +3338,9 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#state.status.activeIssues.set(issueNumber, {
       ...entry,
       updatedAt: updatedAt ?? runnerVisibility.lastActionAt ?? entry.updatedAt,
+      runnerAccounting:
+        this.#state.runningEntries.get(issueNumber)?.accounting ??
+        entry.runnerAccounting,
       runnerVisibility,
     });
   }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -366,7 +366,9 @@ export class BootstrapOrchestrator implements Orchestrator {
       runnerAccounting: aggregateRunnerAccountingSnapshots(
         running
           .map((entry) => entry.accounting)
-          .filter((entry): entry is RunnerAccountingSnapshot => entry !== undefined),
+          .filter(
+            (entry): entry is RunnerAccountingSnapshot => entry !== undefined,
+          ),
       ),
       rateLimits: this.#state.rateLimits,
       recoveryPosture: projectRecoveryPosture({

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -164,6 +164,10 @@ export function upsertActiveIssue(
       update.blockedReason === undefined
         ? (existing?.blockedReason ?? null)
         : update.blockedReason,
+    runnerAccounting:
+      update.runnerAccounting === undefined
+        ? existing?.runnerAccounting
+        : update.runnerAccounting,
     runnerVisibility:
       update.runnerVisibility === undefined
         ? (existing?.runnerVisibility ?? null)

--- a/src/runner/accounting.ts
+++ b/src/runner/accounting.ts
@@ -1,0 +1,101 @@
+export type RunnerAccountingStatus = "unavailable" | "partial" | "complete";
+
+export interface RunnerAccountingSnapshot {
+  readonly status: RunnerAccountingStatus;
+  readonly inputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+}
+
+export function createRunnerAccountingSnapshot(input?: {
+  readonly inputTokens?: number | null;
+  readonly outputTokens?: number | null;
+  readonly totalTokens?: number | null;
+  readonly costUsd?: number | null;
+}): RunnerAccountingSnapshot {
+  const fields = {
+    inputTokens: input?.inputTokens ?? null,
+    outputTokens: input?.outputTokens ?? null,
+    totalTokens: input?.totalTokens ?? null,
+    costUsd: input?.costUsd ?? null,
+  };
+  return {
+    ...fields,
+    status: deriveRunnerAccountingStatus(fields),
+  };
+}
+
+export function deriveRunnerAccountingStatus(input: {
+  readonly inputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+}): RunnerAccountingStatus {
+  if (
+    input.inputTokens === null &&
+    input.outputTokens === null &&
+    input.totalTokens === null &&
+    input.costUsd === null
+  ) {
+    return "unavailable";
+  }
+  if (input.totalTokens !== null && input.costUsd !== null) {
+    return "complete";
+  }
+  return "partial";
+}
+
+export function aggregateRunnerAccountingSnapshots(
+  snapshots: readonly RunnerAccountingSnapshot[],
+): RunnerAccountingSnapshot {
+  if (snapshots.length === 0) {
+    return createRunnerAccountingSnapshot();
+  }
+
+  const statuses = snapshots.map((snapshot) => snapshot.status);
+  const allUnavailable = statuses.every((status) => status === "unavailable");
+  const allComplete = statuses.every((status) => status === "complete");
+
+  return {
+    status: allUnavailable ? "unavailable" : allComplete ? "complete" : "partial",
+    inputTokens: sumIfAllPresent(snapshots.map((snapshot) => snapshot.inputTokens)),
+    outputTokens: sumIfAllPresent(
+      snapshots.map((snapshot) => snapshot.outputTokens),
+    ),
+    totalTokens: sumIfAllPresent(snapshots.map((snapshot) => snapshot.totalTokens)),
+    costUsd: sumIfAllPresent(snapshots.map((snapshot) => snapshot.costUsd)),
+  };
+}
+
+export function sumObservedRunnerAccounting(
+  snapshots: readonly RunnerAccountingSnapshot[],
+): {
+  readonly inputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly totalTokens: number | null;
+  readonly costUsd: number | null;
+} {
+  return {
+    inputTokens: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.inputTokens)),
+    outputTokens: sumIfAnyPresent(
+      snapshots.map((snapshot) => snapshot.outputTokens),
+    ),
+    totalTokens: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.totalTokens)),
+    costUsd: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.costUsd)),
+  };
+}
+
+function sumIfAllPresent(values: readonly (number | null)[]): number | null {
+  const observed = values.filter((value): value is number => value !== null);
+  return observed.length === values.length
+    ? observed.reduce((sum, value) => sum + value, 0)
+    : null;
+}
+
+function sumIfAnyPresent(values: readonly (number | null)[]): number | null {
+  const observed = values.filter((value): value is number => value !== null);
+  return observed.length === 0
+    ? null
+    : observed.reduce((sum, value) => sum + value, 0);
+}

--- a/src/runner/accounting.ts
+++ b/src/runner/accounting.ts
@@ -68,34 +68,11 @@ export function aggregateRunnerAccountingSnapshots(
   };
 }
 
-export function sumObservedRunnerAccounting(
-  snapshots: readonly RunnerAccountingSnapshot[],
-): {
-  readonly inputTokens: number | null;
-  readonly outputTokens: number | null;
-  readonly totalTokens: number | null;
-  readonly costUsd: number | null;
-} {
-  return {
-    inputTokens: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.inputTokens)),
-    outputTokens: sumIfAnyPresent(
-      snapshots.map((snapshot) => snapshot.outputTokens),
-    ),
-    totalTokens: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.totalTokens)),
-    costUsd: sumIfAnyPresent(snapshots.map((snapshot) => snapshot.costUsd)),
-  };
-}
-
-function sumIfAllPresent(values: readonly (number | null)[]): number | null {
+export function sumIfAllPresent(
+  values: readonly (number | null)[],
+): number | null {
   const observed = values.filter((value): value is number => value !== null);
-  return observed.length === values.length
+  return observed.length === values.length && observed.length > 0
     ? observed.reduce((sum, value) => sum + value, 0)
     : null;
-}
-
-function sumIfAnyPresent(values: readonly (number | null)[]): number | null {
-  const observed = values.filter((value): value is number => value !== null);
-  return observed.length === 0
-    ? null
-    : observed.reduce((sum, value) => sum + value, 0);
 }

--- a/src/runner/accounting.ts
+++ b/src/runner/accounting.ts
@@ -58,12 +58,20 @@ export function aggregateRunnerAccountingSnapshots(
   const allComplete = statuses.every((status) => status === "complete");
 
   return {
-    status: allUnavailable ? "unavailable" : allComplete ? "complete" : "partial",
-    inputTokens: sumIfAllPresent(snapshots.map((snapshot) => snapshot.inputTokens)),
+    status: allUnavailable
+      ? "unavailable"
+      : allComplete
+        ? "complete"
+        : "partial",
+    inputTokens: sumIfAllPresent(
+      snapshots.map((snapshot) => snapshot.inputTokens),
+    ),
     outputTokens: sumIfAllPresent(
       snapshots.map((snapshot) => snapshot.outputTokens),
     ),
-    totalTokens: sumIfAllPresent(snapshots.map((snapshot) => snapshot.totalTokens)),
+    totalTokens: sumIfAllPresent(
+      snapshots.map((snapshot) => snapshot.totalTokens),
+    ),
     costUsd: sumIfAllPresent(snapshots.map((snapshot) => snapshot.costUsd)),
   };
 }

--- a/tests/integration/report-cli.test.ts
+++ b/tests/integration/report-cli.test.ts
@@ -66,6 +66,44 @@ describe("report CLI", () => {
     expect(stdout.join("")).toContain("Generated issue report for #44");
   });
 
+  it("renders canonical runner-event accounting without requiring enrichment", async () => {
+    const tempDir = await createTempDir("symphony-report-cli-canonical-");
+    tempRoots.push(tempDir);
+    const workflowPath = await writeReportWorkflow(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44, {
+      accounting: {
+        status: "partial",
+        inputTokens: 2000,
+        outputTokens: 750,
+        totalTokens: 2750,
+        costUsd: null,
+      },
+    });
+
+    await runReportCli(
+      [
+        "node",
+        "symphony-report",
+        "issue",
+        "--issue",
+        "44",
+        "--workflow",
+        workflowPath,
+      ],
+      { issueEnrichers: [] },
+    );
+
+    const reportDir = path.join(tempDir, ".var", "reports", "issues", "44");
+    const reportJson = await fs.readFile(
+      path.join(reportDir, "report.json"),
+      "utf8",
+    );
+    expect(reportJson).toContain('"status": "partial"');
+    expect(reportJson).toContain('"totalTokens": 2750');
+    expect(reportJson).toContain("Canonical runner-event accounting");
+  });
+
   it("renders a failed issue report with explicit token unavailability", async () => {
     const tempDir = await createTempDir("symphony-report-cli-failed-");
     tempRoots.push(tempDir);
@@ -142,10 +180,10 @@ describe("report CLI", () => {
       path.join(reportDir, "report.md"),
       "utf8",
     );
-    expect(reportJson).toContain('"status": "complete"');
+    expect(reportJson).toContain('"status": "partial"');
     expect(reportJson).toContain('"totalTokens": 3210');
     expect(reportJson).toContain("matched Codex JSONL session");
-    expect(reportMd).toContain("Status: complete");
+    expect(reportMd).toContain("Status: partial");
     expect(reportMd).toContain("Final summary:");
   });
 

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -5,6 +5,7 @@ import {
   LocalIssueArtifactStore,
   deriveIssueArtifactPaths,
 } from "../../src/observability/issue-artifacts.js";
+import type { RunnerAccountingSnapshot } from "../../src/runner/accounting.js";
 
 export async function writeReportWorkflow(rootDir: string): Promise<string> {
   const workflowPath = path.join(rootDir, "WORKFLOW.md");
@@ -67,6 +68,7 @@ export async function seedSuccessfulIssueArtifacts(
     readonly latestCommitAt?: string | undefined;
     readonly succeededAt?: string | undefined;
     readonly finalCommitAt?: string | undefined;
+    readonly accounting?: RunnerAccountingSnapshot | undefined;
   },
 ): Promise<void> {
   const store = new LocalIssueArtifactStore(workspaceRoot);
@@ -182,6 +184,7 @@ export async function seedSuccessfulIssueArtifacts(
         `issue-${issueNumber.toString()}`,
       ),
       branch,
+      accounting: options?.accounting,
       logPointers: [
         {
           name: "runner.log",

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -201,6 +201,13 @@ describe("issue artifacts", () => {
         finishedAt: observedAt,
         workspacePath: "/tmp/workspaces/43",
         branch: "symphony/43",
+        accounting: {
+          status: "partial",
+          inputTokens: 1200,
+          outputTokens: 300,
+          totalTokens: 1500,
+          costUsd: null,
+        },
         logPointers: [],
       },
       logPointers: {
@@ -221,6 +228,13 @@ describe("issue artifacts", () => {
     );
     expect(session.provider).toBe("local-runner");
     expect(session.finishedAt).toBe(observedAt);
+    expect(session.accounting).toEqual({
+      status: "partial",
+      inputTokens: 1200,
+      outputTokens: 300,
+      totalTokens: 1500,
+      costUsd: null,
+    });
 
     const logPointers = await readIssueArtifactLogPointers(workspaceRoot, 43);
     expect(logPointers.sessions[sessionId]?.sessionId).toBe(sessionId);

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -193,6 +193,50 @@ describe("issue report enrichment", () => {
     );
   });
 
+  it("preserves canonical cost availability when enrichment fills missing token totals", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-cost-kept-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    const sessionsRoot = deriveCodexSessionsRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44, {
+      accounting: {
+        status: "partial",
+        inputTokens: null,
+        outputTokens: null,
+        totalTokens: null,
+        costUsd: 1.25,
+      },
+    });
+
+    await writeCodexSessionLog({
+      sessionsRoot,
+      startedAt: "2026-03-09T10:05:00.000Z",
+      workspacePath: `${workspaceRoot}/issue-44`,
+      branch: "symphony/44",
+      fileName: "rollout-2026-03-09T10-05-00-cost-kept.jsonl",
+      inputTokens: 2000,
+      cachedInputTokens: 500,
+      outputTokens: 250,
+      reasoningOutputTokens: 100,
+      totalTokens: 2750,
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:06:00.000Z",
+      enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.totalTokens).toBe(2750);
+    expect(generated.report.tokenUsage.costUsd).toBe(1.25);
+    expect(generated.report.tokenUsage.explanation).toContain(
+      "already supplied cost totals for all 1 session(s)",
+    );
+    expect(generated.report.tokenUsage.explanation).not.toContain(
+      "Estimated cost remains unavailable",
+    );
+  });
+
   it("keeps report generation successful when a matching-window Codex log is malformed", async () => {
     const tempDir = await createTempDir("symphony-issue-report-malformed-");
     tempRoots.push(tempDir);

--- a/tests/unit/issue-report-enrichment.test.ts
+++ b/tests/unit/issue-report-enrichment.test.ts
@@ -63,7 +63,7 @@ describe("issue report enrichment", () => {
       enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
     });
 
-    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.status).toBe("partial");
     expect(generated.report.tokenUsage.totalTokens).toBe(2750);
     expect(generated.report.tokenUsage.explanation).toContain(
       "token totals for all 1 session(s)",
@@ -71,7 +71,7 @@ describe("issue report enrichment", () => {
     expect(generated.report.tokenUsage.sessions).toEqual([
       expect.objectContaining({
         sessionId: "sociotechnica-org/symphony-ts#44/attempt-1/session-1",
-        status: "complete",
+        status: "partial",
         inputTokens: 2000,
         cachedInputTokens: 500,
         outputTokens: 250,
@@ -138,7 +138,7 @@ describe("issue report enrichment", () => {
       enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
     });
 
-    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.status).toBe("partial");
     expect(generated.report.tokenUsage.totalTokens).toBe(2750);
     expect(generated.report.tokenUsage.sessions[0]).toEqual(
       expect.objectContaining({
@@ -250,7 +250,7 @@ describe("issue report enrichment", () => {
       enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
     });
 
-    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.status).toBe("partial");
     expect(generated.report.tokenUsage.totalTokens).toBe(2750);
     expect(generated.report.tokenUsage.sessions[0]?.notes).toContain(
       "At least one runner log file in the matching time window could not be parsed; enrichment used the only readable match.",
@@ -409,7 +409,7 @@ describe("issue report enrichment", () => {
       enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
     });
 
-    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.status).toBe("partial");
     expect(generated.report.tokenUsage.totalTokens).toBe(1440);
     expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
       logPath,
@@ -446,7 +446,7 @@ describe("issue report enrichment", () => {
       enrichers: [new CodexIssueReportEnricher({ sessionsRoot })],
     });
 
-    expect(generated.report.tokenUsage.status).toBe("complete");
+    expect(generated.report.tokenUsage.status).toBe("partial");
     expect(generated.report.tokenUsage.totalTokens).toBe(900);
     expect(generated.report.tokenUsage.sessions[0]?.sourceArtifacts).toContain(
       logPath,

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -99,6 +99,12 @@ describe("issue report generation", () => {
     expect(generated.report.tokenUsage.explanation).toContain(
       "Canonical runner-event accounting",
     );
+    expect(generated.report.tokenUsage.explanation).toContain(
+      "1 remained partial",
+    );
+    expect(generated.report.tokenUsage.explanation).not.toContain(
+      "remained estimated",
+    );
   });
 
   it("generates a partial report when issue and event artifacts are missing but session artifacts remain", async () => {

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -66,6 +66,41 @@ describe("issue report generation", () => {
     expect(generated.markdown).toContain("failing checks None");
   });
 
+  it("projects canonical runner-event accounting into report token usage", async () => {
+    const tempDir = await createTempDir("symphony-issue-report-accounting-");
+    tempRoots.push(tempDir);
+    const workspaceRoot = deriveWorkspaceRoot(tempDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44, {
+      accounting: {
+        status: "partial",
+        inputTokens: 2000,
+        outputTokens: 750,
+        totalTokens: 2750,
+        costUsd: null,
+      },
+    });
+
+    const generated = await generateIssueReport(workspaceRoot, 44, {
+      generatedAt: "2026-03-09T13:05:00.000Z",
+    });
+
+    expect(generated.report.tokenUsage.status).toBe("partial");
+    expect(generated.report.tokenUsage.totalTokens).toBe(2750);
+    expect(generated.report.tokenUsage.costUsd).toBeNull();
+    expect(generated.report.tokenUsage.sessions[0]).toEqual(
+      expect.objectContaining({
+        status: "partial",
+        inputTokens: 2000,
+        outputTokens: 750,
+        totalTokens: 2750,
+        costUsd: null,
+      }),
+    );
+    expect(generated.report.tokenUsage.explanation).toContain(
+      "Canonical runner-event accounting",
+    );
+  });
+
   it("generates a partial report when issue and event artifacts are missing but session artifacts remain", async () => {
     const tempDir = await createTempDir("symphony-issue-report-partial-");
     tempRoots.push(tempDir);

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -2543,6 +2543,98 @@ describe("BootstrapOrchestrator", () => {
     }
   });
 
+  it("persists live-session accounting observed during a turn into session artifacts", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(90)],
+    });
+    tracker.setLifecycleSequence(90, [
+      lifecycle("handoff-ready", "symphony/90"),
+    ]);
+    const tempRoot = await createTempDir("symphony-live-accounting-artifact-");
+
+    try {
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        {
+          describeSession() {
+            return createRunnerSessionDescription();
+          },
+          async run(): Promise<RunnerExecutionResult> {
+            throw new Error("runner.run should not be called");
+          },
+          async startSession(): Promise<LiveRunnerSession> {
+            let latestTurnNumber: number | null = null;
+            return {
+              describe() {
+                return {
+                  ...createRunnerSessionDescription(),
+                  backendSessionId: "codex-session-90",
+                  latestTurnNumber,
+                };
+              },
+              async runTurn(turn, options): Promise<RunnerTurnResult> {
+                latestTurnNumber = turn.turnNumber;
+                options?.onUpdate?.({
+                  event: "codex/event/token_count",
+                  payload: {
+                    input_tokens: 123,
+                    output_tokens: 45,
+                    total_tokens: 168,
+                  },
+                  timestamp: formatTurnTimestamp(50, turn.turnNumber),
+                });
+                const timestamp = formatTurnTimestamp(50, turn.turnNumber);
+                return {
+                  exitCode: 0,
+                  stdout: "",
+                  stderr: "",
+                  startedAt: timestamp,
+                  finishedAt: timestamp,
+                  session: {
+                    ...createRunnerSessionDescription(),
+                    backendSessionId: "codex-session-90",
+                    latestTurnNumber,
+                  },
+                };
+              },
+              async close(): Promise<void> {},
+            };
+          },
+        },
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      expect(tracker.completed).toEqual([90]);
+
+      const attempt = await readIssueArtifactAttempt(tempRoot, 90, 1);
+      const session = await readIssueArtifactSession(
+        tempRoot,
+        90,
+        attempt.sessionId!,
+      );
+      expect(session.accounting).toEqual({
+        status: "partial",
+        inputTokens: 123,
+        outputTokens: 45,
+        totalTokens: 168,
+        costUsd: null,
+      });
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the raw missing-target summary when max_turns is one", async () => {
     const tracker = new SequencedTracker({
       ready: [createIssue(89)],

--- a/tests/unit/running-entry.test.ts
+++ b/tests/unit/running-entry.test.ts
@@ -218,4 +218,30 @@ describe("integrateCodexUpdate", () => {
     expect(entry.codexTokenState).toBe("observed");
     expect(entry.codexTotalTokens).toBe(150);
   });
+
+  it("keeps token state pending for cost-only accounting events", () => {
+    const entry = createRunningEntry(99, "issue-99", "open", 1);
+
+    const result = integrateCodexUpdate(entry, {
+      event: "codex/event/token_count",
+      payload: { cost_usd: 1.25 },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(result.tokenDelta).toEqual({
+      costUsd: 1.25,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+    expect(entry.accounting).toEqual({
+      status: "partial",
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: null,
+      costUsd: 1.25,
+    });
+    expect(entry.codexTokenState).toBe("pending");
+    expect(entry.codexTotalTokens).toBe(0);
+  });
 });

--- a/tests/unit/running-entry.test.ts
+++ b/tests/unit/running-entry.test.ts
@@ -117,6 +117,7 @@ describe("integrateCodexUpdate", () => {
 
     expect(result.tokenDelta).toEqual({
       costUsd: 0,
+      costObserved: false,
       inputTokens: 123,
       outputTokens: 45,
       totalTokens: 168,
@@ -230,6 +231,7 @@ describe("integrateCodexUpdate", () => {
 
     expect(result.tokenDelta).toEqual({
       costUsd: 1.25,
+      costObserved: true,
       inputTokens: 0,
       outputTokens: 0,
       totalTokens: 0,
@@ -243,6 +245,31 @@ describe("integrateCodexUpdate", () => {
     });
     expect(entry.codexTokenState).toBe("pending");
     expect(entry.codexTotalTokens).toBe(0);
+  });
+
+  it("preserves explicit zero-cost accounting as observed", () => {
+    const entry = createRunningEntry(99, "issue-99", "open", 1);
+
+    const result = integrateCodexUpdate(entry, {
+      event: "codex/event/token_count",
+      payload: { total_tokens: 150, cost_usd: 0 },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(result.tokenDelta).toEqual({
+      costUsd: 0,
+      costObserved: true,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 150,
+    });
+    expect(entry.accounting).toEqual({
+      status: "complete",
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: 150,
+      costUsd: 0,
+    });
   });
 
   it("preserves per-field token nullability across later non-token events", () => {

--- a/tests/unit/running-entry.test.ts
+++ b/tests/unit/running-entry.test.ts
@@ -244,4 +244,31 @@ describe("integrateCodexUpdate", () => {
     expect(entry.codexTokenState).toBe("pending");
     expect(entry.codexTotalTokens).toBe(0);
   });
+
+  it("preserves per-field token nullability across later non-token events", () => {
+    const entry = createRunningEntry(99, "issue-99", "open", 1);
+
+    integrateCodexUpdate(entry, {
+      event: "codex/event/token_count",
+      payload: { input_tokens: 100 },
+      timestamp: new Date().toISOString(),
+    });
+    integrateCodexUpdate(entry, {
+      event: "thread/started",
+      payload: {
+        method: "thread/started",
+        params: { thread: { id: "thread-live-123" } },
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(entry.accounting).toEqual({
+      status: "partial",
+      inputTokens: 100,
+      outputTokens: null,
+      totalTokens: null,
+      costUsd: null,
+    });
+    expect(entry.codexTokenState).toBe("observed");
+  });
 });

--- a/tests/unit/running-entry.test.ts
+++ b/tests/unit/running-entry.test.ts
@@ -116,6 +116,7 @@ describe("integrateCodexUpdate", () => {
     });
 
     expect(result.tokenDelta).toEqual({
+      costUsd: 0,
       inputTokens: 123,
       outputTokens: 45,
       totalTokens: 168,

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -366,6 +366,7 @@ describe("factory status helpers", () => {
             startedAt: undefined,
             pullRequest: undefined,
             blockedReason: undefined,
+            runnerAccounting: null,
             runnerVisibility: undefined,
           },
         ],
@@ -376,7 +377,8 @@ describe("factory status helpers", () => {
         "utf8",
       );
 
-      await expect(readFactoryStatusSnapshot(filePath)).resolves.toMatchObject({
+      const parsed = await readFactoryStatusSnapshot(filePath);
+      expect(parsed).toMatchObject({
         lastAction: null,
         activeIssues: [
           {
@@ -387,6 +389,7 @@ describe("factory status helpers", () => {
           },
         ],
       });
+      expect(parsed.activeIssues[0]?.runnerAccounting).toBeUndefined();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #167

## Summary
- introduce a provider-neutral runner accounting snapshot and integrate it from runner updates into active run/session artifacts
- project canonical accounting into status and report surfaces while keeping missing token/cost facts explicit
- keep optional Codex log enrichment additive when canonical accounting is partial or unavailable

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
