### PR TITLE
Add Linear queue priority adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ Projects V2 field, normalize supported values into `issue.queuePriority`, and
 keep missing, unset, unmapped, or unsupported project data as `null` so ready
 work still falls back to deterministic issue-number ordering. The current
 GitHub slice supports integer number fields directly plus single-select or text
-fields when `option_rank_map` provides the rank mapping.
+fields when `option_rank_map` provides the rank mapping. For Linear, Symphony
+can optionally normalize the native issue `priority` field into the same
+contract when `tracker.queue_priority.enabled: true`; native `priority: 0`,
+`null`, or disabled config still fall back to `queuePriority: null`.
 
 When multiple remote Codex worker hosts are configured, Symphony selects a host
 at dispatch time, keeps continuation turns on that same host, and prefers the

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -14,6 +14,8 @@ tracker:
     - cursor
     - devin-ai-integration
   # Optional tracker-owned ready-work ordering seam.
+  # GitHub requires project_number / field_name configuration.
+  # Linear only uses enabled: true and maps native issue priority when present.
   # queue_priority:
   #   enabled: true
   #   project_number: 12

--- a/docs/plans/191-linear-queue-priority-adapter/plan.md
+++ b/docs/plans/191-linear-queue-priority-adapter/plan.md
@@ -131,16 +131,16 @@ Not applicable for this slice. The issue changes tracker-boundary normalization,
 
 ## Failure-Class Matrix
 
