### PR TITLE
Use tracker-native priority in ready queue ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The status snapshot includes normalized runner visibility for active issues,
 including worker state, current phase, provider identity, execution transport,
 session identity, heartbeat/action timestamps, waiting reason, and condensed
 output/error summaries.
+It also projects the current ready-queue order with normalized queue-priority
+rank/label facts so operators can see which ready issue would dispatch next and
+when Symphony fell back to deterministic issue-number ordering.
 Status surfaces now also publish a runtime checkout identity for the live
 factory code, including the runtime checkout path, `HEAD` commit SHA, commit
 timestamp, and dirty-state summary when git metadata is available. This

--- a/docs/plans/194-queue-ordering-observability/plan.md
+++ b/docs/plans/194-queue-ordering-observability/plan.md
@@ -1,0 +1,245 @@
+# Issue 194 Plan: Queue Ordering And Observability Projection For Tracker-Native Priority
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make the orchestrator prefer normalized tracker-native `issue.queuePriority` when ordering ready work for dispatch, while preserving existing precedence for running issues and due retries, and expose enough tracker-neutral ordering detail in the status snapshot for operators and tests to see why one ready issue won.
+
+## Scope
+
+- update ready-issue ordering in the orchestrator to use the shared queue-priority comparator before falling back to deterministic issue-number ordering
+- preserve existing queue precedence for running issues, due retries, and dispatch-pressure pauses
+- add a tracker-neutral observability projection that shows the ready queue ordering facts relevant to dispatch decisions
+- cover the new ordering and status projection with focused unit tests and any small integration assertions needed to keep the operator contract stable
+- document the operator-visible ordering behavior briefly where the status surface contract is already described
+
+## Non-goals
+
+- GitHub or Linear transport changes for queue priority
+- changes to the normalized `QueuePriority` contract from `#192`
+- tracker-specific schema details in status output or orchestrator policy
+- retry-budget, continuation-turn, reconciliation, lease, or landing-flow redesign
+- broad TUI or report redesign beyond the minimal tracker-neutral projection required for this slice
+- adding a new dispatch heuristic that combines queue priority with host preference, review state, or other policy outside the existing precedence model
+
+## Current Gaps
+
+- `src/orchestrator/service.ts` still sorts merged queue entries by source and then issue number, so ready issues ignore normalized `issue.queuePriority`
+- the ready/running merge logic preserves the right high-level precedence today, but the ready-work subsection is still incidental rather than explicitly priority-aware
+- `src/orchestrator/status-state.ts` and `src/observability/status.ts` expose active issues and retries, but they do not project any tracker-neutral explanation of ready-work queue ordering
+- operators therefore cannot inspect from the status snapshot which ready issue would dispatch next or whether tracker-native priority influenced that decision
+- current queue-priority tests prove the comparator contract in isolation, but they do not prove the live orchestrator actually uses it
+
+## Decision Notes
+
+- Keep the policy seam narrow: this issue should only change how already-ready issues are ordered relative to each other.
+- Preserve the current top-level precedence contract: running follow-up work and due retries stay ahead of fresh ready issues, and dispatch-pressure pauses still block new ready dispatch.
+- Keep observability tracker-neutral by projecting normalized queue-priority rank/label and a dispatch-order explanation, not GitHub Projects or Linear-native fields.
+- Prefer a small explicit status projection for queued ready candidates over overloading active-issue snapshots, because ready candidates are not yet active runs.
+- Keep the ordering logic in a small pure helper or narrowly-scoped orchestrator seam so tests can prove the policy without depending on tracker adapters.
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: defining that normalized queue priority orders already-ready work before issue-number fallback
+  - belongs: documenting that running/retry precedence remains unchanged
+  - does not belong: tracker-native field parsing or provider-specific priority semantics
+- Configuration Layer
+  - belongs: no new config in this slice; existing queue-priority config remains the policy input at the tracker boundary
+  - does not belong: a second repo-owned switch for orchestrator ordering or observability
+- Coordination Layer
+  - belongs: merged queue ordering that prefers normalized queue priority among ready issues only
+  - belongs: explicit precedence between running work, due retries, and ready work
+  - does not belong: raw tracker payload parsing or tracker-specific queue semantics
+- Execution Layer
+  - belongs: no changes
+  - does not belong: dispatch ordering policy or ready-queue observability
+- Integration Layer
+  - belongs: continuing to provide normalized `issue.queuePriority` facts through `RuntimeIssue`
+  - does not belong: new GitHub or Linear transport/normalization work in this issue
+- Observability Layer
+  - belongs: status snapshot and rendering updates that project normalized ready-queue ordering facts for operators
+  - does not belong: a broader status/TUI/report redesign or tracker-specific schema output
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/orchestrator/service.ts`
+  - apply queue-priority ordering to ready candidates before or within queue merge
+  - keep running / retry precedence unchanged and explicit
+- a small pure ordering helper if the existing comparator alone is not enough
+  - centralize ready-candidate ordering semantics so tests do not rely on incidental sort branches
+- `src/orchestrator/status-state.ts`
+  - build a tracker-neutral snapshot of ready-queue ordering facts
+- `src/observability/status.ts`
+  - extend the persisted snapshot contract and textual rendering for the new ready-queue projection
+- orchestrator and observability tests
+  - prove both dispatch behavior and operator-visible projection
+- concise doc updates in `README.md` and/or observability docs where snapshot fields are described
+
+### Does not belong in this issue
+
+- tracker adapter transport, normalization, or config refactors
+- queue-priority contract changes in `src/domain/issue.ts`
+- host dispatch policy changes beyond preserving the current precedence rules
+- broad active-issue lifecycle refactors
+- report-generation changes unless a status-contract assertion requires a tiny shared type adjustment
+
+## Layering Notes
+
+- `config/workflow`
+  - untouched
+  - should not gain orchestration-order switches for this slice
+- `tracker`
+  - continues to supply normalized `queuePriority`
+  - should not gain dispatch-order policy or status-specific formatting
+- `workspace`
+  - untouched
+  - should not carry ready-queue policy
+- `runner`
+  - untouched
+  - should not know why a ready issue won the queue
+- `orchestrator`
+  - owns the ready-queue ordering decision and the high-level precedence model
+  - should consume only normalized `RuntimeIssue` facts
+- `observability`
+  - owns the snapshot/rendered explanation of the ordering
+  - should not become the source of truth for the dispatch policy
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR by limiting the change to a single coordination/observability seam:
+
+1. switch ready-work ordering to normalized queue priority plus deterministic fallback
+2. preserve existing running and retry precedence
+3. project the ready ordering through the status snapshot
+4. add tests and a concise doc note
+
+This stays reviewable because it does not combine:
+
+- tracker transport or normalization work from `#191` / `#193`
+- retry/reconciliation state-machine changes
+- host-routing refactors
+- broader TUI or report redesign
+
+## Runtime State Model
+
+This slice does not add new runtime states, but it does change the dispatch selection rule within the existing queue merge. The relevant decision model should be explicit in code and tests:
+
+1. `running candidate`
+   - issue is already in `runningCandidates`
+   - remains ahead of fresh ready work
+2. `due retry candidate`
+   - issue has a queued retry that is due now
+   - preserves existing attempt accounting and queue precedence
+3. `ready candidate`
+   - issue is eligible from `fetchReadyIssues()`
+   - ordered by normalized queue priority, then issue number
+4. `dispatch paused`
+   - active dispatch pressure suppresses fresh ready dispatch
+   - running inspection and due-retry listing behavior remains unchanged
+
+Allowed ordering transitions in the merged queue:
+
+- running vs ready: running remains first
+- retry-backed running/ready candidate vs non-retry ready candidate: existing retry precedence remains first
+- ready vs ready: compare `issue.queuePriority`, then issue number
+- paused dispatch vs ready queue: ready queue is projected for observability if useful, but not consumed for new dispatch while paused
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected behavior |
+| --- | --- | --- | --- |
+| Two ready issues both have populated normalized priority | ready candidate list | both `queuePriority` values populated | lower rank sorts first; issue-number fallback used only on ties |
+| One ready issue has priority and another does not | ready candidate list | one populated `queuePriority`, one `null` | prioritized issue sorts first; unprioritized issue remains eligible |
+| All ready issues have `queuePriority: null` | ready candidate list | all priorities absent | preserve deterministic issue-number ordering |
+| Running candidate and ready candidate are both present | merged queue inputs | ready issue may have high priority | running candidate remains ahead; queue priority only reorders ready-vs-ready |
+| Due retry exists while ready issues are available | retry queue plus ready candidate list | ready issues may have priority | existing due-retry precedence remains unchanged |
+| Dispatch pressure is active | dispatch-pressure state | ready issues may carry normalized priority | do not dispatch fresh ready work; status stays explicit about pause posture and queue facts if projected |
+| Status snapshot written during a poll with ready candidates | runtime status state | normalized queue priorities on ready issues | snapshot projects ready order deterministically without tracker-specific fields |
+| Status snapshot is read from disk after the poll | persisted JSON snapshot | projected ready-order facts only | operators can see which ready issue would win and why without reconstructing tracker order manually |
+
+## Storage / Persistence Contract
+
+- no new durable control-plane storage
+- extend the persisted status snapshot JSON only as needed to carry the ready-queue projection
+- keep the projection tracker-neutral and derived from current in-memory ready candidates
+- avoid persisting raw tracker payloads or provider-specific field identifiers
+
+## Observability Requirements
+
+- the status snapshot should expose enough information to inspect ready-queue ordering, including issue identity and normalized queue-priority facts when present
+- the rendered status output should make clear that running issues and retries are separate from the ready queue and that queue priority only influences ready-vs-ready ordering
+- snapshot parsing must validate any new ready-queue fields clearly so stale/corrupt status files fail with actionable errors
+- tests should lock in both the JSON contract and rendered status summary for the new projection
+
+## Implementation Steps
+
+1. Identify the narrowest seam for ready-candidate ordering in `src/orchestrator/service.ts`, and refactor it only if needed so the precedence rules remain explicit.
+2. Apply `compareRuntimeIssuesByQueuePriority` to the ready-work subsection of the merged queue while preserving existing ordering for running candidates and due retries.
+3. Add a small tracker-neutral ready-queue snapshot type to the status contract that captures issue number, identifier/title, and normalized queue-priority facts relevant to ordering.
+4. Populate that projection in `src/orchestrator/status-state.ts` from the current ready candidates or merged ready subsection without leaking tracker-specific details.
+5. Update `src/observability/status.ts` to serialize, parse, and render the ready-queue ordering projection clearly.
+6. Add unit coverage for:
+   - ready-vs-ready dispatch ordering by normalized queue priority
+   - unchanged running/retry precedence
+   - snapshot contract round-trip for the new ready-queue projection
+   - rendered status output that explains the queue order
+7. Add or update orchestrator tests that prove the live dispatcher starts the highest-priority ready issue first.
+8. Update concise operator-facing docs describing that the status snapshot now exposes ready-queue ordering and that queue priority only affects ready-vs-ready dispatch.
+9. Run local self-review plus repo checks before PR creation.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- merged queue keeps running candidates ahead of ready candidates even when a ready issue has a better normalized priority
+- ready candidates sort by lower normalized `queuePriority.rank` first
+- ready candidates with equal or missing priority fall back to issue number ascending
+- status snapshot parse/render round-trips the ready-queue projection
+- status rendering includes the projected queue-priority explanation without tracker-specific fields
+
+### Integration
+
+- orchestrator `runOnce()` starts the highest-priority ready issue first when multiple ready issues are available and capacity is constrained
+- existing due-retry and running follow-up scenarios remain unchanged after the ordering update
+
+### Repo Gate
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- local self-review when a reliable review command is available
+
+## Acceptance Scenarios
+
+1. Given two ready issues with normalized priorities `rank=0` and `rank=2`, a single available slot dispatches the `rank=0` issue first.
+2. Given one ready issue with normalized priority and one without, the prioritized issue dispatches first and the other remains next in deterministic order.
+3. Given two ready issues with equal normalized rank, dispatch falls back to issue number ascending.
+4. Given a running issue plus multiple ready issues, the running issue still takes precedence regardless of ready-work priority.
+5. Given a due retry plus multiple ready issues, the due retry still keeps its existing precedence behavior.
+6. Given a status snapshot published during a poll, operators can inspect the projected ready queue and see the normalized priority facts that explain the winning ready issue.
+7. Given no normalized priority on any ready issue, the status snapshot still shows deterministic fallback order without implying tracker-native priority was used.
+
+## Exit Criteria
+
+- ready-work dispatch in the orchestrator uses normalized queue priority before issue-number fallback
+- existing running/retry/dispatch-pressure precedence remains intact
+- the status snapshot projects ready-queue ordering facts in a tracker-neutral contract
+- tests prove both the live dispatch behavior and the operator-visible projection
+- docs briefly explain the new operator-visible queue-ordering surface
+
+## Deferred To Later Issues Or PRs
+
+- richer TUI visualization of queue priority beyond the base status snapshot/rendering contract
+- report-generation changes centered on historical queue-order analysis
+- new queue heuristics that combine tracker-native priority with host preference, aging, or cost signals
+- further tracker adapter work beyond consuming the normalized priority facts already produced by `#191` and `#193`
+
+## Revision Log
+
+- 2026-03-19: Initial draft created for issue `#194` and marked `plan-ready`.

