### PR TITLE
Generalize the workspace contract for local and remote execution targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ from existing issue reports. They are written under:
 
 1. An issue gets the `symphony:ready` label
 2. Symphony claims it, swaps the label to `symphony:running`
-3. Symphony prepares branch `symphony/<issue-number>` in an isolated local workspace
+3. Symphony prepares branch `symphony/<issue-number>` in an isolated execution workspace (today a local checkout, later also a remote target seam)
 4. The agent drafts a technical plan and stops at a **human review station** (unless waived)
 5. After plan approval, the agent implements the issue and opens a PR
 6. Symphony monitors CI and automated review feedback on the PR
@@ -282,6 +282,8 @@ shares the same runtime semantics. Set `workspace.repo_url` explicitly when you
 want to override the derived source or when using a tracker/config path that
 does not provide enough repository information on its own. Explicit local-path
 `workspace.repo_url` values are resolved relative to the owning `WORKFLOW.md`.
+Startup preparation now hands that mirror to the workspace layer as a typed
+workspace-source override instead of rewriting the configured `workspace.repo_url`.
 
 `agent.runner.kind` keeps backend selection in `WORKFLOW.md`. Use `codex` for
 the built-in long-lived Codex app-server path, `claude-code` for the first-class

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,10 +79,13 @@ Responsible for:
 
 - deterministic workspace paths
 - workspace creation and reuse
+- execution-target metadata for prepared workspaces
 - lifecycle hooks such as `after_create`
 - cleanup policy
 
-This layer owns filesystem preparation, not tracker policy.
+This layer owns execution-workspace preparation, not tracker policy. Today that
+means local filesystem checkouts; future remote targets should extend this
+contract without pushing host/path logic up into runners or the orchestrator.
 
 ### Runner
 

