### PR TITLE
Add Codex dynamic-tool support for tracker-native tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OpenAI released [the Symphony spec](https://github.com/openai/symphony) to addre
 - **Runs locally.** Point it at a repo and it starts working issues. No servers to deploy, no accounts to create.
 - **Adapter pattern for everything.** Pluggable trackers (GitHub and Linear) plus a runner contract that separates provider identity from execution transport. Built-in `codex`, `claude-code`, and `generic-command` adapters stay local today; remote workers can land against the same contract later. Swap any layer without touching the others.
   The `codex` adapter now treats `codex app-server` as its primary structured transport boundary for startup, continuation turns, approvals, streaming events, and shutdown.
+  Codex app-server sessions now also advertise one first-party dynamic tool, `tracker_current_context`, which returns sanitized current issue and PR context through Symphony's runner/tracker boundary instead of shell affordances.
 - **State lives in the tracker.** The entire factory state — what's in progress, what's done, what failed — lives in your tracker (GitHub Issues or Linear) instead of a separate control plane. Today's bootstrap runtime is designed for one local factory instance; broader multi-instance coordination is planned.
 - **Visibility.** The tracker gives you real-time visibility into the whole factory. A local status surface shows worker-level detail.
 - **It builds itself.** Symphony works `symphony-ts` issues and opens PRs back into this repo. The [self-hosting loop](docs/guides/self-hosting-loop.md) is how we develop it.

--- a/docs/plans/186-codex-dynamic-tool-support/plan.md
+++ b/docs/plans/186-codex-dynamic-tool-support/plan.md
@@ -195,16 +195,16 @@ This issue changes stateful live-session behavior inside an active Codex turn, s
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| `item/tool/call` arrives for a supported tool with valid arguments | thread id, turn id, call id, tool name, parsed args | current issue and PR context available through tracker tool service | execute tool, serialize normalized success payload, continue turn |
-| `item/tool/call` arrives for an unknown tool | thread id, turn id, call id, tool name | none needed | return explicit unsupported-tool response, classify as tool request failure, do not hang |
-| tool-call payload is malformed | request id, raw params | none needed | return invalid-params response, classify as malformed-tool-request failure |
-| tracker tool service fails to read current tracker state | request id, tool name, local error | tracker fetch error only | return normalized tool failure payload or explicit request failure, preserving clear operator visibility |
-| tracker tool service returns output that violates the advertised schema | request id, tool name, normalized output candidate | tool result candidate | classify as tool-result-normalization failure and fail the tool call clearly |
-| `item/tool/requestUserInput` arrives in the first non-interactive slice | request id, raw params | none needed | return explicit unsupported/invalid-params response and fail the active tool request without stalling |
-| response write to app-server stdin fails after tool execution | request id, tool name, result payload | tracker result already computed | classify as active-turn transport/tool failure and fail the turn |
-| tool succeeds but observability emission fails | request id, tool name, result payload | normalized tracker result | fail the turn using the existing visibility-failure path; do not silently ignore |
+| Observed condition                                                      | Local facts available                               | Normalized tracker facts available                                  | Expected decision                                                                                        |
+| ----------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `item/tool/call` arrives for a supported tool with valid arguments      | thread id, turn id, call id, tool name, parsed args | current issue and PR context available through tracker tool service | execute tool, serialize normalized success payload, continue turn                                        |
+| `item/tool/call` arrives for an unknown tool                            | thread id, turn id, call id, tool name              | none needed                                                         | return explicit unsupported-tool response, classify as tool request failure, do not hang                 |
+| tool-call payload is malformed                                          | request id, raw params                              | none needed                                                         | return invalid-params response, classify as malformed-tool-request failure                               |
+| tracker tool service fails to read current tracker state                | request id, tool name, local error                  | tracker fetch error only                                            | return normalized tool failure payload or explicit request failure, preserving clear operator visibility |
+| tracker tool service returns output that violates the advertised schema | request id, tool name, normalized output candidate  | tool result candidate                                               | classify as tool-result-normalization failure and fail the tool call clearly                             |
+| `item/tool/requestUserInput` arrives in the first non-interactive slice | request id, raw params                              | none needed                                                         | return explicit unsupported/invalid-params response and fail the active tool request without stalling    |
+| response write to app-server stdin fails after tool execution           | request id, tool name, result payload               | tracker result already computed                                     | classify as active-turn transport/tool failure and fail the turn                                         |
+| tool succeeds but observability emission fails                          | request id, tool name, result payload               | normalized tracker result                                           | fail the turn using the existing visibility-failure path; do not silently ignore                         |
 
 ## Storage Or Persistence Contract
 

--- a/docs/plans/186-codex-dynamic-tool-support/plan.md
+++ b/docs/plans/186-codex-dynamic-tool-support/plan.md
@@ -1,0 +1,296 @@
+# Issue 186 Plan: Add Codex Dynamic-Tool Support For Tracker-Native Client-Side Tools
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add the first explicit dynamic-tool path for Codex app-server sessions so Symphony can advertise one tracker-native client-side tool, execute it through a focused runner-side tool boundary, return normalized results to Codex, and reject unsupported dynamic-tool requests without stalling the live session.
+
+## Scope
+
+- extend the Codex app-server startup/session path to advertise a minimal dynamic-tool surface to the connected Codex client
+- introduce a focused dynamic-tool executor boundary inside `src/runner/` rather than embedding tracker calls directly in the app-server session class
+- add one read-only tracker-native tool as the first shipped surface
+- normalize tool success and failure payloads before returning them to Codex
+- keep tool-request observability explicit in runner visibility/logging and issue artifacts
+- reject unsupported tool names, malformed tool-call payloads, and unsupported interactive tool flows clearly without hanging the session
+- preserve existing approval handling, turn streaming, and tracker orchestration semantics outside the dynamic-tool seam
+
+## Non-goals
+
+- arbitrary shell access or repository-local file tools exposed through dynamic tools
+- a general plugin framework for arbitrary client-side tools
+- tracker lifecycle or review/landing policy changes
+- broad prompt-contract redesign
+- remote Codex app-server execution
+- write-capable tracker tools
+- multi-tool bundles beyond the first reviewable tracker-native slice
+
+## Current Gaps
+
+- `src/runner/codex-app-server-session.ts` currently treats `item/tool/call` as an unsupported request and fails the turn immediately
+- the runner has no dedicated tool-execution boundary; any future dynamic-tool work would otherwise force tracker access directly into the app-server session transport class
+- the existing `Tracker` interface is oriented around orchestration control actions, not on-demand read-only tool queries for an active agent turn
+- tracker sanitization already exists for prompt summaries in `src/tracker/prompt-context.ts`, but there is no reusable normalized tracker-tool result contract that keeps runtime tool output aligned with the repo trust boundary
+- observability humanizes dynamic-tool events in the TUI, but the runner does not yet produce successful dynamic-tool call results or normalized tool-failure summaries
+- test coverage locks in unsupported-request failure behavior for `item/tool/call`, but there is no coverage for successful dynamic-tool advertisement, execution, or normalized result serialization
+
+## Decision Notes
+
+- Keep the transport seam in `src/runner/`: Codex protocol parsing, request dispatch, tool-call response writing, and in-turn failure handling remain runner concerns.
+- Introduce a separate read-only tracker tool service instead of expanding the orchestration `Tracker` interface with ad hoc tool semantics.
+- Reuse repository-owned tracker normalization rules for tool output so the first tool does not become a loophole around the prompt trust boundary.
+- Keep the first tool narrow and high-leverage: read-only tracker context for the current issue/branch/PR state, not arbitrary issue search or mutation.
+- Unsupported or malformed dynamic-tool requests must respond explicitly and terminate the active tool request path without leaving the live session hanging.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the local abstraction mapping from `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: deciding that Symphony exposes an explicit tracker-native dynamic-tool seam to Codex and that the first tool is read-only and trust-boundary-aware
+  - does not belong: JSON-RPC request parsing, schema validation, or tracker transport calls
+- Configuration Layer
+  - belongs: deriving any fixed runner-side dynamic-tool advertisement shape and validating that only supported Codex sessions opt into it
+  - does not belong: tracker query execution, tool-call result formatting, or orchestration state transitions
+- Coordination Layer
+  - belongs: unchanged in this slice; orchestration still reacts only to normalized runner outcomes and tracker handoff state
+  - does not belong: raw tool-call protocol handling, tracker-tool response construction, or app-server request dispatch
+- Execution Layer
+  - belongs: app-server startup advertisement, tool-call request routing, tool execution boundary invocation, response serialization, and turn-level failure handling
+  - does not belong: tracker lifecycle policy or PR handoff decisions
+- Integration Layer
+  - belongs: a focused read-only tracker-tool service plus tracker-specific normalization for the first tool result
+  - does not belong: Codex protocol parsing or runner session-state bookkeeping
+- Observability Layer
+  - belongs: surfacing dynamic-tool advertisement, tool-call start/completion/failure, tool name, and normalized summaries in logs/status/artifacts
+  - does not belong: re-parsing tracker payloads or reconstructing tool results independently of the runner/integration layers
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/runner/`
+  - dynamic-tool advertisement for Codex app-server startup
+  - request classification for `item/tool/call` and `item/tool/requestUserInput`
+  - a focused tool executor interface used by `CodexAppServerSession`
+  - normalized tool success/failure result serialization back to Codex
+- `src/tracker/`
+  - a narrow read-only tracker tool broker/service for the first tool
+  - tracker-specific normalization helpers that shape safe tool output
+- wiring in CLI/runtime composition
+  - only enough dependency injection to let the Codex runner receive the tracker tool service
+- targeted observability and tests
+- minimal docs updates describing the supported first tool and the explicit non-goals
+
+### Does not belong in this issue
+
+- tracker claim/retry/landing policy changes
+- generic cross-runner tool support for Claude Code or generic-command runners
+- a broad new shared runtime service locator
+- arbitrary tracker search or write tools
+- app-server remote transport refactors
+- repo-wide prompt-boundary changes unrelated to the first dynamic-tool seam
+
+## Layering Notes
+
+- `config/workflow`
+  - owns any static config defaults or validation needed to turn on the supported Codex dynamic-tool surface
+  - does not own tracker reads or tool-call dispatch
+- `tracker`
+  - owns read-only tracker-tool data acquisition and normalization into stable result payloads
+  - does not parse Codex request envelopes or decide runner transport behavior
+- `workspace`
+  - remains untouched in this slice
+  - does not learn about dynamic-tool metadata
+- `runner`
+  - owns app-server protocol handling, tool-call routing, response writing, and normalized transport failure mapping
+  - does not reach directly into GitHub CLI commands or tracker-specific normalization logic
+- `orchestrator`
+  - remains unaware of raw dynamic-tool methods and only consumes normal run/turn results
+  - does not coordinate per-tool execution
+- `observability`
+  - owns operator-facing summaries of dynamic-tool events already normalized by the runner
+  - does not derive tracker-tool output on its own
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR by keeping the seam at "Codex runner dynamic tools backed by one read-only tracker-native tool":
+
+1. add a minimal tool executor contract and Codex session support for successful `item/tool/call`
+2. add one tracker-native read-only tool implemented behind a tracker-layer service
+3. normalize tool results and tool failures
+4. add observability and tests for the new path
+
+This stays reviewable because it deliberately does not combine:
+
+- tracker tool support with tracker lifecycle policy changes
+- the first tool slice with general multi-tool/plugin infrastructure
+- Codex dynamic tools with runner-provider-neutral refactors
+- read-only tracker access with write-capable tool mutations
+
+If the first candidate tool would require broad tracker-interface expansion or raw comment-body exposure, narrow it further to a summary-oriented current-issue/current-PR context tool in this PR and defer broader tracker reads.
+
+## Runtime State Model
+
+This issue changes stateful live-session behavior inside an active Codex turn, so the plan requires an explicit dynamic-tool sub-state model within the existing app-server session.
+
+### State variables
+
+- `sessionState`
+  - existing Codex app-server session state
+- `activeTurn`
+  - current turn in progress, if any
+- `activeToolCall`
+  - normalized dynamic-tool request currently being handled, if any
+- `advertisedTools`
+  - static set of tool definitions exposed for this session
+- `toolFailureClass`
+  - normalized tool execution or protocol failure class for the active tool request
+
+### Dynamic-tool states
+
+- `tool-idle`
+  - no active dynamic-tool request
+- `tool-requested`
+  - `item/tool/call` request received and validated structurally
+- `tool-executing`
+  - runner tool executor boundary invoked
+- `tool-awaiting-user-input`
+  - request tried to use an unsupported interactive tool flow such as `item/tool/requestUserInput`
+- `tool-succeeded`
+  - executor returned a normalized success result and the response was written
+- `tool-failed`
+  - executor or protocol handling failed in a normalized way
+
+### Allowed transitions
+
+- `tool-idle -> tool-requested`
+  - well-formed `item/tool/call` request arrives during an active turn
+- `tool-requested -> tool-executing`
+  - tool name and arguments validate against the advertised tool contract
+- `tool-requested -> tool-failed`
+  - unsupported tool name or malformed payload
+- `tool-executing -> tool-succeeded`
+  - tracker tool returns a normalized success payload and the response is written
+- `tool-executing -> tool-failed`
+  - executor throws, returns invalid output, or response write fails
+- `tool-idle -> tool-awaiting-user-input`
+  - `item/tool/requestUserInput` arrives
+- `tool-awaiting-user-input -> tool-failed`
+  - Symphony returns an explicit unsupported/invalid-params response because this first slice remains non-interactive
+- `tool-succeeded -> tool-idle`
+  - session resumes the enclosing turn
+- `tool-failed -> tool-idle`
+  - session records failure and either fails the turn or continues only where the protocol contract explicitly allows
+
+### Coordination rules
+
+- only one dynamic-tool request may be active at a time within the existing single-request session sequencing
+- dynamic-tool execution remains inside the active turn boundary and must not mutate orchestrator retry or continuation counters
+- tracker-native tool results must be normalized before they become model-visible output
+- unsupported interactive tool flows must fail clearly instead of leaving the session waiting indefinitely
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| `item/tool/call` arrives for a supported tool with valid arguments | thread id, turn id, call id, tool name, parsed args | current issue and PR context available through tracker tool service | execute tool, serialize normalized success payload, continue turn |
+| `item/tool/call` arrives for an unknown tool | thread id, turn id, call id, tool name | none needed | return explicit unsupported-tool response, classify as tool request failure, do not hang |
+| tool-call payload is malformed | request id, raw params | none needed | return invalid-params response, classify as malformed-tool-request failure |
+| tracker tool service fails to read current tracker state | request id, tool name, local error | tracker fetch error only | return normalized tool failure payload or explicit request failure, preserving clear operator visibility |
+| tracker tool service returns output that violates the advertised schema | request id, tool name, normalized output candidate | tool result candidate | classify as tool-result-normalization failure and fail the tool call clearly |
+| `item/tool/requestUserInput` arrives in the first non-interactive slice | request id, raw params | none needed | return explicit unsupported/invalid-params response and fail the active tool request without stalling |
+| response write to app-server stdin fails after tool execution | request id, tool name, result payload | tracker result already computed | classify as active-turn transport/tool failure and fail the turn |
+| tool succeeds but observability emission fails | request id, tool name, result payload | normalized tracker result | fail the turn using the existing visibility-failure path; do not silently ignore |
+
+## Storage Or Persistence Contract
+
+- no new durable store is required for this slice
+- tracker-native tool results are computed on demand from the current tracker snapshot
+- existing session artifacts/logs should record normalized tool-call observability facts, but the canonical source of tracker truth remains the tracker itself
+
+## Observability Requirements
+
+- log dynamic-tool advertisement during Codex session startup
+- emit visibility/log summaries when a dynamic tool is requested, completed, or failed
+- include the tool name in normalized summaries where available
+- surface tracker-tool failures distinctly from generic approval or unsupported-request failures
+- preserve raw-enough error detail in logs for debugging malformed tool requests without making downstream consumers parse raw protocol payloads
+
+## Implementation Steps
+
+1. Define a runner-facing dynamic-tool executor contract in `src/runner/` with:
+   - supported tool definitions
+   - `execute(toolName, args, context)` result shape
+   - normalized success/failure response builders for Codex app-server
+2. Extend the Codex app-server protocol helpers to:
+   - parse `item/tool/call` requests into a normalized request shape
+   - build explicit success, invalid-params, and unsupported-tool responses
+   - keep `item/tool/requestUserInput` explicit and non-interactive for this slice
+3. Update `CodexAppServerSession` to:
+   - advertise the supported tool set during startup using the concrete Codex app-server shape required by the installed CLI
+   - route supported tool calls through the new executor boundary
+   - normalize tool-call failures distinctly from generic unsupported requests
+4. Add a focused tracker-layer tool service that exposes one read-only tracker-native tool for the current issue/branch/PR context.
+5. Reuse or extract tracker normalization helpers so tool output follows the same sanitization/trust-boundary rules as other tracker-derived agent context where applicable.
+6. Wire the tracker tool service into Codex runner construction without broadening non-Codex runners.
+7. Add/update tests for:
+   - advertisement of the tool surface at session startup
+   - successful supported tool execution
+   - malformed tool-call payloads
+   - unsupported tool names
+   - unsupported `requestUserInput` handling
+   - tracker tool service failures
+8. Update minimal docs to explain the first dynamic-tool slice and its non-goals.
+
+## Tests And Acceptance Scenarios
+
+### Unit coverage
+
+- Codex protocol helper tests for dynamic-tool request parsing and response serialization
+- runner-session tests for:
+  - advertised tools present on startup
+  - supported tool call succeeds and returns normalized output
+  - unknown tool name returns explicit unsupported response
+  - malformed args return invalid-params response
+  - unsupported `item/tool/requestUserInput` fails explicitly without hanging
+- tracker tool service tests for normalized/sanitized output and tracker read failures
+
+### Integration coverage
+
+- fake Codex app-server integration proving the live session can receive `item/tool/call`, execute the first tracker-native tool, and continue to `turn/completed`
+- GitHub and/or tracker mock coverage proving the tool reads normalized current issue/PR state rather than bypassing tracker abstractions
+
+### End-to-end acceptance scenarios
+
+1. A Codex worker session starts, advertises the first tracker-native tool, receives a supported tool call during a turn, and completes the turn successfully.
+2. Codex requests an unsupported dynamic tool and Symphony replies explicitly instead of stalling the session.
+3. Codex sends malformed tool-call arguments and Symphony fails the tool request clearly with normalized observability.
+4. The first tracker-native tool returns sanitized current issue/PR context that stays aligned with repository trust-boundary rules.
+5. A tracker read failure during tool execution becomes a visible runner/tool failure rather than a silent hang or raw tracker exception leak.
+
+## Exit Criteria
+
+- Codex app-server sessions can advertise and execute one supported tracker-native client-side tool
+- the first tool is read-only, normalized, and covered by unit/integration tests
+- unsupported dynamic-tool requests and unsupported interactive tool flows fail explicitly without stalling the live session
+- runner/tracker/orchestrator boundaries remain clear, with no tracker policy logic embedded in the runner transport
+- docs and observability reflect the supported first slice accurately
+
+## Deferred To Later Issues Or PRs
+
+- additional tracker-native tools
+- write-capable tracker mutations
+- generic client-side tool framework for all runner kinds
+- interactive user-input tool flows
+- richer tool catalog discovery or per-workflow tool configuration
+- broader tracker search/query surfaces beyond the first current-issue/current-PR slice
+
+## Decision Rationale
+
+- The runner needs a dedicated tool executor seam now because otherwise `CodexAppServerSession` becomes a mixed transport/tracker hot file again.
+- The first tool should reuse tracker normalization rules because this issue is about structured client-side access, not about reopening raw tracker text exposure.
+- Keeping the first slice read-only and current-issue-scoped preserves a narrow PR seam while still replacing shell affordances with a real tracker-native path.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { createRunner } from "../runner/factory.js";
 import { runStartupPreparation } from "../startup/service.js";
 import { isAbortError } from "../support/abort.js";
 import { createTracker } from "../tracker/factory.js";
+import { createTrackerToolService } from "../tracker/tool-service.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
 import {
   type FactoryControlStatusSnapshot,
@@ -359,7 +360,12 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     logger,
     startup.workspaceSourceOverride,
   );
-  const runner = createRunner(workflow.config.agent, logger);
+  const runner = createRunner(workflow.config.agent, logger, {
+    trackerToolService: createTrackerToolService(
+      tracker,
+      workflow.config.tracker,
+    ),
+  });
   const livenessProbe =
     workflow.config.polling.watchdog?.enabled === true
       ? new FsLivenessProbe(workflow.config.workspace.root)

--- a/src/runner/codex-app-server-protocol.ts
+++ b/src/runner/codex-app-server-protocol.ts
@@ -70,6 +70,14 @@ export interface CodexAppServerApprovalRequest {
   readonly summary: string;
 }
 
+export interface CodexDynamicToolCallRequest {
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly callId: string;
+  readonly tool: string;
+  readonly arguments: unknown;
+}
+
 export function classifyCodexAppServerMessage(
   payload: unknown,
 ): CodexAppServerMessage | null {
@@ -188,6 +196,51 @@ export function createCodexUnsupportedRequestResponse(
     -32601,
     `Unsupported Codex app-server request '${method}'`,
   );
+}
+
+export function createCodexDynamicToolCallResponse(
+  requestId: string | number,
+  response: {
+    readonly success: boolean;
+    readonly contentItems: readonly Record<string, unknown>[];
+  },
+): Record<string, unknown> {
+  return {
+    id: requestId,
+    result: {
+      contentItems: response.contentItems,
+      success: response.success,
+    },
+  };
+}
+
+export function extractCodexDynamicToolCallRequest(
+  request: CodexAppServerRequestMessage,
+): CodexDynamicToolCallRequest | null {
+  if (request.method !== "item/tool/call") {
+    return null;
+  }
+
+  const params = request.params;
+  const threadId = typeof params?.["threadId"] === "string" ? params["threadId"] : null;
+  const turnId = typeof params?.["turnId"] === "string" ? params["turnId"] : null;
+  const callId = typeof params?.["callId"] === "string" ? params["callId"] : null;
+  const tool = typeof params?.["tool"] === "string" ? params["tool"] : null;
+
+  if (threadId === null || turnId === null || callId === null || tool === null) {
+    throw new CodexAppServerTransportError(
+      "unsupported-request-failure",
+      "Codex app-server sent a malformed dynamic tool request",
+    );
+  }
+
+  return {
+    threadId,
+    turnId,
+    callId,
+    tool,
+    arguments: params?.["arguments"],
+  };
 }
 
 function createCodexErrorResponse(

--- a/src/runner/codex-app-server-protocol.ts
+++ b/src/runner/codex-app-server-protocol.ts
@@ -222,12 +222,20 @@ export function extractCodexDynamicToolCallRequest(
   }
 
   const params = request.params;
-  const threadId = typeof params?.["threadId"] === "string" ? params["threadId"] : null;
-  const turnId = typeof params?.["turnId"] === "string" ? params["turnId"] : null;
-  const callId = typeof params?.["callId"] === "string" ? params["callId"] : null;
+  const threadId =
+    typeof params?.["threadId"] === "string" ? params["threadId"] : null;
+  const turnId =
+    typeof params?.["turnId"] === "string" ? params["turnId"] : null;
+  const callId =
+    typeof params?.["callId"] === "string" ? params["callId"] : null;
   const tool = typeof params?.["tool"] === "string" ? params["tool"] : null;
 
-  if (threadId === null || turnId === null || callId === null || tool === null) {
+  if (
+    threadId === null ||
+    turnId === null ||
+    callId === null ||
+    tool === null
+  ) {
     throw new CodexAppServerTransportError(
       "unsupported-request-failure",
       "Codex app-server sent a malformed dynamic tool request",

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -14,14 +14,18 @@ import {
   CodexAppServerTransportError,
   classifyCodexAppServerMessage,
   createCodexApprovalResponse,
+  createCodexDynamicToolCallResponse,
   createCodexInvalidParamsResponse,
   createCodexUnsupportedRequestResponse,
+  extractCodexDynamicToolCallRequest,
   extractCodexApprovalRequest,
   formatCodexTransportError,
+  type CodexDynamicToolCallRequest,
   type CodexAppServerFailureClass,
   type CodexAppServerRequestMessage,
   type CodexAppServerSessionState,
 } from "./codex-app-server-protocol.js";
+import type { DynamicToolExecutor } from "./dynamic-tool-executor.js";
 import {
   RUNNER_SHUTDOWN_GRACE_MS,
   summarizeRunnerText,
@@ -65,6 +69,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   readonly #runSession: RunSession;
   readonly #baseDescription: RunnerSessionDescription;
   readonly #appServerCommand: CodexAppServerCommand;
+  readonly #dynamicToolExecutor: DynamicToolExecutor;
   #child: ChildProcessWithoutNullStreams | null = null;
   #closePromise: Promise<void> | null = null;
   #closeResolve: (() => void) | null = null;
@@ -86,11 +91,24 @@ export class CodexAppServerSession implements LiveRunnerSession {
   #startupStderr = "";
   #currentOnEvent: ((event: RunnerEvent) => void | Promise<void>) | null = null;
   #currentOnUpdate: ((event: RunUpdateEvent) => void) | null = null;
+  #activeToolCall:
+    | {
+        readonly requestId: string | number;
+        readonly tool: string;
+        readonly callId: string;
+      }
+    | null = null;
 
-  constructor(config: AgentConfig, logger: Logger, session: RunSession) {
+  constructor(
+    config: AgentConfig,
+    logger: Logger,
+    session: RunSession,
+    dynamicToolExecutor: DynamicToolExecutor,
+  ) {
     this.#config = config;
     this.#logger = logger;
     this.#runSession = session;
+    this.#dynamicToolExecutor = dynamicToolExecutor;
     this.#baseDescription = describeLocalRunnerSession(
       config.command,
       "local-stdio-session",
@@ -434,6 +452,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       method: "thread/start",
       params: omitNullValues({
         approvalPolicy: this.#appServerCommand.approvalPolicy,
+        config: buildCodexThreadStartConfig(this.#dynamicToolExecutor),
         cwd: workspacePath,
         model: this.#appServerCommand.model,
         sandbox: this.#appServerCommand.sandbox,
@@ -450,12 +469,18 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
     this.#threadId = threadId;
     this.#sessionState = "ready";
+    const dynamicToolCount = this.#dynamicToolExecutor.toolSpecs.length;
     await this.#emitVisibility({
       state: "starting",
       phase: "session-start",
       lastHeartbeatAt: new Date().toISOString(),
       lastActionAt: new Date().toISOString(),
-      lastActionSummary: "Codex thread started",
+      lastActionSummary:
+        dynamicToolCount > 0
+          ? `Codex thread started (${dynamicToolCount.toString()} dynamic tool${
+              dynamicToolCount === 1 ? "" : "s"
+            } advertised)`
+          : "Codex thread started",
     });
   }
 
@@ -712,62 +737,35 @@ export class CodexAppServerSession implements LiveRunnerSession {
   async #handleRequest(message: CodexAppServerRequestMessage): Promise<void> {
     try {
       const approval = extractCodexApprovalRequest(message);
-      if (approval === null) {
-        await this.#writeMessage(
-          createCodexUnsupportedRequestResponse(message.id, message.method),
-        );
-        this.#rejectActiveTurn(
-          this.#createTransportError(
-            "unsupported-request-failure",
-            `Codex app-server requested unsupported method '${message.method}'`,
-          ),
-        );
+      if (approval !== null) {
+        await this.#handleApprovalRequest(message, approval);
         return;
       }
 
-      this.#sessionState = "awaiting-approval";
-      const observedAt = new Date().toISOString();
-      await this.#emitVisibility({
-        state: "waiting",
-        phase: "awaiting-external",
-        lastHeartbeatAt: observedAt,
-        lastActionAt: observedAt,
-        lastActionSummary: `Codex approval requested (${approval.kind})`,
-        waitingReason: `Waiting on Codex ${approval.kind} approval for ${approval.summary}`,
-      });
-
-      if (this.#appServerCommand.approvalPolicy !== "never") {
-        await this.#writeMessage(
-          createCodexInvalidParamsResponse(
-            message.id,
-            message.method,
-            "Symphony cannot satisfy interactive approvals unless the Codex runner is configured with approvalPolicy=never",
-          ),
-        );
-        this.#rejectActiveTurn(
-          this.#createTransportError(
-            "approval-transport-failure",
-            `Codex app-server requested approval for ${approval.summary}, but the runner is not configured for non-interactive approval`,
-          ),
-        );
+      const dynamicToolRequest = extractCodexDynamicToolCallRequest(message);
+      if (dynamicToolRequest !== null) {
+        await this.#handleDynamicToolCall(message, dynamicToolRequest);
         return;
       }
 
-      await this.#writeMessage(createCodexApprovalResponse(message.id));
-      this.#sessionState = "streaming-turn";
-      await this.#emitVisibility({
-        state: "running",
-        phase: "turn-execution",
-        lastHeartbeatAt: observedAt,
-        lastActionAt: observedAt,
-        lastActionSummary: `Codex approval granted (${approval.kind})`,
-        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
-        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
-      });
+      if (message.method === "item/tool/requestUserInput") {
+        await this.#handleUnsupportedToolUserInputRequest(message);
+        return;
+      }
+
+      await this.#writeMessage(
+        createCodexUnsupportedRequestResponse(message.id, message.method),
+      );
+      this.#rejectActiveTurn(
+        this.#createTransportError(
+          "unsupported-request-failure",
+          `Codex app-server requested unsupported method '${message.method}'`,
+        ),
+      );
     } catch (error) {
       const resolvedError = this.#normalizeTransportError(
         asError(error),
-        "approval-transport-failure",
+        "unsupported-request-failure",
       );
       try {
         await this.#writeMessage(
@@ -780,6 +778,167 @@ export class CodexAppServerSession implements LiveRunnerSession {
       } catch {}
       this.#rejectActiveTurn(resolvedError);
     }
