### PR TITLE
Add SSH stdio transport for remote Codex app-server sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,17 @@ workspace:
   retention:
     on_success: delete
     on_failure: retain
+  worker_hosts:
+    builder:
+      ssh_destination: symphony@builder.example.com
+      workspace_root: /var/tmp/symphony/workspaces
 
 agent:
   runner:
     kind: codex
+    remote_execution:
+      kind: ssh
+      worker_host: builder
   command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
   prompt_transport: stdin
   timeout_ms: 1800000
@@ -260,7 +267,9 @@ policy, code, docs, or local test evidence.
 | `workspace.root`                 | Where isolated workspaces are created                                                  |
 | `workspace.repo_url`             | Explicit clone source URL or local path; local paths resolve relative to `WORKFLOW.md` |
 | `workspace.branch_prefix`        | Issue branch naming prefix                                                             |
+| `workspace.worker_hosts.<name>` | Optional SSH worker-host definitions for remote Codex execution                        |
 | `agent.runner.kind`              | Selects the logical runner provider (`codex`, `claude-code`, or `generic-command`)     |
+| `agent.runner.remote_execution`  | Optional remote execution selection for Codex (`kind: ssh`, `worker_host: <name>`)     |
 | `agent.command`                  | Runner command shape; Codex reuses its flags to launch `codex app-server`              |
 | `agent.prompt_transport`         | Sends the prompt over `stdin` or via a temp file path                                  |
 | `agent.timeout_ms`               | Max wall-clock time per runner turn                                                    |
@@ -308,6 +317,40 @@ subprocess per worker run and reuses a single Codex thread across continuation
 turns. Keep `agent.command` in the familiar `codex exec ...` shape; Symphony
 derives the app-server launch plus thread defaults such as model, sandbox, and
 approval policy from that command instead of shelling out with `codex exec resume`.
+
+When `agent.runner.remote_execution.kind: ssh` is set, Symphony keeps the
+orchestrator local but prepares the issue workspace on the selected
+`workspace.worker_hosts.<name>` target and launches `codex app-server` through
+one local `ssh` subprocess bound to that remote workspace. Remote Codex runs
+currently require:
+
+- `workspace.repo_url` to be a remote clone URL reachable from the worker host
+- `agent.prompt_transport: stdin`
+- one explicit `worker_host` selection per worker run
+
+Example:
+
+```yaml
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: git@github.com:your-org/your-repo.git
+  branch_prefix: symphony/
+  worker_hosts:
+    builder:
+      ssh_destination: symphony@builder.example.com
+      workspace_root: /var/tmp/symphony/workspaces
+
+agent:
+  runner:
+    kind: codex
+    remote_execution:
+      kind: ssh
+      worker_host: builder
+  command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -
+  prompt_transport: stdin
+  timeout_ms: 1800000
+  max_turns: 20
+```
 
 The Claude Code adapter expects a headless JSON command shape so Symphony can
 capture `session_id` for continuation turns and status artifacts. Keep these

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ policy, code, docs, or local test evidence.
 | `workspace.root`                 | Where isolated workspaces are created                                                  |
 | `workspace.repo_url`             | Explicit clone source URL or local path; local paths resolve relative to `WORKFLOW.md` |
 | `workspace.branch_prefix`        | Issue branch naming prefix                                                             |
-| `workspace.worker_hosts.<name>` | Optional SSH worker-host definitions for remote Codex execution                        |
+| `workspace.worker_hosts.<name>`  | Optional SSH worker-host definitions for remote Codex execution                        |
 | `agent.runner.kind`              | Selects the logical runner provider (`codex`, `claude-code`, or `generic-command`)     |
 | `agent.runner.remote_execution`  | Optional remote execution selection for Codex (`kind: ssh`, `worker_host: <name>`)     |
 | `agent.command`                  | Runner command shape; Codex reuses its flags to launch `codex app-server`              |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -30,11 +30,22 @@ workspace:
   retention:
     on_success: delete
     on_failure: retain
+  # Optional remote Codex worker hosts:
+  # worker_hosts:
+  #   builder:
+  #     ssh_destination: symphony@builder.example.com
+  #     workspace_root: /var/tmp/symphony/workspaces
 hooks:
   after_create: []
 agent:
   runner:
     kind: codex
+  # Optional remote Codex execution:
+  # runner:
+  #   kind: codex
+  #   remote_execution:
+  #     kind: ssh
+  #     worker_host: builder
   command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -C . -
   # For runner.kind: codex, Symphony derives a long-lived `codex app-server`
   # session from this exec-style command and reuses one Codex thread per worker run.