--- a/docs/plans/183-generalize-workspace-contract-for-local-and-remote-targets/plan.md
+++ b/docs/plans/183-generalize-workspace-contract-for-local-and-remote-targets/plan.md
@@ -1,0 +1,285 @@
+# Issue 183 Plan: Generalize The Workspace Contract For Local And Remote Execution Targets
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Refactor the workspace contract so Symphony can represent a prepared execution workspace as either:
+
+- a local filesystem checkout on the current host, or
+- a remote execution workspace on another host
+
+while preserving the current local clone/fetch/branch lifecycle as the only concrete implementation in this slice.
+
+The contract should move execution-target facts into the workspace layer instead of leaking them through startup config overrides or forcing runner adapters to invent their own remote-path model later.
+
+## Scope
+
+- define a normalized execution-workspace domain model that can describe local and remote prepared workspaces
+- define a workspace-source / prepared-source contract so startup preparation can hand the workspace layer a prepared source without mutating `workspace.repoUrl`
+- extend workspace preparation and cleanup contracts to carry host-aware metadata needed by future remote runners
+- preserve the existing local workspace behavior as the default concrete implementation
+- update local runner and orchestrator call sites to consume the generalized workspace contract without changing workflow or tracker policy
+- add tests that lock in the new contract while proving the current local path still behaves the same
+- update docs where the execution-layer workspace seam needs to be explicit
+
+## Non-goals
+
+- implementing a real remote workspace manager or remote runner transport
+- introducing SSH, RPC, leases, or remote host coordination protocols
+- changing tracker transport, tracker normalization, or tracker policy
+- changing orchestrator retry, continuation, reconciliation, or handoff behavior
+- redesigning startup mirror policy beyond threading its result through a typed workspace-source seam
+- changing the local branch/reset semantics already covered by `#88`
+
+## Current Gaps
+
+- `src/domain/workspace.ts` defines `PreparedWorkspace` only as `{ key, path, branchName, createdNow }`, so the runtime equates "prepared workspace" with "local cwd on this host"
+- `src/runner/local-execution.ts` and `src/runner/local-live-session.ts` read `session.workspace.path` directly for `cwd`, prompt-file writes, Codex session discovery, and environment variables, which hardcodes local-host execution assumptions into the runner boundary
+- `src/cli/index.ts` still rewrites `workflow.config.workspace.repoUrl` from `startup.workspaceRepoUrlOverride`, so startup preparation leaks source-selection details through config mutation instead of a workspace-owned contract
+- `src/workspace/service.ts` and `src/workspace/local.ts` do not distinguish:
+  - source preparation versus per-issue workspace preparation
+  - execution location metadata versus cleanup inputs
+- current tests prove local workspaces and mirror-backed startup, but they do not lock in a provider-neutral workspace contract that future remote execution can implement without reworking the orchestrator or runner again
+
+## Decision Notes
+
+- Keep this slice inside the execution layer. The deliverable is a stable workspace contract plus local implementation updates, not a remote-execution feature.
+- Reuse the existing startup-preparation seam, but narrow its output to a typed workspace-source override rather than mutating `workspace.repoUrl` at the CLI boundary.
+- Keep local path access explicit and typed. Future remote-capable runners should be able to branch on a normalized execution target, not infer remote-ness from missing fields or ad hoc strings.
+- Do not introduce fake remote execution. The plan should land inert, well-tested plumbing that preserves the current local happy path and makes the later remote slice smaller.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned rule that a prepared workspace is an execution-layer contract, not an implicit local-path assumption
+  - belongs: the rule that startup preparation may provide a prepared workspace source, while workspace preparation owns the per-issue execution workspace result
+  - does not belong: git subprocess wiring, `cwd` branching, or remote transport details
+- Configuration Layer
+  - belongs: preserving `workspace.repoUrl` as the configured source repo and extending typed config only if the generalized contract needs explicit local-target defaults
+  - does not belong: startup source overrides, mirror path rewriting, or remote host session metadata
+- Coordination Layer
+  - belongs: consuming the generalized workspace contract through `WorkspaceManager` and `RunSession`
+  - does not belong: deciding local versus remote path semantics inline in the orchestrator
+- Execution Layer
+  - belongs: workspace source/preparation contracts, host-aware prepared workspace metadata, local workspace manager behavior, and runner consumption of the normalized execution target
+  - does not belong: tracker lifecycle policy or remote worker control-plane design
+- Integration Layer
+  - belongs: unchanged tracker integration; no tracker transport or normalization changes are needed in this slice
+  - does not belong: workspace host metadata or runner `cwd` decisions
+- Observability Layer
+  - belongs: logging the normalized execution target/source facts needed to diagnose local versus future remote workspace preparation
+  - does not belong: deciding source-selection or execution-target policy
+
+## Architecture Boundaries
+
+### Domain / workspace contract
+
+Belongs here:
+
+- a normalized execution workspace model with explicit target metadata
+- a typed representation of the prepared workspace source handed from startup to the workspace layer
+- cleanup inputs that can identify a workspace without assuming only a local path
+
+Does not belong here:
+
+- git command execution
+- runner subprocess launch logic
+- tracker policy
+
+### Startup
+
+Belongs here:
+
+- preparing or refreshing a reusable source checkout / mirror
+- returning a typed prepared-source override for the workspace layer to consume
+
+Does not belong here:
+
+- per-issue workspace branch creation
+- mutating resolved config to sneak in source overrides
+- runner-specific execution metadata
+
+### Workspace
+
+Belongs here:
+
+- consuming the configured source plus any startup-prepared source override
+- creating the per-issue execution workspace
+- returning explicit target metadata for local workspaces now, with a stable seam for remote targets later
+- cleanup based on the generalized workspace identity
+
+Does not belong here:
+
+- remote runner command transport
+- tracker handoff policy
+- startup snapshot persistence
+
+### Runner
+
+Belongs here:
+
+- consuming a normalized execution target from `RunSession.workspace`
+- using local-only operations only when the workspace target kind is local
+
+Does not belong here:
+
+- inventing its own remote workspace model
+- reaching back into startup/config to discover mirror paths or host metadata
+
+### Orchestrator
+
+Belongs here:
+
+- passing the generalized prepared workspace through `RunSession`
+- remaining agnostic to whether the workspace is local or remote unless policy explicitly needs that later
+
+Does not belong here:
+
+- path rewriting or host-transport branching
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR with one execution-layer seam:
+
+1. generalize the workspace domain and service contracts
+2. adapt the current local startup/workspace/runner path to those contracts
+3. keep behavior unchanged for existing local runs
+4. add focused tests and docs
+
+Deferred from this PR:
+
+- any real remote workspace manager
+- remote runner execution or prompt transport
+- host lifecycle, lease, or cleanup coordination across machines
+- config UX for choosing remote execution targets
+
+This seam is reviewable because it stays within workspace/startup/runner contracts and does not combine tracker, orchestration-state, or review-loop changes.
+
+## Execution Workspace State Model
+
+This issue does not change orchestrator retry or handoff state. The stateful surface here is the execution-layer workspace lifecycle.
+
+### Prepared source states
+
+1. `configured-source`
+   - workflow config provides the canonical repo source
+2. `startup-prepared-source`
+   - startup returns a typed source override such as the local Git mirror path
+3. `source-ready`
+   - workspace preparation resolves the effective source it will clone or reuse
+4. `source-failed`
+   - startup or workspace cannot supply a usable source
+
+### Execution workspace states
+
+1. `preparing`
+   - the workspace manager is creating or refreshing the per-issue workspace
+2. `ready`
+   - a normalized prepared workspace is available for the run session
+3. `cleanup-pending`
+   - the run ended and cleanup policy is about to act on the prepared workspace
+4. `cleaned`
+   - cleanup completed or the workspace was already absent
+5. `cleanup-failed`
+   - cleanup could not complete for the prepared workspace identity
+
+### Allowed transitions
+
+- `configured-source -> startup-prepared-source`
+- `configured-source -> source-ready`
+- `startup-prepared-source -> source-ready`
+- `configured-source -> source-failed`
+- `startup-prepared-source -> source-failed`
+- `source-ready -> preparing`
+- `preparing -> ready`
+- `preparing -> source-failed`
+- `ready -> cleanup-pending`
+- `cleanup-pending -> cleaned`
+- `cleanup-pending -> cleanup-failed`
+
+### Contract rules
+
+- every prepared workspace must declare its execution target kind explicitly
+- local-only fields such as filesystem paths must remain accessible through the local target shape, not as nullable top-level fields that every consumer has to interpret
+- cleanup must key off the normalized prepared workspace identity rather than assuming a local path string is always sufficient
+- startup-prepared source data must remain separate from the configured repo source so future remote paths do not overwrite config state
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized workspace facts available | Expected decision |
+| --- | --- | --- | --- |
+| Startup returns no override and workflow uses the configured local repo source | resolved config | source kind is configured/local | workspace manager prepares the local workspace exactly as today |
+| Startup returns a local mirror path | resolved config, mirror path | source kind is startup-prepared/local-path | workspace manager clones/fetches from the prepared source without mutating `workspace.repoUrl` |
+| Runner receives a local prepared workspace | local path, branch name | target kind is `local` | runner uses the local path as `cwd`, prompt-file location, and session-discovery root |
+| Runner receives a future non-local prepared workspace on the current local runner path | target metadata only | target kind is not `local` | fail clearly at the execution boundary instead of silently assuming a local path |
+| Cleanup is requested for a retained or already-absent local workspace | workspace identity, local path | target kind is `local` | cleanup reports `deleted` or `already-absent` just as today |
+| Startup-prepared source metadata is malformed or unsupported | raw startup result | no valid normalized source | fail loudly before workspace preparation starts |
+
+## Storage / Persistence Contract
+
+- no new durable tracker state is introduced
+- no new orchestrator runtime-state persistence is introduced
+- startup artifacts may continue to persist startup summaries, but the runtime should not require them as the system of record for prepared workspace identity
+- the generalized workspace contract should be serializable enough for future status/reporting use, but this slice does not require changing persisted status/report schemas unless the type changes force it
+
+## Observability Requirements
+
+- workspace-ready logs should include the normalized execution target kind and the effective source kind/path used for preparation
+- startup logs should continue to identify when a prepared source override was produced, but without implying that config itself was mutated
+- runner logs should report a clear unsupported-target failure if a local runner is ever asked to execute against a non-local prepared workspace
+- no layer should hide target/source assumptions behind generic `path` logs alone once the contract is generalized
+
+## Implementation Steps
+
+1. Refine `src/domain/workspace.ts` to model:
+   - the prepared workspace source contract
+   - a normalized execution target shape with at least a local target variant and explicit room for a future remote variant
+   - cleanup/result inputs that use the normalized workspace identity
+2. Update `src/workspace/service.ts` so workspace preparation can accept the effective prepared-source context rather than only an issue.
+3. Adapt startup preparation and CLI/runtime wiring so the startup mirror path is threaded as a typed workspace-source override instead of rewriting `workflow.config.workspace.repoUrl`.
+4. Refactor `src/workspace/local.ts` to:
+   - consume the generalized source contract
+   - return the generalized local prepared workspace shape
+   - preserve current clone/fetch/default-branch/cleanup behavior
+5. Update `src/domain/run.ts`, `src/runner/local-execution.ts`, and `src/runner/local-live-session.ts` so the local runner consumes the normalized workspace target explicitly and fails clearly on unsupported non-local targets.
+6. Update any orchestrator or test helpers that construct `PreparedWorkspace` directly so they use the new contract without changing orchestration policy.
+7. Update README and any architecture/config references that currently describe workspaces as only local filesystem paths.
+
+## Tests And Acceptance Scenarios
+
+### Unit / focused tests
+
+- workspace domain / helpers: local prepared workspace shape exposes explicit local target metadata and preserves branch/workspace identity
+- startup-to-workspace wiring: a startup-produced local mirror override is passed through as a typed source override rather than config mutation
+- local workspace manager: current local clone/reuse/default-branch behavior still passes through the generalized contract
+- local runner: accepts a local prepared workspace target and launches exactly as before
+- local runner: rejects a synthetic non-local prepared workspace with a clear unsupported-target error
+- orchestrator/unit fakes: updated fake workspace managers and prepared-workspace fixtures still satisfy the contract cleanly
+
+### Integration / end-to-end scenarios
+
+1. Given the existing GitHub bootstrap mirror path, when startup prepares a local mirror and an issue runs, then workspace preparation consumes that mirror through the typed source contract and the run succeeds unchanged.
+2. Given a reused local workspace, when the workspace manager prepares it again, then the issue branch/reset behavior remains unchanged under the generalized prepared workspace model.
+3. Given a local runner and a synthetic non-local prepared workspace, when a run starts, then the runner fails immediately with an explicit unsupported-target error instead of trying to use a missing local path.
+
+## Exit Criteria
+
+- the runtime no longer defines `PreparedWorkspace` as only a local filesystem path
+- startup-prepared source overrides flow through a typed workspace contract rather than config mutation
+- the local workspace manager remains the working default implementation
+- the local runner consumes explicit local target metadata and fails clearly on unsupported non-local targets
+- tests cover the generalized contract plus the preserved local happy path
+- docs describe the workspace layer as an execution-target seam rather than only a local checkout path
+
+## Deferred To Later Issues Or PRs
+
+- implementing a real remote execution workspace manager
+- wiring a remote runner that can execute against the future remote target variant
+- remote host lifecycle, credentials, or transport contracts
+- observability/reporting changes that expose remote host details to operators
+- config surface for selecting local versus remote execution targets

