### PR TITLE
Finish Codex app-server as the primary transport boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 
 - **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
 - **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) plus a runner contract that separates provider identity from execution transport. Built-in `codex`, `claude-code`, and `generic-command` adapters stay local today; remote workers can land against the same contract later. Swap any layer without touching the others.
+  The `codex` adapter now treats `codex app-server` as its primary structured transport boundary for startup, continuation turns, approvals, streaming events, and shutdown.
 - **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear) instead of a separate control plane. Today's bootstrap runtime is designed for one local factory instance; broader multi-instance coordination is planned.
 - **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
 - **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.

--- a/docs/plans/185-codex-app-server-primary-transport-boundary/plan.md
+++ b/docs/plans/185-codex-app-server-primary-transport-boundary/plan.md
@@ -1,0 +1,312 @@
+# Issue 185 Plan: Finish Codex App-Server As The Primary Transport Boundary
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Finish the Codex runner transition from "uses app-server internally" to "treats app-server as the primary structured transport boundary" by making startup, continuation turns, approvals, unsupported protocol requests, malformed protocol input, shutdown, and transport failure classification explicit runner-layer concerns behind a stable normalized session/event contract.
+
+## Scope
+
+- harden the Codex app-server session boundary inside `src/runner/`
+- extract or isolate protocol parsing, request/response handling, and transport-state transitions so they are not fused into one ad hoc session file
+- formalize transport-level failure classes for:
+  - startup / initialize failures
+  - thread-start failures
+  - turn-start failures
+  - malformed protocol payloads
+  - unsupported requests / unsupported tools
+  - approval requests and approval-handling failures
+  - unexpected process exit during an active request or turn
+- make approval handling explicit and well-tested instead of implicit or silently ignored
+- make unsupported request handling explicit and well-tested instead of relying on generic fallthrough behavior
+- preserve provider-neutral runner/orchestrator boundaries by keeping the orchestrator consuming normalized events, visibility, and results rather than raw app-server messages
+- tighten observability so session status surfaces clearly describe Codex app-server transport facts and transport failures in normalized form
+- add focused unit and integration coverage for the transport boundary and its failure classes
+
+## Non-goals
+
+- SSH or other remote Codex transports
+- tracker lifecycle, review-loop, or landing-policy changes
+- continuation-turn policy redesign
+- dynamic tool implementation beyond the minimum explicit unsupported handling needed for protocol correctness
+- a new provider kind or a broad runner-contract redesign beyond the narrow Codex transport seam required here
+- workspace contract redesign or recovery/lease redesign
+
+## Current Gaps
+
+- `src/runner/codex-app-server-session.ts` currently mixes subprocess lifecycle, request serialization, stdout line buffering, notification parsing, turn resolution, and visibility updates in one file
+- the current session handles `turn/*` notifications, but protocol-level approvals and unsupported requests are not treated as first-class normalized transport decisions
+- malformed startup payloads are handled more strictly than malformed in-turn payloads, but the failure taxonomy is still implicit in message strings rather than a named transport classification surface
+- unexpected protocol methods mostly disappear unless they happen to map onto existing turn notifications
+- current tests cover startup, malformed thread responses, malformed stream lines, unexpected response ids, timeouts, and turn failures, but they do not lock in explicit approval behavior or unsupported request behavior
+- observability already publishes app-server pid/thread/turn facts, but it does not yet make transport-state transitions and transport failure classes explicit enough for future remote reuse of the same boundary
+
+## Decision Notes
+
+- Keep Codex app-server transport logic sealed inside `src/runner/`; do not leak app-server methods into the orchestrator.
+- Treat protocol startup, approval handling, streaming, and shutdown as execution-layer transport concerns, not coordination policy.
+- Prefer a small protocol/session decomposition inside the runner layer over further patching the current monolithic session file.
+- Keep the public runner-facing surface normalized and provider-aware, but do not broaden this issue into a general remote transport framework.
+- Unsupported protocol requests should fail or respond explicitly at the transport boundary; they must not stall the session silently.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the local abstraction mapping from `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: deciding that Codex app-server is the primary transport seam for the `codex` provider and that approval / unsupported-request semantics are normalized transport behavior
+  - does not belong: JSON message parsing, line buffering, subprocess I/O, or request id handling
+- Configuration Layer
+  - belongs: validating and deriving Codex command/runtime settings needed to start the app-server transport cleanly
+  - does not belong: tracker lifecycle behavior, review policy, or transport runtime state transitions
+- Coordination Layer
+  - belongs: continuation-turn sequencing, retry reactions, and consuming normalized runner failures/results
+  - does not belong: app-server method handling, protocol parsing, approval request decoding, or unsupported-request replies
+- Execution Layer
+  - belongs: app-server startup, session initialization, thread creation, turn start, approval handling, unsupported request handling, malformed protocol handling, shutdown, and transport failure classification
+  - does not belong: tracker handoff policy, retry budgeting, or review-loop policy
+- Integration Layer
+  - belongs: unchanged in this slice; tracker adapters continue to consume normalized runner outcomes only
+  - does not belong: Codex protocol details or transport-state bookkeeping
+- Observability Layer
+  - belongs: surfacing normalized app-server transport facts, status transitions, approvals, and transport failures for operators and artifacts
+  - does not belong: reimplementing protocol parsing or reconstructing transport state from raw stdout independently
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/runner/`
+  - Codex app-server protocol message classification
+  - request/response helpers
+  - explicit transport session/state handling
+  - approval and unsupported-request handling
+  - transport failure classification and normalized error mapping
+- `src/runner/service.ts`
+  - only the minimum stable event/session/result shape updates needed to expose normalized transport facts cleanly
+- `src/orchestrator/`
+  - only narrow consumption updates if normalized runner visibility/session metadata gains explicit transport details
+- `src/observability/`
+  - only narrow updates needed to persist/render the new normalized Codex transport facts
+- tests under `tests/unit/` and any targeted integration coverage needed for the Codex runner seam
+- README or runner docs only where the primary Codex transport boundary needs to be clarified
+
+### Does not belong in this issue
+
+- tracker transport, normalization, or policy changes
+- review-loop or landing-flow changes
+- workspace lifecycle redesign
+- remote execution or SSH transport
+- dynamic tool support beyond explicit unsupported handling
+- a repo-wide runner abstraction rewrite
+
+## Layering Notes
+
+- `config/workflow`
+  - owns typed runner config and command validation
+  - does not own app-server protocol negotiation or approval decisions
+- `tracker`
+  - owns normalized issue / PR lifecycle
+  - does not learn about Codex app-server methods or approval payloads
+- `workspace`
+  - owns workspace preparation and local target identity
+  - does not own Codex protocol I/O
+- `runner`
+  - owns app-server subprocess control, protocol normalization, transport-state transitions, and explicit approval / unsupported handling
+  - does not decide tracker policy, retries, or follow-up lifecycle
+- `orchestrator`
+  - owns continuation turns, retry policy, and high-level reactions to normalized runner outcomes
+  - does not parse protocol payloads or branch on raw app-server methods
+- `observability`
+  - owns status/artifact projection of normalized transport facts
+  - does not infer transport semantics that the runner did not already normalize
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR by keeping the seam at the Codex execution transport boundary:
+
+1. isolate the app-server protocol/session logic inside focused `src/runner/` modules
+2. formalize normalized transport-state and failure handling for the Codex session
+3. expose only the minimum extra normalized facts needed by orchestrator/observability consumers
+4. add transport-focused tests and minimal docs updates
+
+This stays reviewable because it does not combine:
+
+- Codex transport work with tracker changes
+- Codex transport work with retry/reconciliation redesign
+- Codex transport work with workspace or remote-execution changes
+- Codex transport work with broad provider-neutral contract refactors unrelated to the Codex app-server seam
+
+If a small structural refactor is needed first, it should remain fully inside `src/runner/` and exist only to keep the transport seam explicit and testable.
+
+## Runtime State Model
+
+This issue changes stateful long-lived execution behavior at the runner transport boundary, so the plan requires an explicit app-server session state machine.
+
+### State variables
+
+- `sessionState`
+  - normalized Codex transport state for one live session
+- `threadId`
+  - Codex thread id created once per worker run
+- `activeRequest`
+  - current request awaiting a response, if any
+- `activeTurn`
+  - current turn in progress, if any
+- `latestTurnId`
+  - latest acknowledged Codex turn id
+- `latestTurnNumber`
+  - latest successful Symphony turn number
+- `transportFailureClass`
+  - normalized failure classification when the transport fails
+- `closingReason`
+  - normal completion, shutdown, timeout, or abort
+
+### States
+
+- `idle`
+  - no app-server process launched
+- `starting-process`
+  - subprocess spawned, awaiting protocol initialization
+- `initializing`
+  - `initialize` request in flight
+- `starting-thread`
+  - initialized session, `thread/start` in flight
+- `ready`
+  - transport is healthy and waiting for a turn
+- `starting-turn`
+  - `turn/start` request in flight
+- `streaming-turn`
+  - turn started and protocol notifications/stream events are flowing
+- `awaiting-approval`
+  - transport is paused on an explicit approval request
+- `turn-succeeded`
+  - terminal successful turn observed
+- `turn-failed`
+  - terminal failure observed for the active turn or transport
+- `closing`
+  - shutdown/cleanup started
+- `closed`
+  - process fully terminated and session no longer usable
+
+### Allowed transitions
+
+- `idle -> starting-process`
+- `starting-process -> initializing`
+- `starting-process -> turn-failed`
+  - process launch or immediate startup failure
+- `initializing -> starting-thread`
+- `initializing -> turn-failed`
+  - malformed or failed initialize response
+- `starting-thread -> ready`
+- `starting-thread -> turn-failed`
+  - malformed or failed thread-start response
+- `ready -> starting-turn`
+- `starting-turn -> streaming-turn`
+- `starting-turn -> turn-failed`
+  - malformed or failed turn-start response
+- `streaming-turn -> awaiting-approval`
+  - explicit approval request received
+- `awaiting-approval -> streaming-turn`
+  - approval response sent successfully
+- `awaiting-approval -> turn-failed`
+  - unsupported approval request or malformed approval payload
+- `streaming-turn -> turn-succeeded`
+  - `turn/completed`
+- `streaming-turn -> turn-failed`
+  - `turn/failed`, `turn/cancelled`, malformed terminal payload, unsupported request, or process death
+- `turn-succeeded -> ready`
+  - continuation turn may start on the same thread
+- `turn-succeeded -> closing`
+  - worker run is ending
+- `turn-failed -> closing`
+- `closing -> closed`
+
+### Coordination rules
+
+- one `thread/start` occurs per worker run; continuation turns reuse that thread
+- continuation-turn budgeting remains orchestrator policy and must stay outside the transport layer
+- app-server approval/unsupported handling remains runner transport behavior and must not leak into tracker or orchestrator policy
+- transport failure closes the live session and returns a normalized runner failure to the existing outer retry path
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| subprocess exits before `initialize` completes | command, workspace, maybe pid, stderr | unchanged | classify as `startup-transport-failure`; close session; hand runner failure to orchestrator |
+| `initialize` returns malformed payload or error | pid, raw payload | unchanged | classify as `initialize-transport-failure`; fail startup explicitly |
+| `thread/start` returns malformed payload or error | pid, initialized session, raw payload | unchanged | classify as `thread-start-transport-failure`; fail session before any turn starts |
+| `turn/start` returns malformed payload or error | pid, thread id, request id | unchanged | classify as `turn-start-transport-failure`; fail active turn |
+| approval request is well-formed and supported | pid, thread id, active turn, approval payload | unchanged | emit normalized approval event/state, respond explicitly, continue turn |
+| approval request is malformed or unsupported | pid, thread id, active turn, raw payload | unchanged | classify as `approval-transport-failure` or `unsupported-request-failure`; fail active turn without stalling |
+| unsupported dynamic tool or other unsupported protocol request arrives | pid, thread id, active turn, request payload | unchanged | send explicit unsupported response when protocol allows, otherwise fail clearly; do not hang |
+| non-terminal malformed stream line arrives after turn start | pid, thread id, active turn | unchanged | log and classify as non-terminal malformed stream only if the protocol can safely continue |
+| terminal payload such as `turn/completed` / `turn/failed` is malformed | pid, thread id, active turn, raw payload | unchanged | classify as `malformed-terminal-payload`; fail active turn and close session |
+| subprocess exits during active turn | pid, thread id, latest turn id | unchanged | classify as `active-turn-transport-failure`; fail turn; outer retry policy decides next step |
+| turn times out while process is still alive | pid, thread id, active turn | unchanged | classify as `turn-timeout`; shut down transport; surface normalized timed-out runner failure |
+| turn completes successfully | pid, thread id, turn id | post-turn lifecycle from tracker/orchestrator | return success; orchestration decides whether to continue |
+
+## Observability Requirements
+
+- record app-server process spawn, initialize success/failure, thread start, turn start, approval wait/resume, terminal turn result, and shutdown in normalized visibility/logging form
+- surface transport state and failure-class information without exposing raw protocol details as the orchestrator contract
+- keep app-server pid, backend thread id, latest turn id, and latest turn number inspectable in session/status surfaces
+- preserve enough raw payload detail in logs for debugging malformed protocol cases without making downstream layers parse protocol JSON
+
+## Implementation Steps
+
+1. Refactor the Codex app-server session internals into focused runner-layer helpers for:
+   - protocol line parsing and JSON decoding
+   - request/response correlation
+   - notification/request classification
+   - explicit transport-state and failure-class mapping
+2. Add explicit approval-request and unsupported-request handling in the Codex transport boundary.
+3. Update the main session implementation to consume those helpers and expose normalized transport facts/events without leaking raw protocol details upward.
+4. Adjust stable runner session/event/result metadata only where needed so orchestrator/observability consumers can see the new normalized transport facts.
+5. Update narrow observability/status consumers if needed to render the new Codex transport facts and failures clearly.
+6. Add or extend targeted tests for startup, approvals, unsupported requests, malformed payloads, turn terminal paths, timeout/shutdown, and continuation-turn reuse.
+7. Update minimal docs to state that Codex uses app-server as its primary transport boundary.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- successful initialize -> thread/start -> turn/start -> turn/completed flow still reuses one thread across continuation turns
+- approval request handling succeeds for the supported path and resumes the active turn
+- malformed approval payload fails explicitly with the expected transport classification
+- unsupported request / unsupported tool handling does not stall the session and fails or responds explicitly as designed
+- malformed `initialize`, `thread/start`, and `turn/start` responses classify correctly
+- malformed terminal notifications fail the turn explicitly
+- non-terminal malformed stream lines only continue when the protocol state is still recoverable
+- process exit during startup and during an active turn classify correctly
+- timeout and shutdown still clean up the app-server process
+
+### Integration coverage
+
+- existing Codex runner integration remains green with the refactored app-server transport
+- orchestrator/status consumers still consume normalized runner output without any raw protocol branching
+
+### Acceptance scenarios
+
+1. A normal local Codex run starts one app-server subprocess, creates one Codex thread, completes multiple continuation turns, and surfaces normalized transport/session metadata.
+2. An app-server approval request is handled explicitly and visibly at the runner boundary without involving tracker/orchestrator policy.
+3. An unsupported request or malformed protocol payload fails clearly and inspectably instead of stalling or being silently ignored.
+4. The orchestrator still reacts only to normalized runner outcomes and remains ignorant of raw app-server methods.
+
+## Exit Criteria
+
+- Codex app-server is treated in code and tests as the primary structured transport boundary for the `codex` runner
+- approval handling, unsupported request handling, malformed protocol handling, and shutdown behavior are explicit and well-tested
+- transport failure classes and state transitions are explicit enough to support future local or remote reuse of the same boundary
+- orchestrator and tracker layers remain insulated from raw app-server protocol details
+
+## Deferred To Later Issues Or PRs
+
+- SSH-backed or otherwise remote Codex app-server transport reuse
+- dynamic tool support beyond explicit unsupported handling
+- broader remote-execution contracts beyond the narrow Codex transport seam
+- continuation-turn policy changes
+- tracker/review-loop/landing behavior changes

