### PR TITLE
Treat missing reviewer-app output as degraded infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ from existing issue reports. They are written under:
 9. Symphony executes a guarded landing path that re-checks mergeability, required checks, required approved bot review presence, and unresolved review threads before merge
 10. Symphony comments on the issue and closes it only after merge is actually observed
 
+If expected reviewer apps are configured and never produce qualifying output on the current head after checks settle, Symphony treats that as degraded external infrastructure rather than a normal review-clean wait state.
+
 If a run fails, Symphony retries. After retries are exhausted, it marks the issue `symphony:failed`.
 
 Active run ownership is persisted locally as a transport-aware execution-owner record. On restart, Symphony reconciles `symphony:running` issues against local state, recovers orphaned runs, and resumes or fails them cleanly without assuming every execution owns a local runner PID. Per-issue reporting artifacts are written to `.var/factory/issues/` so they survive workspace cleanup. Generated per-issue reports are written under `.var/reports/issues/<issue-number>/` when the report command is run.

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -39,7 +39,7 @@ Run this sequence at the start of each operator pass:
    - active issues in `awaiting-human-handoff`
    - active issues or PRs in `awaiting-landing-command`
 4. If the detached runtime is stopped or degraded, repair that first.
-5. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`.
+5. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
 6. After a merge, fast-forward the root checkout and `.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
@@ -90,13 +90,14 @@ Interpret the main recovery-posture families this way:
 - `retry-backoff`: at least one issue is queued for retry; avoid manual reruns unless the posture is stuck or degraded
 - `watchdog-recovery`: a stalled run triggered watchdog recovery or watchdog-driven retry
 - `restart-recovery`: startup is reconciling inherited `symphony:running` work or surfacing restart decisions
-- `degraded` or `degraded-observability`: inspect before taking further action; this is not a healthy wait state
+- `degraded` or `degraded-observability`: inspect before taking further action; this is not a healthy wait state. Missing expected reviewer-app output after checks settle also belongs here.
 
 Issue-level lifecycle checkpoints:
 
 - `awaiting-human-handoff`: review the technical plan and reply with an accepted plan-review marker
 - `awaiting-system-checks`: wait for CI or automated review follow-up unless a check is obviously stuck
 - `awaiting-human-review` or `rework-required`: inspect the PR review state and let the factory push follow-up if it is already responding
+- `degraded-review-infrastructure`: expected reviewer-app output never arrived on the current head after checks settled; inspect the reviewer app/integration before treating the PR as review-clean
 - `awaiting-landing-command`: post `/land` when the PR is green, review-clean, and required approved bot review has been observed on the current head
 - `awaiting-landing`: the landing request was issued; wait for merge observation or a clear landing failure
 
@@ -109,6 +110,7 @@ Use this table:
 | Situation                                                                                        | Operator action                                                                                                             |
 | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `awaiting-human-handoff`                                                                         | Review the plan and post `Plan review: approved`, `Plan review: changes-requested`, or `Plan review: waived`                |
+| `degraded-review-infrastructure`                                                                 | Inspect the missing reviewer-app output path before further automation or manual landing                                    |
 | `awaiting-landing-command` with green, review-clean PR and required approved bot review observed | Post `/land` on the PR                                                                                                      |
 | Detached runtime stopped or degraded                                                             | Use `factory status`, then `factory start` or `factory restart`                                                             |
 | `restart-recovery` visible after startup                                                         | Inspect the recovery summary and per-issue decisions before manual reruns                                                   |
@@ -135,7 +137,7 @@ Two human checkpoints remain explicit even when the factory is otherwise autonom
 1. Technical plan review before substantial implementation unless the review is explicitly waived.
 2. Landing approval through `/land` on a review-clean PR whose current head already has required approved bot review.
 
-If either checkpoint is waiting, treat that as normal `waiting-expected` posture, not a runtime failure.
+If either checkpoint is waiting, treat that as normal `waiting-expected` posture, not a runtime failure. If expected reviewer-app output is missing after checks settle, that is not a normal checkpoint wait; it is degraded infrastructure.
 
 ## Stability Validation
 