+  }
+
+  async #handleApprovalRequest(
+    message: CodexAppServerRequestMessage,
+    approval: NonNullable<ReturnType<typeof extractCodexApprovalRequest>>,
+  ): Promise<void> {
+    this.#sessionState = "awaiting-approval";
+    const observedAt = new Date().toISOString();
+    await this.#emitVisibility({
+      state: "waiting",
+      phase: "awaiting-external",
+      lastHeartbeatAt: observedAt,
+      lastActionAt: observedAt,
+      lastActionSummary: `Codex approval requested (${approval.kind})`,
+      waitingReason: `Waiting on Codex ${approval.kind} approval for ${approval.summary}`,
+    });
+
+    if (this.#appServerCommand.approvalPolicy !== "never") {
+      await this.#writeMessage(
+        createCodexInvalidParamsResponse(
+          message.id,
+          message.method,
+          "Symphony cannot satisfy interactive approvals unless the Codex runner is configured with approvalPolicy=never",
+        ),
+      );
+      this.#rejectActiveTurn(
+        this.#createTransportError(
+          "approval-transport-failure",
+          `Codex app-server requested approval for ${approval.summary}, but the runner is not configured for non-interactive approval`,
+        ),
+      );
+      return;
+    }
+
+    await this.#writeMessage(createCodexApprovalResponse(message.id));
+    this.#sessionState = "streaming-turn";
+    await this.#emitVisibility({
+      state: "running",
+      phase: "turn-execution",
+      lastHeartbeatAt: observedAt,
+      lastActionAt: observedAt,
+      lastActionSummary: `Codex approval granted (${approval.kind})`,
+      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+    });
+  }
+
+  async #handleDynamicToolCall(
+    message: CodexAppServerRequestMessage,
+    request: CodexDynamicToolCallRequest,
+  ): Promise<void> {
+    this.#activeToolCall = {
+      requestId: message.id,
+      tool: request.tool,
+      callId: request.callId,
+    };
+    const observedAt = new Date().toISOString();
+    await this.#emitVisibility({
+      state: "running",
+      phase: "turn-execution",
+      lastHeartbeatAt: observedAt,
+      lastActionAt: observedAt,
+      lastActionSummary: `Dynamic tool call requested (${request.tool})`,
+      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+    });
+
+    try {
+      const outcome = await this.#dynamicToolExecutor.execute(request, {
+        runSession: this.#runSession,
+      });
+
+      if (outcome.kind === "unsupported-tool") {
+        await this.#writeMessage(
+          createCodexUnsupportedRequestResponse(message.id, message.method),
+        );
+        await this.#emitVisibility({
+          state: "running",
+          phase: "turn-execution",
+          lastHeartbeatAt: observedAt,
+          lastActionAt: observedAt,
+          lastActionSummary: `Dynamic tool rejected (${request.tool})`,
+          stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+          stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+          errorSummary: "Unsupported dynamic tool request",
+        });
+        return;
+      }
+
+      if (outcome.kind === "invalid-arguments") {
+        await this.#writeMessage(
+          createCodexInvalidParamsResponse(
+            message.id,
+            message.method,
+            outcome.message,
+          ),
+        );
+        await this.#emitVisibility({
+          state: "running",
+          phase: "turn-execution",
+          lastHeartbeatAt: observedAt,
+          lastActionAt: observedAt,
+          lastActionSummary: `Dynamic tool rejected (${request.tool})`,
+          stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+          stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+          errorSummary: summarizeRunnerText(outcome.message),
+        });
+        return;
+      }
+
+      await this.#writeMessage(
+        createCodexDynamicToolCallResponse(message.id, {
+          contentItems: outcome.result.contentItems.map((item) =>
+            item.type === "inputImage"
+              ? { type: item.type, imageUrl: item.imageUrl ?? "" }
+              : { type: item.type, text: item.text ?? "" },
+          ),
+          success: outcome.result.success,
+        }),
+      );
+      await this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: outcome.result.success
+          ? `Dynamic tool completed (${request.tool})`
+          : `Dynamic tool failed (${request.tool})`,
+        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+        errorSummary: outcome.result.success
+          ? null
+          : summarizeRunnerText(outcome.result.summary),
+      });
+    } finally {
+      this.#activeToolCall = null;
+    }
+  }
+
+  async #handleUnsupportedToolUserInputRequest(
+    message: CodexAppServerRequestMessage,
+  ): Promise<void> {
+    const observedAt = new Date().toISOString();
+    await this.#writeMessage(
+      createCodexInvalidParamsResponse(
+        message.id,
+        message.method,
+        "Symphony does not support interactive dynamic-tool user input in this slice",
+      ),
+    );
+    await this.#emitVisibility({
+      state: "running",
+      phase: "turn-execution",
+      lastHeartbeatAt: observedAt,
+      lastActionAt: observedAt,
+      lastActionSummary: "Dynamic tool user input rejected",
+      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+      errorSummary:
+        "unsupported-request-failure: interactive dynamic-tool user input is unsupported",
+    });
   }
 
   #handleNotification(