--- a/docs/plans/185-codex-app-server-primary-transport-boundary/plan.md
+++ b/docs/plans/185-codex-app-server-primary-transport-boundary/plan.md
@@ -234,20 +234,20 @@ This issue changes stateful long-lived execution behavior at the runner transpor
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| subprocess exits before `initialize` completes | command, workspace, maybe pid, stderr | unchanged | classify as `startup-transport-failure`; close session; hand runner failure to orchestrator |
-| `initialize` returns malformed payload or error | pid, raw payload | unchanged | classify as `initialize-transport-failure`; fail startup explicitly |
-| `thread/start` returns malformed payload or error | pid, initialized session, raw payload | unchanged | classify as `thread-start-transport-failure`; fail session before any turn starts |
-| `turn/start` returns malformed payload or error | pid, thread id, request id | unchanged | classify as `turn-start-transport-failure`; fail active turn |
-| approval request is well-formed and supported | pid, thread id, active turn, approval payload | unchanged | emit normalized approval event/state, respond explicitly, continue turn |
-| approval request is malformed or unsupported | pid, thread id, active turn, raw payload | unchanged | classify as `approval-transport-failure` or `unsupported-request-failure`; fail active turn without stalling |
-| unsupported dynamic tool or other unsupported protocol request arrives | pid, thread id, active turn, request payload | unchanged | send explicit unsupported response when protocol allows, otherwise fail clearly; do not hang |
-| non-terminal malformed stream line arrives after turn start | pid, thread id, active turn | unchanged | log and classify as non-terminal malformed stream only if the protocol can safely continue |
-| terminal payload such as `turn/completed` / `turn/failed` is malformed | pid, thread id, active turn, raw payload | unchanged | classify as `malformed-terminal-payload`; fail active turn and close session |
-| subprocess exits during active turn | pid, thread id, latest turn id | unchanged | classify as `active-turn-transport-failure`; fail turn; outer retry policy decides next step |
-| turn times out while process is still alive | pid, thread id, active turn | unchanged | classify as `turn-timeout`; shut down transport; surface normalized timed-out runner failure |
-| turn completes successfully | pid, thread id, turn id | post-turn lifecycle from tracker/orchestrator | return success; orchestration decides whether to continue |
+| Observed condition                                                     | Local facts available                         | Normalized tracker facts available            | Expected decision                                                                                            |
+| ---------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| subprocess exits before `initialize` completes                         | command, workspace, maybe pid, stderr         | unchanged                                     | classify as `startup-transport-failure`; close session; hand runner failure to orchestrator                  |
+| `initialize` returns malformed payload or error                        | pid, raw payload                              | unchanged                                     | classify as `initialize-transport-failure`; fail startup explicitly                                          |
+| `thread/start` returns malformed payload or error                      | pid, initialized session, raw payload         | unchanged                                     | classify as `thread-start-transport-failure`; fail session before any turn starts                            |
+| `turn/start` returns malformed payload or error                        | pid, thread id, request id                    | unchanged                                     | classify as `turn-start-transport-failure`; fail active turn                                                 |
+| approval request is well-formed and supported                          | pid, thread id, active turn, approval payload | unchanged                                     | emit normalized approval event/state, respond explicitly, continue turn                                      |
+| approval request is malformed or unsupported                           | pid, thread id, active turn, raw payload      | unchanged                                     | classify as `approval-transport-failure` or `unsupported-request-failure`; fail active turn without stalling |
+| unsupported dynamic tool or other unsupported protocol request arrives | pid, thread id, active turn, request payload  | unchanged                                     | send explicit unsupported response when protocol allows, otherwise fail clearly; do not hang                 |
+| non-terminal malformed stream line arrives after turn start            | pid, thread id, active turn                   | unchanged                                     | log and classify as non-terminal malformed stream only if the protocol can safely continue                   |
+| terminal payload such as `turn/completed` / `turn/failed` is malformed | pid, thread id, active turn, raw payload      | unchanged                                     | classify as `malformed-terminal-payload`; fail active turn and close session                                 |
+| subprocess exits during active turn                                    | pid, thread id, latest turn id                | unchanged                                     | classify as `active-turn-transport-failure`; fail turn; outer retry policy decides next step                 |
+| turn times out while process is still alive                            | pid, thread id, active turn                   | unchanged                                     | classify as `turn-timeout`; shut down transport; surface normalized timed-out runner failure                 |
+| turn completes successfully                                            | pid, thread id, turn id                       | post-turn lifecycle from tracker/orchestrator | return success; orchestration decides whether to continue                                                    |
 
 ## Observability Requirements
 

