### PR TITLE
Require only Devin approved bot review for now

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -14,9 +14,6 @@ tracker:
     - cursor
     - devin-ai-integration
   approved_review_bot_logins:
-    - greptile[bot]
-    - bugbot[bot]
-    - greptile-apps
     - devin-ai-integration
   # Optional tracker-owned ready-work ordering seam.
   # GitHub requires project_number / field_name configuration.


### PR DESCRIPTION
## Summary
- narrow  to  in the repo workflow contract
- stop treating missing BugBot/Greptile output as degraded review infrastructure for now
- preserve the broader  list for non-approved review classification

## Testing
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run tests/unit/workflow.test.ts tests/unit/pull-request-policy.test.ts tests/unit/guarded-landing.test.ts tests/integration/github-bootstrap.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