--- a/docs/plans/208-missing-reviewer-app-output-degraded/plan.md
+++ b/docs/plans/208-missing-reviewer-app-output-degraded/plan.md
@@ -1,0 +1,258 @@
+# Issue 208 Plan: Treat Missing Reviewer-App Output As Degraded Infrastructure
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Treat the absence of expected reviewer-app output on the current PR head as degraded external infrastructure once the normal check surface has settled, so Symphony blocks automation with an explicit degraded reason instead of treating the PR as a normal review wait or a clean review surface.
+
+## Scope
+
+- normalize a distinct tracker-side state for "required reviewer app output missing after checks settled"
+- project that state through PR lifecycle evaluation and guarded landing with an explicit degraded reason
+- surface the degraded reviewer-app condition in operator-facing status, artifacts, and docs
+- add regression coverage for the outage path where configured reviewer apps never produce output at all
+
+## Non-goals
+
+- redesigning the broader review loop beyond the missing-reviewer-app outage seam
+- introducing remote reviewer orchestration, app retries, or bot-trigger APIs
+- changing `review_bot_logins` actionable-feedback semantics
+- inventing a tracker-agnostic approval framework beyond the GitHub bootstrap/runtime contract already in place
+- reworking unrelated degraded runtime posture families such as restart recovery or watchdog recovery
+
+## Current Gaps
+
+- `src/tracker/pull-request-snapshot.ts` records whether required approved bot review has been observed, but it does not distinguish "still naturally pending" from "expected reviewer app never produced output"
+- `src/tracker/pull-request-policy.ts` currently reports missing required approved bot review as ordinary `awaiting-human-review`, which reads like a normal review wait instead of an infrastructure failure
+- `src/tracker/guarded-landing.ts` blocks on missing required bot review, but the blocked reason is not modeled as degraded reviewer-app infrastructure
+- orchestrator and status surfaces only receive the existing handoff lifecycle kinds, so this outage path is easy to mistake for ordinary review debt
+- README and operator guidance do not yet say that a configured reviewer app silently disappearing is degraded external infrastructure
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: define that configured required reviewer-app output is mandatory coverage and that silent absence after checks settle is degraded infrastructure, not ordinary review waiting
+  - does not belong: GitHub transport details, raw comment parsing, or merge API behavior
+- Configuration Layer
+  - belongs: reuse the existing `approved_review_bot_logins` contract as the source of "expected reviewer app output" for this slice unless implementation evidence forces a narrower config seam
+  - does not belong: lifecycle/degraded-state evaluation logic
+- Coordination Layer
+  - belongs: consume a normalized degraded review-output lifecycle/reason and block further progression without adding GitHub-specific heuristics
+  - does not belong: raw review/comment/check interpretation
+- Execution Layer
+  - belongs: no workspace or runner changes in this slice
+  - does not belong: reviewer-app outage detection or handoff policy
+- Integration Layer
+  - belongs: normalize when required reviewer-app output is satisfied, naturally pending, or missing after the PR check surface has settled
+  - does not belong: orchestrator retry policy or operator rendering logic
+- Observability Layer
+  - belongs: expose the degraded reviewer-app reason in lifecycle summaries, issue artifacts, status surfaces, and docs
+  - does not belong: re-deriving outage state from raw GitHub payloads
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/tracker/pull-request-snapshot.ts`
+  - add a normalized reviewer-app output state/reason instead of a single overloaded boolean
+- `src/tracker/pull-request-policy.ts`
+  - map the normalized missing-output outage state to a degraded lifecycle outcome rather than ordinary human-review waiting
+- `src/tracker/guarded-landing.ts` and `src/tracker/service.ts`
+  - preserve fail-closed landing behavior while surfacing a degraded reviewer-app reason that matches lifecycle evaluation
+- `src/domain/handoff.ts`, `src/observability/`, and orchestrator status projection
+  - carry the new degraded lifecycle/reason through existing read models without leaking GitHub-specific parsing upward
+- docs and tests
+  - update operator/user-facing wording and add regression coverage
+
+### Does not belong in this issue
+
+- workflow prompt changes
+- tracker transport rewrites or GraphQL schema reshaping unrelated to reviewer-app evidence
+- generic degraded-state refactors across all lifecycle families
+- landing-policy changes unrelated to missing reviewer-app output
+- multi-tracker parity work for Linear
+
+## Layering Notes
+
+- `config/workflow`
+  - remains the repository-owned source of configured required reviewer bots
+  - should not decide when missing output becomes degraded
+- `tracker`
+  - owns the normalization and policy distinction between pending reviewer execution and missing reviewer output
+  - should keep review/comment parsing separate from policy decisions
+- `workspace`
+  - unchanged
+- `runner`
+  - unchanged
+- `orchestrator`
+  - consumes a normalized degraded lifecycle/reason and blocks progression
+  - must not inspect bot logins, comment bodies, or GitHub check names directly
+- `observability`
+  - renders the normalized degraded state clearly
+  - must not infer degraded reviewer-app outages by reverse-engineering tracker payload side effects
+
+## Slice Strategy And PR Seam
+
+Keep this as one reviewable PR focused on a single state-contract seam:
+
+1. normalize reviewer-app output into distinct states rather than a single "approved review satisfied" boolean
+2. project the "missing output after checks settled" state as degraded handoff/landing policy
+3. update status/docs/tests for the new degraded reason
+
+Deferred:
+
+- reviewer-app-specific timeout/backoff policy beyond the current "checks settled but output missing" detection
+- richer per-bot operator dashboards or quorum rules
+- Linear or other tracker implementations of the same degraded reviewer-app contract
+
+This seam is reviewable because it strengthens one existing GitHub handoff contract without reopening runner execution, plan review flow, or broader recovery posture design.
+
+## Runtime State Model
+
+This issue changes stateful handoff behavior, so the plan makes the reviewer-app-output states explicit.
+
+### Normalized reviewer-app coverage states
+
+1. `not-required`
+   - no approved reviewer bots are configured for this workflow
+2. `waiting-on-check-surface`
+   - the PR still has pending checks or is still in the no-check stabilization pass, so reviewer apps may still appear naturally
+3. `satisfied`
+   - at least one configured approved reviewer bot produced qualifying output on the current head
+4. `missing-output-degraded`
+   - checks have settled past the natural waiting phase, but no configured approved reviewer bot produced qualifying output on the current head
+
+### Handoff lifecycle states relevant to this issue
+
+- `awaiting-system-checks`
+  - used while the review/check surface is still naturally pending
+- `rework-required`
+  - used when bot feedback or failed terminal checks require another run
+- `degraded-review-infrastructure`
+  - new explicit lifecycle for silent missing reviewer-app output after checks settle
+- `awaiting-landing-command`
+  - only allowed once reviewer-app coverage is satisfied and no other gates remain
+- `awaiting-landing`
+  - `/land` observed; guarded landing still re-checks reviewer-app coverage
+- `handoff-ready`
+  - merge observed
+
+### Allowed transitions relevant to this issue
+
+- `awaiting-system-checks` -> `degraded-review-infrastructure`
+  - checks/no-check stabilization have settled, but required reviewer-app output is still absent
+- `awaiting-system-checks` -> `awaiting-landing-command`
+  - checks are settled and reviewer-app coverage is satisfied with no other blockers
+- `degraded-review-infrastructure` -> `rework-required`
+  - reviewer app eventually reports actionable feedback on the current head
+- `degraded-review-infrastructure` -> `awaiting-landing-command`
+  - reviewer app eventually reports qualifying non-actionable output on the current head
+- `awaiting-landing` -> `degraded-review-infrastructure`
+  - guarded landing re-check sees that reviewer-app coverage is still missing for the current head
+- `awaiting-landing` -> `handoff-ready`
+  - guarded landing succeeds and merge is observed
+
+### Coordination decision rules
+
+- do not classify reviewer-app absence as degraded while checks are still pending or while the no-check stabilization pass is still active
+- once the PR is otherwise check-clean and reviewer-app output is still absent, fail closed with an explicit degraded lifecycle/reason
+- keep the orchestrator tracker-neutral by consuming only normalized lifecycle kinds/reasons
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Pending CI or requested reviewer-app status is still visible | no landing attempt active | coverage state = `waiting-on-check-surface`; pending checks present | stay in `awaiting-system-checks` |
+| No checks were visible on first inspection | no landing attempt active | no-check stabilization observation absent | stay in `awaiting-system-checks` for stabilization |
+| No checks are visible after the stabilization pass, and no approved reviewer bot has produced output | no landing attempt active | coverage state = `missing-output-degraded` | report `degraded-review-infrastructure` with explicit missing-output reason |
+| Checks are green and a configured approved reviewer bot leaves a qualifying clean output | no landing attempt active | coverage state = `satisfied`; actionable feedback count = 0 | move to `awaiting-landing-command` |
+| Checks are green and a configured approved reviewer bot leaves actionable feedback | no landing attempt active | coverage state = `satisfied`; actionable feedback count > 0 | move to `rework-required` |
+| `/land` exists, but guarded landing re-check still finds no reviewer-app output on current head | landing approval recorded | coverage state = `missing-output-degraded` | block landing with degraded reviewer-app reason and lifecycle fallback |
+| Required approved reviewer bot list is empty | no landing attempt active | coverage state = `not-required` | preserve existing non-degraded behavior |
+
+## Storage / Persistence Contract
+
+- no new durable store is introduced
+- workflow config remains the source of truth for configured approved reviewer bots
+- reviewer-app coverage/degraded state remains a normalized, ephemeral tracker snapshot derived from GitHub facts on the current PR head
+- issue artifacts and landing-blocked summaries should persist the normalized degraded reason, not raw GitHub review payloads
+
+## Observability Requirements
+
+- status and lifecycle summaries must distinguish:
+  - normal review waiting
+  - reviewer-app output satisfied
+  - degraded reviewer-app infrastructure because expected output never appeared
+- issue artifacts/reporting should preserve the explicit degraded lifecycle/reason for later inspection
+- operator docs should state that silent absence from configured reviewer apps is treated as degraded external infrastructure, not a clean review surface
+- landing-blocked output should use the same degraded reason vocabulary as handoff inspection
+
+## Decision Notes
+
+- Reuse `approved_review_bot_logins` as the expected reviewer-app contract for this slice unless implementation evidence shows an unavoidable mismatch between "required reviewer app" and "approved review bot" semantics. That keeps the change narrow and avoids inventing a second overlapping workflow list without proof it is needed.
+- Model this as a distinct normalized state, not just a different summary string. The issue is specifically about classification and operator posture, not only wording.
+- Prefer a dedicated degraded lifecycle kind over overloading `awaiting-human-review`; otherwise operator surfaces and downstream logic will continue to treat infrastructure outage as ordinary review debt.
+
+## Implementation Steps
+
+1. Extend the handoff domain types with a dedicated degraded reviewer-app lifecycle kind and any supporting normalized reason surface needed for artifacts/status.
+2. Replace the single `requiredApprovedReviewSatisfied` gate in `src/tracker/pull-request-snapshot.ts` with a normalized reviewer-app coverage state that can distinguish waiting, satisfied, and missing-output-degraded.
+3. Update `src/tracker/pull-request-policy.ts` so the current-head missing-output outage path returns the degraded lifecycle kind after the check surface has settled.
+4. Update `src/tracker/guarded-landing.ts` and `src/tracker/service.ts` so guarded landing uses the same degraded reviewer-app reason and lifecycle fallback.
+5. Thread the new lifecycle kind through orchestrator/status/artifact projections without adding GitHub-specific logic above the tracker boundary.
+6. Update README and any operator docs that currently imply missing reviewer-app output is ordinary review waiting.
+7. Add regression coverage across unit, integration, and e2e layers for the missing-output-degraded path and the satisfied/actionable follow-up paths.
+8. Run local self-review and repository gates before opening/updating the PR:
+   - `pnpm format:check`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+   - `codex review --base origin/main` if available and reliable
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- reviewer-app coverage normalization distinguishes `waiting-on-check-surface` from `missing-output-degraded`
+- PR lifecycle evaluation returns `degraded-review-infrastructure` once checks are settled and required reviewer-app output is still absent
+- PR lifecycle evaluation stays in `awaiting-system-checks` during the no-check stabilization pass
+- guarded landing rejects with the degraded reviewer-app reason when current-head reviewer output is still missing
+
+### Integration
+
+- `GitHubTracker.inspectIssueHandoff()` reports `degraded-review-infrastructure` for a clean PR whose configured reviewer apps never emit output after checks settle
+- `GitHubTracker.inspectIssueHandoff()` remains `awaiting-system-checks` while requested/in-progress reviewer-app statuses are still present
+- `GitHubTracker.inspectIssueHandoff()` transitions from degraded to `awaiting-landing-command` once a configured reviewer app leaves qualifying clean output on the current head
+- `GitHubTracker.executeLanding()` returns a blocked degraded reviewer-app result when `/land` is present but required reviewer output is still absent
+
+### End-to-end
+
+- factory run opens a PR, CI turns green, configured reviewer apps never emit output, and the run remains visibly degraded instead of looking review-clean
+- factory run opens a PR, reviewer-app output is initially missing, then a configured app emits a clean review on the current head, and the run advances to `awaiting-landing-command`
+- after a follow-up push, stale prior-head reviewer output does not satisfy the requirement for the new head, and the run returns to the degraded/waiting path according to the new normalized state
+
+### Acceptance Scenarios
+
+1. Bugbot is configured in `approved_review_bot_logins`, CI is green, Bugbot never leaves any review output, and Symphony reports degraded reviewer-app infrastructure instead of ordinary human-review waiting.
+2. Bugbot has a requested or in-progress check/status, and Symphony stays in `awaiting-system-checks` rather than prematurely calling the PR degraded.
+3. Bugbot eventually leaves a qualifying clean summary on the current head, and Symphony clears the degraded condition and waits for `/land`.
+4. A `/land` comment on a PR with missing reviewer-app output still fails closed with the same degraded reviewer-app reason.
+
+## Exit Criteria
+
+1. Symphony no longer reports silent missing reviewer-app output as an ordinary review wait once the PR check surface has settled
+2. reviewer-app outage classification is normalized in the tracker instead of inferred ad hoc in observability
+3. guarded landing and handoff inspection use the same degraded reviewer-app vocabulary
+4. operator-facing status/artifacts/docs make the degraded reason explicit
+5. regression coverage exists for pending, degraded, satisfied, and actionable reviewer-app outcomes
+6. `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass
+
+## Deferred To Later Issues Or PRs
+
+- reviewer-app-specific timers, escalation comments, or automatic retrigger behavior
+- per-app quorum rules such as "all configured reviewer apps must respond"
+- non-GitHub implementations of degraded reviewer-app infrastructure semantics
+- broader unification of degraded lifecycle families across handoff, recovery posture, and factory control surfaces