--- a/src/runner/codex-app-server-protocol.ts
+++ b/src/runner/codex-app-server-protocol.ts
@@ -1,0 +1,243 @@
+import { RunnerError } from "../domain/errors.js";
+
+export type CodexAppServerSessionState =
+  | "idle"
+  | "starting-process"
+  | "initializing"
+  | "starting-thread"
+  | "ready"
+  | "starting-turn"
+  | "streaming-turn"
+  | "awaiting-approval"
+  | "turn-succeeded"
+  | "turn-failed"
+  | "closing"
+  | "closed";
+
+export type CodexAppServerFailureClass =
+  | "startup-transport-failure"
+  | "initialize-transport-failure"
+  | "thread-start-transport-failure"
+  | "turn-start-transport-failure"
+  | "approval-transport-failure"
+  | "unsupported-request-failure"
+  | "malformed-terminal-payload"
+  | "active-turn-transport-failure"
+  | "turn-timeout";
+
+export class CodexAppServerTransportError extends RunnerError {
+  readonly failureClass: CodexAppServerFailureClass;
+
+  constructor(
+    failureClass: CodexAppServerFailureClass,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.failureClass = failureClass;
+  }
+}
+
+export type CodexAppServerMessage =
+  | CodexAppServerResponseMessage
+  | CodexAppServerRequestMessage
+  | CodexAppServerNotificationMessage;
+
+export interface CodexAppServerResponseMessage {
+  readonly kind: "response";
+  readonly id: unknown;
+  readonly result: Record<string, unknown> | null;
+  readonly error: unknown;
+}
+
+export interface CodexAppServerRequestMessage {
+  readonly kind: "request";
+  readonly id: string | number;
+  readonly method: string;
+  readonly rawParams: unknown;
+  readonly params: Record<string, unknown> | null;
+}
+
+export interface CodexAppServerNotificationMessage {
+  readonly kind: "notification";
+  readonly method: string;
+  readonly rawParams: unknown;
+  readonly params: Record<string, unknown> | null;
+}
+
+export interface CodexAppServerApprovalRequest {
+  readonly kind: "command" | "file-change";
+  readonly summary: string;
+}
+
+export function classifyCodexAppServerMessage(
+  payload: unknown,
+): CodexAppServerMessage | null {
+  const message = asRecord(payload);
+  if (message === null) {
+    return null;
+  }
+
+  const id = message["id"];
+  const method =
+    typeof message["method"] === "string" ? message["method"] : null;
+
+  if ((typeof id === "number" || typeof id === "string") && method !== null) {
+    return {
+      kind: "request",
+      id,
+      method,
+      rawParams: message["params"],
+      params: asRecord(message["params"]),
+    };
+  }
+
+  if (id !== undefined) {
+    return {
+      kind: "response",
+      id,
+      result: asRecord(message["result"]),
+      error: message["error"],
+    };
+  }
+
+  if (method !== null) {
+    return {
+      kind: "notification",
+      method,
+      rawParams: message["params"],
+      params: asRecord(message["params"]),
+    };
+  }
+
+  return null;
+}
+
+export function extractCodexApprovalRequest(
+  request: CodexAppServerRequestMessage,
+): CodexAppServerApprovalRequest | null {
+  switch (request.method) {
+    case "item/commandExecution/requestApproval": {
+      const command = extractCommandText(request.params);
+      if (command === null) {
+        throw new CodexAppServerTransportError(
+          "approval-transport-failure",
+          "Codex app-server sent a malformed command approval request",
+        );
+      }
+      return {
+        kind: "command",
+        summary: command,
+      };
+    }
+    case "item/fileChange/requestApproval": {
+      const count =
+        request.params?.["fileChangeCount"] ?? request.params?.["changeCount"];
+      if (typeof count !== "number" || !Number.isFinite(count) || count < 0) {
+        throw new CodexAppServerTransportError(
+          "approval-transport-failure",
+          "Codex app-server sent a malformed file-change approval request",
+        );
+      }
+      return {
+        kind: "file-change",
+        summary: `${count} files`,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export function formatCodexTransportError(
+  error: Error,
+  fallbackClass: CodexAppServerFailureClass,
+): string {
+  const failureClass =
+    error instanceof CodexAppServerTransportError
+      ? error.failureClass
+      : fallbackClass;
+  return `${failureClass}: ${error.message}`;
+}
+
+export function createCodexApprovalResponse(
+  requestId: string | number,
+): Record<string, unknown> {
+  return {
+    id: requestId,
+    result: {
+      decision: "approved",
+    },
+  };
+}
+
+export function createCodexInvalidParamsResponse(
+  requestId: string | number,
+  method: string,
+  message: string,
+): Record<string, unknown> {
+  return createCodexErrorResponse(requestId, -32602, `${method}: ${message}`);
+}
+
+export function createCodexUnsupportedRequestResponse(
+  requestId: string | number,
+  method: string,
+): Record<string, unknown> {
+  return createCodexErrorResponse(
+    requestId,
+    -32601,
+    `Unsupported Codex app-server request '${method}'`,
+  );
+}
+
+function createCodexErrorResponse(
+  requestId: string | number,
+  code: number,
+  message: string,
+): Record<string, unknown> {
+  return {
+    id: requestId,
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+function extractCommandText(
+  params: Record<string, unknown> | null,
+): string | null {
+  if (params === null) {
+    return null;
+  }
+
+  const direct =
+    params["command"] ?? params["cmd"] ?? params["commandText"] ?? null;
+  if (typeof direct === "string" && direct.trim() !== "") {
+    return direct.trim();
+  }
+
+  if (Array.isArray(direct)) {
+    const parts = direct.filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    );
+    if (parts.length > 0) {
+      return parts.join(" ");
+    }
+  }
+
+  const command = asRecord(direct);
+  const commandText = command?.["text"];
+  if (typeof commandText === "string" && commandText.trim() !== "") {
+    return commandText.trim();
+  }
+
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -11,6 +11,18 @@ import {
   type CodexAppServerCommand,
 } from "./codex-app-server-command.js";
 import {
+  CodexAppServerTransportError,
+  classifyCodexAppServerMessage,
+  createCodexApprovalResponse,
+  createCodexInvalidParamsResponse,
+  createCodexUnsupportedRequestResponse,
+  extractCodexApprovalRequest,
+  formatCodexTransportError,
+  type CodexAppServerFailureClass,
+  type CodexAppServerRequestMessage,
+  type CodexAppServerSessionState,
+} from "./codex-app-server-protocol.js";
+import {
   RUNNER_SHUTDOWN_GRACE_MS,
   summarizeRunnerText,
   withRunnerTransportLocalProcess,
@@ -66,6 +78,8 @@ export class CodexAppServerSession implements LiveRunnerSession {
   #appServerPid: number | null = null;
   #loggedDroppedArgs = false;
   #closingReason: "timeout" | "aborted" | null = null;
+  #sessionState: CodexAppServerSessionState = "idle";
+  #transportFailureClass: CodexAppServerFailureClass | null = null;
   #forcedShutdown = false;
   #closeTimersScheduled = false;
   #nextTurnStartRequestId = TURN_START_FIRST_REQUEST_ID;
@@ -170,8 +184,10 @@ export class CodexAppServerSession implements LiveRunnerSession {
   async close(): Promise<void> {
     const child = this.#child;
     if (child === null) {
+      this.#sessionState = "closed";
       return;
     }
+    this.#sessionState = "closing";
     if (this.#closePromise === null) {
       this.#closePromise = new Promise<void>((resolve, reject) => {
         this.#closeResolve = resolve;
@@ -197,7 +213,8 @@ export class CodexAppServerSession implements LiveRunnerSession {
       setTimeout(() => {
         if (child.exitCode === null && child.signalCode === null) {
           this.#closeReject?.(
-            new RunnerError(
+            this.#createTransportError(
+              "startup-transport-failure",
               `Codex app-server did not exit after ${CLOSE_TIMEOUT_MS}ms`,
             ),
           );
@@ -213,6 +230,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
 
   async #ensureStarted(options?: RunnerRunOptions): Promise<void> {
     if (this.#threadId !== null) {
+      this.#sessionState = "ready";
       return;
     }
     if (this.#activeTurn !== null || this.#pendingResponse !== null) {
@@ -224,11 +242,18 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     try {
+      this.#sessionState = "initializing";
       await this.#sendInitialize();
       await this.#sendNotification({ method: "initialized", params: {} });
+      this.#sessionState = "starting-thread";
       await this.#startThread();
     } catch (error) {
-      throw this.#withStartupStderr(asError(error));
+      throw this.#withStartupStderr(
+        this.#normalizeTransportError(
+          asError(error),
+          "startup-transport-failure",
+        ),
+      );
     }
   }
 
@@ -269,6 +294,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
 
     this.#child = child;
     this.#appServerPid = child.pid ?? null;
+    this.#sessionState = "starting-process";
     this.#closePromise = new Promise<void>((resolve, reject) => {
       this.#closeResolve = resolve;
       this.#closeReject = reject;
@@ -341,9 +367,12 @@ export class CodexAppServerSession implements LiveRunnerSession {
     child.on("error", (error) => {
       this.#rejectActiveState(
         this.#withStartupStderr(
-          new RunnerError(`Failed to launch codex app-server`, {
-            cause: error,
-          }),
+          this.#normalizeTransportError(
+            new RunnerError(`Failed to launch codex app-server`, {
+              cause: error,
+            }),
+            "startup-transport-failure",
+          ),
         ),
       );
     });
@@ -352,10 +381,15 @@ export class CodexAppServerSession implements LiveRunnerSession {
         this.#closingReason === null &&
         (this.#activeTurn !== null || this.#pendingResponse !== null)
           ? this.#withStartupStderr(
-              new RunnerError(
-                `Codex app-server exited before the active request completed (exit=${String(
-                  exitCode,
-                )}, signal=${String(signalCode)})`,
+              this.#normalizeTransportError(
+                new RunnerError(
+                  `Codex app-server exited before the active request completed (exit=${String(
+                    exitCode,
+                  )}, signal=${String(signalCode)})`,
+                ),
+                this.#activeTurn === null
+                  ? "startup-transport-failure"
+                  : "active-turn-transport-failure",
               ),
             )
           : null;
@@ -364,6 +398,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       }
       this.#child = null;
       this.#closeTimersScheduled = false;
+      this.#sessionState = "closed";
       this.#closeResolve?.();
       this.#closeResolve = null;
       this.#closeReject = null;
@@ -408,11 +443,13 @@ export class CodexAppServerSession implements LiveRunnerSession {
     const thread = asRecord(result["thread"]);
     const threadId = typeof thread?.["id"] === "string" ? thread["id"] : null;
     if (threadId === null) {
-      throw new RunnerError(
+      throw new CodexAppServerTransportError(
+        "thread-start-transport-failure",
         "Codex app-server returned an invalid thread/start response",
       );
     }
     this.#threadId = threadId;
+    this.#sessionState = "ready";
     await this.#emitVisibility({
       state: "starting",
       phase: "session-start",
@@ -438,6 +475,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       this.#runSession,
       "Codex app-server turn execution",
     );
+    this.#sessionState = "starting-turn";
     await this.#emitVisibility({
       state: "running",
       phase: "turn-execution",
@@ -474,13 +512,15 @@ export class CodexAppServerSession implements LiveRunnerSession {
             typeof turnPayload?.["id"] === "string" ? turnPayload["id"] : null;
           if (turnId === null) {
             this.#rejectActiveTurn(
-              new RunnerError(
+              new CodexAppServerTransportError(
+                "turn-start-transport-failure",
                 "Codex app-server returned an invalid turn/start response",
               ),
             );
             return;
           }
           this.#latestTurnId = turnId;
+          this.#sessionState = "streaming-turn";
         })
         .catch((error) => {
           this.#rejectActiveTurn(error);
@@ -588,11 +628,6 @@ export class CodexAppServerSession implements LiveRunnerSession {
       return;
     }
 
-    const message = asRecord(payload);
-    if (message === null) {
-      return;
-    }
-
     const update = parseRunUpdateEvent(payload);
     if (update !== undefined) {
       try {
@@ -606,45 +641,66 @@ export class CodexAppServerSession implements LiveRunnerSession {
       }
     }
 
-    if (message["id"] !== undefined) {
-      this.#handleResponse(message);
+    const message = classifyCodexAppServerMessage(payload);
+    if (message === null) {
       return;
     }
-    this.#handleNotification(message);
+
+    switch (message.kind) {
+      case "response":
+        this.#handleResponse(message);
+        return;
+      case "request":
+        void this.#handleRequest(message);
+        return;
+      case "notification":
+        this.#handleNotification(
+          message.method,
+          message.params,
+          message.rawParams,
+        );
+        return;
+    }
   }
 
-  #handleResponse(message: Record<string, unknown>): void {
+  #handleResponse(message: {
+    readonly id: unknown;
+    readonly result: Record<string, unknown> | null;
+    readonly error: unknown;
+  }): void {
     const pending = this.#pendingResponse;
     if (pending === null) {
       return;
     }
-    if (message["id"] !== pending.id) {
+    if (message.id !== pending.id) {
       this.#logger.warn(
         "Codex app-server returned a response with an unexpected id",
         {
           runSessionId: this.#runSession.id,
           expectedId: pending.id,
-          receivedId: message["id"],
+          receivedId: message.id,
           method: pending.method,
         },
       );
       return;
     }
     this.#pendingResponse = null;
-    if (message["error"] !== undefined) {
+    if (message.error !== undefined) {
       pending.reject(
-        new RunnerError(
+        this.#createTransportError(
+          failureClassForPendingMethod(pending.method),
           `Codex app-server request '${pending.method}' failed: ${JSON.stringify(
-            message["error"],
+            message.error,
           )}`,
         ),
       );
       return;
     }
-    const result = asRecord(message["result"]);
+    const result = message.result;
     if (result === null) {
       pending.reject(
-        new RunnerError(
+        this.#createTransportError(
+          failureClassForPendingMethod(pending.method),
           `Codex app-server request '${pending.method}' returned an invalid result payload`,
         ),
       );
@@ -653,15 +709,85 @@ export class CodexAppServerSession implements LiveRunnerSession {
     pending.resolve(result);
   }
 
-  #handleNotification(message: Record<string, unknown>): void {
-    const method =
-      typeof message["method"] === "string" ? message["method"] : null;
-    if (method === null) {
-      return;
-    }
+  async #handleRequest(message: CodexAppServerRequestMessage): Promise<void> {
+    try {
+      const approval = extractCodexApprovalRequest(message);
+      if (approval === null) {
+        await this.#writeMessage(
+          createCodexUnsupportedRequestResponse(message.id, message.method),
+        );
+        this.#rejectActiveTurn(
+          this.#createTransportError(
+            "unsupported-request-failure",
+            `Codex app-server requested unsupported method '${message.method}'`,
+          ),
+        );
+        return;
+      }
 
+      this.#sessionState = "awaiting-approval";
+      const observedAt = new Date().toISOString();
+      await this.#emitVisibility({
+        state: "waiting",
+        phase: "awaiting-external",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: `Codex approval requested (${approval.kind})`,
+        waitingReason: `Waiting on Codex ${approval.kind} approval for ${approval.summary}`,
+      });
+
+      if (this.#appServerCommand.approvalPolicy !== "never") {
+        await this.#writeMessage(
+          createCodexInvalidParamsResponse(
+            message.id,
+            message.method,
+            "Symphony cannot satisfy interactive approvals unless the Codex runner is configured with approvalPolicy=never",
+          ),
+        );
+        this.#rejectActiveTurn(
+          this.#createTransportError(
+            "approval-transport-failure",
+            `Codex app-server requested approval for ${approval.summary}, but the runner is not configured for non-interactive approval`,
+          ),
+        );
+        return;
+      }
+
+      await this.#writeMessage(createCodexApprovalResponse(message.id));
+      this.#sessionState = "streaming-turn";
+      await this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: `Codex approval granted (${approval.kind})`,
+        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+      });
+    } catch (error) {
+      const resolvedError = this.#normalizeTransportError(
+        asError(error),
+        "approval-transport-failure",
+      );
+      try {
+        await this.#writeMessage(
+          createCodexInvalidParamsResponse(
+            message.id,
+            message.method,
+            resolvedError.message,
+          ),
+        );
+      } catch {}
+      this.#rejectActiveTurn(resolvedError);
+    }
+  }
+
+  #handleNotification(
+    method: string,
+    params: Record<string, unknown> | null,
+    rawParams: unknown,
+  ): void {
     if (method === "turn/started") {
-      const params = asRecord(message["params"]);
       if (params === null) {
         return;
       }
@@ -671,6 +797,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       if (turnId !== null) {
         this.#latestTurnId = turnId;
       }
+      this.#sessionState = "streaming-turn";
       void this.#emitVisibility({
         state: "running",
         phase: "turn-execution",
@@ -684,13 +811,43 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     if (method === "turn/completed") {
+      if (rawParams !== undefined && rawParams !== null && params === null) {
+        this.#rejectActiveTurn(
+          this.#createTransportError(
+            "malformed-terminal-payload",
+            "Codex app-server returned a malformed turn/completed payload",
+          ),
+        );
+        return;
+      }
+      if (params !== null) {
+        const turnPayload = asRecord(params["turn"]);
+        if (turnPayload === null) {
+          this.#rejectActiveTurn(
+            this.#createTransportError(
+              "malformed-terminal-payload",
+              "Codex app-server returned a malformed turn/completed payload",
+            ),
+          );
+          return;
+        }
+      }
       this.#resolveActiveTurn();
       return;
     }
 
     if (method === "turn/failed" || method === "turn/cancelled") {
-      const params = asRecord(message["params"]);
+      if (rawParams !== undefined && rawParams !== null && params === null) {
+        this.#rejectActiveTurn(
+          this.#createTransportError(
+            "malformed-terminal-payload",
+            `Codex app-server returned a malformed ${method} payload`,
+          ),
+        );
+        return;
+      }
       const observedAt = new Date().toISOString();