@@ -1069,6 +1228,25 @@ function omitNullValues(
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== null),
   );
+}
+
+function buildCodexThreadStartConfig(
+  dynamicToolExecutor: DynamicToolExecutor,
+): Record<string, unknown> | null {
+  if (dynamicToolExecutor.toolSpecs.length === 0) {
+    return null;
+  }
+
+  return {
+    experimental_supported_tools: dynamicToolExecutor.toolSpecs.map((tool) => ({
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      name: tool.name,
+      ...(tool.deferLoading === undefined
+        ? {}
+        : { deferLoading: tool.deferLoading }),
+    })),
+  };
 }
 
 function failureClassForPendingMethod(

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -892,11 +892,25 @@ export class CodexAppServerSession implements LiveRunnerSession {
 
       if (outcome.kind === "invalid-arguments") {
         await this.#writeMessage(
-          createCodexInvalidParamsResponse(
-            message.id,
-            message.method,
-            outcome.message,
-          ),
+          createCodexDynamicToolCallResponse(message.id, {
+            contentItems: [
+              {
+                type: "inputText",
+                text: JSON.stringify(
+                  {
+                    tool: request.tool,
+                    error: {
+                      code: "invalid_arguments",
+                      message: outcome.message,
+                    },
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+            success: false,
+          }),
         );
         await this.#emitVisibility({
           state: "running",
@@ -968,6 +982,12 @@ export class CodexAppServerSession implements LiveRunnerSession {
         errorSummary:
           "unsupported-request-failure: interactive dynamic-tool user input is unsupported",
       });
+      this.#rejectActiveTurn(
+        this.#createTransportError(
+          "unsupported-request-failure",
+          "Codex app-server requested unsupported interactive dynamic-tool user input",
+        ),
+      );
     } catch (error) {
       throw this.#normalizeTransportError(
         asError(error),

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -91,13 +91,11 @@ export class CodexAppServerSession implements LiveRunnerSession {
   #startupStderr = "";
   #currentOnEvent: ((event: RunnerEvent) => void | Promise<void>) | null = null;
   #currentOnUpdate: ((event: RunUpdateEvent) => void) | null = null;
-  #activeToolCall:
-    | {
-        readonly requestId: string | number;
-        readonly tool: string;
-        readonly callId: string;
-      }
-    | null = null;
+  #activeToolCall: {
+    readonly requestId: string | number;
+    readonly tool: string;
+    readonly callId: string;
+  } | null = null;
 
   constructor(
     config: AgentConfig,

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -763,7 +763,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
     } catch (error) {
       const resolvedError = this.#normalizeTransportError(
         asError(error),
-        "unsupported-request-failure",
+        failureClassForInboundRequestMethod(message.method),
       );
       try {
         await this.#writeMessage(
@@ -782,75 +782,100 @@ export class CodexAppServerSession implements LiveRunnerSession {
     message: CodexAppServerRequestMessage,
     approval: NonNullable<ReturnType<typeof extractCodexApprovalRequest>>,
   ): Promise<void> {
-    this.#sessionState = "awaiting-approval";
-    const observedAt = new Date().toISOString();
-    await this.#emitVisibility({
-      state: "waiting",
-      phase: "awaiting-external",
-      lastHeartbeatAt: observedAt,
-      lastActionAt: observedAt,
-      lastActionSummary: `Codex approval requested (${approval.kind})`,
-      waitingReason: `Waiting on Codex ${approval.kind} approval for ${approval.summary}`,
-    });
+    try {
+      this.#sessionState = "awaiting-approval";
+      const observedAt = new Date().toISOString();
+      await this.#emitVisibility({
+        state: "waiting",
+        phase: "awaiting-external",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: `Codex approval requested (${approval.kind})`,
+        waitingReason: `Waiting on Codex ${approval.kind} approval for ${approval.summary}`,
+      });
 
-    if (this.#appServerCommand.approvalPolicy !== "never") {
-      await this.#writeMessage(
-        createCodexInvalidParamsResponse(
-          message.id,
-          message.method,
-          "Symphony cannot satisfy interactive approvals unless the Codex runner is configured with approvalPolicy=never",
-        ),
+      if (this.#appServerCommand.approvalPolicy !== "never") {
+        await this.#writeMessage(
+          createCodexInvalidParamsResponse(
+            message.id,
+            message.method,
+            "Symphony cannot satisfy interactive approvals unless the Codex runner is configured with approvalPolicy=never",
+          ),
+        );
+        this.#rejectActiveTurn(
+          this.#createTransportError(
+            "approval-transport-failure",
+            `Codex app-server requested approval for ${approval.summary}, but the runner is not configured for non-interactive approval`,
+          ),
+        );
+        return;
+      }
+
+      await this.#writeMessage(createCodexApprovalResponse(message.id));
+      this.#sessionState = "streaming-turn";
+      await this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: `Codex approval granted (${approval.kind})`,
+        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+      });
+    } catch (error) {
+      throw this.#normalizeTransportError(
+        asError(error),
+        "approval-transport-failure",
       );
