### PR TITLE
Count top-level bot reviews toward required review gate

### DIFF
--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -198,6 +198,16 @@ interface PullRequestReviewThreadsConnection {
   };
 }
 
+interface PullRequestReviewsConnection {
+  readonly nodes: Array<{
+    readonly body: string;
+    readonly submittedAt: string;
+    readonly author: {
+      readonly login: string;
+    } | null;
+  }>;
+}
+
 export interface PullRequestReviewPageResponse {
   readonly repository: {
     readonly pullRequest: {
@@ -209,6 +219,7 @@ export interface PullRequestReviewPageResponse {
         }>;
       };
       readonly comments?: PullRequestReviewCommentsConnection;
+      readonly reviews?: PullRequestReviewsConnection;
       readonly reviewThreads?: PullRequestReviewThreadsConnection;
     } | null;
   } | null;
@@ -223,8 +234,13 @@ export interface PullRequestReviewState {
     }>;
   };
   readonly comments: PullRequestReviewCommentsConnection;
+  readonly reviews?: PullRequestReviewsConnection;
   readonly reviewThreads: PullRequestReviewThreadsConnection;
 }
+
+type MutablePullRequestReviewState = {
+  -readonly [K in keyof PullRequestReviewState]: PullRequestReviewState[K];
+};
 
 type GitHubMergeMethod = "merge" | "squash" | "rebase";
 