--- a/docs/plans/183-generalize-workspace-contract-for-local-and-remote-targets/plan.md
+++ b/docs/plans/183-generalize-workspace-contract-for-local-and-remote-targets/plan.md
@@ -211,14 +211,14 @@ This issue does not change orchestrator retry or handoff state. The stateful sur
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized workspace facts available | Expected decision |
-| --- | --- | --- | --- |
-| Startup returns no override and workflow uses the configured local repo source | resolved config | source kind is configured/local | workspace manager prepares the local workspace exactly as today |
-| Startup returns a local mirror path | resolved config, mirror path | source kind is startup-prepared/local-path | workspace manager clones/fetches from the prepared source without mutating `workspace.repoUrl` |
-| Runner receives a local prepared workspace | local path, branch name | target kind is `local` | runner uses the local path as `cwd`, prompt-file location, and session-discovery root |
-| Runner receives a future non-local prepared workspace on the current local runner path | target metadata only | target kind is not `local` | fail clearly at the execution boundary instead of silently assuming a local path |
-| Cleanup is requested for a retained or already-absent local workspace | workspace identity, local path | target kind is `local` | cleanup reports `deleted` or `already-absent` just as today |
-| Startup-prepared source metadata is malformed or unsupported | raw startup result | no valid normalized source | fail loudly before workspace preparation starts |
+| Observed condition                                                                     | Local facts available          | Normalized workspace facts available       | Expected decision                                                                              |
+| -------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Startup returns no override and workflow uses the configured local repo source         | resolved config                | source kind is configured/local            | workspace manager prepares the local workspace exactly as today                                |
+| Startup returns a local mirror path                                                    | resolved config, mirror path   | source kind is startup-prepared/local-path | workspace manager clones/fetches from the prepared source without mutating `workspace.repoUrl` |
+| Runner receives a local prepared workspace                                             | local path, branch name        | target kind is `local`                     | runner uses the local path as `cwd`, prompt-file location, and session-discovery root          |
+| Runner receives a future non-local prepared workspace on the current local runner path | target metadata only           | target kind is not `local`                 | fail clearly at the execution boundary instead of silently assuming a local path               |
+| Cleanup is requested for a retained or already-absent local workspace                  | workspace identity, local path | target kind is `local`                     | cleanup reports `deleted` or `already-absent` just as today                                    |
+| Startup-prepared source metadata is malformed or unsupported                           | raw startup result             | no valid normalized source                 | fail loudly before workspace preparation starts                                                |
 
 ## Storage / Persistence Contract
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -351,19 +351,13 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  const workspaceConfig =
-    startup.workspaceRepoUrlOverride === null
-      ? workflow.config.workspace
-      : {
-          ...workflow.config.workspace,
-          repoUrl: startup.workspaceRepoUrlOverride,
-        };
   const promptBuilder = createPromptBuilder(workflow);
   const tracker = createTracker(workflow.config.tracker, logger);
   const workspace = new LocalWorkspaceManager(
-    workspaceConfig,
+    workflow.config.workspace,
     workflow.config.hooks.afterCreate,
     logger,
+    startup.workspaceSourceOverride,
   );
   const runner = createRunner(workflow.config.agent, logger);
   const livenessProbe =

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -74,9 +74,7 @@ export function getWorkspaceSourceLocation(source: WorkspaceSource): string {
   }
 }
 
