### PR TITLE
Add GitHub Projects queue priority adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ tracker:
   failed_label: symphony:failed
   queue_priority:
     enabled: true
+    project_number: 12
+    field_name: Priority
+    option_rank_map:
+      P0: 0
+      P1: 1
 
 polling:
   interval_ms: 30000
@@ -246,10 +251,12 @@ agent:
 ```
 
 `tracker.queue_priority` reserves a tracker-boundary contract for normalized
-ready-work ordering metadata. In this slice it only enables the config seam and
-normalized `issue.queuePriority` field; current GitHub and Linear adapters do
-not populate tracker-native priority yet, so missing or unset priority still
-falls back to deterministic issue-number ordering.
+ready-work ordering metadata. For GitHub, Symphony can read one configured
+Projects V2 field, normalize supported values into `issue.queuePriority`, and
+keep missing, unset, unmapped, or unsupported project data as `null` so ready
+work still falls back to deterministic issue-number ordering. The current
+GitHub slice supports integer number fields directly plus single-select or text
+fields when `option_rank_map` provides the rank mapping.
 
 When multiple remote Codex worker hosts are configured, Symphony selects a host
 at dispatch time, keeps continuation turns on that same host, and prefers the

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -13,10 +13,14 @@ tracker:
     - greptile-apps
     - cursor
     - devin-ai-integration
-  # Optional tracker-owned ready-work ordering seam. Current adapters keep
-  # `issue.queuePriority` null until provider-specific mapping lands.
+  # Optional tracker-owned ready-work ordering seam.
   # queue_priority:
   #   enabled: true
+  #   project_number: 12
+  #   field_name: Priority
+  #   option_rank_map:
+  #     P0: 0
+  #     P1: 1
 polling:
   interval_ms: 30000
   max_concurrent_runs: 1

--- a/docs/plans/193-github-projects-queue-priority-adapter/plan.md
+++ b/docs/plans/193-github-projects-queue-priority-adapter/plan.md
@@ -135,16 +135,16 @@ Not applicable for this slice. The issue changes tracker-boundary transport and 
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected behavior |
-| --- | --- | --- | --- |
-| GitHub queue-priority config is absent | resolved tracker config | none | keep current behavior; GitHub issues normalize with `queuePriority: null` |
-| GitHub queue-priority config is malformed | workflow path and raw front matter | none | fail workflow loading with a field-specific config error |
-| Issue is not on the configured project or has no matching project item field value | resolved GitHub config, issue number | issue present, project field absent | normalize to `queuePriority: null`; issue remains eligible |
-| Project field value is present but empty/unset | resolved GitHub config, issue number | project field resolves to null/empty | normalize to `queuePriority: null` |
-| Project field value type is unsupported for this seam | GraphQL payload shape | raw GitHub field metadata only inside tracker | fail or discard at the GitHub normalization boundary according to the documented supported types; do not leak raw payload upward |
-| Project field value cannot be mapped to a stable numeric rank | configured mapping facts plus raw option/text value | no valid normalized priority | normalize to `queuePriority: null` and log/test the fallback contract |
-| Multiple ready issues have valid GitHub-derived priorities | normalized issues | populated `queuePriority` values | existing comparator/order helpers can consume the normalized values without GitHub-specific knowledge |
-| GitHub project GraphQL request fails | request error, repo/project config | no updated queue priority data | surface a tracker error for the fetch rather than silently inventing stale priority facts |
+| Observed condition                                                                 | Local facts available                               | Normalized tracker facts available            | Expected behavior                                                                                                                |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub queue-priority config is absent                                             | resolved tracker config                             | none                                          | keep current behavior; GitHub issues normalize with `queuePriority: null`                                                        |
+| GitHub queue-priority config is malformed                                          | workflow path and raw front matter                  | none                                          | fail workflow loading with a field-specific config error                                                                         |
+| Issue is not on the configured project or has no matching project item field value | resolved GitHub config, issue number                | issue present, project field absent           | normalize to `queuePriority: null`; issue remains eligible                                                                       |
+| Project field value is present but empty/unset                                     | resolved GitHub config, issue number                | project field resolves to null/empty          | normalize to `queuePriority: null`                                                                                               |
+| Project field value type is unsupported for this seam                              | GraphQL payload shape                               | raw GitHub field metadata only inside tracker | fail or discard at the GitHub normalization boundary according to the documented supported types; do not leak raw payload upward |
+| Project field value cannot be mapped to a stable numeric rank                      | configured mapping facts plus raw option/text value | no valid normalized priority                  | normalize to `queuePriority: null` and log/test the fallback contract                                                            |
+| Multiple ready issues have valid GitHub-derived priorities                         | normalized issues                                   | populated `queuePriority` values              | existing comparator/order helpers can consume the normalized values without GitHub-specific knowledge                            |
+| GitHub project GraphQL request fails                                               | request error, repo/project config                  | no updated queue priority data                | surface a tracker error for the fetch rather than silently inventing stale priority facts                                        |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/193-github-projects-queue-priority-adapter/plan.md
+++ b/docs/plans/193-github-projects-queue-priority-adapter/plan.md
@@ -1,0 +1,225 @@
+# Issue 193 Plan: GitHub Projects Adapter For Tracker-Native Queue Priority
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a GitHub tracker adapter seam that reads a configured GitHub Projects V2 field, normalizes that field into Symphony's tracker-neutral `issue.queuePriority` contract, and keeps GitHub Projects schema details contained inside the tracker boundary.
+
+## Scope
+
+- extend GitHub tracker config so operators can opt into queue-priority mapping from one GitHub Projects V2 field
+- add GitHub client transport for reading the configured project item field values needed by ready-issue normalization
+- add GitHub-only normalization that converts the configured field value into the existing `QueuePriority` contract
+- populate normalized `queuePriority` on GitHub `RuntimeIssue` values returned by ready/running/failed issue reads and direct issue fetches
+- add GitHub adapter tests with a mock server that exercises configured, missing, and unusable project-field data
+- document the GitHub configuration seam and fallback behavior
+
+## Non-goals
+
+- changing orchestrator dispatch order in this issue
+- changing the tracker-neutral `QueuePriority` contract from issue `#192`
+- adding Linear queue-priority transport or normalization
+- exposing raw GitHub Projects field IDs, option IDs, or GraphQL payloads outside the tracker boundary
+- redesigning status surfaces or reports beyond any minimal contract-preserving assertions
+- broad GitHub tracker refactors unrelated to queue-priority transport and normalization
+
+## Current Gaps
+
+- `QueuePriorityConfig` only exposes `enabled`, so the GitHub adapter has no repo-owned config for which project field to read
+- `src/tracker/github-client.ts` normalizes REST issue payloads directly to `queuePriority: null`, so GitHub cannot project tracker-native priority today
+- the GitHub adapter has no transport seam for fetching Projects V2 item field values associated with an issue
+- there is no GitHub-specific normalization helper that converts project field values into the tracker-neutral rank/label contract while rejecting provider-specific leakage upward
+- the mock GitHub harness does not currently simulate Projects V2 field queries, so CI cannot prove this feature without real network calls
+
+## Decision Notes
+
+- Keep the config repo-owned and explicit. The operator should name the project field to read instead of relying on implicit board conventions.
+- Keep GitHub project transport and normalization adjacent but separated: GraphQL transport in `github-client`, field-to-contract normalization in a focused helper/module, orchestration unchanged.
+- Preserve the tracker-neutral runtime contract from `#192`; GitHub-specific IDs and option shapes must terminate at the tracker boundary.
+- Missing, unconfigured, or unusable project data must degrade to `queuePriority: null` so current ready-work behavior remains backward-compatible until ordering work lands.
+- This issue should stay one PR by limiting the slice to GitHub config, transport, normalization, tests, and docs.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: defining GitHub queue-priority as one way to populate the existing normalized ordering hint
+  - belongs: documenting fallback semantics when project data is absent or unusable
+  - does not belong: orchestrator queue ordering changes or GitHub GraphQL details in repo-wide policy
+- Configuration Layer
+  - belongs: typed GitHub queue-priority config for project/field selection and validation
+  - does not belong: live GitHub API calls or hidden defaults derived from tracker payloads
+- Coordination Layer
+  - belongs: no behavioral changes in this slice beyond continuing to consume normalized `RuntimeIssue`
+  - does not belong: GitHub Projects queries or field parsing
+- Execution Layer
+  - belongs: no changes
+  - does not belong: tracker-native priority metadata
+- Integration Layer
+  - belongs: GitHub transport for Projects V2 field reads, normalization into `QueuePriority`, and adapter-owned fallback behavior
+  - does not belong: leaking raw project schema or option payloads into `src/domain/` or `src/orchestrator/`
+- Observability Layer
+  - belongs: tests and docs that keep normalized queue-priority facts inspectable for future projection
+  - does not belong: a broader status/report redesign in this slice
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts`
+  - extend GitHub queue-priority config to carry the GitHub-specific selection data needed by the adapter
+  - keep the generic `enabled` seam intact while scoping provider-specific fields to GitHub config only
+- `src/config/workflow.ts`
+  - parse and validate the optional GitHub queue-priority config shape
+  - fail clearly on malformed GitHub config before runtime polling starts
+- `src/tracker/github-client.ts`
+  - add GitHub transport for fetching project item field values and thread that data into normalized issue building
+  - keep GraphQL query details and pagination inside the client
+- new focused GitHub normalization helper(s)
+  - map GitHub project field values into `QueuePriority`
+  - reject malformed or unsupported GitHub field payloads at the integration boundary
+- `tests/support/mock-github-server.ts`
+  - simulate the GitHub Projects data needed by the client and normalization tests
+- GitHub unit/integration tests plus docs
+
+### Does not belong in this issue
+
+- orchestrator ordering changes
+- Linear adapter changes
+- a generic cross-tracker project-field framework
+- status/TUI/report projection work
+- mixing GitHub transport, normalization, plan-review policy, and PR lifecycle logic into one hot file
+
+## Layering Notes
+
+- `config/workflow`
+  - owns parsing and validation of GitHub queue-priority config
+  - does not inspect live issue or project payloads
+- `tracker`
+  - owns GitHub transport, GitHub normalization, and fallback to `queuePriority: null`
+  - does not require the orchestrator to know what a GitHub Project item or field option is
+- `workspace`
+  - untouched
+  - does not carry tracker queue metadata
+- `runner`
+  - untouched
+  - does not participate in GitHub project reads
+- `orchestrator`
+  - untouched in behavior
+  - continues to consume normalized issues only
+- `observability`
+  - may rely on normalized `queuePriority` later
+  - is not the source of truth for GitHub project semantics
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR by keeping the change at the GitHub tracker edge:
+
+1. extend GitHub config with explicit queue-priority field selection
+2. add GitHub client transport for the required Projects V2 field facts
+3. normalize those facts into `issue.queuePriority`
+4. prove the seam with mock-backed tests and small doc updates
+
+This avoids combining:
+
+- orchestrator dispatch policy
+- Linear work
+- broader observability changes
+- unrelated GitHub lifecycle or plan-review behavior
+
+## Runtime State Model
+
+Not applicable for this slice. The issue changes tracker-boundary transport and normalization, not retries, continuations, reconciliation, leases, or handoff states.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected behavior |
+| --- | --- | --- | --- |
+| GitHub queue-priority config is absent | resolved tracker config | none | keep current behavior; GitHub issues normalize with `queuePriority: null` |
+| GitHub queue-priority config is malformed | workflow path and raw front matter | none | fail workflow loading with a field-specific config error |
+| Issue is not on the configured project or has no matching project item field value | resolved GitHub config, issue number | issue present, project field absent | normalize to `queuePriority: null`; issue remains eligible |
+| Project field value is present but empty/unset | resolved GitHub config, issue number | project field resolves to null/empty | normalize to `queuePriority: null` |
+| Project field value type is unsupported for this seam | GraphQL payload shape | raw GitHub field metadata only inside tracker | fail or discard at the GitHub normalization boundary according to the documented supported types; do not leak raw payload upward |
+| Project field value cannot be mapped to a stable numeric rank | configured mapping facts plus raw option/text value | no valid normalized priority | normalize to `queuePriority: null` and log/test the fallback contract |
+| Multiple ready issues have valid GitHub-derived priorities | normalized issues | populated `queuePriority` values | existing comparator/order helpers can consume the normalized values without GitHub-specific knowledge |
+| GitHub project GraphQL request fails | request error, repo/project config | no updated queue priority data | surface a tracker error for the fetch rather than silently inventing stale priority facts |
+
+## Storage / Persistence Contract
+
+- no new durable local storage
+- GitHub project field values remain adapter-local transport facts
+- only the normalized `issue.queuePriority` contract crosses into the runtime domain
+- existing issue snapshots, status payloads, and reports remain unchanged unless they already carry normalized issue data
+
+## Observability Requirements
+
+- config validation errors must identify the malformed `tracker.queue_priority` field
+- tests should lock in the fallback behavior for missing or unusable GitHub project data
+- structured logging should stay sufficient to diagnose GitHub transport failures without exposing raw project-schema details to higher layers
+
+## Implementation Steps
+
+1. Extend the GitHub queue-priority workflow config shape in `src/domain/workflow.ts` and `src/config/workflow.ts` with the minimal GitHub-specific selection fields needed for this adapter slice.
+2. Add focused GitHub field-normalization helpers that convert supported project field values into `QueuePriority`.
+3. Add GitHub client GraphQL transport for reading the configured Projects V2 field values associated with issues returned by the adapter.
+4. Thread the fetched field facts into GitHub issue normalization so `fetchReadyIssues()`, `fetchRunningIssues()`, `fetchFailedIssues()`, and `getIssue()` populate `queuePriority` when configured.
+5. Extend the mock GitHub server to serve the required Projects V2 responses and failure cases.
+6. Add unit coverage for:
+   - valid and invalid GitHub queue-priority config
+   - supported GitHub field normalization paths
+   - fallback to `null` for missing, empty, or unusable field values
+7. Add integration coverage proving the GitHub tracker returns normalized queue priority from mock project data without changing the rest of the issue contract.
+8. Update `README.md` and `WORKFLOW.md` comments with the GitHub configuration seam and fallback semantics.
+9. Run local self-review plus repo checks before opening the PR.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- workflow parsing accepts omitted GitHub queue-priority config
+- workflow parsing accepts valid GitHub queue-priority config and rejects malformed fields with field-specific errors
+- GitHub field normalization converts supported project values into stable `rank` and `label` facts
+- GitHub field normalization falls back to `null` for missing/unset/unusable values without leaking raw schema upward
+
+### Integration
+
+- mock-backed GitHub client/tracker tests return `queuePriority` for issues whose configured project field is populated
+- GitHub issue reads still return `queuePriority: null` when queue-priority config is omitted
+- GitHub issue reads degrade cleanly when the issue lacks a configured project item or field value
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- local self-review when a reliable review tool is available
+
+## Acceptance Scenarios
+
+1. Given a GitHub tracker config with queue priority disabled or omitted, GitHub issues continue to normalize with `queuePriority: null`.
+2. Given a GitHub tracker config that names a supported project field and an issue whose project item has a mapped value, `fetchReadyIssues()` returns that issue with populated normalized queue priority.
+3. Given a configured issue whose GitHub project field is missing or unset, the issue remains readable and normalizes to `queuePriority: null`.
+4. Given malformed GitHub queue-priority config, workflow loading fails before polling with a clear config error.
+5. Given GitHub-derived normalized priorities on returned issues, the existing queue-priority comparator can order them without any GitHub-specific input.
+
+## Exit Criteria
+
+- GitHub tracker config can opt into one project-field-based queue-priority source with explicit validation
+- GitHub adapter transport and normalization populate tracker-neutral `issue.queuePriority` when configured
+- missing or unusable GitHub project data degrades to `queuePriority: null`
+- tests cover supported normalization and fallback paths using the mock GitHub harness
+- the PR stays limited to the GitHub tracker boundary and docs/tests required to support it
+
+## Deferred To Later Issues Or PRs
+
+- orchestrator queue ordering changes that actively prioritize ready work by `queuePriority`
+- richer GitHub support for additional project-field shapes beyond the first supported seam if needed
+- Linear adapter population of the same normalized contract
+- status/report/TUI projection changes centered on queue priority
+- any cross-tracker policy that combines queue priority with dispatch pressure, retries, or other orchestration signals
+
+## Revision Log
+
+- 2026-03-19: Initial draft created for issue `#193` and marked `plan-ready`.

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -14,6 +14,7 @@ import type {
   AgentRunnerConfig,
   CodexRemoteExecutionConfig,
   GitHubCompatibleTrackerConfig,
+  GitHubQueuePriorityConfig,
   LinearTrackerConfig,
   ObservabilityConfig,
   PromptBuilder,
@@ -140,6 +141,17 @@ function requireNumber(value: unknown, field: string): number {
   return value;
 }
 
+function requireInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new ConfigError(`Expected integer for ${field}`);
+  }
+  const number = value;
+  if (!Number.isSafeInteger(number)) {
+    throw new ConfigError(`Expected integer for ${field}`);
+  }
+  return number;
+}
+
 function requireBoolean(value: unknown, field: string): boolean {
   if (typeof value !== "boolean") {
     throw new ConfigError(`Expected boolean for ${field}`);
@@ -202,6 +214,28 @@ function requireNonEmptyStringArray(
     throw new ConfigError(`Expected non-empty string array for ${field}`);
   }
   return items;
+}
+
+function requireNumberRecord(
+  value: unknown,
+  field: string,
+): Readonly<Record<string, number>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigError(`Expected object for ${field}`);
+  }
+
+  const record: Record<string, number> = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (key.trim() === "") {
+      throw new ConfigError(`Expected non-empty string key for ${field}`);
+    }
+    const rank = requireInteger(rawValue, `${field}.${key}`);
+    record[key] = rank;
+  }
+  return record;
 }
 
 function normalizeSecretValue(value: string | null | undefined): string | null {
@@ -893,6 +927,39 @@ function resolveQueuePriorityConfig(
   };
 }
 
