### PR TITLE
Add CLI workflow selection for factory instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ pnpm tsx bin/symphony.ts factory restart
 pnpm tsx bin/symphony.ts factory stop
 ```
 
+From a separate engine checkout, target a project-local instance explicitly:
+
+```bash
+pnpm tsx bin/symphony.ts factory status --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory watch --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory restart --workflow ../target-repo/WORKFLOW.md
+```
+
 `factory start` launches the same startup-preparation path as `symphony run`
 and surfaces startup preparation/failure details through `factory status`
 instead of relying on a separate wrapper command.
@@ -122,6 +130,7 @@ entry point instead of any local `.ralph/` script:
 ```bash
 pnpm operator        # continuous wake-up loop
 pnpm operator:once   # single operator wake-up cycle
+pnpm operator -- --workflow ../target-repo/WORKFLOW.md
 ```
 
 The checked-in loop lives under `skills/symphony-operator/`. `.ralph/` remains

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -15,11 +15,21 @@ pnpm tsx bin/symphony.ts factory restart
 pnpm tsx bin/symphony.ts factory stop
 ```
 
+From an engine checkout that is not the active instance root, pass an explicit
+selector:
+
+```bash
+pnpm tsx bin/symphony.ts factory status --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory watch --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory restart --workflow ../target-repo/WORKFLOW.md
+```
+
 Use the repo-owned operator loop when you want repeated wake-up cycles:
 
 ```bash
 pnpm operator
 pnpm operator:once
+pnpm operator -- --workflow ../target-repo/WORKFLOW.md
 ```
 
 Normal path rules:
@@ -33,8 +43,8 @@ Normal path rules:
 
 Run this sequence at the start of each operator pass:
 
-1. Inspect `pnpm tsx bin/symphony.ts factory status --json`.
-2. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`.
+1. Inspect `pnpm tsx bin/symphony.ts factory status --json`, appending `--workflow <path>` whenever the operator checkout is not the target instance root.
+2. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
 3. Check for operator-gated work the factory cannot clear by itself:
    - active issues in `awaiting-human-handoff`
    - active issues or PRs in `awaiting-landing-command`
@@ -51,6 +61,13 @@ Start or restart from the repo root:
 ```bash
 pnpm tsx bin/symphony.ts factory start
 pnpm tsx bin/symphony.ts factory restart