-export function getWorkspaceTargetPath(
-  target: WorkspaceTarget,
-): string | null {
+export function getWorkspaceTargetPath(target: WorkspaceTarget): string | null {
   if (target.kind !== "local") {
     return null;
   }

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -1,18 +1,90 @@
 import type { RuntimeIssue } from "./issue.js";
 
+export interface ConfiguredWorkspaceSource {
+  readonly kind: "configured-repo";
+  readonly repoUrl: string;
+}
+
+export interface LocalPathWorkspaceSource {
+  readonly kind: "local-path";
+  readonly path: string;
+}
+
+export interface RemoteWorkspaceSource {
+  readonly kind: "remote-path";
+  readonly host: string;
+  readonly path: string;
+}
+
+export type WorkspaceSource =
+  | ConfiguredWorkspaceSource
+  | LocalPathWorkspaceSource
+  | RemoteWorkspaceSource;
+
 export interface WorkspacePreparationRequest {
   readonly issue: RuntimeIssue;
+  readonly sourceOverride?: WorkspaceSource | null;
 }
+
+export interface LocalWorkspaceTarget {
+  readonly kind: "local";
+  readonly path: string;
+}
+
+export interface RemoteWorkspaceTarget {
+  readonly kind: "remote";
+  readonly host: string;
+  readonly workspaceId: string;
+  readonly pathHint?: string | null;
+}
+
+export type WorkspaceTarget = LocalWorkspaceTarget | RemoteWorkspaceTarget;
 
 export interface PreparedWorkspace {
   readonly key: string;
-  readonly path: string;
   /** Canonical issue branch checked out for the run. */
   readonly branchName: string;
   readonly createdNow: boolean;
+  readonly source: WorkspaceSource;
+  readonly target: WorkspaceTarget;
 }
 
 export interface WorkspaceCleanupResult {
   readonly kind: "deleted" | "already-absent";
   readonly workspacePath: string;
+}
+
+export function createConfiguredWorkspaceSource(
+  repoUrl: string,
+): ConfiguredWorkspaceSource {
+  return {
+    kind: "configured-repo",
+    repoUrl,
+  };
+}
+
+export function getWorkspaceSourceLocation(source: WorkspaceSource): string {
+  switch (source.kind) {
+    case "configured-repo":
+      return source.repoUrl;
+    case "local-path":
+      return source.path;
+    case "remote-path":
+      return `${source.host}:${source.path}`;
+  }
+}
+
+export function getWorkspaceTargetPath(
+  target: WorkspaceTarget,
+): string | null {
+  if (target.kind !== "local") {
+    return null;
+  }
+  return target.path;
+}
+
+export function getPreparedWorkspacePath(
+  workspace: PreparedWorkspace,
+): string | null {
+  return getWorkspaceTargetPath(workspace.target);
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -16,6 +16,7 @@ import type {
   TransientFailureSignal,
 } from "../domain/transient-failure.js";
 import type { PreparedWorkspace } from "../domain/workspace.js";
+import { getPreparedWorkspacePath } from "../domain/workspace.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -1101,7 +1102,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       branchName: workspace.branchName,
       status: "running",
       summary: `Running ${issue.identifier}`,
-      workspacePath: workspace.path,
+      workspacePath: getPreparedWorkspacePath(workspace),
       runSessionId: session.id,
       ownerPid: process.pid,
       runnerPid: null,
@@ -2024,7 +2025,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber: runSession.issue.number,
       attempt,
       error: failure.message,
-      workspacePath: runSession.workspace.path,
+      workspacePath: getPreparedWorkspacePath(runSession.workspace),
       runSessionId: runSession.id,
     });
     noteStatusAction(this.#state.status, {
@@ -2316,7 +2317,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
         retentionState: outcome.state,
         terminalOutcome: options.terminalOutcome,
-        workspacePath: options.workspace?.path ?? null,
+        workspacePath:
+          options.workspace === undefined
+            ? null
+            : getPreparedWorkspacePath(options.workspace),
       });
       return outcome;
     }
@@ -2342,7 +2346,10 @@ export class BootstrapOrchestrator implements Orchestrator {
         issueNumber: issue.number,
         retentionState: outcome.state,
         terminalOutcome: options.terminalOutcome,
-        workspacePath: options.workspace?.path ?? null,
+        workspacePath:
+          options.workspace === undefined
+            ? null
+            : getPreparedWorkspacePath(options.workspace),
         error: cleanupError,
       });
       return outcome;
@@ -3094,7 +3101,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       latestTurnNumber: session.latestTurnNumber,
       startedAt: session.runSession.startedAt,
       finishedAt: finishedAt ?? null,