+function resolveGitHubQueuePriorityConfig(
+  value: unknown,
+  field: string,
+): GitHubQueuePriorityConfig | undefined {
+  const config = resolveQueuePriorityConfig(value, field);
+  if (config === undefined) {
+    return undefined;
+  }
+
+  const rawConfig = value as Record<string, unknown>;
+  if (!config.enabled) {
+    return {
+      enabled: false,
+    };
+  }
+
+  return {
+    enabled: true,
+    projectNumber: requireInteger(
+      rawConfig["project_number"],
+      `${field}.project_number`,
+    ),
+    fieldName: requireString(rawConfig["field_name"], `${field}.field_name`),
+    optionRankMap:
+      rawConfig["option_rank_map"] === undefined
+        ? undefined
+        : requireNumberRecord(
+            rawConfig["option_rank_map"],
+            `${field}.option_rank_map`,
+          ),
+  };
+}
+
 function resolveTrackerKind(
   tracker: Readonly<Record<string, unknown>>,
 ): TrackerConfig["kind"] {
@@ -942,7 +1009,7 @@ function resolveGitHubTrackerConfig<
             tracker["review_bot_logins"],
             "tracker.review_bot_logins",
           ),
-    queuePriority: resolveQueuePriorityConfig(
+    queuePriority: resolveGitHubQueuePriorityConfig(
       tracker["queue_priority"],
       "tracker.queue_priority",
     ),

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -5,6 +5,12 @@ export interface QueuePriorityConfig {
   readonly enabled: boolean;
 }
 
+export interface GitHubQueuePriorityConfig extends QueuePriorityConfig {
+  readonly projectNumber?: number | undefined;
+  readonly fieldName?: string | undefined;
+  readonly optionRankMap?: Readonly<Record<string, number>> | undefined;
+}
+
 export interface WatchdogConfig {
   readonly enabled: boolean;
   readonly checkIntervalMs: number;
@@ -25,7 +31,7 @@ interface BaseGitHubTrackerConfig {
   readonly failedLabel: string;
   readonly successComment: string;
   readonly reviewBotLogins: readonly string[];
-  readonly queuePriority?: QueuePriorityConfig | undefined;
+  readonly queuePriority?: GitHubQueuePriorityConfig | undefined;
 }
 
 export interface GitHubTrackerConfig extends BaseGitHubTrackerConfig {

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -1,13 +1,17 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { TrackerError } from "../domain/errors.js";
-import type { RuntimeIssue } from "../domain/issue.js";
+import type { QueuePriority, RuntimeIssue } from "../domain/issue.js";
 import type {
   PullRequestCheck,
   PullRequestCheckStatus,
 } from "../domain/pull-request.js";
 import type { GitHubCompatibleTrackerConfig } from "../domain/workflow.js";
 import type { Logger } from "../observability/logger.js";
+import {
+  normalizeGitHubQueuePriority,
+  type GitHubProjectFieldValue,
+} from "./github-queue-priority.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -90,6 +94,57 @@ interface GraphQlResponse<T> {
   readonly data?: T;
   readonly errors?: ReadonlyArray<{ readonly message: string }>;
 }
+
+interface ProjectQueuePriorityFieldPageResponse {
+  readonly repository: {
+    readonly owner:
+      | {
+          readonly projectV2: {
+            readonly items: {
+              readonly nodes: ReadonlyArray<{
+                readonly content:
+                  | {
+                      readonly __typename: "Issue";
+                      readonly number: number;
+                      readonly repository: {
+                        readonly nameWithOwner: string;
+                      };
+                    }
+                  | {
+                      readonly __typename: string;
+                    }
+                  | null;
+                readonly fieldValueByName:
+                  | ProjectQueuePriorityFieldValueResponse;
+              }>;
+              readonly pageInfo: {
+                readonly hasNextPage: boolean;
+                readonly endCursor: string | null;
+              };
+            };
+          } | null;
+        }
+      | null;
+  } | null;
+}
+
+type ProjectQueuePriorityFieldValueResponse =
+  | {
+      readonly __typename: "ProjectV2ItemFieldNumberValue";
+      readonly number: number | null;
+    }
+  | {
+      readonly __typename: "ProjectV2ItemFieldSingleSelectValue";
+      readonly name: string | null;
+    }
+  | {
+      readonly __typename: "ProjectV2ItemFieldTextValue";
+      readonly text: string | null;
+    }
+  | {
+      readonly __typename: string;
+    }
+  | null;
 
 interface PullRequestReviewCommentsConnection {
   readonly nodes: Array<{
@@ -286,6 +341,88 @@ const RESOLVE_REVIEW_THREAD_MUTATION = `
   }
 `;
 
+const PROJECT_QUEUE_PRIORITY_FIELD_QUERY = `
+  query ProjectQueuePriorityFieldValues(
+    $owner: String!,
+    $repo: String!,
+    $projectNumber: Int!,
+    $fieldName: String!,
+    $after: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      owner {
+        __typename
+        ... on Organization {
+          projectV2(number: $projectNumber) {
+            items(first: 100, after: $after) {
+              nodes {
+                content {
+                  __typename
+                  ... on Issue {
+                    number
+                    repository {
+                      nameWithOwner
+                    }
+                  }
+                }
+                fieldValueByName(name: $fieldName) {
+                  __typename
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                  }
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+        ... on User {
+          projectV2(number: $projectNumber) {
+            items(first: 100, after: $after) {
+              nodes {
+                content {
+                  __typename
+                  ... on Issue {
+                    number
+                    repository {
+                      nameWithOwner
+                    }
+                  }
+                }
+                fieldValueByName(name: $fieldName) {
+                  __typename
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                  }
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 function paginationInfo(
   pageInfo:
     | {
@@ -371,6 +508,7 @@ async function resolveToken(): Promise<string> {
 export function toRuntimeIssue(
   issue: GitHubIssueResponse,
   repo: string,
+  queuePriority: QueuePriority | null = null,
 ): RuntimeIssue {
   return {
     id: String(issue.number),
@@ -383,7 +521,7 @@ export function toRuntimeIssue(
     url: issue.html_url,
     createdAt: issue.created_at,
     updatedAt: issue.updated_at,
-    queuePriority: null,
+    queuePriority,
   };
 }
 
@@ -448,7 +586,7 @@ export class GitHubClient {
       "GET",
       this.#issuePath(`issues?state=open&labels=${encodeURIComponent(label)}`),
     );
-    return issues.map((issue) => toRuntimeIssue(issue, this.#config.repo));
+    return this.#toRuntimeIssues(issues);
   }
 
   async getIssue(issueNumber: number): Promise<RuntimeIssue> {
@@ -456,7 +594,7 @@ export class GitHubClient {
       "GET",
       this.#issuePath(`issues/${issueNumber}`),
     );
-    return toRuntimeIssue(issue, this.#config.repo);
+    return await this.#toRuntimeIssue(issue);
   }
 
   async updateIssue(
@@ -468,7 +606,7 @@ export class GitHubClient {
       this.#issuePath(`issues/${issueNumber}`),
       body,
     );
-    return toRuntimeIssue(issue, this.#config.repo);
+    return await this.#toRuntimeIssue(issue);
   }
 
   async createComment(issueNumber: number, body: string): Promise<void> {
@@ -739,6 +877,96 @@ export class GitHubClient {
     );
   }
 
+  async #toRuntimeIssues(
+    issues: readonly GitHubIssueResponse[],
+  ): Promise<readonly RuntimeIssue[]> {
+    const queuePriorityByIssueNumber =
+      await this.#getQueuePriorityByIssueNumber();
+    return issues.map((issue) =>
+      toRuntimeIssue(
+        issue,
+        this.#config.repo,
+        queuePriorityByIssueNumber.get(issue.number) ?? null,
+      ),
+    );
+  }
+
+  async #toRuntimeIssue(issue: GitHubIssueResponse): Promise<RuntimeIssue> {
+    const queuePriorityByIssueNumber =
+      await this.#getQueuePriorityByIssueNumber();
+    return toRuntimeIssue(
+      issue,
+      this.#config.repo,
+      queuePriorityByIssueNumber.get(issue.number) ?? null,
+    );
+  }
+
+  async #getQueuePriorityByIssueNumber(): Promise<ReadonlyMap<number, QueuePriority>> {
+    if (this.#config.queuePriority?.enabled !== true) {
+      return new Map<number, QueuePriority>();
+    }
+
+    const projectNumber = this.#config.queuePriority.projectNumber;
+    const fieldName = this.#config.queuePriority.fieldName;
+    if (projectNumber === undefined || fieldName === undefined) {
+      throw new TrackerError(
+        "GitHub queue-priority config requires tracker.queue_priority.project_number and tracker.queue_priority.field_name when enabled",
+      );
+    }
+
+    const queuePriorities = new Map<number, QueuePriority>();
+    let after: string | null = null;
+
+    for (;;) {
+      const response: ProjectQueuePriorityFieldPageResponse =
+        await this.#graphqlRequest<ProjectQueuePriorityFieldPageResponse>(
+          PROJECT_QUEUE_PRIORITY_FIELD_QUERY,
+          {
+            owner: this.#repoOwner,
+            repo: this.#repoName,
+            projectNumber,
+            fieldName,
+            after,
+          },
+        );
+
+      const project: NonNullable<
+        NonNullable<
+          ProjectQueuePriorityFieldPageResponse["repository"]
+        >["owner"]
+      >["projectV2"] = response.repository?.owner?.projectV2 ?? null;
+      if (project === null) {
+        throw new TrackerError(
+          `GitHub project ${projectNumber.toString()} was not found for ${this.#config.repo}`,
+        );
+      }
+
+      for (const item of project.items.nodes) {
+        const issue = item.content;
+        if (!isProjectQueuePriorityIssueContent(issue)) {
+          continue;
+        }
+        if (issue.repository.nameWithOwner !== this.#config.repo) {
+          continue;
+        }
+
+        const queuePriority = normalizeGitHubQueuePriority(
+          toGitHubProjectFieldValue(item.fieldValueByName),
+          this.#config.queuePriority,
+        );
+        if (queuePriority !== null) {
+          queuePriorities.set(issue.number, queuePriority);
+        }
+      }
+
+      const pageInfo: typeof project.items.pageInfo = project.items.pageInfo;
+      if (!pageInfo.hasNextPage) {
+        return queuePriorities;
+      }
+      after = pageInfo.endCursor;
+    }
+  }
+
   async #graphqlRequest<T>(
     query: string,
     variables: Record<string, unknown>,
@@ -885,4 +1113,80 @@ export class GitHubClient {
       ? `/repos/${this.#config.repo}`
       : `/repos/${this.#config.repo}/${suffix}`;
   }
+}
+
+function toGitHubProjectFieldValue(
+  value: ProjectQueuePriorityFieldValueResponse,
+): GitHubProjectFieldValue | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (isProjectQueuePriorityNumberFieldValue(value)) {
+    return {
+      kind: "number",
+      value: value.number,
+    };
+  }
+  if (isProjectQueuePrioritySingleSelectFieldValue(value)) {
+    return {
+      kind: "single_select",
+      value: value.name,
+    };
+  }
+  if (isProjectQueuePriorityTextFieldValue(value)) {
+    return {
+      kind: "text",
+      value: value.text,
+    };
+  }
+
+  return {
+    kind: "unsupported",
+  };
+}
+
+function isProjectQueuePriorityIssueContent(
+  value: ProjectQueuePriorityFieldPageResponse["repository"] extends infer TRepository
+    ? TRepository extends { readonly owner: { readonly projectV2: { readonly items: { readonly nodes: ReadonlyArray<infer TNode> } } | null } | null } | null
+      ? TNode extends { readonly content: infer TContent }
+        ? TContent
+        : never
+      : never
+    : never,
+): value is {
+  readonly __typename: "Issue";
+  readonly number: number;
+  readonly repository: {
+    readonly nameWithOwner: string;
+  };
+} {
+  return value?.__typename === "Issue";
+}
+
+function isProjectQueuePriorityNumberFieldValue(
+  value: Exclude<ProjectQueuePriorityFieldValueResponse, null>,
+): value is {
+  readonly __typename: "ProjectV2ItemFieldNumberValue";
+  readonly number: number | null;
+} {
+  return value.__typename === "ProjectV2ItemFieldNumberValue";
+}
+
+function isProjectQueuePrioritySingleSelectFieldValue(
+  value: Exclude<ProjectQueuePriorityFieldValueResponse, null>,
+): value is {
+  readonly __typename: "ProjectV2ItemFieldSingleSelectValue";
+  readonly name: string | null;
+} {
+  return value.__typename === "ProjectV2ItemFieldSingleSelectValue";
+}
+
+function isProjectQueuePriorityTextFieldValue(
+  value: Exclude<ProjectQueuePriorityFieldValueResponse, null>,
+): value is {
+  readonly __typename: "ProjectV2ItemFieldTextValue";
+  readonly text: string | null;
+} {
+  return value.__typename === "ProjectV2ItemFieldTextValue";
 }

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -97,34 +97,31 @@ interface GraphQlResponse<T> {
 
 interface ProjectQueuePriorityFieldPageResponse {
   readonly repository: {
-    readonly owner:
-      | {
-          readonly projectV2: {
-            readonly items: {
-              readonly nodes: ReadonlyArray<{
-                readonly content:
-                  | {
-                      readonly __typename: "Issue";
-                      readonly number: number;
-                      readonly repository: {
-                        readonly nameWithOwner: string;
-                      };
-                    }
-                  | {
-                      readonly __typename: string;
-                    }
-                  | null;
-                readonly fieldValueByName:
-                  | ProjectQueuePriorityFieldValueResponse;
-              }>;
-              readonly pageInfo: {
-                readonly hasNextPage: boolean;
-                readonly endCursor: string | null;
-              };
-            };
-          } | null;
-        }
-      | null;
+    readonly owner: {
+      readonly projectV2: {
+        readonly items: {
+          readonly nodes: ReadonlyArray<{
+            readonly content:
+              | {
+                  readonly __typename: "Issue";
+                  readonly number: number;
+                  readonly repository: {
+                    readonly nameWithOwner: string;
+                  };
+                }
+              | {
+                  readonly __typename: string;
+                }
+              | null;
+            readonly fieldValueByName: ProjectQueuePriorityFieldValueResponse;
+          }>;
+          readonly pageInfo: {
+            readonly hasNextPage: boolean;
+            readonly endCursor: string | null;
+          };
+        };
+      } | null;
+    } | null;
   } | null;
 }
 
@@ -901,7 +898,9 @@ export class GitHubClient {
     );
   }
 