+```
+
+From another checkout, target the intended instance directly:
+
+```bash
+pnpm tsx bin/symphony.ts factory start --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory restart --workflow ../target-repo/WORKFLOW.md
 ```
 
 Healthy detached operation should show:

--- a/docs/plans/215-multi-instance-cli-selection/plan.md
+++ b/docs/plans/215-multi-instance-cli-selection/plan.md
@@ -193,15 +193,15 @@ This issue does not change orchestration retries, handoff states, or reconciliat
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized instance facts available | Expected decision |
-| --- | --- | --- | --- |
-| `run --workflow /project/WORKFLOW.md` launched from the engine checkout | absolute workflow path | instance paths for `/project` | run against `/project` without depending on the engine checkout `cwd` |
-| `factory status --workflow /project/WORKFLOW.md` launched outside the instance root | absolute workflow path | instance runtime root and status/startup paths | inspect `/project`'s detached runtime and never walk from caller `cwd` |
-| `factory watch --workflow /project/WORKFLOW.md` launched from another repo | absolute workflow path | instance runtime root | watch the selected instance only |
-| `factory start` omits `--workflow` and runs inside an instance root | caller `cwd` | discovered instance paths | preserve current local-default behavior |
-| `factory ... --workflow /missing/WORKFLOW.md` | provided path only | none | fail clearly with workflow-path guidance; do not fall back to another discovered instance |
-| operator loop is launched from the engine checkout with a target workflow path | operator-loop args/env, prompt path | selected instance paths | operator probes and control commands act on that project-local instance |
-| two project repos exist on disk and one command selects one of them explicitly | provided workflow path, multiple repos nearby | one resolved instance contract | act on the selected instance only and keep outputs explicit enough to verify which one was chosen |
+| Observed condition                                                                  | Local facts available                         | Normalized instance facts available            | Expected decision                                                                                 |
+| ----------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `run --workflow /project/WORKFLOW.md` launched from the engine checkout             | absolute workflow path                        | instance paths for `/project`                  | run against `/project` without depending on the engine checkout `cwd`                             |
+| `factory status --workflow /project/WORKFLOW.md` launched outside the instance root | absolute workflow path                        | instance runtime root and status/startup paths | inspect `/project`'s detached runtime and never walk from caller `cwd`                            |
+| `factory watch --workflow /project/WORKFLOW.md` launched from another repo          | absolute workflow path                        | instance runtime root                          | watch the selected instance only                                                                  |
+| `factory start` omits `--workflow` and runs inside an instance root                 | caller `cwd`                                  | discovered instance paths                      | preserve current local-default behavior                                                           |
+| `factory ... --workflow /missing/WORKFLOW.md`                                       | provided path only                            | none                                           | fail clearly with workflow-path guidance; do not fall back to another discovered instance         |
+| operator loop is launched from the engine checkout with a target workflow path      | operator-loop args/env, prompt path           | selected instance paths                        | operator probes and control commands act on that project-local instance                           |
+| two project repos exist on disk and one command selects one of them explicitly      | provided workflow path, multiple repos nearby | one resolved instance contract                 | act on the selected instance only and keep outputs explicit enough to verify which one was chosen |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/215-multi-instance-cli-selection/plan.md
+++ b/docs/plans/215-multi-instance-cli-selection/plan.md
@@ -1,0 +1,266 @@
+# Issue 215 Plan: Multi-Instance CLI And Detached Control Selection
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a first-class CLI selection surface so one Symphony engine checkout can target a specific project-local instance by `WORKFLOW.md` path across one-shot commands, detached factory control, and the checked-in operator loop without depending on the current working directory.
+
+This slice should make the selected instance explicit in command parsing, command dispatch, and operator-loop wiring while continuing to use the instance-rooted runtime contract from issue `#214`.
+
+## Scope
+
+- define one supported instance-selection mechanism for the main CLI and operator loop
+- make `run` and `status` consume that mechanism consistently with existing `--workflow` behavior
+- extend `factory start|stop|restart|status|watch` to consume the same explicit selection mechanism instead of resolving only from `cwd`
+- thread the selected workflow path through detached-control path resolution so runtime control operates on the intended project-local instance
+- add operator-loop support for targeting a specific project-local workflow from the engine checkout
+- update command usage/help text and focused docs so the engine-instance distinction is explicit
+- add focused unit and integration coverage for cross-instance command targeting
+
+## Non-goals
+
+- tracker transport, normalization, or lifecycle policy changes
+- orchestrator retry, continuation, reconciliation, lease, or handoff-state changes
+- detached-session collision handling beyond selecting the intended instance
+- operator scratchpad redesign or relocation
+- broad README/runbook expansion beyond the minimal selection contract needed for this slice
+- packaging or installation UX work beyond the checked-in scripts
+
+## Current Gaps
+
+- `src/cli/index.ts` supports `--workflow` for `run` and `status`, but `factory` commands still infer the target instance from `cwd`
+- `src/cli/factory-control.ts` exposes `resolveFactoryPaths()` around filesystem discovery, but it does not accept an explicit workflow path when the operator wants to control another instance from the engine checkout
+- `src/cli/factory-watch.ts` inherits the same implicit-instance behavior through `inspectFactoryControl()`
+- `skills/symphony-operator/operator-prompt.md` and `skills/symphony-operator/operator-loop.sh` assume the repo containing the engine checkout is also the active instance because they call `symphony factory ...` from the operator repo root without an explicit workflow selector
+- current help text and usage strings do not explain how to target a project-local instance when the command is launched from outside that instance root
+- existing tests cover `cwd`-based detached-control resolution, but they do not lock in an explicit selection contract that protects one instance from accidental control of another
+
+## Decision Notes
+
+- Reuse `--workflow <path>` as the single supported instance-selection surface for this slice rather than introducing both `--workflow` and `--instance`. `run`, `status`, and report commands already use `--workflow`, so extending that flag keeps the CLI smaller and more coherent.
+- Keep omission behavior conservative: when `--workflow` is not provided, existing commands may continue to resolve from `cwd` as today. The new value of this issue is explicit targeting, not removing ergonomic local defaults.
+- Treat the selected `WORKFLOW.md` as the authoritative selector. Detached factory control should resolve runtime paths from that workflow's instance contract instead of searching from the current shell location.
+- Keep operator-loop support explicit and script-friendly. The loop should accept and publish the chosen workflow path so unattended operation against a project-local instance is inspectable.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned CLI contract that `--workflow <path>` is the supported explicit instance selector for main CLI commands and the checked-in operator loop
+  - belongs: the rule that omitted selection falls back to current behavior, while explicit selection always wins over `cwd`
+  - does not belong: path walking, shell argument parsing helpers, or detached process inspection internals
+- Configuration Layer
+  - belongs: resolving the selected workflow path to typed instance paths through existing workflow loading and instance-path derivation
+  - does not belong: detached process control, tracker reads, or operator scratchpad state
+- Coordination Layer
+  - belongs: ensuring `run`, `status`, and detached control operate on the same selected instance context for a given invocation
+  - does not belong: retry budgeting, reconciliation rules, or new runtime-state machines
+- Execution Layer
+  - belongs: using the selected instance's runtime root when launching, stopping, or watching the detached worker
+  - does not belong: runner semantics changes or cross-instance process arbitration
+- Integration Layer
+  - belongs: shell/script integration for the operator loop so it can pass the selected workflow path into the supported CLI commands
+  - does not belong: tracker protocol changes or new host-service dependencies
+- Observability Layer
+  - belongs: rendering the selected workflow/instance path clearly enough in command output, status output, and operator-loop status files to prevent operator confusion
+  - does not belong: inventing a second control-state schema or hidden selection state outside the checked-in contract
+
+## Architecture Boundaries
+
+### CLI parsing and dispatch
+
+Belongs here:
+
+- parsing `--workflow <path>` for `factory` actions in the same style as `run` and `status`
+- validating incompatible argument combinations
+- routing the selected workflow path into control/watch helpers
+
+Does not belong here:
+
+- re-deriving instance paths by hand
+- shell discovery logic duplicated across commands
+
+### Configuration / workflow loading
+
+Belongs here:
+
+- reusing `loadWorkflowInstancePaths()` and related helpers to resolve the selected instance
+- centralizing any small workflow-path normalization helper needed by multiple commands
+
+Does not belong here:
+
+- detached screen process management
+- operator-loop argument parsing
+
+### Detached control
+
+Belongs here:
+
+- resolving factory paths from an explicit workflow path when provided
+- falling back to current discovery behavior only when no explicit selector is passed
+- keeping `factory start|stop|restart|status|watch` aligned on the same target resolution contract
+
+Does not belong here:
+
+- choosing among multiple instances heuristically once a workflow path is known
+- new session-collision or lease-coordination policy
+
+### Operator loop
+
+Belongs here:
+
+- accepting a workflow-path selector in `operator-loop.sh`
+- publishing that selector in loop status metadata
+- making the operator prompt and checked-in commands use the selected workflow explicitly
+
+Does not belong here:
+
+- changing operator scheduling policy
+- moving `.ralph` or creating per-instance scratchpad storage in this slice
+
+### Observability and docs
+
+Belongs here:
+
+- command output and usage text that show the selected instance clearly
+- minimal README / operator-skill updates for the supported selection contract
+
+Does not belong here:
+
+- a broad onboarding rewrite
+- unrelated status snapshot schema changes
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR focused on one seam: explicit instance selection plumbing for CLI entrypoints.
+
+What lands in this PR:
+
+1. a unified `--workflow <path>` selection contract for `run`, `status`, `factory`, and operator-loop-driven detached control
+2. detached-control helper changes so explicit selection bypasses `cwd` discovery
+3. operator-loop wiring and prompt/help text updates that make the selected instance explicit
+4. focused tests proving commands target the intended project-local instance
+
+What is deliberately deferred:
+
+- multiple named instances or a separate `--instance` abstraction
+- collision handling when different detached runtimes already exist
+- per-instance operator scratchpads or loop status directories
+- packaging/user-install ergonomics
+
+This seam is reviewable because it stays on CLI/operator selection plumbing. It does not mix tracker edges, orchestrator state refactors, or runtime-layout redesign into the same patch.
+
+## Instance Selection Resolution Model
+
+This issue does not change orchestration retries, handoff states, or reconciliation. The stateful surface here is command-time instance targeting.
+
+### States
+
+1. `selector-omitted`
+   - command invocation does not pass `--workflow`
+2. `selector-provided`
+   - command invocation includes a concrete `--workflow` path
+3. `workflow-resolved`
+   - the workflow path is normalized to an absolute path
+4. `instance-resolved`
+   - the workflow path yields typed instance/runtime paths
+5. `command-dispatched`
+   - `run`, `status`, `factory`, or operator-loop command executes against the resolved instance
+6. `selection-failed`
+   - the provided selector is missing, invalid, or cannot produce instance paths
+
+### Allowed transitions
+
+- `selector-omitted -> workflow-resolved`
+  - via existing default `cwd`-relative behavior for commands that support it
+- `selector-provided -> workflow-resolved`
+- `workflow-resolved -> instance-resolved`
+- `instance-resolved -> command-dispatched`
+- `selector-provided -> selection-failed`
+- `workflow-resolved -> selection-failed`
+- `instance-resolved -> selection-failed`
+
+### Contract rules
+
+- when `--workflow <path>` is provided, command targeting must derive from that workflow path rather than from `cwd`
+- all `factory` actions must share the same workflow-selection contract
+- operator-loop invocations that target a project-local instance must pass the selected workflow explicitly into the supported CLI, not rely on `cd` gymnastics
+- output and errors should name the selected workflow or instance root when helpful for diagnosis
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized instance facts available | Expected decision |
+| --- | --- | --- | --- |
+| `run --workflow /project/WORKFLOW.md` launched from the engine checkout | absolute workflow path | instance paths for `/project` | run against `/project` without depending on the engine checkout `cwd` |
+| `factory status --workflow /project/WORKFLOW.md` launched outside the instance root | absolute workflow path | instance runtime root and status/startup paths | inspect `/project`'s detached runtime and never walk from caller `cwd` |
+| `factory watch --workflow /project/WORKFLOW.md` launched from another repo | absolute workflow path | instance runtime root | watch the selected instance only |
+| `factory start` omits `--workflow` and runs inside an instance root | caller `cwd` | discovered instance paths | preserve current local-default behavior |
+| `factory ... --workflow /missing/WORKFLOW.md` | provided path only | none | fail clearly with workflow-path guidance; do not fall back to another discovered instance |
+| operator loop is launched from the engine checkout with a target workflow path | operator-loop args/env, prompt path | selected instance paths | operator probes and control commands act on that project-local instance |
+| two project repos exist on disk and one command selects one of them explicitly | provided workflow path, multiple repos nearby | one resolved instance contract | act on the selected instance only and keep outputs explicit enough to verify which one was chosen |
+
+## Storage / Persistence Contract
+
+- no new durable orchestration state is introduced
+- operator-loop status files may record the selected workflow path and/or selected instance root as metadata for inspection
+- detached runtime status/startup snapshots remain where the selected instance contract already places them
+- no tracker-side persistence changes are introduced
+
+## Observability Requirements
+
+- `factory` output should continue to print the repository root and runtime root, which now must match the explicitly selected workflow when one is provided
+- usage/help text should make clear that `--workflow <path>` can target a project-local instance from another checkout
+- selection failures should mention the problematic workflow path instead of generic repo-root discovery failures
+- operator-loop status JSON/Markdown should expose the selected workflow path when one is set so unattended operation is diagnosable
+
+## Implementation Steps
+
+1. Extend CLI argument parsing in `src/cli/index.ts` so `factory start|stop|restart|status|watch` accept `--workflow <path>` and carry that path through typed command args.
+2. Refactor factory-control path resolution so `resolveFactoryPaths()` and callers can accept an explicit workflow path while preserving current `cwd` discovery when omitted.
+3. Update `watchFactory()` and the `runCli()` factory dispatch path to pass the selected workflow path consistently to detached control helpers.
+4. Extend `skills/symphony-operator/operator-loop.sh` with a workflow-path selector, likely `--workflow <path>`, and export/publish the resolved selection for the prompt and loop status.
+5. Update `skills/symphony-operator/operator-prompt.md` and any minimal operator docs/help text so checked-in operator commands use the explicit selector when configured.
+6. Update usage strings and minimal README/operator references so third-party users understand how to target a project-local instance from an engine checkout.
+7. Add tests covering parse/dispatch behavior, explicit-vs-implicit resolution, operator-loop argument handling, and cross-instance command targeting.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- `parseArgs()` accepts `--workflow <path>` for every `factory` action and preserves existing validation behavior
+- `resolveFactoryPaths()` resolves the selected instance directly from an explicit workflow path without reading `cwd`
+- explicit factory selection wins over a conflicting caller `cwd`
+- explicit workflow selection failures mention the provided path and do not silently fall back to another instance
+- operator-loop argument parsing accepts `--workflow <path>` and publishes the selection in status metadata
+
+### Integration tests
+
+- from an engine checkout, `runCli()` can execute `factory status --workflow <project>/WORKFLOW.md` against a separate temp project instance
+- two temp project instances can coexist and an explicit factory command against one does not read the other's runtime files
+- operator-loop script can run one cycle with a selected workflow path and emit status metadata that names the targeted instance
+
+### End-to-end acceptance scenarios
+
+1. Given a project repository with its own `WORKFLOW.md`, when an operator runs `pnpm tsx bin/symphony.ts run --workflow /project/WORKFLOW.md` from the engine checkout, then Symphony uses `/project` as the active instance.
+2. Given two project repositories on disk, when an operator runs `pnpm tsx bin/symphony.ts factory status --workflow /project-b/WORKFLOW.md`, then the command inspects only project B's detached runtime and reports project B's repo/runtime roots.
+3. Given the checked-in operator loop is launched with a project-local workflow path, when the prompt performs detached-control checks, then it acts on that selected project instance without requiring the shell `cwd` to be the project root.
+4. Given `factory watch --workflow /missing/WORKFLOW.md`, when the selected workflow does not exist or cannot be loaded, then the command fails with explicit workflow-path guidance instead of probing another nearby instance.
+
+## Exit Criteria
+
+- `factory start|stop|restart|status|watch` all support explicit project-local instance targeting through `--workflow <path>`
+- explicit selection flows through detached control and watch paths without relying on repo-root assumptions
+- the checked-in operator loop can target a project-local instance from the engine checkout using the same selection contract
+- command help/output makes the engine-vs-instance distinction explicit enough to avoid accidental cross-instance control
+- focused tests cover explicit selection for CLI and operator entrypoints
+
+## Deferred To Later Issues Or PRs
+
+- a distinct `--instance` abstraction or named-instance registry
+- cross-instance collision detection and arbitration for detached sessions
+- per-instance operator scratchpad/log root isolation
+- richer documentation or packaging for third-party distribution

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -14,6 +14,7 @@ STATUS_MD="$RALPH_DIR/status.md"
 SCRATCHPAD="$RALPH_DIR/operator-scratchpad.md"
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
+WORKFLOW_PATH="${SYMPHONY_OPERATOR_WORKFLOW_PATH:-}"
 DEFAULT_OPERATOR_COMMAND="codex exec --dangerously-bypass-approvals-and-sandbox -C . -"
 OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-$DEFAULT_OPERATOR_COMMAND}"
 RECORDING_SETTLE_SECONDS=1