-      workspacePath: session.runSession.workspace.path,
+      workspacePath: getPreparedWorkspacePath(session.runSession.workspace),
       branch: session.runSession.workspace.branchName,
       accounting: session.accounting,
       logPointers: session.description.logPointers.map((pointer) =>

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -4,6 +4,7 @@ import type { RunSession, RunTurn, RunUpdateEvent } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { describeLocalRunnerSession } from "./local-session-description.js";
+import { requireLocalWorkspacePath } from "./local-execution.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
 import {
   buildCodexAppServerCommand,
@@ -217,6 +218,10 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   #spawnProcess(onEvent?: (event: RunnerEvent) => void | Promise<void>): void {
+    const workspacePath = requireLocalWorkspacePath(
+      this.#runSession,
+      "Codex app-server runner",
+    );
     if (
       !this.#loggedDroppedArgs &&
       this.#appServerCommand.droppedArgs.length > 0
@@ -232,7 +237,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     const child = spawn("bash", ["-lc", this.#appServerCommand.launchCommand], {
-      cwd: this.#runSession.workspace.path,
+      cwd: workspacePath,
       env: {
         ...process.env,
         ...this.#config.env,
@@ -241,7 +246,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
         SYMPHONY_ISSUE_NUMBER: String(this.#runSession.issue.number),
         SYMPHONY_RUN_ATTEMPT: String(this.#runSession.attempt.sequence),
         SYMPHONY_BRANCH_NAME: this.#runSession.workspace.branchName,
-        SYMPHONY_WORKSPACE_PATH: this.#runSession.workspace.path,
+        SYMPHONY_WORKSPACE_PATH: workspacePath,
         SYMPHONY_RUN_SESSION_ID: this.#runSession.id,
       },
       stdio: ["pipe", "pipe", "pipe"],
@@ -370,12 +375,16 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   async #startThread(): Promise<void> {
+    const workspacePath = requireLocalWorkspacePath(
+      this.#runSession,
+      "Codex app-server thread startup",
+    );
     const result = await this.#sendRequest({
       id: THREAD_START_REQUEST_ID,
       method: "thread/start",
       params: omitNullValues({
         approvalPolicy: this.#appServerCommand.approvalPolicy,
-        cwd: this.#runSession.workspace.path,
+        cwd: workspacePath,
         model: this.#appServerCommand.model,
         sandbox: this.#appServerCommand.sandbox,
       }),
@@ -410,6 +419,10 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     const startedAt = new Date().toISOString();
+    const workspacePath = requireLocalWorkspacePath(
+      this.#runSession,
+      "Codex app-server turn execution",
+    );
     await this.#emitVisibility({
       state: "running",
       phase: "turn-execution",
@@ -431,7 +444,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
         method: "turn/start",
         params: {
           threadId: this.#threadId,
-          cwd: this.#runSession.workspace.path,
+          cwd: workspacePath,
           input: [
             {
               type: "text",

--- a/src/runner/local-execution.ts
+++ b/src/runner/local-execution.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { spawn } from "node:child_process";
 import { RunnerError, RunnerShutdownError } from "../domain/errors.js";
 import type { RunSession, RunUpdateEvent } from "../domain/run.js";
+import { getPreparedWorkspacePath } from "../domain/workspace.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
@@ -32,15 +34,35 @@ export interface LocalCommandExecutionOptions {
   readonly promptTransport: AgentConfig["promptTransport"];
 }
 
+export function requireLocalWorkspacePath(
+  session: RunSession,
+  consumer: string,
+): string {
+  const workspacePath = getPreparedWorkspacePath(session.workspace);
+  if (workspacePath === null) {
+    throw new RunnerError(
+      `${consumer} requires a local workspace target; received ${session.workspace.target.kind}`,
+    );
+  }
+  return workspacePath;
+}
+
 export async function executeLocalRunnerCommand(
   logger: Logger,
   config: AgentConfig,
   execution: LocalCommandExecutionOptions,
 ): Promise<RunnerExecutionResult> {
   const startedAt = new Date().toISOString();
+  const workspacePath = requireLocalWorkspacePath(
+    execution.session,
+    "Local runner execution",
+  );
   // Multi-turn runs keep per-turn prompt files distinct; older one-shot runs
   // used `.symphony-prompt.md`.
-  const promptFile = `${execution.session.workspace.path}/.symphony-prompt.turn-${execution.turnNumber.toString()}.md`;
+  const promptFile = path.join(
+    workspacePath,
+    `.symphony-prompt.turn-${execution.turnNumber.toString()}.md`,
+  );
 
   if (execution.promptTransport === "file") {
     await fs.writeFile(promptFile, execution.prompt, "utf8");
@@ -53,7 +75,7 @@ export async function executeLocalRunnerCommand(
 
   logger.info("Launching runner", {
     command,
-    workspacePath: execution.session.workspace.path,
+    workspacePath,
     issueIdentifier: execution.session.issue.identifier,
     attempt: execution.session.attempt.sequence,
     runSessionId: execution.session.id,
@@ -62,7 +84,7 @@ export async function executeLocalRunnerCommand(
 
   return await new Promise<RunnerExecutionResult>((resolve, reject) => {
     const child = spawn("bash", ["-lc", command], {
-      cwd: execution.session.workspace.path,
+      cwd: workspacePath,
       env: {
         ...process.env,
         ...config.env,
@@ -72,7 +94,7 @@ export async function executeLocalRunnerCommand(
         SYMPHONY_RUN_ATTEMPT: String(execution.session.attempt.sequence),
         SYMPHONY_RUN_TURN: String(execution.turnNumber),
         SYMPHONY_BRANCH_NAME: execution.session.workspace.branchName,
-        SYMPHONY_WORKSPACE_PATH: execution.session.workspace.path,
+        SYMPHONY_WORKSPACE_PATH: workspacePath,
         SYMPHONY_RUN_SESSION_ID: execution.session.id,
       },
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/runner/local-live-session.ts
+++ b/src/runner/local-live-session.ts
@@ -7,6 +7,7 @@ import { findCodexSession } from "./codex-session-discovery.js";
 import {
   type LocalCommandExecutionOptions,
   executeLocalRunnerCommand,
+  requireLocalWorkspacePath,
 } from "./local-execution.js";
 import { describeLocalRunnerSession } from "./local-session-description.js";
 import type {
@@ -87,8 +88,12 @@ export class LocalRunnerSession implements LiveRunnerSession {
       this.#baseDescription.provider === "codex" &&
       this.#backendSessionId === null
     ) {
+      const workspacePath = requireLocalWorkspacePath(
+        this.#runSession,
+        "Codex session discovery",
+      );
       const matchedSession = await findCodexSession({
-        workspacePath: this.#runSession.workspace.path,
+        workspacePath,
         branchName: this.#runSession.workspace.branchName,
         startedAt: executionResult.startedAt,
         finishedAt: executionResult.finishedAt,

--- a/src/startup/github-mirror.ts
+++ b/src/startup/github-mirror.ts
@@ -81,7 +81,9 @@ export function deriveGitHubMirrorPath(workspaceRoot: string): string {
   return path.join(path.dirname(workspaceRoot), "github", "upstream");
 }
 
-function createMirrorWorkspaceSource(mirrorPath: string): LocalPathWorkspaceSource {
+function createMirrorWorkspaceSource(
+  mirrorPath: string,
+): LocalPathWorkspaceSource {
   return {
     kind: "local-path",
     path: mirrorPath,

--- a/src/startup/github-mirror.ts
+++ b/src/startup/github-mirror.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
+import type { LocalPathWorkspaceSource } from "../domain/workspace.js";
 import type { ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { StartupPreparationResult, StartupPreparer } from "./service.js";
@@ -80,6 +81,13 @@ export function deriveGitHubMirrorPath(workspaceRoot: string): string {
   return path.join(path.dirname(workspaceRoot), "github", "upstream");
 }
 
+function createMirrorWorkspaceSource(mirrorPath: string): LocalPathWorkspaceSource {
+  return {
+    kind: "local-path",
+    path: mirrorPath,
+  };
+}
+
 export class GitHubMirrorStartupPreparer implements StartupPreparer {
   readonly id = "github-bootstrap/local-mirror";
 
@@ -142,7 +150,7 @@ export class GitHubMirrorStartupPreparer implements StartupPreparer {
       return {
         kind: "ready",
         summary: `GitHub bootstrap mirror ${action} at ${mirrorPath}.`,
-        workspaceRepoUrlOverride: mirrorPath,
+        workspaceSourceOverride: createMirrorWorkspaceSource(mirrorPath),
       };
     } catch (error) {
       const summary = `GitHub bootstrap mirror setup failed for source ${sourceRepoUrl} at ${mirrorPath}: ${formatExecError(

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { WorkspaceSource } from "../domain/workspace.js";
 import type { ResolvedConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import {
@@ -28,7 +29,7 @@ export interface StartupSnapshot {
 export interface StartupPreparationSuccess {
   readonly kind: "ready";
   readonly summary: string | null;
-  readonly workspaceRepoUrlOverride?: string | null;
+  readonly workspaceSourceOverride?: WorkspaceSource | null;
 }
 
 export interface StartupPreparationFailure {
@@ -53,7 +54,7 @@ export interface StartupPreparationOutcomeReady {
   readonly kind: "ready";
   readonly provider: string;
   readonly summary: string | null;
-  readonly workspaceRepoUrlOverride: string | null;
+  readonly workspaceSourceOverride: WorkspaceSource | null;
   readonly artifactPath: string;
   readonly runtimeIdentity: FactoryRuntimeIdentity;
 }
@@ -62,7 +63,7 @@ export interface StartupPreparationOutcomeFailed {
   readonly kind: "failed";
   readonly provider: string;
   readonly summary: string;
-  readonly workspaceRepoUrlOverride: null;
+  readonly workspaceSourceOverride: null;
   readonly artifactPath: string;
   readonly runtimeIdentity: FactoryRuntimeIdentity;
 }
@@ -209,7 +210,7 @@ export async function runStartupPreparation(options: {
         kind: "failed",
         provider: preparer.id,
         summary: result.summary,
-        workspaceRepoUrlOverride: null,
+        workspaceSourceOverride: null,
         artifactPath,
         runtimeIdentity,
       };
@@ -228,14 +229,14 @@ export async function runStartupPreparation(options: {
       provider: preparer.id,
       startupFilePath: artifactPath,
       summary: result.summary ?? null,
-      workspaceRepoUrlOverride: result.workspaceRepoUrlOverride ?? null,
+      workspaceSourceOverride: result.workspaceSourceOverride ?? null,
       ...factoryRuntimeIdentityLogFields(runtimeIdentity),
     });
     return {
       kind: "ready",
       provider: preparer.id,
       summary: result.summary ?? null,
-      workspaceRepoUrlOverride: result.workspaceRepoUrlOverride ?? null,
+      workspaceSourceOverride: result.workspaceSourceOverride ?? null,
       artifactPath,
       runtimeIdentity,
     };
@@ -264,7 +265,7 @@ export async function runStartupPreparation(options: {
       kind: "failed",
       provider: preparer.id,
       summary,
-      workspaceRepoUrlOverride: null,
+      workspaceSourceOverride: null,
       artifactPath,
       runtimeIdentity,
     };

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -5,8 +5,14 @@ import { promisify } from "node:util";
 import { WorkspaceError } from "../domain/errors.js";
 import type {
   PreparedWorkspace,
+  WorkspaceSource,
   WorkspaceCleanupResult,
   WorkspacePreparationRequest,
+} from "../domain/workspace.js";
+import {
+  createConfiguredWorkspaceSource,
+  getPreparedWorkspacePath,
+  getWorkspaceSourceLocation,
 } from "../domain/workspace.js";
 import type { WorkspaceConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
@@ -112,15 +118,18 @@ export class LocalWorkspaceManager implements WorkspaceManager {
   readonly #config: WorkspaceConfig;
   readonly #afterCreate: readonly string[];
   readonly #logger: Logger;
+  readonly #sourceOverride: WorkspaceSource | null;
 
   constructor(
     config: WorkspaceConfig,
     afterCreate: readonly string[],
     logger: Logger,
+    sourceOverride?: WorkspaceSource | null,
   ) {
     this.#config = config;
     this.#afterCreate = afterCreate;
     this.#logger = logger;
+    this.#sourceOverride = sourceOverride ?? null;
   }
 
   async prepareWorkspace(
@@ -129,6 +138,11 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     const issue = request.issue;
     const workspacePath = this.#workspacePathForIssue(issue.identifier);
     const branchName = `${this.#config.branchPrefix}${issue.number}`;
+    const source =
+      request.sourceOverride ??
+      this.#sourceOverride ??
+      createConfiguredWorkspaceSource(this.#config.repoUrl);
+    const sourceLocation = getWorkspaceSourceLocation(source);
     const exists = await fs
       .stat(workspacePath)
       .then(() => true)
@@ -137,11 +151,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     await fs.mkdir(this.#config.root, { recursive: true });
 
     if (!exists) {
-      await execFileAsync("git", [
-        "clone",
-        this.#config.repoUrl,
-        workspacePath,
-      ]);
+      await execFileAsync("git", ["clone", sourceLocation, workspacePath]);
       for (const command of this.#afterCreate) {
         await runShell(command, workspacePath);
       }
@@ -206,34 +216,45 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       workspacePath,
       issueIdentifier: issue.identifier,
       branchName,
-      repoUrl: this.#config.repoUrl,
+      workspaceSourceKind: source.kind,
+      workspaceSourceLocation: sourceLocation,
       defaultBranch,
       createdNow: !exists,
     });
 
     return {
       key: sanitize(issue.identifier),
-      path: workspacePath,
       branchName,
       createdNow: !exists,
+      source,
+      target: {
+        kind: "local",
+        path: workspacePath,
+      },
     };
   }
 
   async cleanupWorkspace(
     workspace: PreparedWorkspace,
   ): Promise<WorkspaceCleanupResult> {
+    const workspacePath = getPreparedWorkspacePath(workspace);
+    if (workspacePath === null) {
+      throw new WorkspaceError(
+        "Local workspace cleanup requires a local workspace target",
+      );
+    }
     const existed = await fs
-      .stat(workspace.path)
+      .stat(workspacePath)
       .then(() => true)
       .catch(() => false);
     this.#logger.info("Cleaning workspace", {
-      workspacePath: workspace.path,
+      workspacePath,
       existed,
     });
-    await fs.rm(workspace.path, { recursive: true, force: true });
+    await fs.rm(workspacePath, { recursive: true, force: true });
     return {
       kind: existed ? "deleted" : "already-absent",
-      workspacePath: workspace.path,
+      workspacePath,
     };
   }
 
@@ -242,9 +263,16 @@ export class LocalWorkspaceManager implements WorkspaceManager {
   ): Promise<WorkspaceCleanupResult> {
     return await this.cleanupWorkspace({
       key: sanitize(request.issue.identifier),
-      path: this.#workspacePathForIssue(request.issue.identifier),
       branchName: `${this.#config.branchPrefix}${request.issue.number}`,
       createdNow: false,
+      source:
+        request.sourceOverride ??
+        this.#sourceOverride ??
+        createConfiguredWorkspaceSource(this.#config.repoUrl),
+      target: {
+        kind: "local",
+        path: this.#workspacePathForIssue(request.issue.identifier),
+      },
     });
   }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -517,7 +517,7 @@ describe("runCli run", () => {
         kind: "ready",
         provider: "github-bootstrap/noop",
         summary: null,
-        workspaceRepoUrlOverride: null,
+        workspaceSourceOverride: null,
         artifactPath: "/tmp/factory-root/.tmp/startup.json",
         runtimeIdentity: {
           checkoutPath: "/tmp/factory-root",
@@ -605,7 +605,7 @@ describe("runCli run", () => {
         kind: "failed",
         provider: "github-bootstrap/noop",
         summary: "Mirror refresh failed.",
-        workspaceRepoUrlOverride: null,
+        workspaceSourceOverride: null,
         artifactPath: "/tmp/factory-root/.tmp/startup.json",
         runtimeIdentity: {
           checkoutPath: "/tmp/factory-root",

--- a/tests/unit/issue-lease.test.ts
+++ b/tests/unit/issue-lease.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 import type { RunSession } from "../../src/domain/run.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import type { Logger } from "../../src/observability/logger.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
@@ -27,9 +28,13 @@ function createSession(issueNumber: number, workspacePath: string): RunSession {
     },
     workspace: {
       key: `sociotechnica-org_symphony-ts_${issueNumber}`,
-      path: workspacePath,
       branchName: `symphony/${issueNumber}`,
       createdNow: false,
+      source: createConfiguredWorkspaceSource(workspacePath),
+      target: {
+        kind: "local",
+        path: workspacePath,
+      },
     },
     prompt: "test prompt",
     startedAt: timestamp,

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -6,9 +6,7 @@ import type {
   AgentConfig,
   GenericCommandRunnerConfig,
 } from "../../src/domain/workflow.js";
-import {
-  RunnerShutdownError,
-} from "../../src/domain/errors.js";
+import { RunnerShutdownError } from "../../src/domain/errors.js";
 import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import {

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -6,7 +6,10 @@ import type {
   AgentConfig,
   GenericCommandRunnerConfig,
 } from "../../src/domain/workflow.js";
-import { RunnerShutdownError } from "../../src/domain/errors.js";
+import {
+  RunnerShutdownError,
+} from "../../src/domain/errors.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import {
   createRunningEntry,
@@ -45,9 +48,13 @@ function createSession(): RunSession {
     },
     workspace: {
       key: "sociotechnica-org_symphony-ts_1",
-      path: process.cwd(),
       branchName: "symphony/1",
       createdNow: false,
+      source: createConfiguredWorkspaceSource(process.cwd()),
+      target: {
+        kind: "local",
+        path: process.cwd(),
+      },
     },
     prompt: "x".repeat(1024),
     startedAt: new Date().toISOString(),
@@ -331,6 +338,34 @@ async function readLoggedPayloads(
 }
 
 describe("runners", () => {
+  it("fails clearly when a local runner receives a non-local workspace target", async () => {
+    const runner = new GenericCommandRunner(
+      createGenericCommandConfig("printf 'should not run'"),
+      new JsonLogger(),
+    );
+    const session = {
+      ...createSession(),
+      workspace: {
+        key: "sociotechnica-org_symphony-ts_1",
+        branchName: "symphony/1",
+        createdNow: false,
+        source: createConfiguredWorkspaceSource(process.cwd()),
+        target: {
+          kind: "remote",
+          host: "worker-1",
+          workspaceId: "remote-1",
+          pathHint: "/srv/workspaces/1",
+        },
+      },
+    } satisfies RunSession;
+
+    await expect(runner.run(session)).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "requires a local workspace target; received remote",
+      ),
+    });
+  });
+
   it("describes Codex-backed sessions with provider and model metadata", () => {
     const runner = new CodexRunner(createCodexConfig(), new JsonLogger());
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -7,6 +7,10 @@ import type { HandoffLifecycle } from "../../src/domain/handoff.js";
 import type { RuntimeIssue } from "../../src/domain/issue.js";
 import type { RunSession } from "../../src/domain/run.js";
 import type { PreparedWorkspace } from "../../src/domain/workspace.js";
+import {
+  createConfiguredWorkspaceSource,
+  getPreparedWorkspacePath,
+} from "../../src/domain/workspace.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -452,18 +456,26 @@ class StaticWorkspaceManager implements WorkspaceManager {
     this.prepared.push(`/tmp/workspaces/${issue.number}`);
     return {
       key: `sociotechnica-org_symphony-ts_${issue.number}`,
-      path: `/tmp/workspaces/${issue.number}`,
       branchName: `symphony/${issue.number}`,
       createdNow: true,
+      source: createConfiguredWorkspaceSource("/tmp/repo.git"),
+      target: {
+        kind: "local",
+        path: `/tmp/workspaces/${issue.number}`,
+      },
     };
   }
 
   async cleanupWorkspace(
     _workspace: PreparedWorkspace,
   ): Promise<{ kind: "deleted"; workspacePath: string }> {
+    const workspacePath = getPreparedWorkspacePath(_workspace);
+    if (workspacePath === null) {
+      throw new Error("expected local workspace path");
+    }
     return {
       kind: "deleted",
-      workspacePath: _workspace.path,
+      workspacePath,
     };
   }
 
@@ -474,9 +486,13 @@ class StaticWorkspaceManager implements WorkspaceManager {
   }): Promise<{ kind: "deleted"; workspacePath: string }> {
     return await this.cleanupWorkspace({
       key: `sociotechnica-org_symphony-ts_${issue.number}`,
-      path: `/tmp/workspaces/${issue.number}`,
       branchName: `symphony/${issue.number}`,
       createdNow: false,
+      source: createConfiguredWorkspaceSource("/tmp/repo.git"),
+      target: {
+        kind: "local",
+        path: `/tmp/workspaces/${issue.number}`,
+      },
     });
   }
 }
@@ -487,7 +503,11 @@ class CleanupFailingWorkspaceManager extends StaticWorkspaceManager {
   override async cleanupWorkspace(
     workspace: PreparedWorkspace,
   ): Promise<{ kind: "deleted"; workspacePath: string }> {
-    this.cleaned.push(workspace.path);
+    const workspacePath = getPreparedWorkspacePath(workspace);
+    if (workspacePath === null) {
+      throw new Error("expected local workspace path");
+    }
+    this.cleaned.push(workspacePath);
     throw new Error("rm failed");
   }
 }
@@ -498,10 +518,14 @@ class TrackingWorkspaceManager extends StaticWorkspaceManager {
   override async cleanupWorkspace(
     workspace: PreparedWorkspace,
   ): Promise<{ kind: "deleted"; workspacePath: string }> {
-    this.cleaned.push(workspace.path);
+    const workspacePath = getPreparedWorkspacePath(workspace);
+    if (workspacePath === null) {
+      throw new Error("expected local workspace path");
+    }
+    this.cleaned.push(workspacePath);
     return {
       kind: "deleted",
-      workspacePath: workspace.path,
+      workspacePath,
     };
   }
 }

--- a/tests/unit/runner-contract.test.ts
+++ b/tests/unit/runner-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RunSession, RunTurn } from "../../src/domain/run.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
 import type {
   LiveRunnerSession,
   Runner,
@@ -28,9 +29,13 @@ function createSession(): RunSession {
     },
     workspace: {
       key: "sociotechnica-org_symphony-ts_89",
-      path: "/tmp/symphony-89",
       branchName: "symphony/89",
       createdNow: false,
+      source: createConfiguredWorkspaceSource("/tmp/repo.git"),
+      target: {
+        kind: "local",
+        path: "/tmp/symphony-89",
+      },
     },
     prompt: "Initial prompt",
     startedAt: "2026-03-12T10:00:00.000Z",

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { getPreparedWorkspacePath } from "../../src/domain/workspace.js";
 import type { ResolvedConfig } from "../../src/domain/workflow.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import {
@@ -138,9 +139,10 @@ describe("startup service", () => {
 
       expect(outcome.kind).toBe("ready");
       expect(outcome.provider).toBe("github-bootstrap/local-mirror");
-      expect(outcome.workspaceRepoUrlOverride).toBe(
-        deriveGitHubMirrorPath(config.workspace.root),
-      );
+      expect(outcome.workspaceSourceOverride).toEqual({
+        kind: "local-path",
+        path: deriveGitHubMirrorPath(config.workspace.root),
+      });
 
       const mirrorResult = await execFile(
         "git",
@@ -183,20 +185,21 @@ describe("startup service", () => {
       }
 
       const workspace = new LocalWorkspaceManager(
-        {
-          ...config.workspace,
-          repoUrl:
-            firstStartup.workspaceRepoUrlOverride ?? config.workspace.repoUrl,
-        },
+        config.workspace,
         [],
         logger,
+        firstStartup.workspaceSourceOverride,
       );
 
       const firstPrepared = await workspace.prepareWorkspace({
         issue: createIssue(88),
       });
+      const firstWorkspacePath = getPreparedWorkspacePath(firstPrepared);
+      if (firstWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
       expect(
-        await readFileAtRef(firstPrepared.path, "HEAD", "README.md"),
+        await readFileAtRef(firstWorkspacePath, "HEAD", "README.md"),
       ).toContain("# mock repo");
 
       await fs.writeFile(
@@ -218,15 +221,19 @@ describe("startup service", () => {
       const secondPrepared = await workspace.prepareWorkspace({
         issue: createIssue(88),
       });
+      const secondWorkspacePath = getPreparedWorkspacePath(secondPrepared);
+      if (secondWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
       expect(secondPrepared.createdNow).toBe(false);
       expect(
-        await readFileAtRef(secondPrepared.path, "HEAD", "README.md"),
+        await readFileAtRef(secondWorkspacePath, "HEAD", "README.md"),
       ).toContain("# refreshed repo");
 
       const remoteUrl = await execFile(
         "git",
         ["config", "--get", "remote.origin.url"],
-        { cwd: secondPrepared.path },
+        { cwd: secondWorkspacePath },
       );
       expect(remoteUrl.stdout.trim()).toBe(
         deriveGitHubMirrorPath(config.workspace.root),

--- a/tests/unit/workspace-local.test.ts
+++ b/tests/unit/workspace-local.test.ts
@@ -4,6 +4,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { WorkspaceError } from "../../src/domain/errors.js";
+import { getPreparedWorkspacePath } from "../../src/domain/workspace.js";
 import { JsonLogger } from "../../src/observability/logger.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
 import {
@@ -56,8 +57,12 @@ describe("LocalWorkspaceManager", () => {
       const firstPrepared = await manager.prepareWorkspace({
         issue: createIssue(7),
       });
+      const firstWorkspacePath = getPreparedWorkspacePath(firstPrepared);
+      if (firstWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
       const firstHead = await execFile("git", ["rev-parse", "HEAD"], {
-        cwd: firstPrepared.path,
+        cwd: firstWorkspacePath,
       });
 
       await fs.writeFile(
@@ -73,13 +78,17 @@ describe("LocalWorkspaceManager", () => {
       const secondPrepared = await manager.prepareWorkspace({
         issue: createIssue(7),
       });
+      const secondWorkspacePath = getPreparedWorkspacePath(secondPrepared);
+      if (secondWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
       const secondHead = await execFile("git", ["rev-parse", "HEAD"], {
-        cwd: secondPrepared.path,
+        cwd: secondWorkspacePath,
       });
       const currentBranch = await execFile(
         "git",
         ["symbolic-ref", "--short", "HEAD"],
-        { cwd: secondPrepared.path },
+        { cwd: secondWorkspacePath },
       );
 
       expect(firstHead.stdout.trim()).not.toBe(secondHead.stdout.trim());


### PR DESCRIPTION
## Summary
- generalize the workspace domain so prepared workspaces carry typed `source` and `target` metadata instead of assuming a local top-level path
- thread startup mirror preparation into the workspace layer as a typed source override instead of mutating `workspace.repoUrl`
- make local runners explicitly require a local workspace target and add coverage for the preserved local flow plus unsupported remote-target failures

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test

## Plan / Issue
- Closes #183
- Plan: `docs/plans/183-generalize-workspace-contract-for-local-and-remote-targets/plan.md`
- Plan review: approved in issue #183 before implementation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