--- a/docs/plans/194-queue-ordering-observability/plan.md
+++ b/docs/plans/194-queue-ordering-observability/plan.md
@@ -152,16 +152,16 @@ Allowed ordering transitions in the merged queue:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected behavior |
-| --- | --- | --- | --- |
-| Two ready issues both have populated normalized priority | ready candidate list | both `queuePriority` values populated | lower rank sorts first; issue-number fallback used only on ties |
-| One ready issue has priority and another does not | ready candidate list | one populated `queuePriority`, one `null` | prioritized issue sorts first; unprioritized issue remains eligible |
-| All ready issues have `queuePriority: null` | ready candidate list | all priorities absent | preserve deterministic issue-number ordering |
-| Running candidate and ready candidate are both present | merged queue inputs | ready issue may have high priority | running candidate remains ahead; queue priority only reorders ready-vs-ready |
-| Due retry exists while ready issues are available | retry queue plus ready candidate list | ready issues may have priority | existing due-retry precedence remains unchanged |
-| Dispatch pressure is active | dispatch-pressure state | ready issues may carry normalized priority | do not dispatch fresh ready work; status stays explicit about pause posture and queue facts if projected |
-| Status snapshot written during a poll with ready candidates | runtime status state | normalized queue priorities on ready issues | snapshot projects ready order deterministically without tracker-specific fields |
-| Status snapshot is read from disk after the poll | persisted JSON snapshot | projected ready-order facts only | operators can see which ready issue would win and why without reconstructing tracker order manually |
+| Observed condition                                          | Local facts available                 | Normalized tracker facts available          | Expected behavior                                                                                        |
+| ----------------------------------------------------------- | ------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Two ready issues both have populated normalized priority    | ready candidate list                  | both `queuePriority` values populated       | lower rank sorts first; issue-number fallback used only on ties                                          |
+| One ready issue has priority and another does not           | ready candidate list                  | one populated `queuePriority`, one `null`   | prioritized issue sorts first; unprioritized issue remains eligible                                      |
+| All ready issues have `queuePriority: null`                 | ready candidate list                  | all priorities absent                       | preserve deterministic issue-number ordering                                                             |
+| Running candidate and ready candidate are both present      | merged queue inputs                   | ready issue may have high priority          | running candidate remains ahead; queue priority only reorders ready-vs-ready                             |
+| Due retry exists while ready issues are available           | retry queue plus ready candidate list | ready issues may have priority              | existing due-retry precedence remains unchanged                                                          |
+| Dispatch pressure is active                                 | dispatch-pressure state               | ready issues may carry normalized priority  | do not dispatch fresh ready work; status stays explicit about pause posture and queue facts if projected |
+| Status snapshot written during a poll with ready candidates | runtime status state                  | normalized queue priorities on ready issues | snapshot projects ready order deterministically without tracker-specific fields                          |
+| Status snapshot is read from disk after the poll            | persisted JSON snapshot               | projected ready-order facts only            | operators can see which ready issue would win and why without reconstructing tracker order manually      |
 
 ## Storage / Persistence Contract
 

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -171,6 +171,14 @@ export interface FactoryRetrySnapshot {
   readonly lastError: string;
 }
 