+      this.#sessionState = "turn-failed";
       void this.#emitVisibility({
         state: method === "turn/cancelled" ? "cancelled" : "failed",
         phase: method === "turn/cancelled" ? "shutdown" : "turn-finished",
@@ -718,6 +875,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       return;
     }
     this.#latestTurnNumber = activeTurn.turnNumber;
+    this.#sessionState = "turn-succeeded";
     this.#activeTurn = null;
     void this.#emitVisibility({
       state: "completed",
@@ -740,13 +898,19 @@ export class CodexAppServerSession implements LiveRunnerSession {
 
   #rejectActiveTurn(error: unknown): void {
     const activeTurn = this.#activeTurn;
+    const resolvedError = this.#normalizeTransportError(
+      asError(error),
+      this.#closingReason === "timeout"
+        ? "turn-timeout"
+        : "active-turn-transport-failure",
+    );
     if (activeTurn === null) {
-      this.#rejectActiveState(asError(error));
+      this.#rejectActiveState(resolvedError);
       return;
     }
     this.#activeTurn = null;
+    this.#sessionState = "turn-failed";
     const observedAt = new Date().toISOString();
-    const resolvedError = asError(error);
     void this.#emitVisibility({
       state:
         this.#closingReason === "aborted"
@@ -765,7 +929,12 @@ export class CodexAppServerSession implements LiveRunnerSession {
             : "Runner failed",
       stdoutSummary: summarizeRunnerText(activeTurn.stdout),
       stderrSummary: summarizeRunnerText(activeTurn.stderr),
-      errorSummary: summarizeRunnerText(resolvedError.message),
+      errorSummary: summarizeRunnerText(
+        formatCodexTransportError(
+          resolvedError,
+          this.#transportFailureClass ?? "active-turn-transport-failure",
+        ),
+      ),
       cancelledAt: this.#closingReason === "aborted" ? observedAt : null,
       timedOutAt: this.#closingReason === "timeout" ? observedAt : null,
     });
