### PR TITLE
Fix stale pull request snapshot test

### DIFF
--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -378,7 +378,7 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["devin-ai-integration"],
     });
 
-    expect(snapshot.requiredApprovedReviewSatisfied).toBe(true);
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
     expect(snapshot.observedApprovedReviewBotLogins).toEqual([
       "devin-ai-integration",
     ]);


### PR DESCRIPTION
## Summary
- update the stale required approved review assertion to match the current snapshot contract
- restore 
> @sociotechnica/symphony-ts@0.1.0 typecheck /Users/jessmartin/Documents/code/symphony-ts
> tsc --noEmit on main after the review-coverage field rename

## Testing
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run tests/unit/pull-request-snapshot.test.ts tests/unit/pull-request-policy.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