+export interface FactoryReadyQueueIssueSnapshot {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly queuePriorityRank: number | null;
+  readonly queuePriorityLabel: string | null;
+}
+
 export interface FactoryHostDispatchHostSnapshot {
   readonly name: string;
   readonly occupiedByIssueNumber: number | null;
@@ -232,6 +240,7 @@ export interface FactoryStatusSnapshot {
   readonly counts: FactoryStatusCounts;
   readonly lastAction: FactoryStatusAction | null;
   readonly activeIssues: readonly FactoryActiveIssueSnapshot[];
+  readonly readyQueue?: readonly FactoryReadyQueueIssueSnapshot[];
   readonly retries: readonly FactoryRetrySnapshot[];
 }
 
@@ -358,6 +367,7 @@ export function renderFactoryStatusSnapshot(
   const restartRecovery = getFactoryRestartRecovery(snapshot);
   const recoveryPosture = getFactoryRecoveryPosture(snapshot);
   const dispatchPressure = snapshot.dispatchPressure ?? null;
+  const readyQueue = snapshot.readyQueue ?? [];
   lines.push(`Restart recovery: ${restartRecovery.state}`);
   if (restartRecovery.summary !== null) {
     lines.push(`Restart recovery detail: ${restartRecovery.summary}`);
@@ -568,6 +578,36 @@ export function renderFactoryStatusSnapshot(
           lines.push(`    Runner timed out: ${visibility.timedOutAt}`);
         }
       }
+    }
+  }
+
+  lines.push("");
+  lines.push("Ready queue:");
+  if (readyQueue.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const [index, issue] of readyQueue.entries()) {
+      lines.push(
+        `  ${String(index + 1)}. #${issue.issueNumber.toString()} ${issue.title}`,
+      );
+      lines.push(
+        `    Priority: ${
+          issue.queuePriorityRank === null
+            ? "none"
+            : `rank=${issue.queuePriorityRank.toString()}${
+                issue.queuePriorityLabel === null
+                  ? ""
+                  : ` label=${issue.queuePriorityLabel}`
+              }`
+        }`,
+      );
+      lines.push(
+        `    Order reason: ${
+          issue.queuePriorityRank === null
+            ? "issue-number fallback"
+            : "normalized queue priority"
+        }`,
+      );
     }
   }
 