--- a/docs/plans/187-ssh-stdio-transport-for-remote-codex-app-server-sessions/plan.md
+++ b/docs/plans/187-ssh-stdio-transport-for-remote-codex-app-server-sessions/plan.md
@@ -1,0 +1,365 @@
+# Issue 187 Plan: Add SSH Stdio Transport For Remote Codex App-Server Sessions
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add the first real remote execution transport by launching one `codex app-server` session over SSH stdio on a selected worker host, while keeping the Symphony orchestrator local and preserving the existing runner, continuation-turn, lease, and reconciliation contracts introduced by `#182`, `#183`, `#184`, and `#185`.
+
+The resulting slice should let one worker run:
+
+- choose a configured remote worker host,
+- prepare or reuse a remote execution workspace on that host,
+- start Codex app-server remotely over SSH stdio,
+- keep all continuation turns on the same remote host and workspace for that worker run,
+- and surface the remote host plus remote session identity through status and artifacts.
+
+## Scope
+
+- add typed workflow config for remote worker-host selection and SSH-backed Codex remote execution
+- extend the workspace layer with a concrete remote SSH workspace-preparation path that can create or reuse a per-issue remote checkout on one configured host
+- add a Codex SSH stdio live-session transport that speaks the existing app-server protocol over an SSH subprocess instead of a local child process in the workspace
+- keep one remote workspace target and one Codex thread pinned across continuation turns for the lifetime of a worker run
+- thread remote host and remote session identity through execution-owner, status, and issue-artifact observability
+- add focused unit/integration coverage plus at least one end-to-end mocked remote-host workflow
+- document the new workflow config and operating constraints in README and any directly relevant runtime docs
+
+## Non-goals
+
+- multi-host scheduling, load balancing, or remote-worker pools with dynamic selection policy beyond one explicit configured host per run
+- tracker transport, normalization, or lifecycle-policy changes
+- redesigning retry budgets, follow-up budgets, review-loop policy, or landing policy
+- hosted remote task backends, agent daemons, SSH connection multiplexers, or a generalized remote command framework for every runner
+- cross-host lease ownership transfer or remote process recovery beyond the existing transport-aware ownership model
+- remote workspace retention policy beyond the minimum behavior required for this slice
+
+## Current Gaps
+
+- `src/domain/workflow.ts` and `src/config/workflow.ts` do not expose any typed worker-host or remote-execution configuration.
+- `src/workspace/local.ts` is still the only concrete workspace manager, so the `remote` workspace target in `src/domain/workspace.ts` is currently inert.
+- `src/runner/codex.ts` always creates `CodexAppServerSession`, and `src/runner/codex-app-server-session.ts` always spawns a local `codex app-server` child process against a local workspace path.
+- `src/runner/local-execution.ts` and `src/runner/local-session-description.ts` still assume local execution as the only concrete subprocess boundary.
+- Coordination and observability already carry transport-aware execution-owner metadata, but no concrete runner currently emits a real `remote-stdio-session` with a real remote workspace host.
+- Current tests lock in remote-capable contract shapes, but they do not prove that an SSH-backed remote Codex session can start, continue, and publish remote host/session identity through the normal orchestration flow.
+
+## Decision Notes
+
+- Keep this issue as one execution-layer slice: one concrete remote backend for the existing `codex` provider, not a repo-wide remote-runner abstraction rewrite.
+- Reuse the Codex app-server protocol boundary from `#185`. The new transport should swap the underlying stdio carrier from local child stdio to SSH stdio, not fork a second protocol surface.
+- Keep remote-host choice explicit in config and explicit in the prepared workspace target. The orchestrator should not infer host selection from ad hoc command strings.
+- Keep continuation-turn pinning as execution/session state, not tracker policy. One worker run gets one selected host, one prepared remote workspace, and one reusable Codex thread unless the run fails terminally.
+- Keep remote workspace preparation in the workspace layer, not embedded inside the Codex runner, so the runner consumes a normalized remote target rather than inventing its own host/path model.
+- Do not broaden this slice into generic remote support for Claude or generic-command runners.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repository-owned rule that remote Codex execution happens through explicit worker-host config, a remote prepared workspace target, and an SSH stdio transport that preserves one host/workspace/thread per worker run
+  - does not belong: SSH subprocess argument construction, git commands, protocol parsing, or tracker writes
+- Configuration Layer
+  - belongs: parsing and validating worker-host configuration, remote execution selection, SSH options, and any required remote workspace-root defaults
+  - does not belong: live host selection state, remote git workspace mutation, or app-server runtime events
+- Coordination Layer
+  - belongs: consuming normalized remote execution-owner facts, preserving continuation turns on the existing live session, and reacting to remote transport failures through existing retry/reconciliation paths
+  - does not belong: SSH command composition, remote filesystem setup, or Codex protocol handling
+- Execution Layer
+  - belongs: remote workspace preparation, SSH stdio process/session transport, local SSH subprocess lifecycle, normalized remote transport metadata, and remote-host-pinned live-session behavior
+  - does not belong: tracker handoff policy or landing/review decisions
+- Integration Layer
+  - belongs: unchanged in this slice; tracker adapters continue consuming normalized runner outcomes only
+  - does not belong: worker-host configuration, SSH transport details, or remote workspace semantics
+- Observability Layer
+  - belongs: surfacing selected remote worker host, remote workspace identity, remote session/thread facts, and SSH-backed transport kind in status/artifacts/logging
+  - does not belong: inventing transport semantics that the workspace or runner did not already normalize
+
+## Architecture Boundaries
+
+### `src/config/`
+
+Owns:
+
+- typed workflow parsing for remote worker hosts and runner-side remote execution selection
+- validation that the configured remote execution shape is internally coherent
+
+Does not own:
+
+- host scheduling state
+- SSH process management
+- remote workspace creation
+
+### `src/domain/workspace.ts` and `src/workspace/`
+
+Own:
+
+- a concrete remote workspace target/source shape for one SSH worker host
+- preparation and cleanup of the per-issue remote checkout/workspace identity
+- explicit workspace host/path/workspace-id facts used later by the runner and observability
+
+Do not own:
+
+- Codex protocol requests
+- tracker policy
+- remote transport session state
+
+### `src/runner/`
+
+Owns:
+
+- the SSH stdio carrier for Codex app-server
+- reusing the existing Codex app-server protocol/session logic across local and remote stdio carriers
+- normalized `remote-stdio-session` transport metadata, including remote host/session identity where available
+
+Does not own:
+
+- workspace selection policy
+- tracker mutations
+- retry or continuation budgeting
+
+### `src/orchestrator/`
+
+Owns:
+
+- passing the prepared remote workspace through the run session
+- keeping the current live session for continuation turns
+- persisting normalized remote execution-owner metadata already emitted by workspace and runner layers
+
+Does not own:
+
+- SSH command generation
+- remote workspace bootstrapping details
+- Codex app-server protocol parsing
+
+### `src/observability/`
+
+Owns:
+
+- rendering and persisting remote worker-host, workspace-target, and remote transport/session metadata
+
+Does not own:
+
+- remote state transitions
+- recovery policy
+
+## Layering Notes
+
+- `config/workflow`
+  - resolves worker-host and remote-execution settings explicitly
+  - does not become a place to stash live chosen-host/session state
+- `tracker`
+  - remains unchanged
+  - does not learn about SSH, hostnames, or remote workspace paths
+- `workspace`
+  - owns how a remote checkout is prepared and identified
+  - does not own Codex app-server stdio behavior
+- `runner`
+  - owns how to speak Codex app-server over SSH stdio against a prepared remote workspace target
+  - does not choose which issue runs on which host
+- `orchestrator`
+  - owns continuation sequencing and failure handling using normalized session facts
+  - does not reconstruct remote host/path semantics from raw strings
+- `observability`
+  - owns clear projection of remote execution facts
+  - does not become the source of truth for remote-session state
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR with one remote-execution seam:
+
+1. add typed worker-host config and remote execution selection for Codex
+2. add one concrete SSH-backed remote workspace manager path for prepared workspaces
+3. add one concrete SSH stdio transport for Codex app-server using the existing protocol/session boundary
+4. update observability and tests so remote host/session identity is inspectable end to end
+
+Deferred from this PR:
+
+- generic remote transports for other runners
+- multi-host scheduling policy
+- remote cancellation/recovery beyond what the existing transport-aware ownership contract already supports
+- non-SSH remote transports
+- remote worker pools or long-lived remote agents
+
+This seam remains reviewable because it stays inside config/workspace/runner/observability plus narrow orchestration plumbing. It does not combine tracker work, retry-state redesign, or broad provider-neutral transport refactoring.
+
+## Runtime State Model
+
+This issue adds stateful remote execution behavior that depends on continuation turns staying on one host/workspace/session. The plan therefore requires an explicit execution-layer state machine.
+
+### State variables
+
+- `selectedHost`
+  - validated worker host chosen from workflow config for the run
+- `preparedWorkspace`
+  - normalized prepared workspace target for that host
+- `sshTransportState`
+  - local SSH subprocess / stdio carrier lifecycle
+- `codexSessionState`
+  - existing app-server session state from the Codex transport boundary
+- `backendThreadId`
+  - one Codex thread id reused for continuation turns
+- `turnNumber`
+  - current Symphony turn number within the worker run
+
+### States
+
+1. `selecting-host`
+   - config has been resolved and the worker host for this run is being chosen
+2. `preparing-remote-workspace`
+   - remote checkout/workspace path is being created or refreshed on the selected host
+3. `remote-workspace-ready`
+   - normalized remote workspace target is ready for execution
+4. `starting-ssh-transport`
+   - local SSH subprocess is starting and binding stdio to the remote app-server command
+5. `initializing-session`
+   - Codex app-server protocol initialization and thread start are in flight over SSH stdio
+6. `ready`
+   - one live remote Codex thread exists and can accept a turn
+7. `running-turn`
+   - a turn is executing over the live SSH stdio transport
+8. `waiting`
+   - the live remote session is healthy but paused on an external boundary such as approval or review wait
+9. `turn-complete`
+   - a turn completed successfully and the same host/workspace/thread remain available
+10. `failed`
+   - remote workspace preparation, SSH transport, or Codex app-server failed
+11. `closing`
+   - the live session is shutting down and cleanup is running
+12. `closed`
+   - no reusable remote session remains for the run
+
+### Allowed transitions
+
+- `selecting-host -> preparing-remote-workspace`
+- `preparing-remote-workspace -> remote-workspace-ready`
+- `preparing-remote-workspace -> failed`
+- `remote-workspace-ready -> starting-ssh-transport`
+- `starting-ssh-transport -> initializing-session`
+- `starting-ssh-transport -> failed`
+- `initializing-session -> ready`
+- `initializing-session -> failed`
+- `ready -> running-turn`
+- `running-turn -> waiting`
+- `running-turn -> turn-complete`
+- `running-turn -> failed`
+- `waiting -> running-turn`
+- `waiting -> turn-complete`
+- `waiting -> failed`
+- `turn-complete -> ready`
+  - continuation turn on the same host/workspace/thread
+- `turn-complete -> closing`
+- `failed -> closing`
+- `closing -> closed`
+
+### Contract rules
+
+- one worker run selects one configured host and must not silently migrate to another host mid-run
+- one worker run prepares one remote workspace target and all continuation turns use that same target
+- one worker run reuses one live Codex thread when continuation turns continue after a successful turn
+- remote workspace facts must come from the workspace layer, not be reconstructed from SSH command strings in the runner
+- the orchestrator continues to react only to normalized runner/workspace metadata; it does not branch on raw SSH output
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized execution facts available | Expected decision |
+| --- | --- | --- | --- |
+| Remote worker host config is missing or malformed | resolved workflow config | no valid host selection | fail config resolution before dispatch |
+| Selected host is valid but remote workspace bootstrap command fails | selected host, SSH stderr | remote workspace target not ready | fail the run before runner startup; existing retry policy handles the attempt outcome |
+| Remote workspace prepares successfully | selected host, remote path/workspace id | `workspace.target.kind=remote` with host/workspace identity | continue into SSH app-server startup |
+| SSH subprocess starts but cannot connect/authenticate | local SSH pid, stderr | `transport=remote-stdio-session` may be partial or absent | classify as runner startup failure; no local workspace fallback |
+| SSH stdio comes up and Codex initializes/thread-start succeeds | local SSH pid | `transport=remote-stdio-session`, remote host, backend thread id | persist remote execution-owner metadata and run the turn |
+| Turn completes and continuation is required | same selected host, same remote workspace target, live session state | same remote target and backend thread id | reuse the existing live session for the next turn |
+| SSH transport dies during an active turn | local SSH pid exited, stderr | remote host and backend thread may already be known | fail the turn and let existing retry policy decide; do not silently cold-start on another host within the same run |
+| Restart recovery sees remote execution ownership with no local remote process control | persisted execution owner | `transport=remote-stdio-session`, remote host/workspace/session facts | use existing remote-capable recovery path; do not invent local kill semantics |
+| Status/artifact readers load a remote run snapshot | snapshot JSON | remote workspace target and `remote-stdio-session` transport facts | render remote host/session identity cleanly without assuming local workspace path or runner pid |
+
+## Storage / Persistence Contract
+
+- reuse the existing execution-owner schema from `#184`
+- ensure remote runs persist:
+  - `transport.kind = remote-stdio-session`
+  - remote worker host identity through workspace endpoint metadata
+  - remote workspace id/path hint from the prepared workspace target
+  - backend session/thread identity from the Codex session description
+- keep local SSH subprocess pid, if any, as optional local control metadata only when it is safe and meaningful
+- status and issue-artifact snapshots must remain parseable for existing local runs while adding the new remote fields
+
+## Observability Requirements
+
+- active issue status must show the remote worker host when the workspace target is remote
+- runner/session status must distinguish `remote-stdio-session` from local Codex app-server transports
+- issue artifacts must retain remote host, workspace identity, backend session/thread ids, and any local SSH control pid separately
+- structured logs for remote startup failures should identify the selected host and remote workspace path/workspace id without requiring raw SSH command inspection
+
+## Implementation Steps
+
+1. Extend `src/domain/workflow.ts` and `src/config/workflow.ts` with typed remote worker-host / Codex remote-execution config and validation.
+2. Add execution-layer domain helpers for remote worker-host identity and any SSH options that should be normalized before runtime use.
+3. Implement a concrete remote workspace preparation path under `src/workspace/` that:
+   - selects the configured host
+   - creates or refreshes a per-issue remote checkout/workspace
+   - returns a `PreparedWorkspace` with `target.kind = remote`
+4. Refactor the Codex app-server session boundary so the protocol logic can run over either:
+   - local child stdio, or
+   - an SSH-backed stdio carrier
+5. Implement the SSH stdio carrier and wire `CodexRunner` to choose it when the prepared workspace target is remote and the config selects remote Codex execution.
+6. Ensure live-session descriptions emit normalized remote transport metadata and backend thread/session identity.
+7. Update orchestration plumbing only as needed so continuation turns reuse the existing remote live session and persist the correct execution-owner/session facts.
+8. Update status and issue-artifact projection/parsing to render remote host/workspace/session details clearly.
+9. Add focused tests for config parsing, remote workspace preparation, SSH transport/session behavior, orchestration continuation pinning, and status/artifact parsing.
+10. Add or update README/runtime docs for remote Codex worker-host configuration and operational constraints.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- workflow parsing accepts valid remote worker-host config and rejects malformed host/SSH settings
+- remote workspace preparation returns a normalized remote target with host/workspace identity
+- Codex SSH session emits `remote-stdio-session` transport metadata and backend thread identity on successful startup
+- continuation turns reuse the same selected host, prepared workspace target, and backend thread id
+- status and issue-artifact parsers render remote host/session facts without assuming a local workspace path
+
+### Integration tests
+
+- mocked SSH remote workspace bootstrap succeeds and the runner executes Codex app-server over the SSH stdio carrier
+- startup failure, SSH auth/connection failure, and mid-turn SSH drop classify as runner failures without corrupting the workspace/ownership contract
+
+### End-to-end coverage
+
+- one orchestrator run against mocked remote-host helpers:
+  - claims the issue
+  - prepares a remote workspace
+  - starts remote Codex app-server over SSH stdio
+  - completes at least one continuation turn on the same remote host/workspace/thread
+  - publishes status/artifact snapshots with remote host/session identity
+
+### Acceptance scenarios
+
+1. A configured remote Codex worker host executes one worker run entirely over SSH stdio while the local orchestrator remains in control.
+2. When a second turn is needed, Symphony reuses the same remote host, remote workspace target, and Codex thread instead of re-selecting a host or creating a new session.
+3. If remote startup or SSH transport fails, the run fails through the normal runner/orchestrator failure path without tracker-policy changes or hidden local fallback.
+4. Operator-facing status and artifacts identify the remote host and remote session/thread facts distinctly from local pid-based metadata.
+
+## Exit Criteria
+
+- remote Codex execution can be selected through checked-in workflow config
+- a remote prepared workspace target is real, not just a type placeholder
+- Codex app-server can run over SSH stdio against that remote workspace
+- continuation turns stay pinned to one remote host/workspace/thread for the worker run
+- execution-owner, status, and artifact surfaces expose remote host/session identity cleanly
+- local behavior remains green for existing local Codex runs
+- relevant unit, integration, and end-to-end tests pass
+
+## Deferred To Later Issues Or PRs
+
+- generic remote execution for Claude Code and generic-command runners
+- dynamic host scheduling or worker pools
+- remote cancellation/recovery RPC beyond current transport-aware local safety rules
+- remote workspace retention policy refinement and cleanup hardening
+- non-SSH remote transports or hosted remote backends
+
+## Decision Log
+
+- 2026-03-19: Initial draft for issue `#187`. Keeps the seam at one concrete remote Codex backend over SSH stdio and avoids mixing tracker changes or a repo-wide remote-runner redesign into the same PR.

--- a/docs/plans/187-ssh-stdio-transport-for-remote-codex-app-server-sessions/plan.md
+++ b/docs/plans/187-ssh-stdio-transport-for-remote-codex-app-server-sessions/plan.md
@@ -224,11 +224,16 @@ This issue adds stateful remote execution behavior that depends on continuation 
 9. `turn-complete`
    - a turn completed successfully and the same host/workspace/thread remain available
 10. `failed`
-   - remote workspace preparation, SSH transport, or Codex app-server failed
+
+- remote workspace preparation, SSH transport, or Codex app-server failed
+
 11. `closing`
-   - the live session is shutting down and cleanup is running
+
+- the live session is shutting down and cleanup is running
+
 12. `closed`
-   - no reusable remote session remains for the run
+
+- no reusable remote session remains for the run
 
 ### Allowed transitions
 
@@ -263,17 +268,17 @@ This issue adds stateful remote execution behavior that depends on continuation 
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized execution facts available | Expected decision |
-| --- | --- | --- | --- |
-| Remote worker host config is missing or malformed | resolved workflow config | no valid host selection | fail config resolution before dispatch |
-| Selected host is valid but remote workspace bootstrap command fails | selected host, SSH stderr | remote workspace target not ready | fail the run before runner startup; existing retry policy handles the attempt outcome |
-| Remote workspace prepares successfully | selected host, remote path/workspace id | `workspace.target.kind=remote` with host/workspace identity | continue into SSH app-server startup |
-| SSH subprocess starts but cannot connect/authenticate | local SSH pid, stderr | `transport=remote-stdio-session` may be partial or absent | classify as runner startup failure; no local workspace fallback |
-| SSH stdio comes up and Codex initializes/thread-start succeeds | local SSH pid | `transport=remote-stdio-session`, remote host, backend thread id | persist remote execution-owner metadata and run the turn |
-| Turn completes and continuation is required | same selected host, same remote workspace target, live session state | same remote target and backend thread id | reuse the existing live session for the next turn |
-| SSH transport dies during an active turn | local SSH pid exited, stderr | remote host and backend thread may already be known | fail the turn and let existing retry policy decide; do not silently cold-start on another host within the same run |
-| Restart recovery sees remote execution ownership with no local remote process control | persisted execution owner | `transport=remote-stdio-session`, remote host/workspace/session facts | use existing remote-capable recovery path; do not invent local kill semantics |
-| Status/artifact readers load a remote run snapshot | snapshot JSON | remote workspace target and `remote-stdio-session` transport facts | render remote host/session identity cleanly without assuming local workspace path or runner pid |
+| Observed condition                                                                    | Local facts available                                                | Normalized execution facts available                                  | Expected decision                                                                                                  |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Remote worker host config is missing or malformed                                     | resolved workflow config                                             | no valid host selection                                               | fail config resolution before dispatch                                                                             |
+| Selected host is valid but remote workspace bootstrap command fails                   | selected host, SSH stderr                                            | remote workspace target not ready                                     | fail the run before runner startup; existing retry policy handles the attempt outcome                              |
+| Remote workspace prepares successfully                                                | selected host, remote path/workspace id                              | `workspace.target.kind=remote` with host/workspace identity           | continue into SSH app-server startup                                                                               |
+| SSH subprocess starts but cannot connect/authenticate                                 | local SSH pid, stderr                                                | `transport=remote-stdio-session` may be partial or absent             | classify as runner startup failure; no local workspace fallback                                                    |
+| SSH stdio comes up and Codex initializes/thread-start succeeds                        | local SSH pid                                                        | `transport=remote-stdio-session`, remote host, backend thread id      | persist remote execution-owner metadata and run the turn                                                           |
+| Turn completes and continuation is required                                           | same selected host, same remote workspace target, live session state | same remote target and backend thread id                              | reuse the existing live session for the next turn                                                                  |
+| SSH transport dies during an active turn                                              | local SSH pid exited, stderr                                         | remote host and backend thread may already be known                   | fail the turn and let existing retry policy decide; do not silently cold-start on another host within the same run |
+| Restart recovery sees remote execution ownership with no local remote process control | persisted execution owner                                            | `transport=remote-stdio-session`, remote host/workspace/session facts | use existing remote-capable recovery path; do not invent local kill semantics                                      |
+| Status/artifact readers load a remote run snapshot                                    | snapshot JSON                                                        | remote workspace target and `remote-stdio-session` transport facts    | render remote host/session identity cleanly without assuming local workspace path or runner pid                    |
 
 ## Storage / Persistence Contract
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import {
   loadWorkflow,
   loadWorkflowWorkspaceRoot,
 } from "../config/workflow.js";