-      this.#rejectActiveTurn(
-        this.#createTransportError(
-          "approval-transport-failure",
-          `Codex app-server requested approval for ${approval.summary}, but the runner is not configured for non-interactive approval`,
-        ),
-      );
-      return;
     }
-
-    await this.#writeMessage(createCodexApprovalResponse(message.id));
-    this.#sessionState = "streaming-turn";
-    await this.#emitVisibility({
-      state: "running",
-      phase: "turn-execution",
-      lastHeartbeatAt: observedAt,
-      lastActionAt: observedAt,
-      lastActionSummary: `Codex approval granted (${approval.kind})`,
-      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
-      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
-    });
   }
 
   async #handleDynamicToolCall(
     message: CodexAppServerRequestMessage,
     request: CodexDynamicToolCallRequest,
   ): Promise<void> {
-    this.#activeToolCall = {
-      requestId: message.id,
-      tool: request.tool,
-      callId: request.callId,
-    };
-    const observedAt = new Date().toISOString();
-    await this.#emitVisibility({
-      state: "running",
-      phase: "turn-execution",
-      lastHeartbeatAt: observedAt,
-      lastActionAt: observedAt,
-      lastActionSummary: `Dynamic tool call requested (${request.tool})`,
-      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
-      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
-    });
-
     try {
+      this.#activeToolCall = {
+        requestId: message.id,
+        tool: request.tool,
+        callId: request.callId,
+      };
+      const observedAt = new Date().toISOString();
+      await this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: `Dynamic tool call requested (${request.tool})`,
+        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+      });
+
       const outcome = await this.#dynamicToolExecutor.execute(request, {
         runSession: this.#runSession,
       });
 
       if (outcome.kind === "unsupported-tool") {
         await this.#writeMessage(
-          createCodexUnsupportedRequestResponse(message.id, message.method),
+          createCodexDynamicToolCallResponse(message.id, {
+            contentItems: [
+              {
+                type: "inputText",
+                text: JSON.stringify(
+                  {
+                    tool: request.tool,
+                    error: {
+                      code: "unsupported_tool",
+                      message: `Dynamic tool '${request.tool}' is not supported by this Symphony runner`,
+                    },
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+            success: false,
+          }),
         );
         await this.#emitVisibility({
           state: "running",
@@ -910,6 +935,11 @@ export class CodexAppServerSession implements LiveRunnerSession {
           ? null
           : summarizeRunnerText(outcome.result.summary),
       });
+    } catch (error) {
+      throw this.#normalizeTransportError(
+        asError(error),
+        "active-turn-transport-failure",
+      );
     } finally {
       this.#activeToolCall = null;
     }
@@ -918,25 +948,32 @@ export class CodexAppServerSession implements LiveRunnerSession {
   async #handleUnsupportedToolUserInputRequest(
     message: CodexAppServerRequestMessage,
   ): Promise<void> {
-    const observedAt = new Date().toISOString();
-    await this.#writeMessage(
-      createCodexInvalidParamsResponse(
-        message.id,
-        message.method,
-        "Symphony does not support interactive dynamic-tool user input in this slice",
-      ),
-    );
-    await this.#emitVisibility({
-      state: "running",
-      phase: "turn-execution",
-      lastHeartbeatAt: observedAt,
-      lastActionAt: observedAt,
-      lastActionSummary: "Dynamic tool user input rejected",
-      stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
-      stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
-      errorSummary:
-        "unsupported-request-failure: interactive dynamic-tool user input is unsupported",
-    });
+    try {
+      const observedAt = new Date().toISOString();
+      await this.#writeMessage(
+        createCodexInvalidParamsResponse(
+          message.id,
+          message.method,
+          "Symphony does not support interactive dynamic-tool user input in this slice",
+        ),
+      );
+      await this.#emitVisibility({
+        state: "running",
+        phase: "turn-execution",
+        lastHeartbeatAt: observedAt,
+        lastActionAt: observedAt,
+        lastActionSummary: "Dynamic tool user input rejected",
+        stdoutSummary: summarizeRunnerText(this.#activeTurn?.stdout ?? ""),
+        stderrSummary: summarizeRunnerText(this.#activeTurn?.stderr ?? ""),
+        errorSummary:
+          "unsupported-request-failure: interactive dynamic-tool user input is unsupported",
+      });
+    } catch (error) {
+      throw this.#normalizeTransportError(
+        asError(error),
+        "unsupported-request-failure",
+      );
+    }
   }
 
   #handleNotification(