@@ -807,6 +847,17 @@ function parseFactoryStatusSnapshot(
       (entry, index) =>
         parseActiveIssue(entry, filePath, `activeIssues[${index.toString()}]`),
     ),
+    readyQueue: expectArray(
+      snapshot.readyQueue ?? [],
+      filePath,
+      "readyQueue",
+      (entry, index) =>
+        parseReadyQueueIssue(
+          entry,
+          filePath,
+          `readyQueue[${index.toString()}]`,
+        ),
+    ),
     retries: expectArray(
       snapshot.retries,
       filePath,
@@ -836,6 +887,37 @@ function parseHostDispatch(
           filePath,
           `hostDispatch.hosts[${index.toString()}]`,
         ),
+    ),
+  };
+}
+
+function parseReadyQueueIssue(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryReadyQueueIssueSnapshot {
+  const issue = expectObject(value, filePath, field);
+  return {
+    issueNumber: expectInteger(
+      issue.issueNumber,
+      filePath,
+      `${field}.issueNumber`,
+    ),
+    issueIdentifier: expectString(
+      issue.issueIdentifier,
+      filePath,
+      `${field}.issueIdentifier`,
+    ),
+    title: expectString(issue.title, filePath, `${field}.title`),
+    queuePriorityRank: expectNullableInteger(
+      issue.queuePriorityRank,
+      filePath,
+      `${field}.queuePriorityRank`,
+    ),
+    queuePriorityLabel: expectNullableString(
+      issue.queuePriorityLabel,
+      filePath,
+      `${field}.queuePriorityLabel`,
     ),
   };
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -11,6 +11,7 @@ import {
 } from "../domain/errors.js";
 import type { HandoffLifecycle } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
+import { compareRuntimeIssuesByQueuePriority } from "../domain/queue-priority.js";
 import type { RetryClass, RetryState } from "../domain/retry.js";
 import type { RunSession, RunTurn, RunUpdateEvent } from "../domain/run.js";
 import type {
@@ -156,6 +157,7 @@ import {
   noteStatusAction,
   noteTerminalIssue,
   noteWatchdogIssue,
+  setReadyQueue,
   setRestartRecoveryState,
   setTrackerIssueCounts,
   upsertActiveIssue,
@@ -538,8 +540,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         dispatchPressure === null
           ? collectDueRetries(this.#state.retries)
           : listDueRetries(this.#state.retries);
+      const orderedReadyQueue = this.#orderReadyCandidates(
+        readyCandidates,
+        runningCandidates,
+        dueRetries,
+      );
+      setReadyQueue(this.#state.status, orderedReadyQueue);
       queue = this.#mergeQueue(
-        dispatchPressure === null ? readyCandidates : [],
+        dispatchPressure === null ? orderedReadyQueue : [],
         runningCandidates,
         dueRetries,
       );
@@ -645,43 +653,67 @@ export class BootstrapOrchestrator implements Orchestrator {
       retryAttempts.set(retry.issue.number, retry.nextAttempt);
     }
 
-    const merged = new Map<number, QueueEntry>();
-    for (const issue of runningCandidates) {
+    const running: QueueEntry[] = [];
+    for (const issue of [...runningCandidates].sort(
+      (left, right) => left.number - right.number,
+    )) {
       if (
         !retryAttempts.has(issue.number) &&
         hasQueuedRetry(this.#state.retries, issue.number)
       ) {
         continue;
       }
-      merged.set(issue.number, {
+      running.push({
         issue,
         attempt: this.#resolveAttemptNumber(issue.number, retryAttempts),
         source: "running",
       });
     }
+
+    const runningIssueNumbers = new Set(
+      running.map((entry) => entry.issue.number),
+    );
+    const ready: QueueEntry[] = [];
     for (const issue of readyCandidates) {
-      if (
-        !retryAttempts.has(issue.number) &&
-        hasQueuedRetry(this.#state.retries, issue.number)
-      ) {
+      if (runningIssueNumbers.has(issue.number)) {
         continue;
       }
-      if (merged.has(issue.number)) {
-        continue;
-      }
-      merged.set(issue.number, {
+      ready.push({
         issue,
         attempt: this.#resolveAttemptNumber(issue.number, retryAttempts),
         source: "ready",
       });
     }
 
-    return [...merged.values()].sort((left, right) => {
-      if (left.source !== right.source) {
-        return left.source === "running" ? -1 : 1;
-      }
-      return left.issue.number - right.issue.number;
-    });
+    return [...running, ...ready];
+  }
+
+  #orderReadyCandidates(
+    readyCandidates: readonly RuntimeIssue[],
+    runningCandidates: readonly RuntimeIssue[],
+    dueRetries: readonly RetryState[],
+  ): readonly RuntimeIssue[] {
+    const dueRetryIssueNumbers = new Set(
+      dueRetries.map((retry) => retry.issue.number),
+    );
+    const runningIssueNumbers = new Set(
+      runningCandidates.map((issue) => issue.number),
+    );
+
+    return [...readyCandidates]
+      .filter((issue) => {
+        if (runningIssueNumbers.has(issue.number)) {
+          return false;
+        }
+        if (
+          !dueRetryIssueNumbers.has(issue.number) &&
+          hasQueuedRetry(this.#state.retries, issue.number)
+        ) {
+          return false;
+        }
+        return true;
+      })
+      .sort(compareRuntimeIssuesByQueuePriority);
   }
 
   #resolveAttemptNumber(

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -4,6 +4,7 @@ import type {
   FactoryActiveIssueSnapshot,
   FactoryHostDispatchSnapshot,
   FactoryIssueStatus,
+  FactoryReadyQueueIssueSnapshot,
   FactoryRestartRecoveryIssueSnapshot,
   FactoryRestartRecoveryState,
   FactoryState,
@@ -36,6 +37,7 @@ export interface RuntimeStatusState {
   readonly workerStartedAt: string;
   trackerCounts: TrackerIssueCounts;
   readonly activeIssues: Map<number, RuntimeActiveIssueState>;
+  readyQueue: readonly FactoryReadyQueueIssueSnapshot[];
   readonly watchdogIssues: Map<number, RuntimeWatchdogPosture>;
   terminalIssues: readonly RuntimeTerminalCleanupPosture[];
   restartRecovery: {
@@ -57,6 +59,7 @@ export function createRuntimeStatusState(): RuntimeStatusState {
       failed: 0,
     },
     activeIssues: new Map<number, RuntimeActiveIssueState>(),
+    readyQueue: [],
     watchdogIssues: new Map<number, RuntimeWatchdogPosture>(),
     terminalIssues: [],
     restartRecovery: {
@@ -246,6 +249,19 @@ export function clearActiveIssue(
   state.activeIssues.delete(issueNumber);
 }
 
+export function setReadyQueue(
+  state: RuntimeStatusState,
+  issues: readonly RuntimeIssue[],
+): void {
+  state.readyQueue = issues.map((issue) => ({
+    issueNumber: issue.number,
+    issueIdentifier: issue.identifier,
+    title: issue.title,
+    queuePriorityRank: issue.queuePriority?.rank ?? null,
+    queuePriorityLabel: issue.queuePriority?.label ?? null,
+  }));
+}
+
 export function noteWatchdogIssue(
   state: RuntimeStatusState,
   update: RuntimeWatchdogPosture,
@@ -371,6 +387,7 @@ export function buildFactoryStatusSnapshot(input: {
     },
     lastAction: input.state.lastAction,
     activeIssues,
+    readyQueue: input.state.readyQueue,
     retries,
   };
 }

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -967,6 +967,184 @@ describe("BootstrapOrchestrator", () => {
     }
   });
 
+  it("starts the highest-priority ready issue first when capacity is constrained", async () => {
+    const tempRoot = await createTempDir("symphony-ready-priority-test-");
+    try {
+      const lowPriorityIssue = {
+        ...createIssue(1),
+        title: "Low priority",
+        queuePriority: { rank: 2, label: "P2" },
+      };
+      const highestPriorityIssue = {
+        ...createIssue(2),
+        title: "Highest priority",
+        queuePriority: { rank: 0, label: "P0" },
+      };
+      const fallbackIssue = {
+        ...createIssue(3),
+        title: "Fallback issue",
+      };
+      const tracker = new SequencedTracker({
+        ready: [lowPriorityIssue, fallbackIssue, highestPriorityIssue],
+      });
+      tracker.setLifecycleSequence(2, [
+        lifecycle("missing-target", "symphony/2"),
+        lifecycle("handoff-ready", "symphony/2"),
+      ]);
+
+      const runnerIssues: number[] = [];
+      const runner: Runner = {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(session): Promise<RunnerExecutionResult> {
+          runnerIssues.push(session.issue.number);
+          const timestamp = new Date().toISOString();
+          return {
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      };
+
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+          polling: {
+            ...baseConfig.polling,
+            maxConcurrentRuns: 1,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        runner,
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      expect(runnerIssues).toEqual([2]);
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(snapshot.readyQueue).toEqual([
+        {
+          issueNumber: 2,
+          issueIdentifier: "sociotechnica-org/symphony-ts#2",
+          title: "Highest priority",
+          queuePriorityRank: 0,
+          queuePriorityLabel: "P0",
+        },
+        {
+          issueNumber: 1,
+          issueIdentifier: "sociotechnica-org/symphony-ts#1",
+          title: "Low priority",
+          queuePriorityRank: 2,
+          queuePriorityLabel: "P2",
+        },
+        {
+          issueNumber: 3,
+          issueIdentifier: "sociotechnica-org/symphony-ts#3",
+          title: "Fallback issue",
+          queuePriorityRank: null,
+          queuePriorityLabel: null,
+        },
+      ]);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps running-issue precedence ahead of higher-priority ready work", async () => {
+    const tempRoot = await createTempDir("symphony-running-precedence-test-");
+    try {
+      const runningIssue = createIssue(10, "symphony:running");
+      const readyIssue = {
+        ...createIssue(11),
+        title: "Urgent ready issue",
+        queuePriority: { rank: 0, label: "P0" },
+      };
+      const tracker = new SequencedTracker({
+        ready: [readyIssue],
+        running: [runningIssue],
+      });
+      tracker.setLifecycleSequence(10, [
+        lifecycle("awaiting-human-review", "symphony/10"),
+      ]);
+
+      const runnerIssues: number[] = [];
+      const runner: Runner = {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(session): Promise<RunnerExecutionResult> {
+          runnerIssues.push(session.issue.number);
+          const timestamp = new Date().toISOString();
+          return {
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      };
+
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...baseConfig,
+          workspace: {
+            ...baseConfig.workspace,
+            root: tempRoot,
+          },
+          polling: {
+            ...baseConfig.polling,
+            maxConcurrentRuns: 1,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        runner,
+        new NullLogger(),
+      );
+
+      await orchestrator.runOnce();
+
+      expect(runnerIssues).toEqual([]);
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(tempRoot),
+      );
+      expect(snapshot.activeIssues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            issueNumber: 10,
+            status: "awaiting-human-review",
+          }),
+        ]),
+      );
+      expect(snapshot.readyQueue).toEqual([
+        {
+          issueNumber: 11,
+          issueIdentifier: "sociotechnica-org/symphony-ts#11",
+          title: "Urgent ready issue",
+          queuePriorityRank: 0,
+          queuePriorityLabel: "P0",
+        },
+      ]);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps polling after a transient poll-level failure", async () => {
     const tempRoot = await createTempDir("symphony-loop-test-");
     try {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -187,6 +187,22 @@ function createSnapshot(
         },
       },
     ],
+    readyQueue: [
+      {
+        issueNumber: 7,
+        issueIdentifier: "sociotechnica-org/symphony-ts#7",
+        title: "Highest ready priority",
+        queuePriorityRank: 0,
+        queuePriorityLabel: "P0",
+      },
+      {
+        issueNumber: 8,
+        issueIdentifier: "sociotechnica-org/symphony-ts#8",
+        title: "Fallback ready order",
+        queuePriorityRank: null,
+        queuePriorityLabel: null,
+      },
+    ],
     retries: [
       {
         issueNumber: 9,
@@ -373,6 +389,10 @@ describe("factory status helpers", () => {
     expect(rendered).toContain(
       "Scheduled: 2026-03-06T12:00:00.000Z (+300000ms)",
     );
+    expect(rendered).toContain("Ready queue:");
+    expect(rendered).toContain("1. #7 Highest ready priority");
+    expect(rendered).toContain("Priority: rank=0 label=P0");
+    expect(rendered).toContain("Order reason: normalized queue priority");
   });
 
   it("round-trips dispatch pressure in the snapshot contract", async () => {
@@ -595,6 +615,9 @@ describe("factory status helpers", () => {
     );
     expect(output).toContain("Runner action: Waiting for PR checks");
     expect(output).toContain("Pending checks: CI");
+    expect(output).toContain("Ready queue:");
+    expect(output).toContain("2. #8 Fallback ready order");
+    expect(output).toContain("Order reason: issue-number fallback");
     expect(output).toContain("Retries:");
     expect(output).toContain("#9 Retry a failed run attempt 2");
   });


### PR DESCRIPTION
## Summary
- order ready issue dispatch by normalized tracker-native queue priority before issue-number fallback
- project the ordered ready queue through the status snapshot and human-readable status output
- add unit coverage for ready queue ordering, running precedence, and ready queue status rendering

Closes #194

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