+import { getCodexRemoteWorkerHost } from "../domain/workflow.js";
 import { JsonLogger } from "../observability/logger.js";
 import {
   assessFactoryStatusSnapshot,
@@ -22,6 +23,7 @@ import { isAbortError } from "../support/abort.js";
 import { createTracker } from "../tracker/factory.js";
 import { createTrackerToolService } from "../tracker/tool-service.js";
 import { LocalWorkspaceManager } from "../workspace/local.js";
+import { RemoteSshWorkspaceManager } from "../workspace/remote-ssh.js";
 import {
   type FactoryControlStatusSnapshot,
   inspectFactoryControl,
@@ -354,13 +356,24 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 
   const promptBuilder = createPromptBuilder(workflow);
   const tracker = createTracker(workflow.config.tracker, logger);
-  const workspace = new LocalWorkspaceManager(
-    workflow.config.workspace,
-    workflow.config.hooks.afterCreate,
-    logger,
-    startup.workspaceSourceOverride,
-  );
+  const remoteWorkerHost = getCodexRemoteWorkerHost(workflow.config);
+  const workspace =
+    remoteWorkerHost === null
+      ? new LocalWorkspaceManager(
+          workflow.config.workspace,
+          workflow.config.hooks.afterCreate,
+          logger,
+          startup.workspaceSourceOverride,
+        )
+      : new RemoteSshWorkspaceManager(
+          workflow.config.workspace,
+          remoteWorkerHost,
+          workflow.config.hooks.afterCreate,
+          logger,
+          startup.workspaceSourceOverride,
+        );
   const runner = createRunner(workflow.config.agent, logger, {
+    remoteWorkerHost,
     trackerToolService: createTrackerToolService(
       tracker,
       workflow.config.tracker,

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -690,7 +690,10 @@ function resolveCodexRemoteExecutionConfig(
     return undefined;
   }
 
-  const remoteExecution = coerceOptionalObject(raw, "agent.runner.remote_execution");
+  const remoteExecution = coerceOptionalObject(
+    raw,
+    "agent.runner.remote_execution",
+  );
   const kind = requireEnum(
     remoteExecution["kind"],
     ["ssh"],

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -370,9 +370,31 @@ function resolveWorkspaceRepoUrl(
 }
 
 function isRemoteRepoUrl(repoUrl: string): boolean {
-  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(repoUrl)) {
+  if (hasUrlScheme(repoUrl)) {
     return true;
   }
+  return isScpStyleRepoUrl(repoUrl);
+}
+
+function isRemoteExecutionRepoUrl(repoUrl: string): boolean {
+  if (isScpStyleRepoUrl(repoUrl)) {
+    return true;
+  }
+  if (!hasUrlScheme(repoUrl)) {
+    return false;
+  }
+  try {
+    return new URL(repoUrl).protocol !== "file:";
+  } catch {
+    return true;
+  }
+}
+
+function hasUrlScheme(repoUrl: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(repoUrl);
+}
+
+function isScpStyleRepoUrl(repoUrl: string): boolean {
   return /^[^/\\\s]+@[^:/\\\s]+:.+$/.test(repoUrl);
 }
 
@@ -780,7 +802,7 @@ function validateRemoteExecutionConfig(config: ResolvedConfig): void {
     return;
   }
 
-  if (!isRemoteRepoUrl(config.workspace.repoUrl)) {
+  if (!isRemoteExecutionRepoUrl(config.workspace.repoUrl)) {
     throw new ConfigError(
       "workspace.repo_url must be a remote clone URL when agent.runner.remote_execution is enabled",
     );

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -12,11 +12,13 @@ import {
 } from "../tracker/prompt-context.js";
 import type {
   AgentRunnerConfig,
+  CodexRemoteExecutionConfig,
   GitHubCompatibleTrackerConfig,
   LinearTrackerConfig,
   ObservabilityConfig,
   PromptBuilder,
   ResolvedConfig,
+  SshWorkerHostConfig,
   TrackerConfig,
   WorkspaceRetentionMode,
   WatchdogConfig,
@@ -465,6 +467,29 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   };
   const resolvedWatchdog = resolveWatchdogConfig(polling["watchdog"]);
   const agentCommand = requireString(agent["command"], "agent.command");
+  const resolvedWorkspace = {
+    root: path.resolve(
+      path.dirname(workflowPath),
+      requireString(workspace["root"], "workspace.root"),
+    ),
+    repoUrl: resolveRepoUrl(
+      workspace["repo_url"],
+      derivedRepoUrl,
+      repoOverride !== undefined,
+      workflowPath,
+    ),
+    branchPrefix: requireString(
+      workspace["branch_prefix"],
+      "workspace.branch_prefix",
+    ),
+    retention: resolveWorkspaceRetentionPolicy(workspace),
+    workerHosts: resolveWorkerHostsConfig(workspace["worker_hosts"]),
+  } as const;
+  const resolvedRunner = resolveAgentRunnerConfig(
+    agent,
+    agentCommand,
+    resolvedWorkspace.workerHosts,
+  );
 
   const resolved: ResolvedConfig = {
     workflowPath,
@@ -476,23 +501,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
             ...resolvedPolling,
             watchdog: resolvedWatchdog,
           },
-    workspace: {
-      root: path.resolve(
-        path.dirname(workflowPath),
-        requireString(workspace["root"], "workspace.root"),
-      ),
-      repoUrl: resolveRepoUrl(
-        workspace["repo_url"],
-        derivedRepoUrl,
-        repoOverride !== undefined,
-        workflowPath,
-      ),
-      branchPrefix: requireString(
-        workspace["branch_prefix"],
-        "workspace.branch_prefix",
-      ),
-      retention: resolveWorkspaceRetentionPolicy(workspace),
-    },
+    workspace: resolvedWorkspace,
     hooks: {
       afterCreate:
         hooks["after_create"] === undefined
@@ -500,7 +509,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
           : requireStringArray(hooks["after_create"], "hooks.after_create"),
     },
     agent: {
-      runner: resolveAgentRunnerConfig(agent, agentCommand),
+      runner: resolvedRunner,
       command: agentCommand,
       promptTransport: requireString(
         agent["prompt_transport"],
@@ -540,6 +549,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   if (resolved.polling.retry.maxAttempts < 1) {
     throw new ConfigError("polling.retry.max_attempts must be >= 1");
   }
+  validateRemoteExecutionConfig(resolved);
   return resolved;
 }
 
@@ -578,9 +588,54 @@ function resolveWorkspaceRetentionPolicy(
   } as const;
 }
 
+function resolveWorkerHostsConfig(
+  raw: unknown,
+): Readonly<Record<string, SshWorkerHostConfig>> {
+  if (raw === undefined) {
+    return {};
+  }
+
+  const workerHosts = coerceOptionalObject(raw, "workspace.worker_hosts");
+  const resolved = Object.entries(workerHosts).map(([name, value]) => {
+    const workerHost = coerceOptionalObject(
+      value,
+      `workspace.worker_hosts.${name}`,
+    );
+    return [
+      name,
+      {
+        name,
+        sshDestination: requireString(
+          workerHost["ssh_destination"],
+          `workspace.worker_hosts.${name}.ssh_destination`,
+        ),
+        sshExecutable:
+          requireOptionalString(
+            workerHost["ssh_executable"],
+            `workspace.worker_hosts.${name}.ssh_executable`,
+          ) ?? "ssh",
+        sshOptions:
+          workerHost["ssh_options"] === undefined
+            ? []
+            : requireStringArray(
+                workerHost["ssh_options"],
+                `workspace.worker_hosts.${name}.ssh_options`,
+              ),
+        workspaceRoot: requireString(
+          workerHost["workspace_root"],
+          `workspace.worker_hosts.${name}.workspace_root`,
+        ),
+      } satisfies SshWorkerHostConfig,
+    ] as const;
+  });
+
+  return Object.fromEntries(resolved);
+}
+
 function resolveAgentRunnerConfig(
   agent: Readonly<Record<string, unknown>>,
   command: string,
+  workerHosts: Readonly<Record<string, SshWorkerHostConfig>>,
 ): AgentRunnerConfig {
   const rawRunner = agent["runner"];
 
@@ -600,7 +655,7 @@ function resolveAgentRunnerConfig(
 
   switch (kind) {
     case "codex":
-      return { kind: "codex" };
+      return resolveCodexRunnerConfig(runner, workerHosts);
     case "generic-command":
       return resolveGenericCommandRunnerConfig(runner);
     case "claude-code":
@@ -608,6 +663,54 @@ function resolveAgentRunnerConfig(
     default:
       return exhaustiveAgentRunnerKind(kind);
   }
+}
+
+function resolveCodexRunnerConfig(
+  runner: Readonly<Record<string, unknown>>,
+  workerHosts: Readonly<Record<string, SshWorkerHostConfig>>,
+): AgentRunnerConfig {
+  const remoteExecution = resolveCodexRemoteExecutionConfig(
+    runner["remote_execution"],
+    workerHosts,
+  );
+  if (remoteExecution === undefined) {
+    return { kind: "codex" };
+  }
+  return {
+    kind: "codex",
+    remoteExecution,
+  };
+}
+
+function resolveCodexRemoteExecutionConfig(
+  raw: unknown,
+  workerHosts: Readonly<Record<string, SshWorkerHostConfig>>,
+): CodexRemoteExecutionConfig | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const remoteExecution = coerceOptionalObject(raw, "agent.runner.remote_execution");
+  const kind = requireEnum(
+    remoteExecution["kind"],
+    ["ssh"],
+    "agent.runner.remote_execution.kind",
+  );
+  const workerHostName = requireString(
+    remoteExecution["worker_host"],
+    "agent.runner.remote_execution.worker_host",
+  );
+  const workerHost = workerHosts[workerHostName];
+  if (workerHost === undefined) {
+    throw new ConfigError(
+      `agent.runner.remote_execution.worker_host '${workerHostName}' is not defined in workspace.worker_hosts`,
+    );
+  }
+  return {
+    kind,
+    workerHostName,
+    workerHost,
+  };
 }
 
 function inferAgentRunnerConfig(command: string): AgentRunnerConfig {
@@ -662,6 +765,29 @@ function validateExplicitAgentRunnerKind(
   throw new ConfigError(
     `agent.runner.kind '${kind}' requires agent.command to invoke the ${requiredExecutable} CLI`,
   );
+}
+
+function validateRemoteExecutionConfig(config: ResolvedConfig): void {
+  if (config.agent.runner.kind !== "codex") {
+    return;
+  }
+
+  const remoteExecution = config.agent.runner.remoteExecution;
+  if (remoteExecution === undefined) {
+    return;
+  }
+
+  if (!isRemoteRepoUrl(config.workspace.repoUrl)) {
+    throw new ConfigError(
+      "workspace.repo_url must be a remote clone URL when agent.runner.remote_execution is enabled",
+    );
+  }
+
+  if (config.agent.promptTransport !== "stdin") {
+    throw new ConfigError(
+      "agent.prompt_transport must be 'stdin' for Codex SSH remote execution",
+    );
+  }
 }
 
 function exhaustiveAgentRunnerKind(value: never): never {

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -62,6 +62,7 @@ export interface WorkspaceConfig {
   readonly repoUrl: string;
   readonly branchPrefix: string;
   readonly retention: WorkspaceRetentionPolicy;
+  readonly workerHosts?: Readonly<Record<string, SshWorkerHostConfig>>;
 }
 
 export type WorkspaceRetentionMode = "delete" | "retain";
@@ -77,7 +78,24 @@ export interface HooksConfig {
 
 export interface CodexRunnerConfig {
   readonly kind: "codex";
+  readonly remoteExecution?: CodexRemoteExecutionConfig | undefined;
 }
+
+export interface SshWorkerHostConfig {
+  readonly name: string;
+  readonly sshDestination: string;
+  readonly sshExecutable: string;
+  readonly sshOptions: readonly string[];
+  readonly workspaceRoot: string;
+}
+
+export interface CodexSshRemoteExecutionConfig {
+  readonly kind: "ssh";
+  readonly workerHostName: string;
+  readonly workerHost: SshWorkerHostConfig;
+}
+
+export type CodexRemoteExecutionConfig = CodexSshRemoteExecutionConfig;
 
 export interface GenericCommandRunnerConfig {
   readonly kind: "generic-command";
@@ -122,6 +140,21 @@ export interface ResolvedConfig {
 export interface WorkflowDefinition {
   readonly config: ResolvedConfig;
   readonly promptTemplate: string;
+}
+
+export function getCodexRemoteWorkerHost(
+  config: ResolvedConfig,
+): SshWorkerHostConfig | null {
+  if (
+    typeof config.agent !== "object" ||
+    config.agent === null ||
+    typeof config.agent.runner !== "object" ||
+    config.agent.runner === null ||
+    config.agent.runner.kind !== "codex"
+  ) {
+    return null;
+  }
+  return config.agent.runner.remoteExecution?.workerHost ?? null;
 }
 
 export interface PromptBuilder {

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -145,16 +145,24 @@ export interface WorkflowDefinition {
 export function getCodexRemoteWorkerHost(
   config: ResolvedConfig,
 ): SshWorkerHostConfig | null {
+  const agent = (config as { agent?: unknown }).agent;
   if (
-    typeof config.agent !== "object" ||
-    config.agent === null ||
-    typeof config.agent.runner !== "object" ||
-    config.agent.runner === null ||
-    config.agent.runner.kind !== "codex"
+    typeof agent !== "object" ||
+    agent === null ||
+    !("runner" in agent) ||
+    typeof agent.runner !== "object" ||
+    agent.runner === null ||
+    !("kind" in agent.runner) ||
+    agent.runner.kind !== "codex"
   ) {
     return null;
   }
-  return config.agent.runner.remoteExecution?.workerHost ?? null;
+  const runner = agent.runner as {
+    remoteExecution?: { workerHost?: SshWorkerHostConfig };
+  };
+  return "remoteExecution" in agent.runner
+    ? (runner.remoteExecution?.workerHost ?? null)
+    : null;
 }
 
 export interface PromptBuilder {

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -81,7 +81,9 @@ export function getWorkspaceTargetPath(target: WorkspaceTarget): string | null {
   return target.path;
 }
 
-export function getWorkspaceTargetPathHint(target: WorkspaceTarget): string | null {
+export function getWorkspaceTargetPathHint(
+  target: WorkspaceTarget,
+): string | null {
   switch (target.kind) {
     case "local":
       return target.path;

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -81,8 +81,23 @@ export function getWorkspaceTargetPath(target: WorkspaceTarget): string | null {
   return target.path;
 }
 
+export function getWorkspaceTargetPathHint(target: WorkspaceTarget): string | null {
+  switch (target.kind) {
+    case "local":
+      return target.path;
+    case "remote":
+      return target.pathHint ?? null;
+  }
+}
+
 export function getPreparedWorkspacePath(
   workspace: PreparedWorkspace,
 ): string | null {
   return getWorkspaceTargetPath(workspace.target);
+}
+
+export function getPreparedWorkspacePathHint(
+  workspace: PreparedWorkspace,
+): string | null {
+  return getWorkspaceTargetPathHint(workspace.target);
 }

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -428,7 +428,7 @@ export function renderFactoryStatusSnapshot(
       );
       if (issue.executionOwner !== null) {
         lines.push(
-          `    Execution: transport=${issue.executionOwner.transport.kind} factory=${issue.executionOwner.factory.host}/${issue.executionOwner.factory.instanceId} session=${issue.executionOwner.runSessionId}`,
+          `    Execution: transport=${issue.executionOwner.transport.kind} factory=${issue.executionOwner.factory.host}/${issue.executionOwner.factory.instanceId} session=${issue.executionOwner.runSessionId} remote=${issue.executionOwner.transport.remoteSessionId ?? "n/a"} host=${issue.executionOwner.endpoint.workspaceHost ?? "n/a"} workspace=${issue.executionOwner.endpoint.workspaceId ?? "n/a"}`,
         );
       }
       lines.push(
@@ -460,7 +460,7 @@ export function renderFactoryStatusSnapshot(
       );
       if (issue.executionOwner !== null) {
         lines.push(
-          `    Execution: transport=${issue.executionOwner.transport.kind} factory=${issue.executionOwner.factory.host}/${issue.executionOwner.factory.instanceId}`,
+          `    Execution: transport=${issue.executionOwner.transport.kind} factory=${issue.executionOwner.factory.host}/${issue.executionOwner.factory.instanceId} remote=${issue.executionOwner.transport.remoteSessionId ?? "n/a"} host=${issue.executionOwner.endpoint.workspaceHost ?? "n/a"} workspace=${issue.executionOwner.endpoint.workspaceId ?? "n/a"}`,
         );
       }
       lines.push(

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -1242,7 +1242,19 @@ function formatRunnerLabel(
   }
   const model =
     visibility.session.model === null ? null : visibility.session.model.trim();
-  return model === null || model === "" ? provider : `${provider}/${model}`;
+  const base =
+    model === null || model === "" ? provider : `${provider}/${model}`;
+  const remoteSessionId = visibility.session.transport.remoteSessionId;
+  if (
+    visibility.session.transport.kind === "remote-stdio-session" &&
+    remoteSessionId !== null
+  ) {
+    const host = remoteSessionId.split(":")[0]?.trim() ?? "";
+    if (host !== "") {
+      return `${base}@${host}`;
+    }
+  }
+  return base;
 }
 
 function describeLifecycleContext(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -20,7 +20,9 @@ import type {
   TransientFailureSignal,
 } from "../domain/transient-failure.js";
 import type { PreparedWorkspace } from "../domain/workspace.js";
-import { getPreparedWorkspacePath } from "../domain/workspace.js";
+import {
+  getPreparedWorkspacePathHint,
+} from "../domain/workspace.js";
 import type {
   PromptBuilder,
   ResolvedConfig,
@@ -1118,7 +1120,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       branchName: workspace.branchName,
       status: "running",
       summary: `Running ${issue.identifier}`,
-      workspacePath: getPreparedWorkspacePath(workspace),
+      workspacePath: getPreparedWorkspacePathHint(workspace),
       runSessionId: session.id,
       executionOwner: initialExecutionOwner,
       ownerPid: process.pid,
@@ -2055,7 +2057,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       issueNumber: runSession.issue.number,
       attempt,
       error: failure.message,
-      workspacePath: getPreparedWorkspacePath(runSession.workspace),
+      workspacePath: getPreparedWorkspacePathHint(runSession.workspace),
       runSessionId: runSession.id,
     });
     noteStatusAction(this.#state.status, {
@@ -2350,7 +2352,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         workspacePath:
           options.workspace === undefined
             ? null
-            : getPreparedWorkspacePath(options.workspace),
+            : getPreparedWorkspacePathHint(options.workspace),
       });
       return outcome;
     }
@@ -2379,7 +2381,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         workspacePath:
           options.workspace === undefined
             ? null
-            : getPreparedWorkspacePath(options.workspace),
+            : getPreparedWorkspacePathHint(options.workspace),
         error: cleanupError,
       });
       return outcome;
@@ -3176,7 +3178,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       latestTurnNumber: session.latestTurnNumber,
       startedAt: session.runSession.startedAt,
       finishedAt: finishedAt ?? null,
-      workspacePath: getPreparedWorkspacePath(session.runSession.workspace),
+      workspacePath: getPreparedWorkspacePathHint(session.runSession.workspace),
       branch: session.runSession.workspace.branchName,
       accounting: session.accounting,
       logPointers: session.description.logPointers.map((pointer) =>

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -20,9 +20,7 @@ import type {
   TransientFailureSignal,
 } from "../domain/transient-failure.js";
 import type { PreparedWorkspace } from "../domain/workspace.js";
-import {
-  getPreparedWorkspacePathHint,
-} from "../domain/workspace.js";
+import { getPreparedWorkspacePathHint } from "../domain/workspace.js";
 import type {
   PromptBuilder,
   ResolvedConfig,

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -5,6 +5,7 @@ import { getPreparedWorkspacePathHint } from "../domain/workspace.js";
 import type { AgentConfig, SshWorkerHostConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { quoteShellToken } from "./local-command.js";
+import { buildSshRemoteCommand } from "./ssh-command.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
 import { createRunnerEnvironment } from "./run-environment.js";
 import {
@@ -183,9 +184,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       [
         ...workerHost.sshOptions,
         workerHost.sshDestination,
-        "bash",
-        "-lc",
-        remoteCommand,
+        buildSshRemoteCommand(["bash", "-lc", remoteCommand]),
       ],
       {
         stdio: ["pipe", "pipe", "pipe"],

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -159,7 +159,9 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   #requireWorkspacePathHint(consumer: string): string {
-    const workspacePath = getPreparedWorkspacePathHint(this.#runSession.workspace);
+    const workspacePath = getPreparedWorkspacePathHint(
+      this.#runSession.workspace,
+    );
     if (workspacePath === null) {
       throw new RunnerError(
         `${consumer} requires a prepared workspace path; received ${this.#runSession.workspace.target.kind}`,

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -1,11 +1,12 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { RunnerError, RunnerShutdownError } from "../domain/errors.js";
 import type { RunSession, RunTurn, RunUpdateEvent } from "../domain/run.js";
-import type { AgentConfig } from "../domain/workflow.js";
+import { getPreparedWorkspacePathHint } from "../domain/workspace.js";
+import type { AgentConfig, SshWorkerHostConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import { describeLocalRunnerSession } from "./local-session-description.js";
-import { requireLocalWorkspacePath } from "./local-execution.js";
+import { quoteShellToken } from "./local-command.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
+import { createRunnerEnvironment } from "./run-environment.js";
 import {
   buildCodexAppServerCommand,
   type CodexAppServerCommand,
@@ -28,6 +29,7 @@ import {
 import type { DynamicToolExecutor } from "./dynamic-tool-executor.js";
 import {
   RUNNER_SHUTDOWN_GRACE_MS,
+  createRunnerTransportMetadata,
   summarizeRunnerText,
   withRunnerTransportLocalProcess,
   type RunnerTransportMetadata,
@@ -70,6 +72,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   readonly #baseDescription: RunnerSessionDescription;
   readonly #appServerCommand: CodexAppServerCommand;
   readonly #dynamicToolExecutor: DynamicToolExecutor;
+  readonly #remoteWorkerHost: SshWorkerHostConfig | null;
   #child: ChildProcessWithoutNullStreams | null = null;
   #closePromise: Promise<void> | null = null;
   #closeResolve: (() => void) | null = null;
@@ -102,16 +105,36 @@ export class CodexAppServerSession implements LiveRunnerSession {
     logger: Logger,
     session: RunSession,
     dynamicToolExecutor: DynamicToolExecutor,
+    remoteWorkerHost: SshWorkerHostConfig | null = null,
   ) {
+    const appServerCommand = buildCodexAppServerCommand(config.command);
     this.#config = config;
     this.#logger = logger;
     this.#runSession = session;
     this.#dynamicToolExecutor = dynamicToolExecutor;
-    this.#baseDescription = describeLocalRunnerSession(
-      config.command,
-      "local-stdio-session",
-    );
-    this.#appServerCommand = buildCodexAppServerCommand(config.command);
+    this.#remoteWorkerHost = remoteWorkerHost;
+    this.#baseDescription = {
+      provider: "codex",
+      model: appServerCommand.model,
+      transport: createRunnerTransportMetadata(
+        this.#runSession.workspace.target.kind === "remote"
+          ? "remote-stdio-session"
+          : "local-stdio-session",
+        {
+          canTerminateLocalProcess: true,
+          remoteSessionId:
+            this.#runSession.workspace.target.kind === "remote"
+              ? `${this.#runSession.workspace.target.host}:${this.#runSession.id}`
+              : null,
+        },
+      ),
+      backendSessionId: null,
+      backendThreadId: null,
+      latestTurnId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    };
+    this.#appServerCommand = appServerCommand;
   }
 
   describe(): RunnerSessionDescription {
@@ -133,6 +156,52 @@ export class CodexAppServerSession implements LiveRunnerSession {
       this.#baseDescription.transport,
       this.#appServerPid,
     );
+  }
+
+  #requireWorkspacePathHint(consumer: string): string {
+    const workspacePath = getPreparedWorkspacePathHint(this.#runSession.workspace);
+    if (workspacePath === null) {
+      throw new RunnerError(
+        `${consumer} requires a prepared workspace path; received ${this.#runSession.workspace.target.kind}`,
+      );
+    }
+    return workspacePath;
+  }
+
+  #spawnRemoteProcess(workspacePath: string): ChildProcessWithoutNullStreams {
+    const workerHost = this.#remoteWorkerHost;
+    if (workerHost === null) {
+      throw new RunnerError(
+        "Codex SSH remote execution requires a configured worker host",
+      );
+    }
+    const remoteCommand = this.#buildRemoteLaunchCommand(workspacePath);
+    return spawn(
+      workerHost.sshExecutable,
+      [
+        ...workerHost.sshOptions,
+        workerHost.sshDestination,
+        "bash",
+        "-lc",
+        remoteCommand,
+      ],
+      {
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+  }
+
+  #buildRemoteLaunchCommand(workspacePath: string): string {
+    const env = createRunnerEnvironment(
+      this.#runSession,
+      1,
+      workspacePath,
+      this.#config.env,
+    );
+    const envAssignments = Object.entries(env)
+      .map(([key, value]) => `${key}=${quoteShellToken(String(value))}`)
+      .join(" ");
+    return `set -euo pipefail\ncd ${quoteShellToken(workspacePath)}\nexec env ${envAssignments} ${this.#appServerCommand.launchCommand}`;
   }
 
   async runTurn(
@@ -274,8 +343,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   #spawnProcess(onEvent?: (event: RunnerEvent) => void | Promise<void>): void {
-    const workspacePath = requireLocalWorkspacePath(
-      this.#runSession,
+    const workspacePath = this.#requireWorkspacePathHint(
       "Codex app-server runner",
     );
     if (
@@ -292,21 +360,22 @@ export class CodexAppServerSession implements LiveRunnerSession {
       this.#loggedDroppedArgs = true;
     }
 
-    const child = spawn("bash", ["-lc", this.#appServerCommand.launchCommand], {
-      cwd: workspacePath,
-      env: {
-        ...process.env,
-        ...this.#config.env,
-        SYMPHONY_ISSUE_ID: this.#runSession.issue.id,
-        SYMPHONY_ISSUE_IDENTIFIER: this.#runSession.issue.identifier,
-        SYMPHONY_ISSUE_NUMBER: String(this.#runSession.issue.number),
-        SYMPHONY_RUN_ATTEMPT: String(this.#runSession.attempt.sequence),
-        SYMPHONY_BRANCH_NAME: this.#runSession.workspace.branchName,
-        SYMPHONY_WORKSPACE_PATH: workspacePath,
-        SYMPHONY_RUN_SESSION_ID: this.#runSession.id,
-      },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    const child =
+      this.#runSession.workspace.target.kind === "remote"
+        ? this.#spawnRemoteProcess(workspacePath)
+        : spawn("bash", ["-lc", this.#appServerCommand.launchCommand], {
+            cwd: workspacePath,
+            env: {
+              ...process.env,
+              ...createRunnerEnvironment(
+                this.#runSession,
+                1,
+                workspacePath,
+                this.#config.env,
+              ),
+            },
+            stdio: ["pipe", "pipe", "pipe"],
+          });
 
     this.#child = child;
     this.#appServerPid = child.pid ?? null;
@@ -441,8 +510,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
   }
 
   async #startThread(): Promise<void> {
-    const workspacePath = requireLocalWorkspacePath(
-      this.#runSession,
+    const workspacePath = this.#requireWorkspacePathHint(
       "Codex app-server thread startup",
     );
     const result = await this.#sendRequest({
@@ -494,8 +562,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
     }
 
     const startedAt = new Date().toISOString();
-    const workspacePath = requireLocalWorkspacePath(
-      this.#runSession,
+    const workspacePath = this.#requireWorkspacePathHint(
       "Codex app-server turn execution",
     );
     this.#sessionState = "starting-turn";

--- a/src/runner/codex-app-server-session.ts
+++ b/src/runner/codex-app-server-session.ts
@@ -4,7 +4,10 @@ import type { RunSession, RunTurn, RunUpdateEvent } from "../domain/run.js";
 import { getPreparedWorkspacePathHint } from "../domain/workspace.js";
 import type { AgentConfig, SshWorkerHostConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
-import { quoteShellToken } from "./local-command.js";
+import {
+  formatShellEnvironmentEntry,
+  quoteShellToken,
+} from "./local-command.js";
 import { buildSshRemoteCommand } from "./ssh-command.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
 import { createRunnerEnvironment } from "./run-environment.js";
@@ -200,7 +203,7 @@ export class CodexAppServerSession implements LiveRunnerSession {
       this.#config.env,
     );
     const envAssignments = Object.entries(env)
-      .map(([key, value]) => `${key}=${quoteShellToken(String(value))}`)
+      .map(([key, value]) => formatShellEnvironmentEntry(key, String(value)))
       .join(" ");
     return `set -euo pipefail\ncd ${quoteShellToken(workspacePath)}\nexec env ${envAssignments} ${this.#appServerCommand.launchCommand}`;
   }

--- a/src/runner/codex.ts
+++ b/src/runner/codex.ts
@@ -1,5 +1,5 @@
 import type { RunSession } from "../domain/run.js";
-import type { AgentConfig } from "../domain/workflow.js";
+import type { AgentConfig, SshWorkerHostConfig } from "../domain/workflow.js";
 import { RunnerError } from "../domain/errors.js";
 import type { Logger } from "../observability/logger.js";
 import type { TrackerToolService } from "../tracker/tool-service.js";
@@ -7,23 +7,25 @@ import { describeLocalRunnerBackend } from "./local-command.js";
 import { executeLocalRunnerCommand } from "./local-execution.js";
 import { CodexAppServerSession } from "./codex-app-server-session.js";
 import { RunnerDynamicToolExecutor } from "./dynamic-tool-executor.js";
-import { describeLocalRunnerSession } from "./local-session-description.js";
 import type {
   Runner,
   RunnerExecutionResult,
   RunnerRunOptions,
   RunnerSessionDescription,
 } from "./service.js";
+import { createRunnerTransportMetadata } from "./service.js";
 
 export class CodexRunner implements Runner {
   readonly #config: AgentConfig;
   readonly #logger: Logger;
   readonly #dynamicToolExecutor: RunnerDynamicToolExecutor;
+  readonly #remoteWorkerHost: SshWorkerHostConfig | null;
 
   constructor(
     config: AgentConfig,
     logger: Logger,
     trackerToolService: TrackerToolService | null = null,
+    remoteWorkerHost: SshWorkerHostConfig | null = null,
   ) {
     if (config.runner.kind !== "codex") {
       throw new RunnerError(
@@ -43,13 +45,38 @@ export class CodexRunner implements Runner {
     this.#dynamicToolExecutor = new RunnerDynamicToolExecutor(
       trackerToolService,
     );
+    this.#remoteWorkerHost = remoteWorkerHost;
   }
 
-  describeSession(_session: RunSession): RunnerSessionDescription {
-    return describeLocalRunnerSession(
-      this.#config.command,
-      "local-stdio-session",
-    );
+  describeSession(session: RunSession): RunnerSessionDescription {
+    const backend = describeLocalRunnerBackend(this.#config.command);
+    const remoteTransport =
+      session.workspace.target.kind === "remote"
+        ? {
+            kind: "remote-stdio-session" as const,
+            remoteSessionId: `${session.workspace.target.host}:${session.id}`,
+          }
+        : null;
+    return {
+      provider: backend.provider,
+      model: backend.model,
+      transport: createRunnerTransportMetadata(
+        remoteTransport?.kind ?? "local-stdio-session",
+        remoteTransport === null
+          ? {
+              canTerminateLocalProcess: true,
+            }
+          : {
+              canTerminateLocalProcess: true,
+              remoteSessionId: remoteTransport.remoteSessionId,
+            },
+      ),
+      backendSessionId: null,
+      backendThreadId: null,
+      latestTurnId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    };
   }
 
   startSession(session: RunSession): Promise<CodexAppServerSession> {
@@ -60,6 +87,7 @@ export class CodexRunner implements Runner {
           this.#logger,
           session,
           this.#dynamicToolExecutor,
+          this.#remoteWorkerHost,
         ),
       );
     } catch (error) {
@@ -71,6 +99,21 @@ export class CodexRunner implements Runner {
     session: RunSession,
     options?: RunnerRunOptions,
   ): Promise<RunnerExecutionResult> {
+    if (session.workspace.target.kind === "remote") {
+      const liveSession = await this.startSession(session);
+      try {
+        const result = await liveSession.runTurn(
+          {
+            prompt: session.prompt,
+            turnNumber: 1,
+          },
+          options,
+        );
+        return result;
+      } finally {
+        await liveSession.close();
+      }
+    }
     return await CodexRunner.executeCommand(this.#logger, this.#config, {
       command: this.#config.command,
       prompt: session.prompt,

--- a/src/runner/factory.ts
+++ b/src/runner/factory.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from "../domain/workflow.js";
+import type { AgentConfig, SshWorkerHostConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import type { TrackerToolService } from "../tracker/tool-service.js";
 import { ClaudeCodeRunner } from "./claude-code.js";
@@ -10,6 +10,7 @@ export function createRunner(
   config: AgentConfig,
   logger: Logger,
   options?: {
+    readonly remoteWorkerHost?: SshWorkerHostConfig | null;
     readonly trackerToolService?: TrackerToolService | null;
   },
 ): Runner {
@@ -19,6 +20,7 @@ export function createRunner(
         config,
         logger,
         options?.trackerToolService ?? null,
+        options?.remoteWorkerHost ?? null,
       );
     case "generic-command":
       return new GenericCommandRunner(config, logger);

--- a/src/runner/local-command.ts
+++ b/src/runner/local-command.ts
@@ -146,3 +146,15 @@ export function quoteShellToken(token: string): string {
   }
   return `'${token.replace(/'/gu, `'\"'\"'`)}'`;
 }
+
+export function formatShellEnvironmentEntry(
+  key: string,
+  value: string,
+): string {
+  if (key.includes("=") || key.includes("\u0000")) {
+    throw new Error(
+      `Invalid environment variable name: ${JSON.stringify(key)}`,
+    );
+  }
+  return quoteShellToken(`${key}=${value}`);
+}

--- a/src/runner/local-execution.ts
+++ b/src/runner/local-execution.ts
@@ -7,6 +7,7 @@ import { getPreparedWorkspacePath } from "../domain/workspace.js";
 import type { AgentConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { parseRunUpdateEvent } from "./run-update-event.js";
+import { createRunnerEnvironment } from "./run-environment.js";
 import {
   RUNNER_SHUTDOWN_GRACE_MS,
   createRunnerTransportMetadata,
@@ -88,15 +89,12 @@ export async function executeLocalRunnerCommand(
       cwd: workspacePath,
       env: {
         ...process.env,
-        ...config.env,
-        SYMPHONY_ISSUE_ID: execution.session.issue.id,
-        SYMPHONY_ISSUE_IDENTIFIER: execution.session.issue.identifier,
-        SYMPHONY_ISSUE_NUMBER: String(execution.session.issue.number),
-        SYMPHONY_RUN_ATTEMPT: String(execution.session.attempt.sequence),
-        SYMPHONY_RUN_TURN: String(execution.turnNumber),
-        SYMPHONY_BRANCH_NAME: execution.session.workspace.branchName,
-        SYMPHONY_WORKSPACE_PATH: workspacePath,
-        SYMPHONY_RUN_SESSION_ID: execution.session.id,
+        ...createRunnerEnvironment(
+          execution.session,
+          execution.turnNumber,
+          workspacePath,
+          config.env,
+        ),
       },
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/src/runner/run-environment.ts
+++ b/src/runner/run-environment.ts
@@ -1,0 +1,20 @@
+import type { RunSession } from "../domain/run.js";
+
+export function createRunnerEnvironment(
+  session: RunSession,
+  turnNumber: number,
+  workspacePath: string,
+  env: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> {
+  return {
+    ...env,
+    SYMPHONY_ISSUE_ID: session.issue.id,
+    SYMPHONY_ISSUE_IDENTIFIER: session.issue.identifier,
+    SYMPHONY_ISSUE_NUMBER: String(session.issue.number),
+    SYMPHONY_RUN_ATTEMPT: String(session.attempt.sequence),
+    SYMPHONY_RUN_TURN: String(turnNumber),
+    SYMPHONY_BRANCH_NAME: session.workspace.branchName,
+    SYMPHONY_WORKSPACE_PATH: workspacePath,
+    SYMPHONY_RUN_SESSION_ID: session.id,
+  };
+}

--- a/src/runner/ssh-command.ts
+++ b/src/runner/ssh-command.ts
@@ -1,0 +1,6 @@
+import { quoteShellToken } from "./local-command.js";
+
+export function buildSshRemoteCommand(args: readonly string[]): string {
+  return args.map((arg) => quoteShellToken(arg)).join(" ");
+}
+

--- a/src/runner/ssh-command.ts
+++ b/src/runner/ssh-command.ts
@@ -3,4 +3,3 @@ import { quoteShellToken } from "./local-command.js";
 export function buildSshRemoteCommand(args: readonly string[]): string {
   return args.map((arg) => quoteShellToken(arg)).join(" ");
 }
-

--- a/src/workspace/remote-ssh.ts
+++ b/src/workspace/remote-ssh.ts
@@ -1,0 +1,290 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { WorkspaceError } from "../domain/errors.js";
+import type {
+  PreparedWorkspace,
+  WorkspaceCleanupResult,
+  WorkspacePreparationRequest,
+  WorkspaceSource,
+} from "../domain/workspace.js";
+import {
+  createConfiguredWorkspaceSource,
+  getWorkspaceSourceLocation,
+} from "../domain/workspace.js";
+import type {
+  SshWorkerHostConfig,
+  WorkspaceConfig,
+} from "../domain/workflow.js";
+import type { Logger } from "../observability/logger.js";
+import { quoteShellToken } from "../runner/local-command.js";
+import type { WorkspaceManager } from "./service.js";
+
+const execFileAsync = promisify(execFile);
+
+function sanitize(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function renderRemotePath(workerHost: SshWorkerHostConfig, workspacePath: string): string {
+  return `${workerHost.name}:${workspacePath}`;
+}
+
+function buildSshArgs(workerHost: SshWorkerHostConfig, command: string): string[] {
+  return [
+    ...workerHost.sshOptions,
+    workerHost.sshDestination,
+    "bash",
+    "-lc",
+    command,
+  ];
+}
+
+async function runRemoteCommand(
+  workerHost: SshWorkerHostConfig,
+  command: string,
+): Promise<void> {
+  try {
+    await execFileAsync(
+      workerHost.sshExecutable,
+      buildSshArgs(workerHost, command),
+    );
+  } catch (error) {
+    throw new WorkspaceError(
+      `SSH command failed on worker host '${workerHost.name}'`,
+      {
+        cause: error as Error,
+      },
+    );
+  }
+}
+
+function buildPrepareWorkspaceCommand(input: {
+  readonly workspacePath: string;
+  readonly branchName: string;
+  readonly sourceLocation: string;
+  readonly afterCreate: readonly string[];
+}): string {
+  const workspacePath = quoteShellToken(input.workspacePath);
+  const workspaceRoot = quoteShellToken(path.dirname(input.workspacePath));
+  const branchName = quoteShellToken(input.branchName);
+  const sourceLocation = quoteShellToken(input.sourceLocation);
+  const afterCreate =
+    input.afterCreate.length === 0
+      ? ""
+      : `${input.afterCreate.join("\n")}\n`;
+
+  return `set -euo pipefail
+workspace_path=${workspacePath}
+workspace_root=${workspaceRoot}
+branch_name=${branchName}
+source_location=${sourceLocation}
+
+mkdir -p "$workspace_root"
+
+if [ ! -d "$workspace_path/.git" ]; then
+  git clone "$source_location" "$workspace_path"
+  cd "$workspace_path"
+${afterCreate}fi
+
+cd "$workspace_path"
+git fetch origin
+git remote set-head origin --auto >/dev/null 2>&1 || true
+
+default_branch=""
+if branch_ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
+  case "$branch_ref" in
+    origin/*)
+      default_branch="\${branch_ref#origin/}"
+      ;;
+  esac
+fi
+
+if [ -z "$default_branch" ]; then
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    default_branch=main
+  elif git show-ref --verify --quiet refs/remotes/origin/master; then
+    default_branch=master
+  else
+    printf '%s\\n' "Could not resolve the default branch for origin in $workspace_path. Expected refs/remotes/origin/HEAD or a known fallback branch." >&2
+    exit 1
+  fi
+fi
+
+default_branch_ref="origin/$default_branch"
+has_local_branch=0
+has_remote_branch=0
+if git branch --list "$branch_name" | grep -q .; then
+  has_local_branch=1
+fi
+if git branch --remotes --list "origin/$branch_name" | grep -q .; then
+  has_remote_branch=1
+fi
+
+if [ "$has_remote_branch" -eq 1 ]; then
+  git checkout -B "$branch_name"
+  git reset --hard "origin/$branch_name"
+else
+  git checkout -B "$default_branch" "$default_branch_ref"
+  git reset --hard "$default_branch_ref"
+  if [ "$has_local_branch" -eq 1 ]; then
+    git checkout "$branch_name"
+    git reset --hard "$default_branch_ref"
+  else
+    git checkout -b "$branch_name"
+  fi
+fi
+`;
+}
+
+function buildCleanupWorkspaceCommand(workspacePath: string): string {
+  return `set -euo pipefail
+workspace_path=${quoteShellToken(workspacePath)}
+if [ -e "$workspace_path" ]; then
+  rm -rf "$workspace_path"
+  printf 'deleted\\n'
+else
+  printf 'already-absent\\n'
+fi
+`;
+}
+
+export class RemoteSshWorkspaceManager implements WorkspaceManager {
+  readonly #config: WorkspaceConfig;
+  readonly #workerHost: SshWorkerHostConfig;
+  readonly #afterCreate: readonly string[];
+  readonly #logger: Logger;
+  readonly #sourceOverride: WorkspaceSource | null;
+
+  constructor(
+    config: WorkspaceConfig,
+    workerHost: SshWorkerHostConfig,
+    afterCreate: readonly string[],
+    logger: Logger,
+    sourceOverride?: WorkspaceSource | null,
+  ) {
+    this.#config = config;
+    this.#workerHost = workerHost;
+    this.#afterCreate = afterCreate;
+    this.#logger = logger;
+    this.#sourceOverride = sourceOverride ?? null;
+  }
+
+  async prepareWorkspace(
+    request: WorkspacePreparationRequest,
+  ): Promise<PreparedWorkspace> {
+    const issue = request.issue;
+    const branchName = `${this.#config.branchPrefix}${issue.number}`;
+    const workspacePath = this.#workspacePathForIssue(issue.identifier);
+    const effectiveSource =
+      this.#resolveWorkspaceSource(request.sourceOverride) ??
+      createConfiguredWorkspaceSource(this.#config.repoUrl);
+    const sourceLocation = getWorkspaceSourceLocation(effectiveSource);
+
+    await runRemoteCommand(
+      this.#workerHost,
+      buildPrepareWorkspaceCommand({
+        workspacePath,
+        branchName,
+        sourceLocation,
+        afterCreate: this.#afterCreate,
+      }),
+    );
+
+    this.#logger.info("Remote workspace ready", {
+      workerHost: this.#workerHost.name,
+      workspacePath,
+      issueIdentifier: issue.identifier,
+      branchName,
+      workspaceSourceKind: effectiveSource.kind,
+      workspaceSourceLocation: sourceLocation,
+    });
+
+    return {
+      key: sanitize(issue.identifier),
+      branchName,
+      createdNow: false,
+      source: effectiveSource,
+      target: {
+        kind: "remote",
+        host: this.#workerHost.name,
+        workspaceId: `${this.#workerHost.name}:${sanitize(issue.identifier)}`,
+        pathHint: workspacePath,
+      },
+    };
+  }
+
+  async cleanupWorkspace(
+    workspace: PreparedWorkspace,
+  ): Promise<WorkspaceCleanupResult> {
+    const workspacePath =
+      workspace.target.kind === "remote"
+        ? workspace.target.pathHint ?? null
+        : null;
+    if (workspacePath === null) {
+      throw new WorkspaceError(
+        "Remote SSH workspace cleanup requires a remote workspace target with pathHint",
+      );
+    }
+    const result = await execFileAsync(
+      this.#workerHost.sshExecutable,
+      buildSshArgs(
+        this.#workerHost,
+        buildCleanupWorkspaceCommand(workspacePath),
+      ),
+    );
+    const kind = result.stdout.trim() === "deleted" ? "deleted" : "already-absent";
+    return {
+      kind,
+      workspacePath: renderRemotePath(this.#workerHost, workspacePath),
+    };
+  }
+
+  async cleanupWorkspaceForIssue(
+    request: WorkspacePreparationRequest,
+  ): Promise<WorkspaceCleanupResult> {
+    return await this.cleanupWorkspace({
+      key: sanitize(request.issue.identifier),
+      branchName: `${this.#config.branchPrefix}${request.issue.number}`,
+      createdNow: false,
+      source:
+        this.#resolveWorkspaceSource(request.sourceOverride) ??
+        createConfiguredWorkspaceSource(this.#config.repoUrl),
+      target: {
+        kind: "remote",
+        host: this.#workerHost.name,
+        workspaceId: `${this.#workerHost.name}:${sanitize(request.issue.identifier)}`,
+        pathHint: this.#workspacePathForIssue(request.issue.identifier),
+      },
+    });
+  }
+
+  #resolveWorkspaceSource(
+    sourceOverride?: WorkspaceSource | null,
+  ): WorkspaceSource | null {
+    const source =
+      sourceOverride ?? this.#sourceOverride ?? createConfiguredWorkspaceSource(this.#config.repoUrl);
+    if (source.kind === "configured-repo") {
+      return source;
+    }
+    if (
+      source.kind === "remote-path" &&
+      source.host === this.#workerHost.name
+    ) {
+      return source;
+    }
+    this.#logger.warn("Ignoring local-only workspace source override for remote SSH workspace", {
+      workerHost: this.#workerHost.name,
+      sourceKind: source.kind,
+      sourceLocation: getWorkspaceSourceLocation(source),
+    });
+    return createConfiguredWorkspaceSource(this.#config.repoUrl);
+  }
+
+  #workspacePathForIssue(issueIdentifier: string): string {
+    return path.posix.join(
+      this.#workerHost.workspaceRoot,
+      sanitize(issueIdentifier),
+    );
+  }
+}

--- a/src/workspace/remote-ssh.ts
+++ b/src/workspace/remote-ssh.ts
@@ -18,6 +18,7 @@ import type {
 } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
 import { quoteShellToken } from "../runner/local-command.js";
+import { buildSshRemoteCommand } from "../runner/ssh-command.js";
 import type { WorkspaceManager } from "./service.js";
 
 const execFileAsync = promisify(execFile);
@@ -40,9 +41,7 @@ function buildSshArgs(
   return [
     ...workerHost.sshOptions,
     workerHost.sshDestination,
-    "bash",
-    "-lc",
-    command,
+    buildSshRemoteCommand(["bash", "-lc", command]),
   ];
 }
 

--- a/src/workspace/remote-ssh.ts
+++ b/src/workspace/remote-ssh.ts
@@ -26,11 +26,17 @@ function sanitize(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
-function renderRemotePath(workerHost: SshWorkerHostConfig, workspacePath: string): string {
+function renderRemotePath(
+  workerHost: SshWorkerHostConfig,
+  workspacePath: string,
+): string {
   return `${workerHost.name}:${workspacePath}`;
 }
 
-function buildSshArgs(workerHost: SshWorkerHostConfig, command: string): string[] {
+function buildSshArgs(
+  workerHost: SshWorkerHostConfig,
+  command: string,
+): string[] {
   return [
     ...workerHost.sshOptions,
     workerHost.sshDestination,
@@ -70,9 +76,7 @@ function buildPrepareWorkspaceCommand(input: {
   const branchName = quoteShellToken(input.branchName);
   const sourceLocation = quoteShellToken(input.sourceLocation);
   const afterCreate =
-    input.afterCreate.length === 0
-      ? ""
-      : `${input.afterCreate.join("\n")}\n`;
+    input.afterCreate.length === 0 ? "" : `${input.afterCreate.join("\n")}\n`;
 
   return `set -euo pipefail
 workspace_path=${workspacePath}
@@ -219,7 +223,7 @@ export class RemoteSshWorkspaceManager implements WorkspaceManager {
   ): Promise<WorkspaceCleanupResult> {
     const workspacePath =
       workspace.target.kind === "remote"
-        ? workspace.target.pathHint ?? null
+        ? (workspace.target.pathHint ?? null)
         : null;
     if (workspacePath === null) {
       throw new WorkspaceError(
@@ -233,7 +237,8 @@ export class RemoteSshWorkspaceManager implements WorkspaceManager {
         buildCleanupWorkspaceCommand(workspacePath),
       ),
     );
-    const kind = result.stdout.trim() === "deleted" ? "deleted" : "already-absent";
+    const kind =
+      result.stdout.trim() === "deleted" ? "deleted" : "already-absent";
     return {
       kind,
       workspacePath: renderRemotePath(this.#workerHost, workspacePath),
@@ -263,7 +268,9 @@ export class RemoteSshWorkspaceManager implements WorkspaceManager {
     sourceOverride?: WorkspaceSource | null,
   ): WorkspaceSource | null {
     const source =
-      sourceOverride ?? this.#sourceOverride ?? createConfiguredWorkspaceSource(this.#config.repoUrl);
+      sourceOverride ??
+      this.#sourceOverride ??
+      createConfiguredWorkspaceSource(this.#config.repoUrl);
     if (source.kind === "configured-repo") {
       return source;
     }
@@ -273,11 +280,14 @@ export class RemoteSshWorkspaceManager implements WorkspaceManager {
     ) {
       return source;
     }
-    this.#logger.warn("Ignoring local-only workspace source override for remote SSH workspace", {
-      workerHost: this.#workerHost.name,
-      sourceKind: source.kind,
-      sourceLocation: getWorkspaceSourceLocation(source),
-    });
+    this.#logger.warn(
+      "Ignoring local-only workspace source override for remote SSH workspace",
+      {
+        workerHost: this.#workerHost.name,
+        sourceKind: source.kind,
+        sourceLocation: getWorkspaceSourceLocation(source),
+      },
+    );
     return createConfiguredWorkspaceSource(this.#config.repoUrl);
   }
 

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -421,9 +421,10 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     const fakeCodex = await createFakeCodexExecutable();
     const fakeSsh = await createFakeSshExecutable();
     const remoteWorkspaceRoot = path.join(tempDir, "remote-workers");
+    process.env["GIT_SSH"] = fakeSsh;
     const workflowPath = await writeWorkflow({
       rootDir: tempDir,
-      remotePath: `file://${remotePath}`,
+      remotePath: `builder@example.test:${remotePath}`,
       apiUrl: server.baseUrl,
       runnerKind: "codex",
       agentCommand: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`,

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -6,6 +6,7 @@ import {
   createPromptBuilder,
   loadWorkflow,
 } from "../../src/config/workflow.js";
+import { getCodexRemoteWorkerHost } from "../../src/domain/workflow.js";
 import {
   deriveIssueArtifactPaths,
   readIssueArtifactAttempt,
@@ -23,6 +24,7 @@ import { createTracker } from "../../src/tracker/factory.js";
 import { createTrackerToolService } from "../../src/tracker/tool-service.js";
 import { parsePlanReadyCommentMetadata } from "../../src/tracker/plan-review-comment.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
+import { RemoteSshWorkspaceManager } from "../../src/workspace/remote-ssh.js";
 import {
   countRemoteBranchCommits,
   createSeedRemote,
@@ -32,6 +34,8 @@ import {
 import { MockGitHubServer } from "../support/mock-github-server.js";
 import { waitForExit } from "../support/process.js";
 import { StatusDashboard } from "../../src/observability/tui.js";
+import { createFakeCodexExecutable } from "../support/fake-codex.js";
+import { createFakeSshExecutable } from "../support/fake-ssh.js";
 
 const originalEnv = { ...process.env };
 
@@ -44,10 +48,19 @@ async function writeWorkflow(options: {
   runnerKind?: "codex" | "generic-command" | "claude-code";
   runnerProvider?: string;
   runnerModel?: string;
+  agentEnv?: Readonly<Record<string, string>>;
   retryBackoffMs?: number;
   maxAttempts?: number;
   maxTurns?: number;
   maxConcurrentRuns?: number;
+  remoteWorkerHost?:
+    | {
+        readonly name: string;
+        readonly sshDestination: string;
+        readonly sshExecutable: string;
+        readonly workspaceRoot: string;
+      }
+    | undefined;
   watchdog?:
     | {
         readonly enabled: boolean;
@@ -58,6 +71,28 @@ async function writeWorkflow(options: {
     | undefined;
 }): Promise<string> {
   const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
+  const workerHostsBlock =
+    options.remoteWorkerHost === undefined
+      ? ""
+      : `  worker_hosts:
+    ${options.remoteWorkerHost.name}:
+      ssh_destination: ${options.remoteWorkerHost.sshDestination}
+      ssh_executable: ${options.remoteWorkerHost.sshExecutable}
+      workspace_root: ${options.remoteWorkerHost.workspaceRoot}
+`;
+  const remoteExecutionBlock =
+    options.remoteWorkerHost === undefined
+      ? ""
+      : `    remote_execution:
+      kind: ssh
+      worker_host: ${options.remoteWorkerHost.name}
+`;
+  const agentEnvBlock =
+    Object.entries(options.agentEnv ?? {}).length === 0
+      ? "    {}\n"
+      : Object.entries(options.agentEnv ?? {})
+          .map(([key, value]) => `    ${key}: ${JSON.stringify(value)}\n`)
+          .join("");
   await fs.writeFile(
     workflowPath,
     `---
@@ -93,29 +128,28 @@ workspace:
   repo_url: ${options.remotePath}
   branch_prefix: symphony/
   cleanup_on_success: true
-hooks:
+${workerHostsBlock}hooks:
   after_create: []
 agent:
   runner:
     kind: ${options.runnerKind ?? "generic-command"}
-${
-  options.runnerProvider === undefined
-    ? ""
-    : `    provider: ${options.runnerProvider}
+${remoteExecutionBlock}${
+      options.runnerProvider === undefined
+        ? ""
+        : `    provider: ${options.runnerProvider}
 `
-}
-${
-  options.runnerModel === undefined
-    ? ""
-    : `    model: ${options.runnerModel}
+    }${
+      options.runnerModel === undefined
+        ? ""
+        : `    model: ${options.runnerModel}
 `
-}
+    }
   command: ${options.agentCommand}
   prompt_transport: stdin
   timeout_ms: 30000
   max_turns: ${options.maxTurns ?? 3}
-  env: {}
----
+  env:
+${agentEnvBlock}---
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 Issue summary: {{ issue.summary }}
 {% if pull_request %}
@@ -147,12 +181,22 @@ async function createOrchestrator(
   const logger = new JsonLogger();
   const promptBuilder = createPromptBuilder(workflow);
   const tracker = createTracker(workflow.config.tracker, logger);
-  const workspace = new LocalWorkspaceManager(
-    workflow.config.workspace,
-    workflow.config.hooks.afterCreate,
-    logger,
-  );
+  const remoteWorkerHost = getCodexRemoteWorkerHost(workflow.config);
+  const workspace =
+    remoteWorkerHost === null
+      ? new LocalWorkspaceManager(
+          workflow.config.workspace,
+          workflow.config.hooks.afterCreate,
+          logger,
+        )
+      : new RemoteSshWorkspaceManager(
+          workflow.config.workspace,
+          remoteWorkerHost,
+          workflow.config.hooks.afterCreate,
+          logger,
+        );
   const runner = createRunner(workflow.config.agent, logger, {
+    remoteWorkerHost,
     trackerToolService: createTrackerToolService(
       tracker,
       workflow.config.tracker,
@@ -364,6 +408,85 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       "IMPLEMENTED.txt",
     );
     expect(implemented).toContain("sociotechnica-org/symphony-ts#1");
+  });
+
+  it("runs a Codex app-server session over SSH and publishes remote execution identity", async () => {
+    server.seedIssue({
+      number: 7,
+      title: "Remote Codex execution",
+      body: "Use the SSH worker host",
+      labels: ["symphony:ready"],
+    });
+
+    const fakeCodex = await createFakeCodexExecutable();
+    const fakeSsh = await createFakeSshExecutable();
+    const remoteWorkspaceRoot = path.join(tempDir, "remote-workers");
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath: `file://${remotePath}`,
+      apiUrl: server.baseUrl,
+      runnerKind: "codex",
+      agentCommand: `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`,
+      remoteWorkerHost: {
+        name: "builder",
+        sshDestination: "builder@example.test",
+        sshExecutable: fakeSsh,
+        workspaceRoot: remoteWorkspaceRoot,
+      },
+      agentEnv: {
+        FAKE_CODEX_AGENT_COMMAND: path.resolve(
+          "tests/fixtures/fake-agent-success-unique.sh",
+        ),
+      },
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.activeIssues[0]).toMatchObject({
+      workspacePath: path.join(
+        remoteWorkspaceRoot,
+        "sociotechnica-org_symphony-ts_7",
+      ),
+      executionOwner: {
+        transport: {
+          kind: "remote-stdio-session",
+          remoteSessionId: expect.stringContaining(
+            "builder:sociotechnica-org/symphony-ts#7/attempt-1",
+          ),
+        },
+        endpoint: {
+          workspaceTargetKind: "remote",
+          workspaceHost: "builder",
+          workspaceId: "builder:sociotechnica-org_symphony-ts_7",
+        },
+      },
+    });
+
+    const summary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      7,
+    );
+    const session = await readIssueArtifactSession(
+      path.join(tempDir, ".tmp", "workspaces"),
+      7,
+      summary.latestSessionId!,
+    );
+    expect(session.transport).toMatchObject({
+      kind: "remote-stdio-session",
+      remoteSessionId: expect.stringContaining(
+        "builder:sociotechnica-org/symphony-ts#7/attempt-1",
+      ),
+    });
+    expect(session.executionOwner?.endpoint).toMatchObject({
+      workspaceTargetKind: "remote",
+      workspaceHost: "builder",
+      workspaceId: "builder:sociotechnica-org_symphony-ts_7",
+    });
+    expect(await countRemoteBranchCommits(remotePath, "symphony/7")).toBe(1);
   });
 
   it("records configured provider and model metadata for generic command runs", async () => {

--- a/tests/e2e/linear-factory.test.ts
+++ b/tests/e2e/linear-factory.test.ts
@@ -5,6 +5,7 @@ import {
   createPromptBuilder,
   loadWorkflow,
 } from "../../src/config/workflow.js";
+import { getCodexRemoteWorkerHost } from "../../src/domain/workflow.js";
 import {
   readIssueArtifactSummary,
   readIssueArtifactEvents,
@@ -16,6 +17,7 @@ import { createRunner } from "../../src/runner/factory.js";
 import { createTracker } from "../../src/tracker/factory.js";
 import { createTrackerToolService } from "../../src/tracker/tool-service.js";
 import { LocalWorkspaceManager } from "../../src/workspace/local.js";
+import { RemoteSshWorkspaceManager } from "../../src/workspace/remote-ssh.js";
 import {
   countRemoteBranchCommits,
   createSeedRemote,
@@ -84,12 +86,22 @@ async function createOrchestrator(
   const logger = new JsonLogger();
   const promptBuilder = createPromptBuilder(workflow);
   const tracker = createTracker(workflow.config.tracker, logger);
-  const workspace = new LocalWorkspaceManager(
-    workflow.config.workspace,
-    workflow.config.hooks.afterCreate,
-    logger,
-  );
+  const remoteWorkerHost = getCodexRemoteWorkerHost(workflow.config);
+  const workspace =
+    remoteWorkerHost === null
+      ? new LocalWorkspaceManager(
+          workflow.config.workspace,
+          workflow.config.hooks.afterCreate,
+          logger,
+        )
+      : new RemoteSshWorkspaceManager(
+          workflow.config.workspace,
+          remoteWorkerHost,
+          workflow.config.hooks.afterCreate,
+          logger,
+        );
   const runner = createRunner(workflow.config.agent, logger, {
+    remoteWorkerHost,
     trackerToolService: createTrackerToolService(
       tracker,
       workflow.config.tracker,

--- a/tests/support/fake-codex.ts
+++ b/tests/support/fake-codex.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createTempDir } from "./git.js";
+
+export async function createFakeCodexExecutable(): Promise<string> {
+  const dir = await createTempDir("fake-codex-");
+  const executablePath = path.join(dir, "codex");
+  await fs.writeFile(
+    executablePath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+const readline = require("node:readline");
+
+const logFile = process.env.FAKE_CODEX_LOG_FILE ?? null;
+const agentCommand = process.env.FAKE_CODEX_AGENT_COMMAND ?? null;
+let turnCount = 0;
+const threadId = "thread-1";
+
+function log(entry) {
+  if (!logFile) return;
+  fs.appendFileSync(logFile, JSON.stringify(entry) + "\\n");
+}
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+if (process.argv[2] !== "app-server") {
+  process.stderr.write("unexpected command: " + process.argv.slice(2).join(" "));
+  process.exit(1);
+}
+
+process.on("SIGTERM", () => {
+  process.exit(0);
+});
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let payload;
+  try {
+    payload = JSON.parse(line);
+  } catch (error) {
+    process.stderr.write(String(error));
+    process.exit(1);
+  }
+  log(payload);
+
+  if (payload.method === "initialize") {
+    send({ id: payload.id, result: { userAgent: "fake-codex" } });
+    return;
+  }
+
+  if (payload.method === "initialized") {
+    return;
+  }
+
+  if (payload.method === "thread/start") {
+    send({
+      id: payload.id,
+      result: {
+        approvalPolicy: "never",
+        cwd: process.cwd(),
+        model: "gpt-5.4",
+        modelProvider: "openai",
+        sandbox: { type: "dangerFullAccess" },
+        thread: { id: threadId },
+      },
+    });
+    return;
+  }
+
+  if (payload.method === "turn/start") {
+    turnCount += 1;
+    const turnId = "turn-" + String(turnCount);
+    send({ id: payload.id, result: { turn: { id: turnId } } });
+    send({
+      method: "turn/started",
+      params: {
+        threadId,
+        turn: { id: turnId },
+      },
+    });
+
+    const complete = (code, stderr) => {
+      if (code === 0) {
+        send({
+          method: "turn/completed",
+          params: {
+            threadId,
+            turn: { id: turnId },
+          },
+        });
+        return;
+      }
+      send({
+        method: "turn/failed",
+        params: {
+          threadId,
+          turn: { id: turnId },
+          message: stderr || "fake codex agent command failed",
+        },
+      });
+    };
+
+    if (!agentCommand) {
+      complete(0, "");
+      return;
+    }
+
+    const child = spawn("bash", ["-lc", agentCommand], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end(
+      JSON.stringify(payload.params?.input ?? []) + "\\n",
+      "utf8",
+    );
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("exit", (code) => {
+      complete(code ?? 1, stderr.trim());
+    });
+    return;
+  }
+});
+`,
+    "utf8",
+  );
+  await fs.chmod(executablePath, 0o755);
+  return executablePath;
+}

--- a/tests/support/fake-ssh.ts
+++ b/tests/support/fake-ssh.ts
@@ -11,7 +11,44 @@ export async function createFakeSshExecutable(): Promise<string> {
 const { spawn } = require("node:child_process");
 
 const args = process.argv.slice(2);
-let destinationIndex = args.findIndex((arg) => !arg.startsWith("-"));
+const optionsWithValues = new Set([
+  "-B",
+  "-b",
+  "-c",
+  "-D",
+  "-E",
+  "-e",
+  "-F",
+  "-I",
+  "-i",
+  "-J",
+  "-L",
+  "-l",
+  "-m",
+  "-O",
+  "-o",
+  "-p",
+  "-Q",
+  "-R",
+  "-S",
+  "-W",
+  "-w",
+]);
+let destinationIndex = -1;
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  if (arg === "--") {
+    destinationIndex = index + 1;
+    break;
+  }
+  if (!arg.startsWith("-")) {
+    destinationIndex = index;
+    break;
+  }
+  if (optionsWithValues.has(arg)) {
+    index += 1;
+  }
+}
 if (destinationIndex < 0) {
   process.stderr.write("fake ssh expected a destination\\n");
   process.exit(1);

--- a/tests/support/fake-ssh.ts
+++ b/tests/support/fake-ssh.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createTempDir } from "./git.js";
+
+export async function createFakeSshExecutable(): Promise<string> {
+  const dir = await createTempDir("fake-ssh-");
+  const executablePath = path.join(dir, "ssh");
+  await fs.writeFile(
+    executablePath,
+    `#!/usr/bin/env node
+const { spawn } = require("node:child_process");
+
+const args = process.argv.slice(2);
+let destinationIndex = args.findIndex((arg) => !arg.startsWith("-"));
+if (destinationIndex < 0) {
+  process.stderr.write("fake ssh expected a destination\\n");
+  process.exit(1);
+}
+const commandArgs = args.slice(destinationIndex + 1);
+if (commandArgs.length === 0) {
+  process.stderr.write("fake ssh expected a remote command\\n");
+  process.exit(1);
+}
+
+const child = spawn(commandArgs[0], commandArgs.slice(1), {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    FAKE_SSH_DESTINATION: args[destinationIndex],
+  },
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+`,
+    "utf8",
+  );
+  await fs.chmod(executablePath, 0o755);
+  return executablePath;
+}

--- a/tests/support/fake-ssh.ts
+++ b/tests/support/fake-ssh.ts
@@ -22,7 +22,7 @@ if (commandArgs.length === 0) {
   process.exit(1);
 }
 
-const child = spawn(commandArgs[0], commandArgs.slice(1), {
+const child = spawn("sh", ["-lc", commandArgs.join(" ")], {
   stdio: "inherit",
   env: {
     ...process.env,

--- a/tests/unit/codex-remote-runner.test.ts
+++ b/tests/unit/codex-remote-runner.test.ts
@@ -76,7 +76,9 @@ describe("CodexRunner remote SSH transport", () => {
     const remoteDir = await createTempDir("codex-remote-workspace-");
     const session = createSession(remoteDir);
     const runner = new CodexRunner(
-      createConfig(`${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`),
+      createConfig(
+        `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`,
+      ),
       new JsonLogger(),
       null,
       {
@@ -112,7 +114,8 @@ describe("CodexRunner remote SSH transport", () => {
         createRunnerTransportMetadata("remote-stdio-session", {
           localProcessPid: spawnedPid,
           canTerminateLocalProcess: true,
-          remoteSessionId: "builder:sociotechnica-org/symphony-ts#187/attempt-1",
+          remoteSessionId:
+            "builder:sociotechnica-org/symphony-ts#187/attempt-1",
         }),
       );
       expect(turn.session.backendThreadId).toBe("thread-1");

--- a/tests/unit/codex-remote-runner.test.ts
+++ b/tests/unit/codex-remote-runner.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { RunSession } from "../../src/domain/run.js";
+import { createConfiguredWorkspaceSource } from "../../src/domain/workspace.js";
+import type { AgentConfig } from "../../src/domain/workflow.js";
+import { JsonLogger } from "../../src/observability/logger.js";
+import { CodexRunner } from "../../src/runner/codex.js";
+import { createRunnerTransportMetadata } from "../../src/runner/service.js";
+import { createFakeCodexExecutable } from "../support/fake-codex.js";
+import { createFakeSshExecutable } from "../support/fake-ssh.js";
+import { createTempDir } from "../support/git.js";
+
+function createSession(remotePath: string): RunSession {
+  return {
+    id: "sociotechnica-org/symphony-ts#187/attempt-1",
+    issue: {
+      id: "187",
+      identifier: "sociotechnica-org/symphony-ts#187",
+      number: 187,
+      title: "Remote Codex over SSH",
+      description: "",
+      labels: [],
+      state: "open",
+      url: "https://example.test/issues/187",
+      createdAt: "2026-03-19T12:00:00.000Z",
+      updatedAt: "2026-03-19T12:00:00.000Z",
+    },
+    workspace: {
+      key: "sociotechnica-org_symphony-ts_187",
+      branchName: "symphony/187",
+      createdNow: false,
+      source: createConfiguredWorkspaceSource("git@example.test:repo.git"),
+      target: {
+        kind: "remote",
+        host: "builder",
+        workspaceId: "builder:sociotechnica-org_symphony-ts_187",
+        pathHint: remotePath,
+      },
+    },
+    prompt: "Implement the remote transport",
+    startedAt: "2026-03-19T12:00:00.000Z",
+    attempt: {
+      sequence: 1,
+    },
+  };
+}
+
+function createConfig(command: string): AgentConfig {
+  return {
+    runner: {
+      kind: "codex",
+      remoteExecution: {
+        kind: "ssh",
+        workerHostName: "builder",
+        workerHost: {
+          name: "builder",
+          sshDestination: "builder@example.test",
+          sshExecutable: "/tmp/fake-ssh",
+          sshOptions: [],
+          workspaceRoot: "/tmp/remote-workspaces",
+        },
+      },
+    },
+    command,
+    promptTransport: "stdin",
+    timeoutMs: 5_000,
+    maxTurns: 2,
+    env: {},
+  };
+}
+
+describe("CodexRunner remote SSH transport", () => {
+  it("starts Codex app-server over SSH stdio and reports remote transport metadata", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const fakeSsh = await createFakeSshExecutable();
+    const remoteDir = await createTempDir("codex-remote-workspace-");
+    const session = createSession(remoteDir);
+    const runner = new CodexRunner(
+      createConfig(`${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`),
+      new JsonLogger(),
+      null,
+      {
+        name: "builder",
+        sshDestination: "builder@example.test",
+        sshExecutable: fakeSsh,
+        sshOptions: [],
+        workspaceRoot: "/tmp/remote-workspaces",
+      },
+    );
+
+    const liveSession = await runner.startSession(session);
+    let spawnedPid = -1;
+
+    try {
+      const turn = await liveSession.runTurn(
+        {
+          turnNumber: 1,
+          prompt: "first",
+        },
+        {
+          onEvent(event) {
+            if (event.kind === "spawned") {
+              spawnedPid = event.transport.localProcess?.pid ?? -1;
+            }
+          },
+          onUpdate() {},
+        },
+      );
+
+      expect(spawnedPid).toBeGreaterThan(0);
+      expect(turn.session.transport).toEqual(
+        createRunnerTransportMetadata("remote-stdio-session", {
+          localProcessPid: spawnedPid,
+          canTerminateLocalProcess: true,
+          remoteSessionId: "builder:sociotechnica-org/symphony-ts#187/attempt-1",
+        }),
+      );
+      expect(turn.session.backendThreadId).toBe("thread-1");
+      expect(turn.session.latestTurnId).toBe("turn-1");
+      expect(turn.session.backendSessionId).toBe("thread-1-turn-1");
+    } finally {
+      await liveSession.close();
+      await fs.rm(remoteDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/codex-remote-runner.test.ts
+++ b/tests/unit/codex-remote-runner.test.ts
@@ -45,7 +45,10 @@ function createSession(remotePath: string): RunSession {
   };
 }
 
-function createConfig(command: string): AgentConfig {
+function createConfig(
+  command: string,
+  env: Readonly<Record<string, string>> = {},
+): AgentConfig {
   return {
     runner: {
       kind: "codex",
@@ -65,7 +68,7 @@ function createConfig(command: string): AgentConfig {
     promptTransport: "stdin",
     timeoutMs: 5_000,
     maxTurns: 2,
-    env: {},
+    env,
   };
 }
 
@@ -121,6 +124,52 @@ describe("CodexRunner remote SSH transport", () => {
       expect(turn.session.backendThreadId).toBe("thread-1");
       expect(turn.session.latestTurnId).toBe("turn-1");
       expect(turn.session.backendSessionId).toBe("thread-1-turn-1");
+    } finally {
+      await liveSession.close();
+      await fs.rm(remoteDir, { recursive: true, force: true });
+    }
+  });
+
+  it("quotes full remote env entries so keys with spaces survive the SSH shell", async () => {
+    const fakeCodex = await createFakeCodexExecutable();
+    const fakeSsh = await createFakeSshExecutable();
+    const remoteDir = await createTempDir("codex-remote-env-workspace-");
+    const session = createSession(remoteDir);
+    const runner = new CodexRunner(
+      createConfig(
+        `${fakeCodex} exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -`,
+        {
+          "MY VAR": "hello remote env",
+          FAKE_CODEX_AGENT_COMMAND:
+            'node -e \'if (process.env["MY VAR"] !== "hello remote env") { console.error("missing spaced env key"); process.exit(1); }\'',
+        },
+      ),
+      new JsonLogger(),
+      null,
+      {
+        name: "builder",
+        sshDestination: "builder@example.test",
+        sshExecutable: fakeSsh,
+        sshOptions: [],
+        workspaceRoot: "/tmp/remote-workspaces",
+      },
+    );
+
+    const liveSession = await runner.startSession(session);
+
+    try {
+      const turn = await liveSession.runTurn(
+        {
+          turnNumber: 1,
+          prompt: "first",
+        },
+        {
+          onUpdate() {},
+        },
+      );
+
+      expect(turn.exitCode).toBe(0);
+      expect(turn.stderr).toBe("");
     } finally {
       await liveSession.close();
       await fs.rm(remoteDir, { recursive: true, force: true });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -1832,4 +1832,117 @@ ${buildSharedWorkflowSections()}`,
       "Expected non-empty string array for tracker.active_states",
     );
   });
+
+  it("loads explicit SSH remote Codex execution config", async () => {
+    const dir = await createTempDir("workflow-remote-codex-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  worker_hosts:
+    builder:
+      ssh_destination: symphony@example.test
+      ssh_executable: /tmp/fake-ssh
+      ssh_options:
+        - -p
+        - "2222"
+      workspace_root: /srv/symphony/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+    remote_execution:
+      kind: ssh
+      worker_host: builder
+  command: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.4 -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.agent.runner.kind).toBe("codex");
+    if (workflow.config.agent.runner.kind !== "codex") {
+      throw new Error("expected codex runner config");
+    }
+    expect(workflow.config.agent.runner.remoteExecution).toEqual({
+      kind: "ssh",
+      workerHostName: "builder",
+      workerHost: {
+        name: "builder",
+        sshDestination: "symphony@example.test",
+        sshExecutable: "/tmp/fake-ssh",
+        sshOptions: ["-p", "2222"],
+        workspaceRoot: "/srv/symphony/workspaces",
+      },
+    });
+  });
+
+  it("rejects local workspace sources for SSH remote Codex execution", async () => {
+    const dir = await createTempDir("workflow-remote-codex-invalid-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: ../repo
+  branch_prefix: symphony/
+  worker_hosts:
+    builder:
+      ssh_destination: symphony@example.test
+      workspace_root: /srv/symphony/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+    remote_execution:
+      kind: ssh
+      worker_host: builder
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      /workspace.repo_url must be a remote clone URL/,
+    );
+  });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -1945,4 +1945,52 @@ agent:
       /workspace.repo_url must be a remote clone URL/,
     );
   });
+
+  it("rejects file URLs for SSH remote Codex execution", async () => {
+    const dir = await createTempDir("workflow-remote-codex-file-url-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+workspace:
+  root: ./.tmp/ws
+  repo_url: file:///tmp/repo.git
+  branch_prefix: symphony/
+  worker_hosts:
+    builder:
+      ssh_destination: symphony@example.test
+      workspace_root: /srv/symphony/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+    remote_execution:
+      kind: ssh
+      worker_host: builder
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      /workspace.repo_url must be a remote clone URL/,
+    );
+  });
 });

--- a/tests/unit/workspace-remote-ssh.test.ts
+++ b/tests/unit/workspace-remote-ssh.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { JsonLogger } from "../../src/observability/logger.js";
+import { RemoteSshWorkspaceManager } from "../../src/workspace/remote-ssh.js";
+import {
+  commitAllFiles,
+  createSeedRemote,
+  createTempDir,
+} from "../support/git.js";
+import { createFakeSshExecutable } from "../support/fake-ssh.js";
+
+const execFile = promisify(execFileCallback);
+
+function createIssue(number: number) {
+  return {
+    id: String(number),
+    identifier: `repo#${number.toString()}`,
+    number,
+    title: `Issue ${number.toString()}`,
+    description: "desc",
+    labels: [],
+    state: "open" as const,
+    url: `https://example.test/issues/${number.toString()}`,
+    createdAt: "2026-03-19T12:00:00.000Z",
+    updatedAt: "2026-03-19T12:00:00.000Z",
+  };
+}
+
+describe("RemoteSshWorkspaceManager", () => {
+  it("prepares and cleans up a remote issue workspace over SSH", async () => {
+    const tempDir = await createTempDir("workspace-remote-ssh-");
+    const remote = await createSeedRemote();
+    const fakeSsh = await createFakeSshExecutable();
+    const logger = new JsonLogger();
+    const remoteRoot = path.join(tempDir, "remote-root");
+    const manager = new RemoteSshWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remote.remotePath,
+        branchPrefix: "symphony/",
+        retention: {
+          onSuccess: "retain",
+          onFailure: "retain",
+        },
+      },
+      {
+        name: "builder",
+        sshDestination: "builder@example.test",
+        sshExecutable: fakeSsh,
+        sshOptions: [],
+        workspaceRoot: remoteRoot,
+      },
+      [],
+      logger,
+    );
+
+    try {
+      const prepared = await manager.prepareWorkspace({
+        issue: createIssue(17),
+      });
+      expect(prepared.target).toEqual({
+        kind: "remote",
+        host: "builder",
+        workspaceId: "builder:repo_17",
+        pathHint: path.join(remoteRoot, "repo_17"),
+      });
+      const currentBranch = await execFile(
+        "git",
+        ["symbolic-ref", "--short", "HEAD"],
+        { cwd: path.join(remoteRoot, "repo_17") },
+      );
+      expect(currentBranch.stdout.trim()).toBe("symphony/17");
+
+      await fs.writeFile(
+        path.join(remote.seedPath, "README.md"),
+        "# remote ssh update\n",
+        "utf8",
+      );
+      await commitAllFiles(remote.seedPath, "update remote ssh seed");
+      await execFile("git", ["push", "origin", "HEAD"], {
+        cwd: remote.seedPath,
+      });
+
+      await manager.prepareWorkspace({
+        issue: createIssue(17),
+      });
+      const readme = await fs.readFile(
+        path.join(remoteRoot, "repo_17", "README.md"),
+        "utf8",
+      );
+      expect(readme).toContain("remote ssh update");
+
+      const cleanup = await manager.cleanupWorkspace(prepared);
+      expect(cleanup).toEqual({
+        kind: "deleted",
+        workspacePath: `builder:${path.join(remoteRoot, "repo_17")}`,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add SSH-backed remote workspace preparation and Codex app-server stdio execution
- validate and wire remote worker host workflow config through the CLI, runner factory, and observability surfaces
- cover the new path with unit tests and bootstrap e2e coverage using fake ssh/codex fixtures

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

## Review
- Manual self-review completed via git diff and targeted test reruns
- No separate reliable local review tool was available in this workspace

Closes #187
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