@@ -773,6 +942,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   #rejectActiveState(error: Error): void {
+    this.#sessionState = "turn-failed";
     if (this.#pendingResponse !== null) {
       const pending = this.#pendingResponse;
       this.#pendingResponse = null;
@@ -799,7 +969,38 @@ export class CodexAppServerSession implements LiveRunnerSession {
     if (stderr.length === 0 || this.#latestTurnNumber !== null) {
       return error;
     }
+    if (error instanceof CodexAppServerTransportError) {
+      return new CodexAppServerTransportError(
+        error.failureClass,
+        `${error.message}\nStartup stderr:\n${stderr}`,
+        {
+          cause: error,
+        },
+      );
+    }
     return new RunnerError(`${error.message}\nStartup stderr:\n${stderr}`, {
+      cause: error,
+    });
+  }
+
+  #createTransportError(
+    failureClass: CodexAppServerFailureClass,
+    message: string,
+    options?: ErrorOptions,
+  ): CodexAppServerTransportError {
+    this.#transportFailureClass = failureClass;
+    return new CodexAppServerTransportError(failureClass, message, options);
+  }
+
+  #normalizeTransportError(
+    error: Error,
+    fallbackClass: CodexAppServerFailureClass,
+  ): Error {
+    if (error instanceof CodexAppServerTransportError) {
+      this.#transportFailureClass = error.failureClass;
+      return error;
+    }
+    return this.#createTransportError(fallbackClass, error.message, {
       cause: error,
     });
   }