@@ -29,17 +30,19 @@ NEXT_WAKE_AT=""
 
 usage() {
   cat <<'EOF'
-Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--help]
+Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--workflow <path>] [--help]
 
 Environment:
   SYMPHONY_OPERATOR_COMMAND           Command that reads the operator prompt from stdin.
                                       Default: codex exec --dangerously-bypass-approvals-and-sandbox -C . -
                                       Warning: the default bypasses Codex approvals and sandboxing.
   SYMPHONY_OPERATOR_INTERVAL_SECONDS  Sleep interval for continuous mode. Default: 300
+  SYMPHONY_OPERATOR_WORKFLOW_PATH     Optional WORKFLOW.md path for the target Symphony instance.
 
 Examples:
   pnpm operator
   pnpm operator:once
+  pnpm operator -- --workflow ../target-repo/WORKFLOW.md
   SYMPHONY_OPERATOR_INTERVAL_SECONDS=60 pnpm operator
 EOF
 }
@@ -62,6 +65,10 @@ now_utc() {
 
 future_utc() {
   node -e 'const interval = Number(process.argv[1]); if (!Number.isInteger(interval) || interval <= 0) process.exit(1); console.log(new Date(Date.now() + interval * 1000).toISOString().replace(/\.\d{3}Z$/, "Z"));' "$1"
+}
+
+resolve_path() {
+  node -p 'require("node:path").resolve(process.argv[1])' "$1"
 }
 
 pid_is_live() {
@@ -89,6 +96,7 @@ write_status() {
   "command": "$(json_escape "$OPERATOR_COMMAND")",
   "promptFile": "$(json_escape "$PROMPT_FILE")",
   "scratchpad": "$(json_escape "$SCRATCHPAD")",
+  "selectedWorkflowPath": $(if [ -n "$WORKFLOW_PATH" ]; then printf '"%s"' "$(json_escape "$WORKFLOW_PATH")"; else printf 'null'; fi),
   "lastCycle": {
     "startedAt": $(if [ -n "$LAST_CYCLE_STARTED_AT" ]; then printf '"%s"' "$(json_escape "$LAST_CYCLE_STARTED_AT")"; else printf 'null'; fi),
     "finishedAt": $(if [ -n "$LAST_CYCLE_FINISHED_AT" ]; then printf '"%s"' "$(json_escape "$LAST_CYCLE_FINISHED_AT")"; else printf 'null'; fi),
@@ -108,6 +116,7 @@ EOF
 - Repo root: $REPO_ROOT
 - Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
 - Interval seconds: $INTERVAL_SECONDS
+- Selected workflow: ${WORKFLOW_PATH:-n/a}
 - Scratchpad: $SCRATCHPAD
 - Prompt: $PROMPT_FILE
 - Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
@@ -202,6 +211,7 @@ run_cycle() {
     printf '== Symphony operator cycle ==\n'
     printf 'started_at=%s\n' "$LAST_CYCLE_STARTED_AT"
     printf 'repo_root=%s\n' "$REPO_ROOT"
+    printf 'selected_workflow=%s\n' "${WORKFLOW_PATH:-}"
     printf 'command=%s\n' "$OPERATOR_COMMAND"
     printf 'prompt=%s\n' "$PROMPT_FILE"
     printf '\n'
@@ -216,6 +226,7 @@ run_cycle() {
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
     export SYMPHONY_OPERATOR_LOG_DIR="$LOG_DIR"
     export SYMPHONY_OPERATOR_PROMPT_FILE="$PROMPT_FILE"
+    export SYMPHONY_OPERATOR_WORKFLOW_PATH="$WORKFLOW_PATH"
     # Intentionally use a login shell so PATH-managed runner installs such as
     # codex or claude remain discoverable during unattended operator cycles.
     bash -l -c "$OPERATOR_COMMAND" <"$PROMPT_FILE"
@@ -257,6 +268,14 @@ while [ $# -gt 0 ]; do
       INTERVAL_SECONDS="$2"
       shift 2
       ;;
+    --workflow)
+      if [ $# -lt 2 ]; then
+        echo "operator-loop: --workflow requires a value" >&2
+        exit 1
+      fi
+      WORKFLOW_PATH="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -282,6 +301,10 @@ fi
 if ! command -v node >/dev/null 2>&1; then
   echo "operator-loop: node not found in PATH; required for timestamp calculation" >&2
   exit 1
+fi
+
+if [ -n "$WORKFLOW_PATH" ]; then
+  WORKFLOW_PATH="$(resolve_path "$WORKFLOW_PATH")"
 fi
 
 warn_default_command

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -6,17 +6,18 @@ Required workflow:
 
 1. Read `skills/symphony-operator/SKILL.md`.
 2. Read `.ralph/operator-scratchpad.md` if it exists.
-3. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
-4. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-5. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-6. Review active issues, PRs, CI, and automated review feedback.
-7. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-8. As mandatory operator checkpoints for this wake-up, explicitly:
+3. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
+4. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
+5. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
+6. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+7. Review active issues, PRs, CI, and automated review feedback.
+8. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+9. As mandatory operator checkpoints for this wake-up, explicitly:
    - review any active `plan-ready` / `awaiting-human-handoff` issue and post a plan decision,
    - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
    - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
-9. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-10. Update `.ralph/operator-scratchpad.md` before finishing the cycle.
+10. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+11. Update `.ralph/operator-scratchpad.md` before finishing the cycle.
 
 Constraints:
 

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -118,6 +118,7 @@ export interface FactoryUtf8LocaleSelection {
 }
 
 export interface FactoryControlDeps {
+  readonly workflowPath?: string | null;
   readonly cwd?: () => string;
   readonly environment?: () => NodeJS.ProcessEnv;
   readonly pathExists?: (targetPath: string) => Promise<boolean>;
@@ -154,7 +155,10 @@ export async function resolveFactoryPaths(
   const loadInstancePaths =
     deps.loadWorkflowInstancePaths ?? loadWorkflowInstancePaths;
 
-  const workflowPath = await findFactoryWorkflowPath(cwd(), pathExists);
+  const workflowPath =
+    deps.workflowPath === undefined || deps.workflowPath === null
+      ? await findFactoryWorkflowPath(cwd(), pathExists)
+      : path.resolve(deps.workflowPath);
   const instance =
     loadWorkspaceRoot !== undefined
       ? deriveRuntimeInstancePaths({

--- a/src/cli/factory-watch.ts
+++ b/src/cli/factory-watch.ts
@@ -8,7 +8,10 @@ import { isAbortError } from "../support/abort.js";
 const DEFAULT_WATCH_INTERVAL_MS = 1_000;
 
 export interface FactoryWatchDeps {
-  readonly inspectFactoryControl?: () => Promise<FactoryControlStatusSnapshot>;
+  readonly workflowPath?: string | null;
+  readonly inspectFactoryControl?: (options?: {
+    readonly workflowPath?: string | null;
+  }) => Promise<FactoryControlStatusSnapshot>;
   readonly renderFactoryControlStatus?: (
     snapshot: FactoryControlStatusSnapshot,
     options?: {
@@ -46,7 +49,11 @@ export async function watchFactory(deps: FactoryWatchDeps = {}): Promise<void> {
 
   try {
     while (!abortController.signal.aborted) {
-      const body = await inspect()
+      const inspectOptions =
+        deps.workflowPath === undefined
+          ? undefined
+          : { workflowPath: deps.workflowPath };
+      const body = await inspect(inspectOptions)
         .then((snapshot) => render(snapshot, { format: "human" }))
         .catch((error: unknown) => renderWatchError(error));
       const frame = renderWatchFrame(body, isStdoutTTY(), clearScreen);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,16 +49,19 @@ export type CliArgs =
       readonly command: "factory";
       readonly action: "start" | "stop" | "restart";
       readonly format: "human" | "json";
+      readonly workflowPath: string | null;
     }
   | {
       readonly command: "factory";
       readonly action: "watch";
       readonly format: "human";
+      readonly workflowPath: string | null;
     }
   | {
       readonly command: "factory";
       readonly action: "status";
       readonly format: "human" | "json";
+      readonly workflowPath: string | null;
     };
 
 export function parseArgs(argv: readonly string[]): CliArgs {
@@ -94,21 +97,26 @@ export function parseArgs(argv: readonly string[]): CliArgs {
 
   if (command === "factory") {
     const action = args[1];
+    const workflowPath = readOptionValue(args, "--workflow");
+    const resolvedWorkflowPath =
+      workflowPath === null ? null : path.resolve(process.cwd(), workflowPath);
     if (action === "start" || action === "stop" || action === "restart") {
       return {
         command: "factory",
         action,
         format: args.includes("--json") ? "json" : "human",
+        workflowPath: resolvedWorkflowPath,
       };
     }
     if (action === "watch") {
       if (args.includes("--json")) {
-        throw new Error("Usage: symphony factory watch");
+        throw new Error("Usage: symphony factory watch [--workflow <path>]");
       }
       return {
         command: "factory",
         action: "watch",
         format: "human",
+        workflowPath: resolvedWorkflowPath,
       };
     }
     if (action === "status") {
@@ -116,10 +124,11 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         command: "factory",
         action: "status",
         format: args.includes("--json") ? "json" : "human",
+        workflowPath: resolvedWorkflowPath,
       };
     }
     throw new Error(
-      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
     );
   }
 
@@ -134,7 +143,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     case "factory":
       switch (args.action) {
         case "start": {
-          const result = await startFactory();
+          const result = await startFactory({
+            workflowPath: args.workflowPath,
+          });
           process.stdout.write(
             `Factory ${
               result.kind === "started"
@@ -156,7 +167,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         }
 
         case "stop": {
-          const result = await stopFactory();
+          const result = await stopFactory({
+            workflowPath: args.workflowPath,
+          });
           process.stdout.write(
             `Factory ${
               result.status.controlState === "degraded"
@@ -181,7 +194,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         }
 
         case "restart": {
-          const stopResult = await stopFactory();
+          const stopResult = await stopFactory({
+            workflowPath: args.workflowPath,
+          });
           if (stopResult.status.controlState === "degraded") {
             process.stdout.write(
               "Factory restart blocked because stop left the runtime degraded.\n",
@@ -200,7 +215,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
             return;
           }
 
-          const startResult = await startFactory();
+          const startResult = await startFactory({
+            workflowPath: args.workflowPath,
+          });
           const verb =
             startResult.kind === "blocked-degraded"
               ? "restart blocked by degraded cleanup"
@@ -230,7 +247,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         }
 
         case "status": {
-          const snapshot = await inspectFactoryControl();
+          const snapshot = await inspectFactoryControl({
+            workflowPath: args.workflowPath,
+          });
           process.stdout.write(
             renderFactoryControlStatus(snapshot, {
               format: args.format,
@@ -241,7 +260,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
         }
 
         case "watch":
-          await watchFactory();
+          await watchFactory({ workflowPath: args.workflowPath });
           return;
       }
       return;

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDir } from "../support/git.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = process.cwd();
+const ralphDir = path.join(repoRoot, ".ralph");
+const statusJsonPath = path.join(ralphDir, "status.json");
+const statusMdPath = path.join(ralphDir, "status.md");
+const scratchpadPath = path.join(ralphDir, "operator-scratchpad.md");
+
+interface FileBackup {
+  readonly existed: boolean;
+  readonly content: string | null;
+}
+
+async function backupFile(filePath: string): Promise<FileBackup> {
+  try {
+    return {
+      existed: true,
+      content: await fs.readFile(filePath, "utf8"),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        existed: false,
+        content: null,
+      };
+    }
+    throw error;
+  }
+}
+
+async function restoreFile(
+  filePath: string,
+  backup: FileBackup,
+): Promise<void> {
+  if (!backup.existed) {
+    await fs.rm(filePath, { force: true });
+    return;
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, backup.content ?? "", "utf8");
+}
+
+describe("operator loop workflow selection", () => {
+  const createdPaths = new Set<string>();
+
+  afterEach(async () => {
+    for (const filePath of createdPaths) {
+      await fs.rm(filePath, { force: true });
+    }
+    createdPaths.clear();
+  });
+
+  it("publishes the selected workflow path in loop status metadata", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-");
+    const workflowPath = path.join(tempDir, "WORKFLOW.md");
+    await fs.writeFile(workflowPath, "tracker:\n  kind: github\n", "utf8");
+
+    const statusJsonBackup = await backupFile(statusJsonPath);
+    const statusMdBackup = await backupFile(statusMdPath);
+    const scratchpadBackup = await backupFile(scratchpadPath);
+    let createdLogFile: string | null = null;
+
+    try {
+      await execFileAsync(
+        "bash",
+        [
+          path.join("skills", "symphony-operator", "operator-loop.sh"),
+          "--once",
+          "--workflow",
+          workflowPath,
+        ],
+        {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+          },
+        },
+      );
+
+      const statusJson = JSON.parse(
+        await fs.readFile(statusJsonPath, "utf8"),
+      ) as {
+        readonly state: string;
+        readonly selectedWorkflowPath: string | null;
+        readonly lastCycle: {
+          readonly logFile: string | null;
+        };
+      };
+      const statusMd = await fs.readFile(statusMdPath, "utf8");
+
+      createdLogFile = statusJson.lastCycle.logFile;
+      if (createdLogFile !== null) {
+        createdPaths.add(createdLogFile);
+      }
+
+      expect(statusJson.state).toBe("idle");
+      expect(statusJson.selectedWorkflowPath).toBe(workflowPath);
+      expect(statusMd).toContain(`- Selected workflow: ${workflowPath}`);
+    } finally {
+      await restoreFile(statusJsonPath, statusJsonBackup);
+      await restoreFile(statusMdPath, statusMdBackup);
+      await restoreFile(scratchpadPath, scratchpadBackup);
+      await fs.rm(tempDir, { recursive: true, force: true });
+      if (createdLogFile !== null) {
+        await fs.rm(createdLogFile, { force: true });
+      }
+    }
+  });
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -196,6 +196,7 @@ describe("parseArgs", () => {
       command: "factory",
       action: "status",
       format: "json",
+      workflowPath: null,
     });
   });
 
@@ -205,6 +206,7 @@ describe("parseArgs", () => {
       command: "factory",
       action: "restart",
       format: "human",
+      workflowPath: null,
     });
   });
 
@@ -214,6 +216,7 @@ describe("parseArgs", () => {
       command: "factory",
       action: "watch",
       format: "human",
+      workflowPath: null,
     });
   });
 
@@ -222,11 +225,13 @@ describe("parseArgs", () => {
       command: "factory",
       action: "start",
       format: "human",
+      workflowPath: null,
     });
     expect(parseArgs(["node", "symphony", "factory", "stop"])).toEqual({
       command: "factory",
       action: "stop",
       format: "human",
+      workflowPath: null,
     });
   });
 
@@ -237,6 +242,7 @@ describe("parseArgs", () => {
       command: "factory",
       action: "start",
       format: "json",
+      workflowPath: null,
     });
     expect(
       parseArgs(["node", "symphony", "factory", "stop", "--json"]),
@@ -244,6 +250,7 @@ describe("parseArgs", () => {
       command: "factory",
       action: "stop",
       format: "json",
+      workflowPath: null,
     });
     expect(
       parseArgs(["node", "symphony", "factory", "restart", "--json"]),
@@ -251,24 +258,75 @@ describe("parseArgs", () => {
       command: "factory",
       action: "restart",
       format: "json",
+      workflowPath: null,
+    });
+  });
+
+  it("parses --workflow for every factory action", () => {
+    const workflowPath = path.resolve("/tmp/project/WORKFLOW.md");
+
+    expect(
+      parseArgs([
+        "node",
+        "symphony",
+        "factory",
+        "start",
+        "--workflow",
+        "/tmp/project/WORKFLOW.md",
+      ]),
+    ).toEqual({
+      command: "factory",
+      action: "start",
+      format: "human",
+      workflowPath,
+    });
+    expect(
+      parseArgs([
+        "node",
+        "symphony",
+        "factory",
+        "status",
+        "--workflow",
+        "/tmp/project/WORKFLOW.md",
+      ]),
+    ).toEqual({
+      command: "factory",
+      action: "status",
+      format: "human",
+      workflowPath,
+    });
+    expect(
+      parseArgs([
+        "node",
+        "symphony",
+        "factory",
+        "watch",
+        "--workflow",
+        "/tmp/project/WORKFLOW.md",
+      ]),
+    ).toEqual({
+      command: "factory",
+      action: "watch",
+      format: "human",
+      workflowPath,
     });
   });
 
   it("shows factory-specific usage for missing or unknown factory actions", () => {
     expect(() => parseArgs(["node", "symphony", "factory"])).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
     );
     expect(() =>
       parseArgs(["node", "symphony", "factory", "deploy"]),
     ).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json]\n       symphony factory watch",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
     );
   });
 
   it("rejects --json for factory watch", () => {
     expect(() =>
       parseArgs(["node", "symphony", "factory", "watch", "--json"]),
-    ).toThrowError("Usage: symphony factory watch");
+    ).toThrowError("Usage: symphony factory watch [--workflow <path>]");
   });
 });
 
@@ -766,65 +824,67 @@ describe("runCli run", () => {
 describe("runCli factory", () => {
   it("renders a precise restart message when the factory is already running again", async () => {
     vi.resetModules();
+    const startFactory = vi.fn(async () => ({
+      kind: "already-running",
+      status: {
+        controlState: "running",
+        paths: {
+          repoRoot: "/repo",
+          runtimeRoot: "/repo/.tmp/factory-main",
+          workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+          statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+          startupFilePath: "/repo/.tmp/factory-main/.tmp/startup.json",
+        },
+        sessionName: "symphony-factory",
+        sessions: [],
+        workerAlive: false,
+        startup: null,
+        snapshotFreshness: {
+          freshness: "unavailable",
+          reason: "missing-snapshot",
+          summary: "No runtime snapshot is available.",
+          workerAlive: null,
+          publicationState: null,
+        },
+        statusSnapshot: null,
+        processIds: [],
+        problems: [],
+      },
+    }));
+    const stopFactory = vi.fn(async () => ({
+      kind: "already-stopped",
+      status: {
+        controlState: "stopped",
+        paths: {
+          repoRoot: "/repo",
+          runtimeRoot: "/repo/.tmp/factory-main",
+          workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
+          statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
+          startupFilePath: "/repo/.tmp/factory-main/.tmp/startup.json",
+        },
+        sessionName: "symphony-factory",
+        sessions: [],
+        workerAlive: false,
+        startup: null,
+        snapshotFreshness: {
+          freshness: "unavailable",
+          reason: "missing-snapshot",
+          summary: "No runtime snapshot is available.",
+          workerAlive: null,
+          publicationState: null,
+        },
+        statusSnapshot: null,
+        processIds: [],
+        problems: [],
+      },
+      terminatedPids: [],
+    }));
 
     vi.doMock("../../src/cli/factory-control.js", () => ({
       inspectFactoryControl: vi.fn(),
       renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
-      startFactory: vi.fn(async () => ({
-        kind: "already-running",
-        status: {
-          controlState: "running",
-          paths: {
-            repoRoot: "/repo",
-            runtimeRoot: "/repo/.tmp/factory-main",
-            workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
-            statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
-            startupFilePath: "/repo/.tmp/factory-main/.tmp/startup.json",
-          },
-          sessionName: "symphony-factory",
-          sessions: [],
-          workerAlive: false,
-          startup: null,
-          snapshotFreshness: {
-            freshness: "unavailable",
-            reason: "missing-snapshot",
-            summary: "No runtime snapshot is available.",
-            workerAlive: null,
-            publicationState: null,
-          },
-          statusSnapshot: null,
-          processIds: [],
-          problems: [],
-        },
-      })),
-      stopFactory: vi.fn(async () => ({
-        kind: "already-stopped",
-        status: {
-          controlState: "stopped",
-          paths: {
-            repoRoot: "/repo",
-            runtimeRoot: "/repo/.tmp/factory-main",
-            workflowPath: "/repo/.tmp/factory-main/WORKFLOW.md",
-            statusFilePath: "/repo/.tmp/factory-main/.tmp/status.json",
-            startupFilePath: "/repo/.tmp/factory-main/.tmp/startup.json",
-          },
-          sessionName: "symphony-factory",
-          sessions: [],
-          workerAlive: false,
-          startup: null,
-          snapshotFreshness: {
-            freshness: "unavailable",
-            reason: "missing-snapshot",
-            summary: "No runtime snapshot is available.",
-            workerAlive: null,
-            publicationState: null,
-          },
-          statusSnapshot: null,
-          processIds: [],
-          problems: [],
-        },
-        terminatedPids: [],
-      })),
+      startFactory,
+      stopFactory,
     }));
 
     const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
@@ -842,6 +902,8 @@ describe("runCli factory", () => {
     await mockedRunCli(["node", "symphony", "factory", "restart"]);
 
     expect(stdout.join("")).toContain("Factory was already running.");
+    expect(stopFactory).toHaveBeenCalledWith({ workflowPath: null });
+    expect(startFactory).toHaveBeenCalledWith({ workflowPath: null });
   });
 
   it("renders factory start status as JSON when requested", async () => {
@@ -1116,6 +1178,74 @@ describe("runCli factory", () => {
 
     await mockedRunCli(["node", "symphony", "factory", "watch"]);
 
-    expect(watchFactory).toHaveBeenCalledTimes(1);
+    expect(watchFactory).toHaveBeenCalledWith({ workflowPath: null });
+  });
+
+  it("forwards explicit workflow selection to factory control and watch commands", async () => {
+    vi.resetModules();
+    const workflowPath = "/tmp/project/WORKFLOW.md";
+    const startFactory = vi.fn(async () => ({
+      kind: "started",
+      status: createFactoryControlSnapshot("running"),
+    }));
+    const stopFactory = vi.fn(async () => ({
+      kind: "stopped",
+      status: createFactoryControlSnapshot("stopped"),
+      terminatedPids: [],
+    }));
+    const inspectFactoryControl = vi.fn(async () =>
+      createFactoryControlSnapshot("stopped"),
+    );
+    const watchFactory = vi.fn(async () => {});
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl,
+      renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
+      startFactory,
+      stopFactory,
+    }));
+    vi.doMock("../../src/cli/factory-watch.js", () => ({
+      watchFactory,
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "factory",
+      "start",
+      "--workflow",
+      workflowPath,
+    ]);
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "factory",
+      "stop",
+      "--workflow",
+      workflowPath,
+    ]);
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "factory",
+      "status",
+      "--workflow",
+      workflowPath,
+    ]);
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "factory",
+      "watch",
+      "--workflow",
+      workflowPath,
+    ]);
+
+    expect(startFactory).toHaveBeenCalledWith({ workflowPath });
+    expect(stopFactory).toHaveBeenCalledWith({ workflowPath });
+    expect(inspectFactoryControl).toHaveBeenCalledWith({ workflowPath });
+    expect(watchFactory).toHaveBeenCalledWith({ workflowPath });
   });
 });

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -205,6 +205,67 @@ afterEach(() => {
 });
 
 describe("resolveFactoryPaths", () => {
+  it("resolves an explicit workflow path without relying on cwd discovery", async () => {
+    const tempDir = await createTempDir("symphony-factory-paths-");
+    const otherDir = await createTempDir("symphony-factory-paths-other-");
+    const workflowContent = `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+workspace:
+  root: ./.tmp/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`;
+
+    await fs.mkdir(path.join(tempDir, ".tmp", "factory-main"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(otherDir, ".tmp", "factory-main"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(tempDir, "WORKFLOW.md"),
+      workflowContent,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(otherDir, "WORKFLOW.md"),
+      workflowContent,
+      "utf8",
+    );
+
+    try {
+      const paths = await resolveFactoryPaths({
+        cwd: () => otherDir,
+        workflowPath: path.join(tempDir, "WORKFLOW.md"),
+      });
+      expect(paths.repoRoot).toBe(tempDir);
+      expect(paths.runtimeRoot).toBe(
+        path.join(tempDir, ".tmp", "factory-main"),
+      );
+      expect(paths.workflowPath).toBe(path.join(tempDir, "WORKFLOW.md"));
+      expect(paths.statusFilePath).toBe(
+        path.join(tempDir, ".tmp", "status.json"),
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(otherDir, { recursive: true, force: true });
+    }
+  });
+
   it("finds the outer repo root from a nested working directory", async () => {
     const tempDir = await createTempDir("symphony-factory-paths-");
     const runtimeRoot = path.join(tempDir, ".tmp", "factory-main");

--- a/tests/unit/factory-watch.test.ts
+++ b/tests/unit/factory-watch.test.ts
@@ -65,9 +65,11 @@ describe("watchFactory", () => {
     const writes: string[] = [];
     const listeners = new Map<NodeJS.Signals, () => void>();
     let iterations = 0;
+    const inspectFactoryControl = vi.fn(async () => createSnapshot());
 
     await watchFactory({
-      inspectFactoryControl: vi.fn(async () => createSnapshot()),
+      workflowPath: "/repo/WORKFLOW.md",
+      inspectFactoryControl,
       renderFactoryControlStatus: vi.fn(() => "Factory control: running\n"),
       writeStdout: (chunk) => {
         writes.push(chunk);
@@ -91,6 +93,12 @@ describe("watchFactory", () => {
     expect(writes[0]).toContain("Detached factory watch");
     expect(writes[1]).toContain("Factory control: running");
     expect(listeners.size).toBe(0);
+    expect(inspectFactoryControl).toHaveBeenNthCalledWith(1, {
+      workflowPath: "/repo/WORKFLOW.md",
+    });
+    expect(inspectFactoryControl).toHaveBeenNthCalledWith(2, {
+      workflowPath: "/repo/WORKFLOW.md",
+    });
   });
 
   it("removes its own signal handlers when interrupted", async () => {


### PR DESCRIPTION
Closes #215

## Summary
- add `--workflow <path>` support to all `symphony factory` actions and thread that selector through detached control and watch resolution
- teach the checked-in operator loop and operator prompt to accept, export, and publish an explicit workflow selection for project-local instances
- document the explicit selection path and add unit/integration coverage for CLI, factory-control, watch, and operator-loop behavior

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

## Self-review
- No dedicated local review tool was available in this workspace, so I ran a manual diff review before opening this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