-| Observed condition                                                   | Local facts available                        | Normalized tracker facts available     | Expected behavior                                                                 |
-| -------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
-| Linear queue-priority config is absent                               | resolved tracker config                      | native priority may exist              | preserve current behavior; normalize `queuePriority: null`                        |
-| Linear queue-priority config is present with `enabled: false`        | resolved tracker config                      | native priority may exist              | normalize `queuePriority: null`                                                   |
-| Linear queue-priority config is present with `enabled: true`         | resolved tracker config                      | native priority integer or null        | map supported native priority into normalized `QueuePriority`                     |
-| Linear issue priority is `0` or `null`                              | resolved tracker config                      | native priority unset                  | normalize `queuePriority: null`                                                   |
-| Linear issue priority is in the supported `1-4` range               | resolved tracker config                      | native priority integer                | normalize to a stable `rank` and human-readable `label` inside the tracker layer  |
-| Linear issue priority is outside the supported range or not integer | normalization field path                     | malformed raw Linear payload           | fail at the Linear normalization boundary; do not leak malformed priority upward   |
-| Two issues have different normalized Linear-derived priorities       | normalized runtime issues                    | populated `queuePriority` values       | shared queue-priority comparator can order them without Linear-specific knowledge  |
-| Linear issue is otherwise readable but priority mapping is disabled  | tracker config, issue identity               | native priority ignored by policy seam | issue remains readable; no lifecycle or eligibility behavior changes              |
+| Observed condition                                                  | Local facts available          | Normalized tracker facts available     | Expected behavior                                                                 |
+| ------------------------------------------------------------------- | ------------------------------ | -------------------------------------- | --------------------------------------------------------------------------------- |
+| Linear queue-priority config is absent                              | resolved tracker config        | native priority may exist              | preserve current behavior; normalize `queuePriority: null`                        |
+| Linear queue-priority config is present with `enabled: false`       | resolved tracker config        | native priority may exist              | normalize `queuePriority: null`                                                   |
+| Linear queue-priority config is present with `enabled: true`        | resolved tracker config        | native priority integer or null        | map supported native priority into normalized `QueuePriority`                     |
+| Linear issue priority is `0` or `null`                              | resolved tracker config        | native priority unset                  | normalize `queuePriority: null`                                                   |
+| Linear issue priority is in the supported `1-4` range               | resolved tracker config        | native priority integer                | normalize to a stable `rank` and human-readable `label` inside the tracker layer  |
+| Linear issue priority is outside the supported range or not integer | normalization field path       | malformed raw Linear payload           | fail at the Linear normalization boundary; do not leak malformed priority upward  |
+| Two issues have different normalized Linear-derived priorities      | normalized runtime issues      | populated `queuePriority` values       | shared queue-priority comparator can order them without Linear-specific knowledge |
+| Linear issue is otherwise readable but priority mapping is disabled | tracker config, issue identity | native priority ignored by policy seam | issue remains readable; no lifecycle or eligibility behavior changes              |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/191-linear-queue-priority-adapter/plan.md
+++ b/docs/plans/191-linear-queue-priority-adapter/plan.md
@@ -1,0 +1,223 @@
+# Issue 191 Plan: Linear Adapter For Tracker-Native Queue Priority
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a Linear tracker adapter seam that maps Linear-native issue priority into Symphony's normalized `issue.queuePriority` contract so Linear-backed queues can participate in the shared queue-priority ordering model without leaking Linear schema into the orchestrator.
+
+## Scope
+
+- reuse the existing Linear issue transport field for native priority rather than adding new Linear API queries
+- extend Linear tracker config validation only as needed to keep the existing `tracker.queue_priority.enabled` seam explicit and well documented
+- normalize Linear priority values into the tracker-neutral `QueuePriority` contract inside the Linear adapter boundary
+- populate normalized `queuePriority` on `RuntimeIssue` values returned by Linear tracker reads
+- add focused unit and mock-backed integration coverage for configured, disabled, unset, and invalid Linear priority cases
+- update docs to explain the Linear queue-priority seam and its fallback behavior
+
+## Non-goals
+
+- changing orchestrator dispatch order in this issue
+- changing the tracker-neutral `QueuePriority` contract from issue `#192`
+- GitHub queue-priority work beyond staying compatible with the existing contract
+- redesigning existing Linear active, terminal, review, or handoff lifecycle behavior
+- introducing new Linear transport endpoints, broader GraphQL refactors, or status/report redesign
+- combining Linear queue priority with retries, leases, reconciliation, or landing policy
+
+## Current Gaps
+
+- `src/tracker/linear-normalize.ts` already validates Linear native `priority` into the adapter snapshot, but `runtimeIssue.queuePriority` is still hard-coded to `null`
+- `LinearTracker` therefore drops tracker-native ordering metadata even when the repo opts into queue priority
+- the current Linear workflow config only preserves `tracker.queue_priority.enabled`; the adapter does not yet consume that switch to populate normalized queue-priority facts
+- README and `WORKFLOW.md` document the GitHub queue-priority seam, but do not yet explain the Linear-native mapping path
+- existing Linear tests lock in `queuePriority: null`, which means the queue-priority contract is not yet proven for Linear-backed queues
+
+## Decision Notes
+
+- Keep the slice at the Linear integration boundary. Linear already returns native `priority`, so this issue should not add transport complexity that the current GraphQL payload does not require.
+- Preserve the tracker-neutral runtime contract from `#192`; only normalized `rank` and optional `label` should cross the tracker boundary.
+- Treat Linear `priority: 0` and `priority: null` as unset and degrade to `queuePriority: null` so ready work stays eligible and deterministic fallback ordering remains intact.
+- Keep Linear-specific mapping policy in focused normalization helpers instead of spreading it across `linear.ts`, workflow parsing, and tests.
+- Stay reviewable as one PR by limiting the slice to config consumption, normalization, tests, and docs.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: defining how Linear-native priority populates the existing normalized ordering hint
+  - belongs: documenting fallback semantics for disabled, missing, or unset Linear priority
+  - does not belong: orchestrator queue-order changes or raw Linear schema outside the tracker boundary
+- Configuration Layer
+  - belongs: preserving the explicit `tracker.queue_priority.enabled` opt-in for Linear
+  - does not belong: embedding Linear normalization rules inside workflow parsing beyond the typed config seam
+- Coordination Layer
+  - belongs: no behavioral changes in this slice beyond continuing to consume normalized `RuntimeIssue`
+  - does not belong: raw Linear priority parsing or adapter-specific fallback logic
+- Execution Layer
+  - belongs: no changes
+  - does not belong: tracker-native priority metadata or queue-order policy
+- Integration Layer
+  - belongs: Linear normalization from native priority into `QueuePriority`, plus adapter-owned fallback behavior
+  - does not belong: leaking Linear integer enum details into `src/domain/` or `src/orchestrator/`
+- Observability Layer
+  - belongs: docs and tests that keep normalized queue-priority facts inspectable for later projection
+  - does not belong: a broader TUI, report, or status-surface redesign in this slice
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts`
+  - retain the Linear queue-priority config seam and tighten the type only if the current generic shape is insufficient for explicit Linear adapter consumption
+- `src/config/workflow.ts`
+  - validate and resolve Linear queue-priority config exactly at the workflow boundary
+- `src/tracker/linear-normalize.ts`
+  - add focused Linear priority normalization into `runtimeIssue.queuePriority`
+  - keep raw Linear priority handling and fallback behavior localized here or in a small adjacent helper
+- `src/tracker/linear.ts`
+  - consume the normalized issue contract without reinterpreting Linear-native fields
+- Linear unit and integration tests plus concise docs updates
+
+### Does not belong in this issue
+
+- orchestrator ordering changes
+- GitHub adapter changes
+- new Linear transport or pagination behavior unrelated to queue priority
+- lifecycle-policy changes for claim, human review, rework, merge, or terminal handling
+- status/report/TUI work centered on queue-priority display
+- mixing Linear transport, normalization, and orchestrator policy in one broad patch
+
+## Layering Notes
+
+- `config/workflow`
+  - owns parsing and validation of the optional Linear queue-priority config seam
+  - does not inspect live Linear issue payloads
+- `tracker`
+  - owns Linear priority normalization and fallback to `queuePriority: null`
+  - does not require the orchestrator to know Linear's `0-4` native range
+- `workspace`
+  - untouched
+  - does not carry tracker queue metadata
+- `runner`
+  - untouched
+  - does not participate in queue-priority mapping
+- `orchestrator`
+  - untouched in behavior
+  - continues to consume normalized issues only
+- `observability`
+  - may project normalized `queuePriority` later
+  - is not the source of truth for Linear priority semantics
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR by keeping the change inside the Linear tracker edge:
+
+1. consume the existing `tracker.queue_priority.enabled` seam for Linear
+2. normalize Linear native `priority` into `issue.queuePriority`
+3. prove fallback behavior with unit and mock-backed integration tests
+4. document the Linear configuration and normalization path
+
+This avoids combining:
+
+- orchestrator dispatch-policy changes
+- new Linear API transport work
+- GitHub queue-priority behavior
+- broader observability or lifecycle refactors
+
+## Runtime State Model
+
+Not applicable for this slice. The issue changes tracker-boundary normalization, not retries, continuations, reconciliation, leases, or handoff states.
+
+## Failure-Class Matrix
+
+| Observed condition                                                   | Local facts available                        | Normalized tracker facts available     | Expected behavior                                                                 |
+| -------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| Linear queue-priority config is absent                               | resolved tracker config                      | native priority may exist              | preserve current behavior; normalize `queuePriority: null`                        |
+| Linear queue-priority config is present with `enabled: false`        | resolved tracker config                      | native priority may exist              | normalize `queuePriority: null`                                                   |
+| Linear queue-priority config is present with `enabled: true`         | resolved tracker config                      | native priority integer or null        | map supported native priority into normalized `QueuePriority`                     |
+| Linear issue priority is `0` or `null`                              | resolved tracker config                      | native priority unset                  | normalize `queuePriority: null`                                                   |
+| Linear issue priority is in the supported `1-4` range               | resolved tracker config                      | native priority integer                | normalize to a stable `rank` and human-readable `label` inside the tracker layer  |
+| Linear issue priority is outside the supported range or not integer | normalization field path                     | malformed raw Linear payload           | fail at the Linear normalization boundary; do not leak malformed priority upward   |
+| Two issues have different normalized Linear-derived priorities       | normalized runtime issues                    | populated `queuePriority` values       | shared queue-priority comparator can order them without Linear-specific knowledge  |
+| Linear issue is otherwise readable but priority mapping is disabled  | tracker config, issue identity               | native priority ignored by policy seam | issue remains readable; no lifecycle or eligibility behavior changes              |
+
+## Storage / Persistence Contract
+
+- no new durable local storage
+- Linear native priority remains adapter-local transport data
+- only the normalized `issue.queuePriority` contract crosses into the runtime domain
+- existing issue snapshots, status payloads, and reports remain unchanged unless they already carry normalized issue metadata
+
+## Observability Requirements
+
+- config validation errors must continue to identify malformed `tracker.queue_priority` input clearly
+- tests should lock in the fallback contract for disabled or unset Linear priority
+- docs should state that Linear uses native priority normalization and falls back to `null` when disabled or unset
+
+## Implementation Steps
+
+1. Confirm the current Linear workflow config seam is sufficient; narrow any type/config change to the minimum needed for explicit Linear adapter consumption.
+2. Add a focused Linear queue-priority normalization helper or adjacent normalization path that maps supported native priority values into the shared `QueuePriority` contract.
+3. Thread that normalized value into `runtimeIssue.queuePriority` in `normalizeLinearIssueSnapshot()` only when Linear queue priority is enabled.
+4. Keep existing Linear snapshot fields stable so active/terminal/handoff policy continues to use the same adapter snapshot inputs as before.
+5. Add unit coverage for:
+   - disabled Linear queue priority
+   - enabled mapping for supported `1-4` native priorities
+   - fallback to `null` for `0` and `null`
+   - clear failure on malformed native priority values
+6. Add mock-backed integration coverage proving Linear tracker reads populate normalized `queuePriority` when enabled and preserve `null` when disabled or omitted.
+7. Update `README.md` and `WORKFLOW.md` comments with the Linear configuration seam and fallback semantics.
+8. Run local self-review plus repo checks before PR creation.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- workflow parsing accepts omitted Linear queue-priority config
+- workflow parsing accepts explicit disabled Linear queue-priority config
+- Linear normalization maps supported native priorities into stable normalized `rank` and `label` facts when enabled
+- Linear normalization falls back to `null` for disabled config, `priority: 0`, and `priority: null`
+- malformed native priority values still fail clearly at the normalization boundary
+
+### Integration
+
+- mock-backed Linear tracker reads return populated normalized queue priority when `tracker.queue_priority.enabled: true`
+- Linear tracker reads still return `queuePriority: null` when Linear queue priority is omitted or disabled
+- existing Linear ready/running/failed issue reads remain otherwise unchanged
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- local self-review when a reliable review command is available
+
+## Acceptance Scenarios
+
+1. Given a Linear tracker config with queue priority omitted, Linear issues continue to normalize with `queuePriority: null`.
+2. Given a Linear tracker config with `queue_priority.enabled: false`, Linear issues still normalize with `queuePriority: null` even when native priority is present.
+3. Given a Linear tracker config with `queue_priority.enabled: true` and an issue whose native priority is in Linear's supported `1-4` range, `fetchReadyIssues()` returns that issue with populated normalized queue priority.
+4. Given enabled Linear queue priority and an issue whose native priority is `0` or `null`, the issue remains readable and normalizes to `queuePriority: null`.
+5. Given malformed native Linear priority outside the supported range, normalization fails clearly at the tracker boundary.
+6. Given Linear-derived normalized priorities on returned issues, the shared queue-priority comparator can order them without any Linear-specific input.
+
+## Exit Criteria
+
+- Linear tracker config exposes an explicit, documented queue-priority opt-in that the adapter actually consumes
+- Linear adapter normalizes native priority into tracker-neutral `issue.queuePriority` when enabled
+- disabled or unset Linear priority degrades to `queuePriority: null`
+- tests cover supported normalization and fallback paths using the existing mock Linear harness
+- the PR stays limited to the Linear tracker boundary and required docs/tests
+
+## Deferred To Later Issues Or PRs
+
+- orchestrator queue ordering changes that actively prioritize ready work by `queuePriority`
+- richer observability or status/report projection of queue-priority metadata
+- any Linear transport expansions unrelated to native priority normalization
+- any cross-tracker policy that combines queue priority with retries, pressure, or handoff state
+- any redesign of existing Linear active or terminal lifecycle handling
+
+## Revision Log
+
+- 2026-03-19: Initial draft created for issue `#191` and marked `plan-ready`.

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -1,5 +1,6 @@
 import type { RuntimeIssue } from "../domain/issue.js";
 import { TrackerError } from "../domain/errors.js";