-  async #getQueuePriorityByIssueNumber(): Promise<ReadonlyMap<number, QueuePriority>> {
+  async #getQueuePriorityByIssueNumber(): Promise<
+    ReadonlyMap<number, QueuePriority>
+  > {
     if (this.#config.queuePriority?.enabled !== true) {
       return new Map<number, QueuePriority>();
     }
@@ -1148,7 +1147,13 @@ function toGitHubProjectFieldValue(
 
 function isProjectQueuePriorityIssueContent(
   value: ProjectQueuePriorityFieldPageResponse["repository"] extends infer TRepository
-    ? TRepository extends { readonly owner: { readonly projectV2: { readonly items: { readonly nodes: ReadonlyArray<infer TNode> } } | null } | null } | null
+    ? TRepository extends {
+        readonly owner: {
+          readonly projectV2: {
+            readonly items: { readonly nodes: ReadonlyArray<infer TNode> };
+          } | null;
+        } | null;
+      } | null
       ? TNode extends { readonly content: infer TContent }
         ? TContent
         : never

--- a/src/tracker/github-queue-priority.ts
+++ b/src/tracker/github-queue-priority.ts
@@ -1,0 +1,74 @@
+import type { QueuePriority } from "../domain/issue.js";
+import type { GitHubQueuePriorityConfig } from "../domain/workflow.js";
+
+export type GitHubProjectFieldValue =
+  | {
+      readonly kind: "number";
+      readonly value: number | null;
+    }
+  | {
+      readonly kind: "single_select";
+      readonly value: string | null;
+    }
+  | {
+      readonly kind: "text";
+      readonly value: string | null;
+    }
+  | {
+      readonly kind: "unsupported";
+    };
+
+export function normalizeGitHubQueuePriority(
+  value: GitHubProjectFieldValue | null,
+  config: GitHubQueuePriorityConfig | undefined,
+): QueuePriority | null {
+  if (config?.enabled !== true || value === null) {
+    return null;
+  }
+
+  switch (value.kind) {
+    case "number":
+      return normalizeNumericPriority(value.value);
+    case "single_select":
+    case "text":
+      return normalizeMappedPriority(value.value, config.optionRankMap);
+    case "unsupported":
+      return null;
+    default:
+      return exhaustiveGitHubProjectFieldValue(value);
+  }
+}
+
+function normalizeNumericPriority(value: number | null): QueuePriority | null {
+  if (value === null || !Number.isSafeInteger(value)) {
+    return null;
+  }
+
+  return {
+    rank: value,
+    label: value.toString(),
+  };
+}
+
+function normalizeMappedPriority(
+  value: string | null,
+  optionRankMap: Readonly<Record<string, number>> | undefined,
+): QueuePriority | null {
+  if (value === null || value.trim() === "" || optionRankMap === undefined) {
+    return null;
+  }
+
+  const rank = optionRankMap[value];
+  if (rank === undefined || !Number.isSafeInteger(rank)) {
+    return null;
+  }
+
+  return {
+    rank,
+    label: value,
+  };
+}
+
+function exhaustiveGitHubProjectFieldValue(value: never): never {
+  throw new Error(`Unsupported GitHub project field value: ${String(value)}`);
+}

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -13,7 +13,15 @@ import { createTempDir } from "../support/git.js";
 
 const logger = new JsonLogger();
 
-function createTracker(server: MockGitHubServer): GitHubTracker {
+function createTracker(
+  server: MockGitHubServer,
+  queuePriority?: {
+    enabled: boolean;
+    projectNumber?: number;
+    fieldName?: string;
+    optionRankMap?: Readonly<Record<string, number>>;
+  },
+): GitHubTracker {
   return new GitHubTracker(
     {
       kind: "github",
@@ -24,6 +32,7 @@ function createTracker(server: MockGitHubServer): GitHubTracker {
       failedLabel: "symphony:failed",
       successComment: "done",
       reviewBotLogins: ["greptile[bot]", "bugbot[bot]"],
+      queuePriority,
     },
     logger,
   );
@@ -119,6 +128,52 @@ describe("GitHubTracker", () => {
 
     expect(lifecycle.kind).toBe("missing-target");
     expect(lifecycle.summary).toMatch(/no open pull request/i);
+  });
+
+  it("returns normalized queue priority from configured GitHub project data", async () => {
+    server.setProjectFieldValue({
+      projectNumber: 12,
+      issueNumber: 7,
+      fieldName: "Priority",
+      value: {
+        kind: "single_select",
+        value: "P1",
+      },
+    });
+    const tracker = createTracker(server, {
+      enabled: true,
+      projectNumber: 12,
+      fieldName: "Priority",
+      optionRankMap: {
+        P1: 1,
+      },
+    });
+
+    const ready = await tracker.fetchReadyIssues();
+
+    expect(ready[0]?.queuePriority).toEqual({
+      rank: 1,
+      label: "P1",
+    });
+  });
+
+  it("falls back to null queue priority when the issue has no configured project item value", async () => {
+    server.addIssueToProject({
+      projectNumber: 12,
+      issueNumber: 7,
+    });
+    const tracker = createTracker(server, {
+      enabled: true,
+      projectNumber: 12,
+      fieldName: "Priority",
+      optionRankMap: {
+        P1: 1,
+      },
+    });
+
+    const ready = await tracker.fetchReadyIssues();
+
+    expect(ready[0]?.queuePriority).toBeNull();
   });
 
   it("reports awaiting-human-handoff when the latest issue handoff is plan-ready", async () => {

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -252,7 +252,9 @@ export class MockGitHubServer {
     repo?: string;
   }): void {
     const items = this.#projects.get(input.projectNumber) ?? [];
-    const existing = items.find((item) => item.issueNumber === input.issueNumber);
+    const existing = items.find(
+      (item) => item.issueNumber === input.issueNumber,
+    );
     if (existing) {
       return;
     }

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -107,6 +107,29 @@ interface MockLabel {
   description: string;
 }
 
+type MockProjectFieldValue =
+  | {
+      readonly kind: "number";
+      readonly value: number | null;
+    }
+  | {
+      readonly kind: "single_select";
+      readonly value: string | null;
+    }
+  | {
+      readonly kind: "text";
+      readonly value: string | null;
+    }
+  | {
+      readonly kind: "unsupported";
+    };
+
+interface MockProjectItem {
+  readonly issueNumber: number;
+  readonly repo: string;
+  readonly fieldValues: Map<string, MockProjectFieldValue | null>;
+}
+
 function json(
   response: ServerResponse,
   statusCode: number,
@@ -130,6 +153,7 @@ export class MockGitHubServer {
   readonly #issues = new Map<number, MockIssue>();
   readonly #labels = new Map<string, MockLabel>();
   readonly #prs = new Map<number, PullRequestRecord>();
+  readonly #projects = new Map<number, MockProjectItem[]>();
   readonly #requestCounts = new Map<string, number>();
   readonly #branchCommitTimes = new Map<string, string>();
   #repositoryMergeConfig: MockRepositoryMergeConfig = {
@@ -220,6 +244,54 @@ export class MockGitHubServer {
     }
     issue.state = state;
     issue.updated_at = new Date().toISOString();
+  }
+
+  addIssueToProject(input: {
+    projectNumber: number;
+    issueNumber: number;
+    repo?: string;
+  }): void {
+    const items = this.#projects.get(input.projectNumber) ?? [];
+    const existing = items.find((item) => item.issueNumber === input.issueNumber);
+    if (existing) {
+      return;
+    }
+    items.push({
+      issueNumber: input.issueNumber,
+      repo: input.repo ?? "sociotechnica-org/symphony-ts",
+      fieldValues: new Map<string, MockProjectFieldValue | null>(),
+    });
+    this.#projects.set(input.projectNumber, items);
+  }
+
+  setProjectFieldValue(input: {
+    projectNumber: number;
+    issueNumber: number;
+    fieldName: string;
+    value: MockProjectFieldValue | null;
+    repo?: string;
+  }): void {
+    const projectInput: {
+      projectNumber: number;
+      issueNumber: number;
+      repo?: string;
+    } = {
+      projectNumber: input.projectNumber,
+      issueNumber: input.issueNumber,
+    };
+    if (input.repo !== undefined) {
+      projectInput.repo = input.repo;
+    }
+    this.addIssueToProject(projectInput);
+    const item = this.#projects
+      .get(input.projectNumber)
+      ?.find((entry) => entry.issueNumber === input.issueNumber);
+    if (!item) {
+      throw new Error(
+        `Project item ${input.projectNumber.toString()}/${input.issueNumber.toString()} not found`,
+      );
+    }
+    item.fieldValues.set(input.fieldName, input.value);
   }
 
   addIssueComment(input: {
@@ -826,6 +898,55 @@ export class MockGitHubServer {
     body: { query: string; variables: Record<string, unknown> },
     response: ServerResponse,
   ): Promise<void> {
+    if (body.query.includes("ProjectQueuePriorityFieldValues")) {
+      const projectNumber = Number(body.variables["projectNumber"]);
+      const fieldName = String(body.variables["fieldName"]);
+      const items = this.#projects.get(projectNumber);
+      if (!items) {
+        json(response, 200, {
+          data: {
+            repository: {
+              owner: {
+                projectV2: null,
+              },
+            },
+          },
+        });
+        return;
+      }
+
+      json(response, 200, {
+        data: {
+          repository: {
+            owner: {
+              __typename: "Organization",
+              projectV2: {
+                items: {
+                  nodes: items.map((item) => ({
+                    content: {
+                      __typename: "Issue",
+                      number: item.issueNumber,
+                      repository: {
+                        nameWithOwner: item.repo,
+                      },
+                    },
+                    fieldValueByName: toGraphqlProjectFieldValue(
+                      item.fieldValues.get(fieldName) ?? null,
+                    ),
+                  })),
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      return;
+    }
+
     if (body.query.includes("PullRequestReviewState")) {
       const number = Number(body.variables["number"]);
       const pullRequest = this.#prs.get(number);
@@ -1011,4 +1132,40 @@ export class MockGitHubServer {
     }
     throw new Error(`Review thread ${threadId} not found`);
   }
+}
+
+function toGraphqlProjectFieldValue(
+  value: MockProjectFieldValue | null,
+): Record<string, unknown> | null {
+  if (value === null) {
+    return null;
+  }
+
+  switch (value.kind) {
+    case "number":
+      return {
+        __typename: "ProjectV2ItemFieldNumberValue",
+        number: value.value,
+      };
+    case "single_select":
+      return {
+        __typename: "ProjectV2ItemFieldSingleSelectValue",
+        name: value.value,
+      };
+    case "text":
+      return {
+        __typename: "ProjectV2ItemFieldTextValue",
+        text: value.value,
+      };
+    case "unsupported":
+      return {
+        __typename: "ProjectV2ItemFieldDateValue",
+      };
+    default:
+      return exhaustiveProjectFieldValue(value);
+  }
+}
+
+function exhaustiveProjectFieldValue(value: never): never {
+  throw new Error(`Unsupported mock project field value: ${String(value)}`);
 }

--- a/tests/unit/github-client.test.ts
+++ b/tests/unit/github-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../src/observability/logger.js";
 import { GitHubClient } from "../../src/tracker/github-client.js";
+import { MockGitHubServer } from "../support/mock-github-server.js";
 
 describe("GitHubClient", () => {
   const previousToken = process.env.GH_TOKEN;
@@ -377,5 +378,58 @@ describe("GitHubClient", () => {
         allowedMergeMethods: ["merge", "squash", "rebase"],
       },
     );
+  });
+
+  it("reads configured project queue priority values from GitHub GraphQL", async () => {
+    const server = new MockGitHubServer();
+    await server.start();
+    try {
+      server.seedIssue({
+        number: 7,
+        title: "Queue priority",
+        body: "",
+        labels: ["symphony:ready"],
+      });
+      server.setProjectFieldValue({
+        projectNumber: 12,
+        issueNumber: 7,
+        fieldName: "Priority",
+        value: {
+          kind: "single_select",
+          value: "P1",
+        },
+      });
+
+      const client = new GitHubClient(
+        {
+          kind: "github",
+          repo: "sociotechnica-org/symphony-ts",
+          apiUrl: server.baseUrl,
+          readyLabel: "symphony:ready",
+          runningLabel: "symphony:running",
+          failedLabel: "symphony:failed",
+          successComment: "done",
+          reviewBotLogins: [],
+          queuePriority: {
+            enabled: true,
+            projectNumber: 12,
+            fieldName: "Priority",
+            optionRankMap: {
+              P1: 1,
+            },
+          },
+        },
+        createLoggerSpy(),
+      );
+
+      const issue = await client.getIssue(7);
+
+      expect(issue.queuePriority).toEqual({
+        rank: 1,
+        label: "P1",
+      });
+    } finally {
+      await server.stop();
+    }
   });
 });

--- a/tests/unit/github-queue-priority.test.ts
+++ b/tests/unit/github-queue-priority.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGitHubQueuePriority } from "../../src/tracker/github-queue-priority.js";
+
+describe("normalizeGitHubQueuePriority", () => {
+  it("normalizes numeric GitHub project field values into queue priority", () => {
+    expect(
+      normalizeGitHubQueuePriority(
+        {
+          kind: "number",
+          value: 2,
+        },
+        {
+          enabled: true,
+          projectNumber: 7,
+          fieldName: "Priority",
+        },
+      ),
+    ).toEqual({
+      rank: 2,
+      label: "2",
+    });
+  });
+
+  it("normalizes mapped single-select values into queue priority", () => {
+    expect(
+      normalizeGitHubQueuePriority(
+        {
+          kind: "single_select",
+          value: "P1",
+        },
+        {
+          enabled: true,
+          projectNumber: 7,
+          fieldName: "Priority",
+          optionRankMap: {
+            P0: 0,
+            P1: 1,
+          },
+        },
+      ),
+    ).toEqual({
+      rank: 1,
+      label: "P1",
+    });
+  });
+
+  it("falls back to null for unmapped or unsupported values", () => {
+    expect(
+      normalizeGitHubQueuePriority(
+        {
+          kind: "text",
+          value: "urgent",
+        },
+        {
+          enabled: true,
+          projectNumber: 7,
+          fieldName: "Priority",
+        },
+      ),
+    ).toBeNull();
+    expect(
+      normalizeGitHubQueuePriority(
+        {
+          kind: "unsupported",
+        },
+        {
+          enabled: true,
+          projectNumber: 7,
+          fieldName: "Priority",
+        },
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -263,7 +263,9 @@ ${buildSharedWorkflowSections()}`,
   });
 
   it("fails clearly when enabled GitHub queue priority omits the project number", async () => {
-    const dir = await createTempDir("workflow-github-queue-priority-no-project-");
+    const dir = await createTempDir(
+      "workflow-github-queue-priority-no-project-",
+    );
     const workflowPath = path.join(dir, "WORKFLOW.md");
     await fs.writeFile(
       workflowPath,

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -164,6 +164,11 @@ ${buildSharedWorkflowSections()}`,
   success_comment: done
   queue_priority:
     enabled: true
+    project_number: 7
+    field_name: Priority
+    option_rank_map:
+      P0: 0
+      P1: 1
 ${buildSharedWorkflowSections()}`,
       ),
       "utf8",
@@ -173,6 +178,12 @@ ${buildSharedWorkflowSections()}`,
 
     expect(workflow.config.tracker.queuePriority).toEqual({
       enabled: true,
+      projectNumber: 7,
+      fieldName: "Priority",
+      optionRankMap: {
+        P0: 0,
+        P1: 1,
+      },
     });
   });
 
@@ -248,6 +259,60 @@ ${buildSharedWorkflowSections()}`,
 
     await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
       "Expected boolean for tracker.queue_priority.enabled",
+    );
+  });
+
+  it("fails clearly when enabled GitHub queue priority omits the project number", async () => {
+    const dir = await createTempDir("workflow-github-queue-priority-no-project-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: github
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  queue_priority:
+    enabled: true
+    field_name: Priority
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected integer for tracker.queue_priority.project_number",
+    );
+  });
+
+  it("fails clearly when enabled GitHub queue priority omits the field name", async () => {
+    const dir = await createTempDir("workflow-github-queue-priority-no-field-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  kind: github
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  queue_priority:
+    enabled: true
+    project_number: 7
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    await expect(loadWorkflow(workflowPath)).rejects.toThrowError(
+      "Expected non-empty string for tracker.queue_priority.field_name",
     );
   });
 


### PR DESCRIPTION
Closes #193

## Summary
- add GitHub queue-priority config for one Projects V2 field plus optional option-rank mapping
- fetch GitHub project field values through the tracker GraphQL boundary and normalize them into `issue.queuePriority`
- extend the mock GitHub harness, integration coverage, and docs for configured and fallback behavior

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