--- a/docs/plans/208-missing-reviewer-app-output-degraded/plan.md
+++ b/docs/plans/208-missing-reviewer-app-output-degraded/plan.md
@@ -163,15 +163,15 @@ This issue changes stateful handoff behavior, so the plan makes the reviewer-app
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Pending CI or requested reviewer-app status is still visible | no landing attempt active | coverage state = `waiting-on-check-surface`; pending checks present | stay in `awaiting-system-checks` |
-| No checks were visible on first inspection | no landing attempt active | no-check stabilization observation absent | stay in `awaiting-system-checks` for stabilization |
-| No checks are visible after the stabilization pass, and no approved reviewer bot has produced output | no landing attempt active | coverage state = `missing-output-degraded` | report `degraded-review-infrastructure` with explicit missing-output reason |
-| Checks are green and a configured approved reviewer bot leaves a qualifying clean output | no landing attempt active | coverage state = `satisfied`; actionable feedback count = 0 | move to `awaiting-landing-command` |
-| Checks are green and a configured approved reviewer bot leaves actionable feedback | no landing attempt active | coverage state = `satisfied`; actionable feedback count > 0 | move to `rework-required` |
-| `/land` exists, but guarded landing re-check still finds no reviewer-app output on current head | landing approval recorded | coverage state = `missing-output-degraded` | block landing with degraded reviewer-app reason and lifecycle fallback |
-| Required approved reviewer bot list is empty | no landing attempt active | coverage state = `not-required` | preserve existing non-degraded behavior |
+| Observed condition                                                                                   | Local facts available     | Normalized tracker facts available                                  | Expected decision                                                           |
+| ---------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Pending CI or requested reviewer-app status is still visible                                         | no landing attempt active | coverage state = `waiting-on-check-surface`; pending checks present | stay in `awaiting-system-checks`                                            |
+| No checks were visible on first inspection                                                           | no landing attempt active | no-check stabilization observation absent                           | stay in `awaiting-system-checks` for stabilization                          |
+| No checks are visible after the stabilization pass, and no approved reviewer bot has produced output | no landing attempt active | coverage state = `missing-output-degraded`                          | report `degraded-review-infrastructure` with explicit missing-output reason |
+| Checks are green and a configured approved reviewer bot leaves a qualifying clean output             | no landing attempt active | coverage state = `satisfied`; actionable feedback count = 0         | move to `awaiting-landing-command`                                          |
+| Checks are green and a configured approved reviewer bot leaves actionable feedback                   | no landing attempt active | coverage state = `satisfied`; actionable feedback count > 0         | move to `rework-required`                                                   |
+| `/land` exists, but guarded landing re-check still finds no reviewer-app output on current head      | landing approval recorded | coverage state = `missing-output-degraded`                          | block landing with degraded reviewer-app reason and lifecycle fallback      |
+| Required approved reviewer bot list is empty                                                         | no landing attempt active | coverage state = `not-required`                                     | preserve existing non-degraded behavior                                     |
 
 ## Storage / Persistence Contract
 