@@ -868,4 +1069,19 @@ function omitNullValues(
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== null),
   );
+}
+
+function failureClassForPendingMethod(
+  method: string,
+): CodexAppServerFailureClass {
+  switch (method) {
+    case "initialize":
+      return "initialize-transport-failure";
+    case "thread/start":
+      return "thread-start-transport-failure";
+    case "turn/start":
+      return "turn-start-transport-failure";
+    default:
+      return "startup-transport-failure";
+  }
 }

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -128,11 +128,16 @@ type FakeCodexMode =
   | "success"
   | "hang"
   | "token-count-event-msg"
+  | "command-approval"
+  | "command-approval-requires-input"
+  | "malformed-command-approval"
+  | "unsupported-request"
   | "turn-failed"
   | "turn-failed-null-params"
   | "turn-failed-without-params"
   | "completed-null-params"
   | "completed-without-params"
+  | "completed-malformed-params"
   | "malformed-stream"
   | "startup-stderr-exit"
   | "malformed-thread"
@@ -152,6 +157,9 @@ const mode = process.env.FAKE_CODEX_MODE ?? "success";
 const logFile = process.env.FAKE_CODEX_LOG_FILE ?? null;
 let turnCount = 0;
 const threadId = "thread-1";
+let pendingTurnId = null;
+let pendingServerRequestId = null;
+let pendingServerRequestKind = null;
 
 function log(entry) {
   if (!logFile) return;
@@ -253,6 +261,33 @@ rl.on("line", (line) => {
   }
   log(payload);
 
+  if (payload.id !== undefined && payload.method === undefined) {
+    if (payload.id === pendingServerRequestId) {
+      const requestKind = pendingServerRequestKind;
+      const turnId = pendingTurnId;
+      pendingServerRequestId = null;
+      pendingServerRequestKind = null;
+      pendingTurnId = null;
+
+      if (requestKind === "command-approval" && turnId !== null) {
+        setTimeout(() => completeTurn(turnId), 5);
+        return;
+      }
+      if (requestKind === "unsupported-request" && turnId !== null) {
+        send({
+          method: "turn/failed",
+          params: {
+            threadId,
+            turn: { id: turnId },
+            message: "unsupported request rejected",
+          },
+        });
+        return;
+      }
+    }
+    return;
+  }
+
   if (payload.method === "initialize") {
     send({ id: payload.id, result: { userAgent: "fake-codex" } });
     return;
@@ -299,6 +334,49 @@ rl.on("line", (line) => {
         turn: { id: turnId },
       },
     });
+    if (mode === "command-approval" || mode === "command-approval-requires-input") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9000 + turnCount;
+      pendingServerRequestKind = "command-approval";
+      send({
+        id: pendingServerRequestId,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          command: "rm -rf /",
+        },
+      });
+      return;
+    }
+    if (mode === "malformed-command-approval") {
+      send({
+        id: 9100 + turnCount,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          command: 7,
+        },
+      });
+      return;
+    }
+    if (mode === "unsupported-request") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9200 + turnCount;
+      pendingServerRequestKind = "unsupported-request";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/call",
+        params: {
+          tool: "unknown",
+        },
+      });
+      return;
+    }
+    if (mode === "completed-malformed-params") {
+      send({
+        method: "turn/completed",
+        params: [],
+      });
+      return;
+    }
     setTimeout(() => completeTurn(turnId), 5);
   }
 });