@@ -1260,4 +1297,21 @@ function failureClassForPendingMethod(
     default:
       return "startup-transport-failure";
   }
+}
+
+function failureClassForInboundRequestMethod(
+  method: string,
+): CodexAppServerFailureClass {
+  if (
+    method === "item/commandExecution/requestApproval" ||
+    method === "item/fileChange/requestApproval"
+  ) {
+    return "approval-transport-failure";
+  }
+
+  if (method === "item/tool/call") {
+    return "active-turn-transport-failure";
+  }
+
+  return "unsupported-request-failure";
 }

--- a/src/runner/codex.ts
+++ b/src/runner/codex.ts
@@ -2,9 +2,11 @@ import type { RunSession } from "../domain/run.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import { RunnerError } from "../domain/errors.js";
 import type { Logger } from "../observability/logger.js";
+import type { TrackerToolService } from "../tracker/tool-service.js";
 import { describeLocalRunnerBackend } from "./local-command.js";
 import { executeLocalRunnerCommand } from "./local-execution.js";
 import { CodexAppServerSession } from "./codex-app-server-session.js";
+import { RunnerDynamicToolExecutor } from "./dynamic-tool-executor.js";
 import { describeLocalRunnerSession } from "./local-session-description.js";
 import type {
   Runner,
@@ -16,8 +18,13 @@ import type {
 export class CodexRunner implements Runner {
   readonly #config: AgentConfig;
   readonly #logger: Logger;
+  readonly #dynamicToolExecutor: RunnerDynamicToolExecutor;
 
-  constructor(config: AgentConfig, logger: Logger) {
+  constructor(
+    config: AgentConfig,
+    logger: Logger,
+    trackerToolService: TrackerToolService | null = null,
+  ) {
     if (config.runner.kind !== "codex") {
       throw new RunnerError(
         `CodexRunner requires agent.runner.kind 'codex', got '${config.runner.kind}'`,
@@ -33,6 +40,9 @@ export class CodexRunner implements Runner {
 
     this.#config = config;
     this.#logger = logger;
+    this.#dynamicToolExecutor = new RunnerDynamicToolExecutor(
+      trackerToolService,
+    );
   }
 
   describeSession(_session: RunSession): RunnerSessionDescription {
@@ -45,7 +55,12 @@ export class CodexRunner implements Runner {
   startSession(session: RunSession): Promise<CodexAppServerSession> {
     try {
       return Promise.resolve(
-        new CodexAppServerSession(this.#config, this.#logger, session),
+        new CodexAppServerSession(
+          this.#config,
+          this.#logger,
+          session,
+          this.#dynamicToolExecutor,
+        ),
       );
     } catch (error) {
       return Promise.reject(error);

--- a/src/runner/dynamic-tool-executor.ts
+++ b/src/runner/dynamic-tool-executor.ts
@@ -1,0 +1,159 @@
+import type { RunSession } from "../domain/run.js";
+import type { TrackerToolService } from "../tracker/tool-service.js";
+
+export const TRACKER_CURRENT_CONTEXT_TOOL_NAME = "tracker_current_context";
+
+export interface DynamicToolSpec {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Record<string, unknown>;
+  readonly deferLoading?: boolean;
+}
+
+export interface DynamicToolExecutionRequest {
+  readonly tool: string;
+  readonly arguments: unknown;
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly callId: string;
+}
+
+export interface DynamicToolExecutionContext {
+  readonly runSession: RunSession;
+}
+
+export interface DynamicToolContentItem {
+  readonly type: "inputText" | "inputImage";
+  readonly text?: string;
+  readonly imageUrl?: string;
+}
+
+export interface DynamicToolExecutionResult {
+  readonly success: boolean;
+  readonly contentItems: readonly DynamicToolContentItem[];
+  readonly summary: string;
+}
+
+export type DynamicToolExecutionOutcome =
+  | {
+      readonly kind: "unsupported-tool";
+    }
+  | {
+      readonly kind: "invalid-arguments";
+      readonly message: string;
+    }
+  | {
+      readonly kind: "completed";
+      readonly result: DynamicToolExecutionResult;
+    };
+
+export interface DynamicToolExecutor {
+  readonly toolSpecs: readonly DynamicToolSpec[];
+  execute(
+    request: DynamicToolExecutionRequest,
+    context: DynamicToolExecutionContext,
+  ): Promise<DynamicToolExecutionOutcome>;
+}
+
+const TRACKER_CURRENT_CONTEXT_TOOL_SPEC: DynamicToolSpec = {
+  name: TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+  description:
+    "Read the sanitized current tracker issue and pull request context for this Symphony run.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+export class RunnerDynamicToolExecutor implements DynamicToolExecutor {
+  readonly #trackerToolService: TrackerToolService | null;
+
+  constructor(trackerToolService: TrackerToolService | null = null) {
+    this.#trackerToolService = trackerToolService;
+  }
+
+  get toolSpecs(): readonly DynamicToolSpec[] {
+    return this.#trackerToolService === null
+      ? []
+      : [TRACKER_CURRENT_CONTEXT_TOOL_SPEC];
+  }
+
+  async execute(
+    request: DynamicToolExecutionRequest,
+    context: DynamicToolExecutionContext,
+  ): Promise<DynamicToolExecutionOutcome> {
+    if (
+      request.tool !== TRACKER_CURRENT_CONTEXT_TOOL_NAME ||
+      this.#trackerToolService === null
+    ) {
+      return { kind: "unsupported-tool" };
+    }
+
+    if (!isEmptyObject(request.arguments)) {
+      return {
+        kind: "invalid-arguments",
+        message:
+          "tracker_current_context does not accept arguments; expected an empty object",
+      };
+    }
+
+    try {
+      const trackerContext = await this.#trackerToolService.readCurrentContext(
+        context.runSession,
+      );
+      const serialized = JSON.stringify(
+        {
+          tool: TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+          branchName: trackerContext.branchName,
+          issue: trackerContext.issue,
+          pullRequest: trackerContext.pullRequest,
+          retrievedAt: trackerContext.retrievedAt,
+        },
+        null,
+        2,
+      );
+
+      return {
+        kind: "completed",
+        result: {
+          success: true,
+          contentItems: [{ type: "inputText", text: serialized }],
+          summary: "tracker context loaded",
+        },
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown tracker tool failure";
+      const serialized = JSON.stringify(
+        {
+          tool: TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+          error: {
+            code: "tracker_read_failed",
+            message,
+          },
+        },
+        null,
+        2,
+      );
+
+      return {
+        kind: "completed",
+        result: {
+          success: false,
+          contentItems: [{ type: "inputText", text: serialized }],
+          summary: "tracker context load failed",
+        },
+      };
+    }
+  }
+}
+
+function isEmptyObject(value: unknown): value is Record<string, never> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  );
+}

--- a/src/runner/dynamic-tool-executor.ts
+++ b/src/runner/dynamic-tool-executor.ts
@@ -150,8 +150,11 @@ export class RunnerDynamicToolExecutor implements DynamicToolExecutor {
 }
 
 function isEmptyObject(value: unknown): value is Record<string, never> {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
   return (
-    value !== null &&
     typeof value === "object" &&
     !Array.isArray(value) &&
     Object.keys(value as Record<string, unknown>).length === 0

--- a/src/runner/factory.ts
+++ b/src/runner/factory.ts
@@ -1,14 +1,25 @@
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import type { TrackerToolService } from "../tracker/tool-service.js";
 import { ClaudeCodeRunner } from "./claude-code.js";
 import { CodexRunner } from "./codex.js";
 import { GenericCommandRunner } from "./generic-command.js";
 import type { Runner } from "./service.js";
 
-export function createRunner(config: AgentConfig, logger: Logger): Runner {
+export function createRunner(
+  config: AgentConfig,
+  logger: Logger,
+  options?: {
+    readonly trackerToolService?: TrackerToolService | null;
+  },
+): Runner {
   switch (config.runner.kind) {
     case "codex":
-      return new CodexRunner(config, logger);
+      return new CodexRunner(
+        config,
+        logger,
+        options?.trackerToolService ?? null,
+      );
     case "generic-command":
       return new GenericCommandRunner(config, logger);
     case "claude-code":

--- a/src/tracker/tool-service.ts
+++ b/src/tracker/tool-service.ts
@@ -1,0 +1,54 @@
+import type { RunSession } from "../domain/run.js";
+import type {
+  PromptIssueContext,
+  PromptPullRequestContext,
+} from "../domain/prompt-context.js";
+import type { TrackerConfig } from "../domain/workflow.js";
+import { buildPromptIssueContext, buildPromptPullRequestContext } from "./prompt-context.js";
+import type { Tracker } from "./service.js";
+
+export interface TrackerCurrentContextToolResult {
+  readonly branchName: string;
+  readonly issue: PromptIssueContext;
+  readonly pullRequest: PromptPullRequestContext | null;
+  readonly retrievedAt: string;
+}
+
+export interface TrackerToolService {
+  readCurrentContext(
+    runSession: RunSession,
+  ): Promise<TrackerCurrentContextToolResult>;
+}
+
+class RuntimeTrackerToolService implements TrackerToolService {
+  readonly #tracker: Tracker;
+  readonly #config: TrackerConfig;
+
+  constructor(tracker: Tracker, config: TrackerConfig) {
+    this.#tracker = tracker;
+    this.#config = config;
+  }
+
+  async readCurrentContext(
+    runSession: RunSession,
+  ): Promise<TrackerCurrentContextToolResult> {
+    const [issue, lifecycle] = await Promise.all([
+      this.#tracker.getIssue(runSession.issue.number),
+      this.#tracker.inspectIssueHandoff(runSession.workspace.branchName),
+    ]);
+
+    return {
+      branchName: runSession.workspace.branchName,
+      issue: buildPromptIssueContext(issue, this.#config),
+      pullRequest: buildPromptPullRequestContext(lifecycle),
+      retrievedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export function createTrackerToolService(
+  tracker: Tracker,
+  config: TrackerConfig,
+): TrackerToolService {
+  return new RuntimeTrackerToolService(tracker, config);
+}

--- a/src/tracker/tool-service.ts
+++ b/src/tracker/tool-service.ts
@@ -4,7 +4,10 @@ import type {
   PromptPullRequestContext,
 } from "../domain/prompt-context.js";
 import type { TrackerConfig } from "../domain/workflow.js";
-import { buildPromptIssueContext, buildPromptPullRequestContext } from "./prompt-context.js";
+import {
+  buildPromptIssueContext,
+  buildPromptPullRequestContext,
+} from "./prompt-context.js";
 import type { Tracker } from "./service.js";
 
 export interface TrackerCurrentContextToolResult {

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -20,6 +20,7 @@ import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import { FsLivenessProbe } from "../../src/orchestrator/liveness-probe.js";
 import { createRunner } from "../../src/runner/factory.js";
 import { createTracker } from "../../src/tracker/factory.js";
+import { createTrackerToolService } from "../../src/tracker/tool-service.js";
 import { parsePlanReadyCommentMetadata } from "../../src/tracker/plan-review-comment.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
 import {
@@ -151,7 +152,12 @@ async function createOrchestrator(
     workflow.config.hooks.afterCreate,
     logger,
   );
-  const runner = createRunner(workflow.config.agent, logger);
+  const runner = createRunner(workflow.config.agent, logger, {
+    trackerToolService: createTrackerToolService(
+      tracker,
+      workflow.config.tracker,
+    ),
+  });
   return new BootstrapOrchestrator(
     workflow.config,
     promptBuilder,

--- a/tests/e2e/linear-factory.test.ts
+++ b/tests/e2e/linear-factory.test.ts
@@ -14,6 +14,7 @@ import { readFactoryStatusSnapshot } from "../../src/observability/status.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import { createRunner } from "../../src/runner/factory.js";
 import { createTracker } from "../../src/tracker/factory.js";
+import { createTrackerToolService } from "../../src/tracker/tool-service.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
 import {
   countRemoteBranchCommits,
@@ -88,7 +89,12 @@ async function createOrchestrator(
     workflow.config.hooks.afterCreate,
     logger,
   );
-  const runner = createRunner(workflow.config.agent, logger);
+  const runner = createRunner(workflow.config.agent, logger, {
+    trackerToolService: createTrackerToolService(
+      tracker,
+      workflow.config.tracker,
+    ),
+  });
   return new BootstrapOrchestrator(
     workflow.config,
     promptBuilder,

--- a/tests/unit/dynamic-tool-executor.test.ts
+++ b/tests/unit/dynamic-tool-executor.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { RunSession } from "../../src/domain/run.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
+import {
+  RunnerDynamicToolExecutor,
+  TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+} from "../../src/runner/dynamic-tool-executor.js";
+import type { TrackerToolService } from "../../src/tracker/tool-service.js";
+
+function createRunSession(): RunSession {
+  return {
+    id: "session-186",
+    issue: {
+      id: "186",
+      identifier: "sociotechnica-org/symphony-ts#186",
+      number: 186,
+      title: "Dynamic tools",
+      description: "",
+      labels: ["symphony:running"],
+      state: "open",
+      url: "https://example.test/issues/186",
+      createdAt: "2026-03-19T00:00:00.000Z",
+      updatedAt: "2026-03-19T00:00:00.000Z",
+    },
+    workspace: {
+      key: "sociotechnica-org_symphony-ts_186",
+      branchName: "symphony/186",
+      createdNow: false,
+      source: createConfiguredWorkspaceSource(process.cwd()),
+      target: {
+        kind: "local",
+        path: process.cwd(),
+      },
+    },
+    prompt: "prompt",
+    startedAt: "2026-03-19T00:00:00.000Z",
+    attempt: {
+      sequence: 1,
+    },
+  };
+}
+
+function createTrackerToolService(): TrackerToolService {
+  return {
+    async readCurrentContext(runSession) {
+      return {
+        branchName: runSession.workspace.branchName,
+        issue: {
+          identifier: runSession.issue.identifier,
+          number: runSession.issue.number,
+          title: runSession.issue.title,
+          labels: runSession.issue.labels,
+          state: runSession.issue.state,
+          url: runSession.issue.url,
+          summary: "Sanitized tracker summary",
+        },
+        pullRequest: null,
+        retrievedAt: "2026-03-19T00:00:00.000Z",
+      };
+    },
+  };
+}
+
+describe("runner dynamic tool executor", () => {
+  it("accepts omitted arguments for tracker_current_context", async () => {
+    const executor = new RunnerDynamicToolExecutor(createTrackerToolService());
+    const runSession = createRunSession();
+
+    await expect(
+      executor.execute(
+        {
+          tool: TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+          arguments: undefined,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+        },
+        {
+          runSession,
+        },
+      ),
+    ).resolves.toMatchObject({
+      kind: "completed",
+      result: {
+        success: true,
+      },
+    });
+  });
+
+  it("accepts null arguments for tracker_current_context", async () => {
+    const executor = new RunnerDynamicToolExecutor(createTrackerToolService());
+    const runSession = createRunSession();
+
+    await expect(
+      executor.execute(
+        {
+          tool: TRACKER_CURRENT_CONTEXT_TOOL_NAME,
+          arguments: null,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+        },
+        {
+          runSession,
+        },
+      ),
+    ).resolves.toMatchObject({
+      kind: "completed",
+      result: {
+        success: true,
+      },
+    });
+  });
+});

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -29,6 +29,7 @@ import {
 import { waitForExit } from "../support/process.js";
 import { createTempDir } from "../support/git.js";
 import type { Logger } from "../../src/observability/logger.js";
+import type { TrackerToolService } from "../../src/tracker/tool-service.js";
 
 function createSession(): RunSession {
   return {
@@ -132,6 +133,10 @@ type FakeCodexMode =
   | "command-approval-requires-input"
   | "malformed-command-approval"
   | "unsupported-request"
+  | "dynamic-tool-success"
+  | "dynamic-tool-unknown"
+  | "dynamic-tool-malformed"
+  | "dynamic-tool-request-user-input"
   | "turn-failed"
   | "turn-failed-null-params"
   | "turn-failed-without-params"
@@ -284,6 +289,16 @@ rl.on("line", (line) => {
         });
         return;
       }
+      if (
+        (requestKind === "dynamic-tool-success" ||
+          requestKind === "dynamic-tool-unknown" ||
+          requestKind === "dynamic-tool-malformed" ||
+          requestKind === "dynamic-tool-request-user-input") &&
+        turnId !== null
+      ) {
+        setTimeout(() => completeTurn(turnId), 5);
+        return;
+      }
     }
     return;
   }
@@ -370,6 +385,71 @@ rl.on("line", (line) => {
       });
       return;
     }
+    if (mode === "dynamic-tool-success") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9300 + turnCount;
+      pendingServerRequestKind = "dynamic-tool-success";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/call",
+        params: {
+          threadId,
+          turnId,
+          callId: "tool-call-" + String(turnCount),
+          tool: "tracker_current_context",
+          arguments: {},
+        },
+      });
+      return;
+    }
+    if (mode === "dynamic-tool-unknown") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9310 + turnCount;
+      pendingServerRequestKind = "dynamic-tool-unknown";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/call",
+        params: {
+          threadId,
+          turnId,
+          callId: "tool-call-" + String(turnCount),
+          tool: "unknown_tracker_tool",
+          arguments: {},
+        },
+      });
+      return;
+    }
+    if (mode === "dynamic-tool-malformed") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9320 + turnCount;
+      pendingServerRequestKind = "dynamic-tool-malformed";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/call",
+        params: {
+          threadId,
+          turnId,
+          tool: "tracker_current_context",
+        },
+      });
+      return;
+    }
+    if (mode === "dynamic-tool-request-user-input") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9330 + turnCount;
+      pendingServerRequestKind = "dynamic-tool-request-user-input";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId,
+          turnId,
+          itemId: "tool-item-" + String(turnCount),
+          questions: [],
+        },
+      });
+      return;
+    }
     if (mode === "completed-malformed-params") {
       send({
         method: "turn/completed",
@@ -391,6 +471,7 @@ function createCodexRunnerForMode(
   fakeCodex: string,
   mode: FakeCodexMode,
   logger: Logger = new JsonLogger(),
+  trackerToolService: TrackerToolService | null = null,
 ): CodexRunner {
   return new CodexRunner(
     createCodexConfig({
@@ -400,6 +481,7 @@ function createCodexRunnerForMode(
       },
     }),
     logger,
+    trackerToolService,
   );
 }
 
@@ -412,6 +494,32 @@ async function readLoggedPayloads(
     .split("\n")
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function createTrackerToolServiceStub(options?: {
+  readonly fail?: boolean;
+}): TrackerToolService {
+  return {
+    async readCurrentContext(runSession) {
+      if (options?.fail === true) {
+        throw new Error("tracker lookup failed");
+      }
+      return {
+        branchName: runSession.workspace.branchName,
+        issue: {
+          identifier: runSession.issue.identifier,
+          number: runSession.issue.number,
+          title: runSession.issue.title,
+          labels: runSession.issue.labels,
+          state: runSession.issue.state,
+          url: runSession.issue.url,
+          summary: "Sanitized tracker summary",
+        },
+        pullRequest: null,
+        retrievedAt: "2026-03-19T00:00:00.000Z",
+      };
+    },
+  };
 }
 
 describe("runners", () => {
@@ -1290,7 +1398,7 @@ describe("runners", () => {
     );
   });
 
-  it("responds explicitly to unsupported Codex server requests", async () => {
+  it("responds explicitly to malformed dynamic tool requests", async () => {
     const fakeCodex = await createFakeCodexExecutable();
     const logFile = path.join(
       await createTempDir("fake-codex-log-"),
@@ -1314,9 +1422,7 @@ describe("runners", () => {
           turnNumber: 1,
           prompt: "first",
         }),
-      ).rejects.toThrowError(
-        /Codex app-server requested unsupported method 'item\/tool\/call'/,
-      );
+      ).rejects.toThrowError(/malformed dynamic tool request/);
     } finally {
       await liveSession.close().catch(() => {});
     }
@@ -1326,7 +1432,246 @@ describe("runners", () => {
       expect.objectContaining({
         id: 9201,
         error: expect.objectContaining({
+          code: -32602,
+        }),
+      }),
+    );
+  });
+
+  it("advertises and executes the tracker dynamic tool successfully", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-success",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    const threadStart = payloads.find(
+      (payload) => payload["method"] === "thread/start",
+    );
+    expect(threadStart).toMatchObject({
+      params: {
+        config: {
+          experimental_supported_tools: [
+            expect.objectContaining({
+              name: "tracker_current_context",
+            }),
+          ],
+        },
+      },
+    });
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9301,
+        result: expect.objectContaining({
+          success: true,
+          contentItems: [
+            expect.objectContaining({
+              type: "inputText",
+              text: expect.stringContaining('"tool": "tracker_current_context"'),
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("returns an explicit unsupported-tool response without stalling the turn", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-unknown",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9311,
+        error: expect.objectContaining({
           code: -32601,
+        }),
+      }),
+    );
+  });
+
+  it("returns invalid params for malformed dynamic tool calls", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-malformed",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).rejects.toThrowError(/malformed dynamic tool request/);
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9321,
+        error: expect.objectContaining({
+          code: -32602,
+        }),
+      }),
+    );
+  });
+
+  it("returns invalid params for unsupported dynamic tool user-input requests", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-request-user-input",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9331,
+        error: expect.objectContaining({
+          code: -32602,
+        }),
+      }),
+    );
+  });
+
+  it("returns a normalized failed tool result when the tracker read fails", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-success",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub({ fail: true }),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9301,
+        result: expect.objectContaining({
+          success: false,
+          contentItems: [
+            expect.objectContaining({
+              type: "inputText",
+              text: expect.stringContaining("tracker_read_failed"),
+            }),
+          ],
         }),
       }),
     );

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -349,7 +349,10 @@ rl.on("line", (line) => {
         turn: { id: turnId },
       },
     });
-    if (mode === "command-approval" || mode === "command-approval-requires-input") {
+    if (
+      mode === "command-approval" ||
+      mode === "command-approval-requires-input"
+    ) {
       pendingTurnId = turnId;
       pendingServerRequestId = 9000 + turnCount;
       pendingServerRequestKind = "command-approval";
@@ -1542,8 +1545,14 @@ describe("runners", () => {
     expect(payloads).toContainEqual(
       expect.objectContaining({
         id: 9311,
-        error: expect.objectContaining({
-          code: -32601,
+        result: expect.objectContaining({
+          success: false,
+          contentItems: [
+            expect.objectContaining({
+              type: "inputText",
+              text: expect.stringContaining('"code": "unsupported_tool"'),
+            }),
+          ],
         }),
       }),
     );

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -378,9 +378,9 @@ rl.on("line", (line) => {
       pendingServerRequestKind = "unsupported-request";
       send({
         id: pendingServerRequestId,
-        method: "item/tool/call",
+        method: "item/unsupported",
         params: {
-          tool: "unknown",
+          value: "unknown",
         },
       });
       return;
@@ -1398,7 +1398,7 @@ describe("runners", () => {
     );
   });
 
-  it("responds explicitly to malformed dynamic tool requests", async () => {
+  it("responds explicitly to generic unsupported Codex requests", async () => {
     const fakeCodex = await createFakeCodexExecutable();
     const logFile = path.join(
       await createTempDir("fake-codex-log-"),
@@ -1422,7 +1422,9 @@ describe("runners", () => {
           turnNumber: 1,
           prompt: "first",
         }),
-      ).rejects.toThrowError(/malformed dynamic tool request/);
+      ).rejects.toThrowError(
+        /Codex app-server requested unsupported method 'item\/unsupported'/,
+      );
     } finally {
       await liveSession.close().catch(() => {});
     }
@@ -1432,7 +1434,8 @@ describe("runners", () => {
       expect.objectContaining({
         id: 9201,
         error: expect.objectContaining({
-          code: -32602,
+          code: -32601,
+          message: "Unsupported Codex app-server request 'item/unsupported'",
         }),
       }),
     );

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -135,6 +135,7 @@ type FakeCodexMode =
   | "unsupported-request"
   | "dynamic-tool-success"
   | "dynamic-tool-unknown"
+  | "dynamic-tool-invalid-arguments"
   | "dynamic-tool-malformed"
   | "dynamic-tool-request-user-input"
   | "turn-failed"
@@ -292,6 +293,7 @@ rl.on("line", (line) => {
       if (
         (requestKind === "dynamic-tool-success" ||
           requestKind === "dynamic-tool-unknown" ||
+          requestKind === "dynamic-tool-invalid-arguments" ||
           requestKind === "dynamic-tool-malformed" ||
           requestKind === "dynamic-tool-request-user-input") &&
         turnId !== null
@@ -418,6 +420,25 @@ rl.on("line", (line) => {
           callId: "tool-call-" + String(turnCount),
           tool: "unknown_tracker_tool",
           arguments: {},
+        },
+      });
+      return;
+    }
+    if (mode === "dynamic-tool-invalid-arguments") {
+      pendingTurnId = turnId;
+      pendingServerRequestId = 9315 + turnCount;
+      pendingServerRequestKind = "dynamic-tool-invalid-arguments";
+      send({
+        id: pendingServerRequestId,
+        method: "item/tool/call",
+        params: {
+          threadId,
+          turnId,
+          callId: "tool-call-" + String(turnCount),
+          tool: "tracker_current_context",
+          arguments: {
+            unexpected: true,
+          },
         },
       });
       return;
@@ -1599,7 +1620,56 @@ describe("runners", () => {
     );
   });
 
-  it("returns invalid params for unsupported dynamic tool user-input requests", async () => {
+  it("returns a failed tool result for invalid dynamic tool arguments", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const logFile = path.join(
+      await createTempDir("fake-codex-log-"),
+      "rpc.jsonl",
+    );
+    const runner = new CodexRunner(
+      createCodexConfig({
+        command: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -`,
+        env: {
+          FAKE_CODEX_MODE: "dynamic-tool-invalid-arguments",
+          FAKE_CODEX_LOG_FILE: logFile,
+        },
+      }),
+      new JsonLogger(),
+      createTrackerToolServiceStub(),
+    );
+    const liveSession = await runner.startSession(createSession());
+
+    try {
+      await expect(
+        liveSession.runTurn({
+          turnNumber: 1,
+          prompt: "first",
+        }),
+      ).resolves.toMatchObject({
+        exitCode: 0,
+      });
+    } finally {
+      await liveSession.close().catch(() => {});
+    }
+
+    const payloads = await readLoggedPayloads(logFile);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        id: 9316,
+        result: expect.objectContaining({
+          success: false,
+          contentItems: [
+            expect.objectContaining({
+              type: "inputText",
+              text: expect.stringContaining('"code": "invalid_arguments"'),
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("fails unsupported dynamic tool user-input requests explicitly", async () => {
     const fakeCodex = await createFakeCodexExecutable();
     const logFile = path.join(
       await createTempDir("fake-codex-log-"),
@@ -1624,9 +1694,7 @@ describe("runners", () => {
           turnNumber: 1,
           prompt: "first",
         }),
-      ).resolves.toMatchObject({
-        exitCode: 0,
-      });
+      ).rejects.toThrowError(/unsupported interactive dynamic-tool user input/);
     } finally {
       await liveSession.close().catch(() => {});
     }

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -1493,7 +1493,9 @@ describe("runners", () => {
           contentItems: [
             expect.objectContaining({
               type: "inputText",
-              text: expect.stringContaining('"tool": "tracker_current_context"'),
+              text: expect.stringContaining(
+                '"tool": "tracker_current_context"',
+              ),
             }),
           ],
         }),

--- a/tests/unit/tracker-tool-service.test.ts
+++ b/tests/unit/tracker-tool-service.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type { HandoffLifecycle } from "../../src/domain/handoff.js";
+import type { PullRequestHandle } from "../../src/domain/handoff.js";
+import type { RuntimeIssue } from "../../src/domain/issue.js";
+import type { RunSession } from "../../src/domain/run.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
+import { createTrackerToolService } from "../../src/tracker/tool-service.js";
+import type {
+  LandingExecutionResult,
+  Tracker,
+} from "../../src/tracker/service.js";
+
+function createIssue(): RuntimeIssue {
+  return {
+    id: "issue-1",
+    identifier: "sociotechnica-org/symphony-ts#186",
+    number: 186,
+    title: "Dynamic tools",
+    description:
+      "Summary line\n\n```ts\nconst secret = true;\n```\n\n<!-- hidden -->More context",
+    labels: ["symphony:running"],
+    state: "open",
+    url: "https://example.test/issues/186",
+    createdAt: "2026-03-19T00:00:00.000Z",
+    updatedAt: "2026-03-19T00:00:00.000Z",
+  };
+}
+
+function createLifecycle(): HandoffLifecycle {
+  return {
+    kind: "awaiting-human-review",
+    branchName: "symphony/186",
+    pullRequest: {
+      number: 44,
+      url: "https://example.test/pulls/44",
+      branchName: "symphony/186",
+      headSha: "abc123",
+      latestCommitAt: "2026-03-19T00:00:00.000Z",
+    },
+    checks: [],
+    pendingCheckNames: ["build"],
+    failingCheckNames: [],
+    actionableReviewFeedback: [
+      {
+        id: "feedback-1",
+        kind: "issue-comment",
+        threadId: null,
+        authorLogin: "review-bot",
+        body: "Please revisit `dangerous()` and remove the raw markdown.",
+        createdAt: "2026-03-19T00:00:00.000Z",
+        url: "https://example.test/comments/1",
+        path: "src/example.ts",
+        line: 12,
+      },
+    ],
+    unresolvedThreadIds: [],
+    summary: "PR is waiting for human review.",
+  };
+}
+
+function createRunSession(): RunSession {
+  return {
+    id: "session-1",
+    issue: createIssue(),
+    workspace: {
+      key: "sociotechnica-org_symphony-ts_186",
+      branchName: "symphony/186",
+      createdNow: false,
+      source: createConfiguredWorkspaceSource(process.cwd()),
+      target: {
+        kind: "local",
+        path: process.cwd(),
+      },
+    },
+    prompt: "prompt",
+    startedAt: "2026-03-19T00:00:00.000Z",
+    attempt: {
+      sequence: 1,
+    },
+  };
+}
+
+class StubTracker implements Tracker {
+  readonly #issue: RuntimeIssue;
+  readonly #lifecycle: HandoffLifecycle;
+
+  constructor(issue: RuntimeIssue, lifecycle: HandoffLifecycle) {
+    this.#issue = issue;
+    this.#lifecycle = lifecycle;
+  }
+
+  subject(): string {
+    return "stub";
+  }
+
+  isHumanReviewFeedback(_authorLogin: string | null): boolean {
+    return false;
+  }
+
+  async ensureLabels(): Promise<void> {}
+
+  async fetchReadyIssues(): Promise<readonly RuntimeIssue[]> {
+    return [];
+  }
+
+  async fetchRunningIssues(): Promise<readonly RuntimeIssue[]> {
+    return [];
+  }
+
+  async fetchFailedIssues(): Promise<readonly RuntimeIssue[]> {
+    return [];
+  }
+
+  async getIssue(_issueNumber: number): Promise<RuntimeIssue> {
+    return this.#issue;
+  }
+
+  async claimIssue(_issueNumber: number): Promise<RuntimeIssue | null> {
+    return null;
+  }
+
+  async inspectIssueHandoff(_branchName: string): Promise<HandoffLifecycle> {
+    return this.#lifecycle;
+  }
+
+  async reconcileSuccessfulRun(
+    _branchName: string,
+    _lifecycle: HandoffLifecycle | null,
+  ): Promise<HandoffLifecycle> {
+    return this.#lifecycle;
+  }
+
+  async executeLanding(
+    _pullRequest: PullRequestHandle,
+  ): Promise<LandingExecutionResult> {
+    return {
+      kind: "requested",
+      summary: "requested",
+    };
+  }
+
+  async recordRetry(
+    _issueNumber: number,
+    _reason: string,
+  ): Promise<void> {}
+
+  async completeIssue(_issueNumber: number): Promise<void> {}
+
+  async markIssueFailed(
+    _issueNumber: number,
+    _reason: string,
+  ): Promise<void> {}
+}
+
+describe("tracker tool service", () => {
+  it("returns sanitized current issue and PR context", async () => {
+    const tracker = new StubTracker(createIssue(), createLifecycle());
+    const service = createTrackerToolService(tracker, {
+      kind: "github",
+      repo: "sociotechnica-org/symphony-ts",
+      apiUrl: "https://api.github.example.test",
+      readyLabel: "symphony:ready",
+      runningLabel: "symphony:running",
+      failedLabel: "symphony:failed",
+      reviewBotLogins: [],
+      successComment: "done",
+    });
+
+    const result = await service.readCurrentContext(createRunSession());
+
+    expect(result.branchName).toBe("symphony/186");
+    expect(result.issue.summary).toContain("Summary line");
+    expect(result.issue.summary).not.toContain("```");
+    expect(result.issue.summary).not.toContain("<!--");
+    expect(result.pullRequest).toMatchObject({
+      kind: "awaiting-human-review",
+      summary: "PR is waiting for human review.",
+      pullRequest: expect.objectContaining({
+        number: 44,
+      }),
+      actionableReviewFeedback: [
+        expect.objectContaining({
+          summary: expect.stringContaining("Please revisit dangerous()"),
+        }),
+      ],
+    });
+  });
+});

--- a/tests/unit/tracker-tool-service.test.ts
+++ b/tests/unit/tracker-tool-service.test.ts
@@ -139,17 +139,11 @@ class StubTracker implements Tracker {
     };
   }
 
-  async recordRetry(
-    _issueNumber: number,
-    _reason: string,
-  ): Promise<void> {}
+  async recordRetry(_issueNumber: number, _reason: string): Promise<void> {}
 
   async completeIssue(_issueNumber: number): Promise<void> {}
 
-  async markIssueFailed(
-    _issueNumber: number,
-    _reason: string,
-  ): Promise<void> {}
+  async markIssueFailed(_issueNumber: number, _reason: string): Promise<void> {}
 }
 
 describe("tracker tool service", () => {


### PR DESCRIPTION
Closes #186

## Summary
- advertise a first-party `tracker_current_context` Codex dynamic tool during app-server session startup
- route `item/tool/call` through a focused runner-side executor backed by a narrow tracker tool service
- normalize supported, unsupported, malformed, and tracker-failure tool responses with tests and docs

## Checks
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