--- a/src/domain/handoff.ts
+++ b/src/domain/handoff.ts
@@ -3,6 +3,7 @@ export type HandoffLifecycleKind =
   | "awaiting-human-handoff"
   | "awaiting-human-review"
   | "awaiting-system-checks"
+  | "degraded-review-infrastructure"
   | "awaiting-landing-command"
   | "awaiting-landing"
   | "rework-required"

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -39,6 +39,7 @@ export type IssueArtifactOutcome =
   | "merged"
   | "awaiting-human-review"
   | "awaiting-system-checks"
+  | "degraded-review-infrastructure"
   | "awaiting-landing-command"
   | "awaiting-landing"
   | "rework-required"

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -1473,6 +1473,7 @@ function readLifecycleKindFromDetails(
   return lifecycleKind === "merged" ||
     lifecycleKind === "awaiting-human-review" ||
     lifecycleKind === "awaiting-system-checks" ||
+    lifecycleKind === "degraded-review-infrastructure" ||
     lifecycleKind === "rework-required" ||
     lifecycleKind === "awaiting-landing-command" ||
     lifecycleKind === "awaiting-landing"

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -42,6 +42,7 @@ export type FactoryIssueStatus =
   | "merged"
   | "awaiting-human-review"
   | "awaiting-system-checks"
+  | "degraded-review-infrastructure"
   | "awaiting-landing-command"
   | "awaiting-landing"
   | "rework-required";
@@ -95,6 +96,7 @@ export interface FactoryRestartRecoveryIssueSnapshot {
     | "awaiting-human-handoff"
     | "awaiting-human-review"
     | "awaiting-system-checks"
+    | "degraded-review-infrastructure"
     | "awaiting-landing-command"
     | "awaiting-landing"
     | "rework-required"
@@ -1196,6 +1198,7 @@ function parseRestartRecoveryIssue(
         "awaiting-human-handoff",
         "awaiting-human-review",
         "awaiting-system-checks",
+        "degraded-review-infrastructure",
         "awaiting-landing-command",
         "awaiting-landing",
         "rework-required",
@@ -1335,6 +1338,7 @@ function parseActiveIssue(
         "merged",
         "awaiting-human-review",
         "awaiting-system-checks",
+        "degraded-review-infrastructure",
         "awaiting-landing-command",
         "awaiting-landing",
         "rework-required",

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -1185,6 +1185,8 @@ function resolveStageLabel(entry: TuiSnapshot["running"][number]): string {
       return "human-review";
     case "awaiting-system-checks":
       return "system-checks";
+    case "degraded-review-infrastructure":
+      return "degraded-review";
     case "awaiting-landing-command":
       return "landing-command";
     case "awaiting-landing":

--- a/src/orchestrator/recovery-posture.ts
+++ b/src/orchestrator/recovery-posture.ts
@@ -137,6 +137,19 @@ export function projectRecoveryPosture(input: {
       continue;
     }
 
+    if (issue.status === "degraded-review-infrastructure") {
+      upsertIssueEntry(issueEntries, {
+        family: "degraded",
+        issueNumber: issue.issueNumber,
+        issueIdentifier: issue.issueIdentifier,
+        title: issue.title,
+        source: "active-issue",
+        summary: issue.blockedReason ?? issue.summary,
+        observedAt: issue.updatedAt,
+      });
+      continue;
+    }
+
     if (WAITING_STATUSES.has(issue.status)) {
       upsertIssueEntry(issueEntries, {
         family: "waiting-expected",

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -880,6 +880,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       lifecycle.kind === "awaiting-system-checks" ||
       lifecycle.kind === "awaiting-human-handoff" ||
       lifecycle.kind === "awaiting-human-review" ||
+      lifecycle.kind === "degraded-review-infrastructure" ||
       lifecycle.kind === "awaiting-landing-command"
     ) {
       clearLandingRuntimeState(this.#state.landing, issue.number);
@@ -1749,6 +1750,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       lifecycle.kind === "awaiting-system-checks" ||
       lifecycle.kind === "awaiting-human-handoff" ||
       lifecycle.kind === "awaiting-human-review" ||
+      lifecycle.kind === "degraded-review-infrastructure" ||
       lifecycle.kind === "awaiting-landing-command" ||
       lifecycle.kind === "awaiting-landing" ||
       lifecycle.kind === "rework-required"
@@ -3126,6 +3128,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       lifecycle.kind !== "awaiting-landing-command" &&
       lifecycle.kind !== "awaiting-human-review" &&
       lifecycle.kind !== "awaiting-system-checks" &&
+      lifecycle.kind !== "degraded-review-infrastructure" &&
       lifecycle.kind !== "awaiting-landing" &&
       lifecycle.kind !== "rework-required"
     ) {
@@ -3157,6 +3160,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     | "awaiting-plan-review"
     | "awaiting-human-review"
     | "awaiting-system-checks"
+    | "degraded-review-infrastructure"
     | "awaiting-landing-command"
     | "awaiting-landing"
     | "rework-required"
@@ -3168,6 +3172,8 @@ export class BootstrapOrchestrator implements Orchestrator {
         return "awaiting-human-review";
       case "awaiting-system-checks":
         return "awaiting-system-checks";
+      case "degraded-review-infrastructure":
+        return "degraded-review-infrastructure";
       case "awaiting-landing-command":
         return "awaiting-landing-command";
       case "awaiting-landing":

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -207,11 +207,13 @@ export function noteLifecycleForIssue(
             ? "awaiting-human-review"
             : lifecycle.kind === "awaiting-system-checks"
               ? "awaiting-system-checks"
-              : lifecycle.kind === "awaiting-landing-command"
-                ? "awaiting-landing-command"
-                : lifecycle.kind === "awaiting-landing"
-                  ? "awaiting-landing"
-                  : "queued",
+              : lifecycle.kind === "degraded-review-infrastructure"
+                ? "degraded-review-infrastructure"
+                : lifecycle.kind === "awaiting-landing-command"
+                  ? "awaiting-landing-command"
+                  : lifecycle.kind === "awaiting-landing"
+                    ? "awaiting-landing"
+                    : "queued",
     summary: lifecycle.summary,
     pullRequest:
       lifecycle.pullRequest === null
@@ -234,6 +236,7 @@ export function noteLifecycleForIssue(
       lifecycle.kind === "awaiting-human-handoff" ||
       lifecycle.kind === "awaiting-human-review" ||
       lifecycle.kind === "awaiting-system-checks" ||
+      lifecycle.kind === "degraded-review-infrastructure" ||
       lifecycle.kind === "awaiting-landing-command" ||
       lifecycle.kind === "awaiting-landing" ||
       lifecycle.kind === "rework-required"

--- a/src/tracker/github.ts
+++ b/src/tracker/github.ts
@@ -220,7 +220,7 @@ export class GitHubTracker implements Tracker {
           feedback.kind === "review-thread" &&
           !this.#isBotReviewFeedback(feedback.authorLogin),
       ).length,
-      requiredApprovedReviewSatisfied: snapshot.requiredApprovedReviewSatisfied,
+      requiredApprovedReviewCoverage: snapshot.requiredApprovedReviewCoverage,
     };
     const decision = evaluateGuardedLanding(gateSnapshot);
     if (decision.kind === "blocked") {

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -15,7 +15,7 @@ export interface GuardedLandingSnapshot {
   readonly failingCheckNames: readonly string[];
   readonly botActionableReviewFeedback: PullRequestSnapshot["botActionableReviewFeedback"];
   readonly unresolvedReviewThreadCount: number;
-  readonly requiredApprovedReviewSatisfied: boolean;
+  readonly requiredApprovedReviewCoverage: PullRequestSnapshot["requiredApprovedReviewCoverage"];
 }
 
 // Fail closed: GitHub can report "unstable" when only non-required checks fail,
@@ -126,12 +126,12 @@ export function evaluateGuardedLanding(
     };
   }
 
-  if (!snapshot.requiredApprovedReviewSatisfied) {
+  if (snapshot.requiredApprovedReviewCoverage === "missing") {
     return {
       kind: "blocked",
       reason: "required-bot-review-missing",
-      lifecycleKind: "awaiting-human-review",
-      summary: `Landing blocked for ${formatPullRequest(snapshot)} because required approved bot review has not been observed on the current head.`,
+      lifecycleKind: "degraded-review-infrastructure",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because expected reviewer-app output has not been observed on the current head and external review coverage is degraded.`,
     };
   }
 

--- a/src/tracker/pull-request-policy.ts
+++ b/src/tracker/pull-request-policy.ts
@@ -190,10 +190,10 @@ export function evaluatePullRequestLifecycle(
     }
   }
 
-  if (!snapshot.requiredApprovedReviewSatisfied) {
+  if (snapshot.requiredApprovedReviewCoverage === "missing") {
     return {
       lifecycle: {
-        kind: "awaiting-human-review",
+        kind: "degraded-review-infrastructure",
         branchName: snapshot.branchName,
         pullRequest: snapshot.pullRequest,
         checks: snapshot.checks,
@@ -201,7 +201,7 @@ export function evaluatePullRequestLifecycle(
         failingCheckNames: snapshot.failingCheckNames,
         actionableReviewFeedback: [],
         unresolvedThreadIds: [],
-        summary: `Waiting for required approved bot review on ${snapshot.pullRequest.url}`,
+        summary: `Degraded external review infrastructure for ${snapshot.pullRequest.url}; expected reviewer-app output has not been observed on the current head.`,
       },
       nextNoCheckObservation: previousNoCheckObservation ?? null,
     };

--- a/src/tracker/pull-request-snapshot.ts
+++ b/src/tracker/pull-request-snapshot.ts
@@ -21,7 +21,10 @@ export interface PullRequestSnapshot {
   readonly actionableReviewFeedback: readonly ReviewFeedback[];
   readonly botActionableReviewFeedback: readonly ReviewFeedback[];
   readonly unresolvedThreadIds: readonly string[];
-  readonly requiredApprovedReviewSatisfied: boolean;
+  readonly requiredApprovedReviewCoverage:
+    | "not-required"
+    | "satisfied"
+    | "missing";
   readonly observedApprovedReviewBotLogins: readonly string[];
 }
 
@@ -223,9 +226,12 @@ export function createPullRequestSnapshot(input: {
             ].map((login) => login.toLowerCase()),
           ),
         ];
-  const requiredApprovedReviewSatisfied =
-    approvedReviewBotLogins.size === 0 ||
-    observedApprovedReviewBotLogins.length > 0;
+  const requiredApprovedReviewCoverage =
+    approvedReviewBotLogins.size === 0
+      ? "not-required"
+      : observedApprovedReviewBotLogins.length > 0
+        ? "satisfied"
+        : "missing";
 
   return {
     branchName: input.branchName,
@@ -244,7 +250,7 @@ export function createPullRequestSnapshot(input: {
     actionableReviewFeedback,
     botActionableReviewFeedback,
     unresolvedThreadIds,
-    requiredApprovedReviewSatisfied,
+    requiredApprovedReviewCoverage,
     observedApprovedReviewBotLogins,
   };
 }

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -24,6 +24,7 @@ export interface LandingBlockedResult {
     | "merged"
     | "awaiting-human-review"
     | "awaiting-system-checks"
+    | "degraded-review-infrastructure"
     | "awaiting-landing-command"
     | "awaiting-landing"
     | "rework-required";

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -1101,10 +1101,10 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     );
     expect(status.activeIssues[0]).toMatchObject({
       issueNumber: 207,
-      status: "awaiting-human-review",
+      status: "degraded-review-infrastructure",
     });
     expect(status.activeIssues[0]?.summary).toMatch(
-      /required approved bot review/i,
+      /degraded external review infrastructure/i,
     );
 
     server.addPullRequestComment({

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -991,8 +991,10 @@ describe("GitHubTracker", () => {
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
-    expect(lifecycle.kind).toBe("awaiting-human-review");
-    expect(lifecycle.summary).toMatch(/required approved bot review/i);
+    expect(lifecycle.kind).toBe("degraded-review-infrastructure");
+    expect(lifecycle.summary).toMatch(
+      /degraded external review infrastructure/i,
+    );
   });
 
   it("treats a clean bot summary comment as satisfying required approved bot review", async () => {
@@ -1039,7 +1041,7 @@ describe("GitHubTracker", () => {
     });
 
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
-    expect(lifecycle.kind).toBe("awaiting-human-review");
+    expect(lifecycle.kind).toBe("degraded-review-infrastructure");
 
     const result = await tracker.executeLanding({
       number: 1,
@@ -1052,7 +1054,7 @@ describe("GitHubTracker", () => {
     expect(result).toMatchObject({
       kind: "blocked",
       reason: "required-bot-review-missing",
-      lifecycleKind: "awaiting-human-review",
+      lifecycleKind: "degraded-review-infrastructure",
     });
   });
 

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -24,7 +24,7 @@ function createSnapshot(
     failingCheckNames: [],
     botActionableReviewFeedback: [],
     unresolvedReviewThreadCount: 0,
-    requiredApprovedReviewSatisfied: true,
+    requiredApprovedReviewCoverage: "satisfied",
     ...overrides,
   };
 }
@@ -181,14 +181,14 @@ describe("evaluateGuardedLanding", () => {
   it("rejects landing when required approved bot review is missing", () => {
     const result = evaluateGuardedLanding(
       createSnapshot({
-        requiredApprovedReviewSatisfied: false,
+        requiredApprovedReviewCoverage: "missing",
       }),
     );
 
     expect(result).toMatchObject({
       kind: "blocked",
       reason: "required-bot-review-missing",
-      lifecycleKind: "awaiting-human-review",
+      lifecycleKind: "degraded-review-infrastructure",
     });
   });
 

--- a/tests/unit/pull-request-policy.test.ts
+++ b/tests/unit/pull-request-policy.test.ts
@@ -22,7 +22,7 @@ function createSnapshot(
     actionableReviewFeedback: [],
     botActionableReviewFeedback: [],
     unresolvedThreadIds: [],
-    requiredApprovedReviewSatisfied: true,
+    requiredApprovedReviewCoverage: "satisfied",
     observedApprovedReviewBotLogins: [],
     ...overrides,
   };
@@ -115,18 +115,20 @@ describe("pull-request-policy", () => {
             detailsUrl: null,
           },
         ],
-        requiredApprovedReviewSatisfied: false,
+        requiredApprovedReviewCoverage: "missing",
       }),
       undefined,
     ).lifecycle;
 
-    expect(lifecycle.kind).toBe("awaiting-human-review");
-    expect(lifecycle.summary).toMatch(/required approved bot review/i);
+    expect(lifecycle.kind).toBe("degraded-review-infrastructure");
+    expect(lifecycle.summary).toMatch(
+      /degraded external review infrastructure/i,
+    );
   });
 
   it("preserves no-check stabilization while required approved bot review is missing", () => {
     const snapshot = createSnapshot({
-      requiredApprovedReviewSatisfied: false,
+      requiredApprovedReviewCoverage: "missing",
     });
 
     const first = evaluatePullRequestLifecycle(snapshot, undefined);
@@ -140,9 +142,9 @@ describe("pull-request-policy", () => {
     );
 
     expect(first.lifecycle.kind).toBe("awaiting-system-checks");
-    expect(second.lifecycle.kind).toBe("awaiting-human-review");
+    expect(second.lifecycle.kind).toBe("degraded-review-infrastructure");
     expect(second.nextNoCheckObservation).toEqual(first.nextNoCheckObservation);
-    expect(third.lifecycle.kind).toBe("awaiting-human-review");
+    expect(third.lifecycle.kind).toBe("degraded-review-infrastructure");
     expect(third.nextNoCheckObservation).toEqual(first.nextNoCheckObservation);
   });
 

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -244,7 +244,7 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["greptile-apps"],
     });
 
-    expect(snapshot.requiredApprovedReviewSatisfied).toBe(true);
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
     expect(snapshot.observedApprovedReviewBotLogins).toEqual(["greptile-apps"]);
   });
 
@@ -283,7 +283,7 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["greptile-apps"],
     });
 
-    expect(snapshot.requiredApprovedReviewSatisfied).toBe(false);
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
     expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
   });
 
@@ -324,7 +324,7 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["cursor[bot]"],
     });
 
-    expect(snapshot.requiredApprovedReviewSatisfied).toBe(false);
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
     expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- classify missing expected reviewer-app output as explicit degraded review infrastructure once checks settle
- carry the degraded lifecycle through landing gates, status snapshots, artifacts, and operator posture
- update docs and regression coverage for the missing-reviewer-app outage path

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test

Refs #208
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