@@ -1072,6 +1150,188 @@ describe("runners", () => {
     expect(entry.codexTotalTokens).toBe(168);
   });
 
+  it("auto-approves supported Codex command approval requests", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const events: RunnerEvent[] = [];
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "command-approval",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn(
+          {
+            turnNumber: 1,
+            prompt: "first",
+          },
+          {
+            onEvent(event) {
+              events.push(event);
+            },
+          },
+        ),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close();
+    }
+
+    const waitingEvent = events.find(
+      (event) =>
+        event.kind === "visibility" &&
+        event.visibility.state === "waiting" &&
+        event.visibility.waitingReason?.includes("rm -rf /") === true,
+    );
+    expect(waitingEvent).toBeDefined();
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9001,
+        result: {
+          decision: "approved",
+        },
+      }),
+    );
+  });
+
+  it("fails explicitly when Codex requests interactive approval", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --ask-for-approval on-request -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "command-approval-requires-input",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).rejects.toThrowError(/Codex app-server requested approval/);
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9001,
+        error: expect.objectContaining({
+          code: -32602,
+        }),
+      }),
+    );
+  });
+
+  it("fails explicitly when Codex sends a malformed approval request", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "malformed-command-approval",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).rejects.toThrowError(
+        /Codex app-server sent a malformed command approval request/,
+      );
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9101,
+        error: expect.objectContaining({
+          code: -32602,
+        }),
+      }),
+    );
+  });
+
+  it("responds explicitly to unsupported Codex server requests", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "unsupported-request",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).rejects.toThrowError(
+        /Codex app-server requested unsupported method 'item\/tool\/call'/,
+      );
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9201,
+        error: expect.objectContaining({
+          code: -32601,
+        }),
+      }),
+    );
+  });
+
   it("completes a Codex turn when turn/completed omits params", async () => {
     const fakeCodex = await createFakeCodexExecutable();
     const runner = createCodexRunnerForMode(
@@ -1091,6 +1351,28 @@ describe("runners", () => {
       });
     } finally {
       await liveSession.close();
+    }
+  });
+
+  it("fails clearly when turn/completed sends malformed params", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const runner = createCodexRunnerForMode(
+      fakeCodex,
+      "completed-malformed-params",
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).rejects.toThrowError(
+        /Codex app-server returned a malformed turn\/completed payload/,
+      );
+    } finally {
+      await liveSession.close().catch(() => {});
     }
   });
 


### PR DESCRIPTION
## Summary
- harden the Codex app-server session boundary with explicit protocol message classification and named transport failure classes
- add explicit handling for server-initiated approval requests, unsupported requests, and malformed terminal payloads
- extend the fake Codex app-server harness and runner tests to lock in the new transport boundary behavior

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

## Self-review
- Attempted `codex review --base origin/main`; the preview review command did not produce a final verdict in this environment, so I completed a manual diff review after the full validation pass.

Closes #185.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