@@ -283,6 +299,15 @@ const PULL_REQUEST_REVIEW_STATE_QUERY = `
           pageInfo {
             hasNextPage
             endCursor
+          }
+        }
+        reviews(first: 100) {
+          nodes {
+            body
+            submittedAt
+            author {
+              login
+            }
           }
         }
         reviewThreads(first: 100, after: $reviewThreadsAfter) @include(if: $includeReviewThreads) {
@@ -781,7 +806,7 @@ export class GitHubClient {
     let reviewThreadsAfter: string | null = null;
     let commentsExhausted = false;
     let reviewThreadsExhausted = false;
-    let pullRequest: PullRequestReviewState | null = null;
+    let pullRequest: MutablePullRequestReviewState | null = null;
 
     for (;;) {
       const response: PullRequestReviewPageResponse =
@@ -811,6 +836,9 @@ export class GitHubClient {
         nodes: [],
         pageInfo: { hasNextPage: false, endCursor: null },
       };
+      const reviews = page.reviews ?? {
+        nodes: [],
+      };
       const reviewThreads = page.reviewThreads ?? {
         nodes: [],
         pageInfo: { hasNextPage: false, endCursor: null },
@@ -823,6 +851,9 @@ export class GitHubClient {
             nodes: [...comments.nodes],
             pageInfo: paginationInfo(comments.pageInfo),
           },
+          reviews: {
+            nodes: [...reviews.nodes],
+          },
           reviewThreads: {
             nodes: [...reviewThreads.nodes],
             pageInfo: paginationInfo(reviewThreads.pageInfo),
@@ -831,6 +862,11 @@ export class GitHubClient {
       } else {
         if (!commentsExhausted) {
           pullRequest.comments.nodes.push(...comments.nodes);
+        }
+        if ((pullRequest.reviews?.nodes.length ?? 0) === 0) {
+          pullRequest.reviews = {
+            nodes: [...reviews.nodes],
+          };
         }
         if (!reviewThreadsExhausted) {
           pullRequest.reviewThreads.nodes.push(...reviewThreads.nodes);

--- a/src/tracker/pull-request-snapshot.ts
+++ b/src/tracker/pull-request-snapshot.ts
@@ -220,6 +220,17 @@ export function createPullRequestSnapshot(input: {
                   );
                 })
                 .map((comment) => comment.author!.login),
+              ...(input.reviewState.reviews?.nodes ?? [])
+                .filter((review) => {
+                  const authorLogin = review.author?.login;
+                  return (
+                    typeof authorLogin === "string" &&
+                    approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
+                    isQualifyingApprovedReviewBody(review.body) &&
+                    isAfter(review.submittedAt, latestCommitAt)
+                  );
+                })
+                .map((review) => review.author!.login),
             ].map((login) => login.toLowerCase()),
           ),
         ];

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -1019,6 +1019,30 @@ describe("GitHubTracker", () => {
     expect(lifecycle.kind).toBe("awaiting-landing-command");
   });
 
+  it("treats a clean top-level bot review as satisfying required approved bot review", async () => {
+    const tracker = createTracker(server, undefined, ["devin-ai-integration"]);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestReview({
+      head: "symphony/7",
+      authorLogin: "devin-ai-integration",
+      body: "## ✅ Devin Review: No Issues Found",
+      submittedAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("awaiting-landing-command");
+  });
+
   it("blocks guarded landing when required approved bot review is missing", async () => {
     const tracker = createTracker(server, undefined, ["greptile[bot]"]);
 

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -14,6 +14,7 @@ interface PullRequestRecord {
   latestCommitAt: string | null;
   latestCommitSha: string;
   readonly comments: MockPullRequestComment[];
+  readonly reviews: MockPullRequestReview[];
   readonly reviewThreads: MockReviewThread[];
   checkRuns: MockCheckRun[];
   statuses: MockCommitStatus[];
@@ -46,6 +47,12 @@ interface MockPullRequestComment {
   readonly body: string;
   readonly createdAt: string;
   readonly url: string;
+}
+
+interface MockPullRequestReview {
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly submittedAt: string;
 }
 
 interface MockReviewThread {
@@ -373,6 +380,7 @@ export class MockGitHubServer {
       latestCommitAt,
       latestCommitSha: randomUUID(),
       comments: [],
+      reviews: [],
       reviewThreads: [],
       checkRuns: [],
       statuses: [],
@@ -528,6 +536,20 @@ export class MockGitHubServer {
       ],
     });
     return threadId;
+  }
+
+  addPullRequestReview(input: {
+    head: string;
+    authorLogin: string | null;
+    body: string;
+    submittedAt?: string;
+  }): void {
+    const pullRequest = this.#requirePullRequestByHead(input.head);
+    pullRequest.reviews.push({
+      authorLogin: input.authorLogin,
+      body: input.body,
+      submittedAt: input.submittedAt ?? new Date().toISOString(),
+    });
   }
 
   injectPullRequestReviewThreadOnReviewStateRead(input: {
@@ -1008,6 +1030,18 @@ export class MockGitHubServer {
                   hasNextPage: false,
                   endCursor: null,
                 },
+              },
+              reviews: {
+                nodes: pullRequest.reviews.map((review) => ({
+                  body: review.body,
+                  submittedAt: review.submittedAt,
+                  author:
+                    review.authorLogin === null
+                      ? null
+                      : {
+                          login: review.authorLogin,
+                        },
+                })),
               },
               reviewThreads: {
                 nodes: pullRequest.reviewThreads.map((thread) => ({

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -29,6 +29,9 @@ function createReviewState(
     comments: {
       nodes: [],
     },
+    reviews: {
+      nodes: [],
+    },
     reviewThreads: {
       nodes: [
         {
@@ -195,6 +198,9 @@ describe("createPullRequestSnapshot", () => {
             },
           ],
         },
+        reviews: {
+          nodes: [],
+        },
         reviewThreads: {
           nodes: [],
         },
@@ -236,6 +242,9 @@ describe("createPullRequestSnapshot", () => {
             },
           ],
         },
+        reviews: {
+          nodes: [],
+        },
         reviewThreads: {
           nodes: [],
         },
@@ -274,6 +283,9 @@ describe("createPullRequestSnapshot", () => {
               url: "https://example.test/pr/24#comment-1",
             },
           ],
+        },
+        reviews: {
+          nodes: [],
         },
         reviewThreads: {
           nodes: [],
@@ -316,6 +328,9 @@ describe("createPullRequestSnapshot", () => {
             },
           ],
         },
+        reviews: {
+          nodes: [],
+        },
         reviewThreads: {
           nodes: [],
         },
@@ -326,6 +341,47 @@ describe("createPullRequestSnapshot", () => {
 
     expect(snapshot.requiredApprovedReviewSatisfied).toBe(false);
     expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
+  });
+
+  it("records required approved bot review presence from a top-level PR review", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [
+            {
+              author: { login: "devin-ai-integration" },
+              body: "## ✅ Devin Review: No Issues Found",
+              submittedAt: "2026-03-06T01:00:00.000Z",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
+      approvedReviewBotLogins: ["devin-ai-integration"],
+    });
+
+    expect(snapshot.requiredApprovedReviewSatisfied).toBe(true);
+    expect(snapshot.observedApprovedReviewBotLogins).toEqual([
+      "devin-ai-integration",
+    ]);
   });
 
   it("detects a human /land command on the current PR head", () => {


### PR DESCRIPTION
## Summary
- count top-level PR reviews from approved review bots when evaluating the required-review gate
- extend the GitHub review-state query and mock server to surface top-level reviews
- add unit and integration coverage for clean Devin-style reviews on the current head

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