+import type { QueuePriorityConfig } from "../domain/workflow.js";
 import {
   requireArray,
   requireBoolean,
@@ -12,6 +13,7 @@ import {
   parseLinearWorkpad,
   type LinearWorkpadEntry,
 } from "./linear-workpad.js";
+import { normalizeLinearQueuePriority } from "./linear-queue-priority.js";
 
 export interface LinearWorkflowState {
   readonly id: string;
@@ -43,6 +45,7 @@ export interface LinearIssueRelationSnapshot {
 
 export interface LinearIssueNormalizationOptions {
   readonly configuredAssignee: string | null;
+  readonly queuePriority?: QueuePriorityConfig | undefined;
 }
 
 export interface LinearIssueSnapshot {
@@ -80,6 +83,7 @@ export interface LinearProjectIssuesSnapshot {
 
 const DEFAULT_OPTIONS: LinearIssueNormalizationOptions = {
   configuredAssignee: null,
+  queuePriority: undefined,
 };
 
 export function normalizeLinearProject(value: unknown): LinearProjectSnapshot {
@@ -209,6 +213,10 @@ export function normalizeLinearIssueSnapshot(
   );
   const normalizedDescription = description ?? "";
   const workpad = parseLinearWorkpad(description);
+  const priority = normalizeLinearPriority(
+    record["priority"],
+    `${field}.priority`,
+  );
 
   const runtimeIssue: RuntimeIssue = {
     id: requireString(record["id"], `${field}.id`),
@@ -221,7 +229,10 @@ export function normalizeLinearIssueSnapshot(
     url: requireString(record["url"], `${field}.url`),
     createdAt: requireString(record["createdAt"], `${field}.createdAt`),
     updatedAt: requireString(record["updatedAt"], `${field}.updatedAt`),
-    queuePriority: null,
+    queuePriority: normalizeLinearQueuePriority(
+      priority,
+      options.queuePriority,
+    ),
   };
 
   return {
@@ -230,7 +241,7 @@ export function normalizeLinearIssueSnapshot(
     number: runtimeIssue.number,
     title: runtimeIssue.title,
     description: runtimeIssue.description,
-    priority: normalizeLinearPriority(record["priority"], `${field}.priority`),
+    priority,
     branchName: requireNullableString(
       record["branchName"],
       `${field}.branchName`,

--- a/src/tracker/linear-queue-priority.ts
+++ b/src/tracker/linear-queue-priority.ts
@@ -1,0 +1,28 @@
+import type { QueuePriority } from "../domain/issue.js";
+import type { QueuePriorityConfig } from "../domain/workflow.js";
+
+const LINEAR_QUEUE_PRIORITY_LABELS: Readonly<Record<number, string>> = {
+  1: "Urgent",
+  2: "High",
+  3: "Normal",
+  4: "Low",
+};
+
+export function normalizeLinearQueuePriority(
+  value: number | null,
+  config: QueuePriorityConfig | undefined,
+): QueuePriority | null {
+  if (config?.enabled !== true || value === null) {
+    return null;
+  }
+
+  const label = LINEAR_QUEUE_PRIORITY_LABELS[value];
+  if (label === undefined) {
+    return null;
+  }
+
+  return {
+    rank: value,
+    label,
+  };
+}

--- a/src/tracker/linear.ts
+++ b/src/tracker/linear.ts
@@ -311,6 +311,7 @@ export class LinearTracker implements Tracker {
   #normalizeOptions() {
     return {
       configuredAssignee: this.#config.assignee,
+      queuePriority: this.#config.queuePriority,
     } as const;
   }
 }

--- a/tests/integration/linear.test.ts
+++ b/tests/integration/linear.test.ts
@@ -17,6 +17,7 @@ function createConfig(
     assignee: "worker@example.test",
     activeStates: ["Todo", "In Progress"],
     terminalStates: ["Done", "Canceled"],
+    queuePriority: undefined,
     ...overrides,
   };
 }
@@ -92,6 +93,58 @@ describe("LinearTracker", () => {
     expect(ready[0]?.queuePriority).toBeNull();
     expect(ready[1]?.labels).toEqual(["needs review"]);
     expect(server.countRequests("GetProjectIssuesPage")).toBe(2);
+  });
+
+  it("returns normalized queue priority from Linear native priority when enabled", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "Urgent issue",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+      priority: 1,
+    });
+
+    const tracker = new LinearTracker(
+      createConfig(server, {
+        queuePriority: { enabled: true },
+      }),
+      new JsonLogger(),
+    );
+    const ready = await tracker.fetchReadyIssues();
+
+    expect(ready[0]?.queuePriority).toEqual({
+      rank: 1,
+      label: "Urgent",
+    });
+  });
+
+  it("keeps Linear queue priority null when omitted or disabled", async () => {
+    server.seedIssue({
+      projectSlug: "symphony-linear",
+      number: 1,
+      title: "High issue",
+      stateName: "Todo",
+      assigneeEmail: "worker@example.test",
+      priority: 2,
+    });
+
+    const omittedTracker = new LinearTracker(
+      createConfig(server),
+      new JsonLogger(),
+    );
+    const disabledTracker = new LinearTracker(
+      createConfig(server, {
+        queuePriority: { enabled: false },
+      }),
+      new JsonLogger(),
+    );
+
+    const omittedReady = await omittedTracker.fetchReadyIssues();
+    const disabledReady = await disabledTracker.fetchReadyIssues();
+
+    expect(omittedReady[0]?.queuePriority).toBeNull();
+    expect(disabledReady[0]?.queuePriority).toBeNull();
   });
 
   it("filters ready issues by normalized assignee routing instead of GraphQL query parameters", async () => {

--- a/tests/unit/linear-normalize.test.ts
+++ b/tests/unit/linear-normalize.test.ts
@@ -91,6 +91,7 @@ describe("normalizeLinearIssueSnapshot", () => {
     expect(snapshot.assignedToWorker).toBe(true);
     expect(snapshot.labels).toEqual(["backend", "needs review"]);
     expect(snapshot.runtimeIssue.labels).toEqual(["backend", "needs review"]);
+    expect(snapshot.runtimeIssue.queuePriority).toBeNull();
     expect(snapshot.blockedBy).toEqual([
       {
         id: "issue-0",
@@ -99,6 +100,37 @@ describe("normalizeLinearIssueSnapshot", () => {
         state: "In Progress",
       },
     ]);
+  });
+
+  it("normalizes enabled Linear priority into queue priority metadata", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload({ priority: 1 }),
+      "issue",
+      {
+        configuredAssignee: null,
+        queuePriority: { enabled: true },
+      },
+    );
+
+    expect(snapshot.priority).toBe(1);
+    expect(snapshot.runtimeIssue.queuePriority).toEqual({
+      rank: 1,
+      label: "Urgent",
+    });
+  });
+
+  it("keeps queue priority null when Linear queue priority is disabled", () => {
+    const snapshot = normalizeLinearIssueSnapshot(
+      createIssuePayload({ priority: 2 }),
+      "issue",
+      {
+        configuredAssignee: null,
+        queuePriority: { enabled: false },
+      },
+    );
+
+    expect(snapshot.priority).toBe(2);
+    expect(snapshot.runtimeIssue.queuePriority).toBeNull();
   });
 
   it("tolerates missing optional assignee, labels, relations, and branch metadata", () => {
@@ -117,6 +149,7 @@ describe("normalizeLinearIssueSnapshot", () => {
 
     expect(snapshot.description).toBe("");
     expect(snapshot.priority).toBeNull();
+    expect(snapshot.runtimeIssue.queuePriority).toBeNull();
     expect(snapshot.branchName).toBeNull();
     expect(snapshot.assignee).toBeNull();
     expect(snapshot.assignedToWorker).toBe(true);
@@ -131,6 +164,7 @@ describe("normalizeLinearIssueSnapshot", () => {
     );
 
     expect(snapshot.priority).toBeNull();
+    expect(snapshot.runtimeIssue.queuePriority).toBeNull();
   });
 
   it("silently skips a 'blocks' relation whose issue is null", () => {


### PR DESCRIPTION
## Summary
- normalize Linear native priority into the shared `issue.queuePriority` contract behind `tracker.queue_priority.enabled`
- keep disabled, omitted, `0`, and `null` Linear priority values on the deterministic fallback path
- add Linear unit/integration coverage and document the Linear queue-priority seam

Closes #191

## Verification
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test

## Self-review
- Performed local self-review from the staged diff; no dedicated automated local review tool is available in this repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
