### PR TITLE
Multi-instance support: isolate detached runtime and operator state

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ installed UTF-8 locale and starts GNU Screen with `-U`. If the host does not
 provide any usable UTF-8 locale, `factory start` / `factory restart` fail
 clearly instead of silently launching a mojibake-prone TUI.
 
-For detached monitoring, do not use raw `screen -r symphony-factory` as the
-normal watch path. Attaching that way gives your terminal the worker's
+For detached monitoring, do not use raw `screen -r <instance-session-name>` as
+the normal watch path. Attaching that way gives your terminal the worker's
 foreground signal boundary, so an accidental `Ctrl-C` can stop the factory.
 
 The status snapshot includes normalized runner visibility for active issues,
@@ -134,7 +134,8 @@ pnpm operator -- --workflow ../target-repo/WORKFLOW.md
 ```
 
 The checked-in loop lives under `skills/symphony-operator/`. `.ralph/` remains
-local/generated-only for scratch notes, loop status, logs, and lock files.
+local/generated-only for per-instance scratch notes, loop status, logs, and
+lock files under `.ralph/instances/<instance-key>/`.
 The current entry point requires a Unix-like shell environment such as macOS,
 Linux, or WSL/Git Bash on Windows.
 

--- a/bin/resolve-operator-instance.ts
+++ b/bin/resolve-operator-instance.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+} from "../src/domain/instance-identity.js";
+
+interface Args {
+  readonly workflowPath: string;
+  readonly operatorRepoRoot: string;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const workflowPath = readOptionValue(argv, "--workflow");
+  const operatorRepoRoot = readOptionValue(argv, "--operator-repo-root");
+  if (workflowPath === null) {
+    throw new Error("Missing value for --workflow");
+  }
+  if (operatorRepoRoot === null) {
+    throw new Error("Missing value for --operator-repo-root");
+  }
+  return {
+    workflowPath: path.resolve(workflowPath),
+    operatorRepoRoot: path.resolve(operatorRepoRoot),
+  };
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const identity = deriveSymphonyInstanceIdentity(args.workflowPath);
+const operatorState = deriveOperatorInstanceStatePaths({
+  operatorRepoRoot: args.operatorRepoRoot,
+  instanceKey: identity.instanceKey,
+});
+
+process.stdout.write(
+  `${JSON.stringify({
+    workflowPath: args.workflowPath,
+    operatorRepoRoot: args.operatorRepoRoot,
+    instanceKey: identity.instanceKey,
+    detachedSessionName: identity.detachedSessionName,
+    ...operatorState,
+  })}\n`,
+);

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -36,7 +36,7 @@ Normal path rules:
 
 - Treat `factory status --json` as the primary source of truth.
 - Use `factory watch` as the supported live read-only monitor.
-- Do not use raw `screen -r symphony-factory` as the normal watch path because `Ctrl-C` there can stop the detached worker.
+- Do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can stop the detached worker.
 - Prefer `factory start|stop|restart` over ad hoc `screen`, `ps`, or `pkill`.
 
 ## Daily Loop
@@ -149,6 +149,11 @@ Those paths are instance-owned. The repository containing the active
 `WORKFLOW.md` is the instance root, and its `.tmp/`, `.var/`, and
 `.tmp/factory-main` directories are the local runtime surface for that one
 instance.
+
+Operator-loop generated state is separate from that runtime surface. It stays
+under the operator checkout's `.ralph/instances/<instance-key>/` tree so two
+operator loops targeting different instances do not overwrite each other's
+scratchpad, status, logs, or lock files.
 
 Workspace retention is config-driven. By default, failures stay inspectable and successes are cleaned up. If you need to inspect a successful workspace, temporarily set `workspace.retention.on_success: retain` before the run.
 

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -102,9 +102,9 @@ pnpm operator:once
 
 `pnpm operator` runs the continuous wake-up loop. `pnpm operator:once` runs one
 operator cycle and exits. The loop writes only local/generated artifacts under
-`.ralph/` such as `operator-scratchpad.md`, `status.json`, `status.md`,
-`logs/`, and lock files; the durable tooling and prompt live in
-`skills/symphony-operator/`.
+`.ralph/instances/<instance-key>/` such as `operator-scratchpad.md`,
+`status.json`, `status.md`, `logs/`, and lock files; the durable tooling and
+prompt live in `skills/symphony-operator/`.
 This entry point currently expects a Unix-like shell environment such as macOS,
 Linux, or WSL/Git Bash on Windows.
 
@@ -127,7 +127,7 @@ factory runtime: it selects an installed UTF-8 locale for detached startup,
 launches GNU Screen with `-U`, and fails clearly when the host cannot provide a
 usable UTF-8 locale.
 
-Do not use raw `screen -r symphony-factory` as the normal watch path. That
+Do not use raw `screen -r <instance-session-name>` as the normal watch path. That
 attach path gives your terminal direct foreground ownership of the worker, so
 an accidental `Ctrl-C` can stop the detached factory.
 

--- a/docs/plans/216-multi-instance-detached-runtime-and-operator-state-isolation/plan.md
+++ b/docs/plans/216-multi-instance-detached-runtime-and-operator-state-isolation/plan.md
@@ -1,0 +1,275 @@
+# Issue 216 Plan: Multi-Instance Detached Runtime And Operator-State Isolation
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make concurrent detached local Symphony instances safe by isolating detached-session identity, detached-control lookups, and operator-local generated state per selected instance.
+
+This slice should finish the local multi-instance seam started by `#214` and `#215`: instance-rooted runtime paths already exist, and CLI commands can already target an explicit `WORKFLOW.md`; now the detached runtime and operator loop must stop assuming there is only one global detached session name or one shared repo-root operator scratch area.
+
+## Scope
+
+- define one deterministic instance-scoped identity contract for detached session naming and operator-local generated state
+- make `factory start|stop|restart|status|watch` use the selected instance's detached session identity instead of the global `symphony-factory` constant
+- make detached control inspection and stop logic isolate sessions by the targeted instance so concurrent detached runtimes do not collide
+- move checked-in operator-loop generated state from one shared `.ralph/` namespace to per-instance generated paths while preserving the same operator features
+- update operator prompt/skill/docs so the selected instance and its operator-local paths are explicit
+- add focused unit, integration, and end-to-end coverage for two instances running or being supervised concurrently from the same engine checkout
+
+## Non-goals
+
+- tracker transport, normalization, or lifecycle policy changes
+- cross-instance queue coordination, leases, or same-tracker ownership election
+- orchestrator retry, continuation, reconciliation, or landing-state redesign
+- changing the instance-rooted runtime layout from `#214`
+- introducing a second instance selector beyond the `--workflow` contract from `#215`
+- redesigning the operator workflow itself beyond isolating its generated local state
+- changing the detached runtime checkout location from `<instance-root>/.tmp/factory-main`
+
+## Current Gaps
+
+- `src/cli/factory-control.ts` hardcodes one detached session name, `symphony-factory`, so concurrent detached instances can match and stop each other's screen sessions
+- detached-control inspection currently filters `screen -ls` output only by that global name, so status and stop operations cannot distinguish instances safely
+- the checked-in operator loop writes lock files, status snapshots, logs, and the scratchpad into one repo-root `.ralph/` namespace, so two operator loops pointed at different instances can overwrite each other's local state
+- the operator prompt and skill still describe `.ralph/operator-scratchpad.md` as a single persistent notebook rather than an instance-scoped one
+- current tests lock explicit workflow selection from `#215`, but they do not prove that two detached instances can run concurrently without screen-session or operator-state collisions
+- docs describe instance-owned `.tmp/` and `.var/` paths, but the detached-session and operator-local state contracts still imply one global local instance
+
+## Decision Notes
+
+- Keep one deterministic instance identity source rather than separate ad hoc naming helpers in factory control and the operator loop.
+- Derive detached session identity and operator-local state paths from the resolved selected instance, not from caller `cwd` and not from the engine checkout alone.
+- Prefer deterministic, inspectable names over random suffixes. Operators should be able to predict which session and operator-state directory belong to which instance.
+- Keep operator-local state separate from instance-owned runtime state. `.tmp/` and `.var/` stay instance-owned runtime surfaces; `.ralph/` remains operator-local generated state, but it must be partitioned per targeted instance.
+- Keep this issue on the local-isolation seam only. Do not broaden it into tracker-side concurrency or distributed runtime coordination.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned rule that detached session identity and operator-local generated state are scoped to one selected instance
+  - belongs: the rule that deterministic instance identity, not a global repo-root singleton, owns detached runtime/control naming
+  - does not belong: `screen` process inspection, shell lock creation, or filesystem writes
+- Configuration Layer
+  - belongs: deriving a reusable instance identity value and any instance-scoped generated-path helpers from the selected workflow/instance contract
+  - does not belong: screen launch/stop behavior or operator wake-up policy
+- Coordination Layer
+  - belongs: selecting the targeted instance's detached session identity and operator-state root consistently across `factory` commands and the operator loop
+  - does not belong: tracker queue arbitration or retry-state changes
+- Execution Layer
+  - belongs: launching, stopping, and inspecting detached runtime sessions under the targeted instance's session name
+  - does not belong: tracker lifecycle semantics, review-loop policy, or operator scratchpad content rules
+- Integration Layer
+  - belongs: shell/operator-loop integration that reads and writes instance-scoped generated files and passes the selected workflow path through to factory-control commands
+  - does not belong: tracker API changes or mixed tracker/runtime policy
+- Observability Layer
+  - belongs: surfacing instance-scoped session names, selected workflow paths, and operator-state locations clearly in control/status output and docs
+  - does not belong: inventing detached-session names independently of the shared instance identity contract
+
+## Architecture Boundaries
+
+### Policy / local multi-instance contract
+
+Belongs here:
+
+- the rule that one selected instance gets one deterministic detached session identity
+- the rule that operator-local generated state is partitioned per selected instance
+
+Does not belong here:
+
+- raw `screen -ls` parsing
+- shell lock acquisition details
+
+### Configuration / instance identity helpers
+
+Belongs here:
+
+- deriving a stable instance key from resolved instance facts
+- deriving detached session names and operator-state paths from that key
+- validating any length/character constraints needed by downstream shells or `screen`
+
+Does not belong here:
+
+- launching the detached runtime
+- deciding when to restart or stop the runtime
+
+### Detached factory control
+
+Belongs here:
+
+- resolving factory paths plus detached session identity from the selected instance
+- filtering, launching, and stopping only the targeted instance's detached screen session
+- preserving current single-instance ergonomics while removing cross-instance collisions
+
+Does not belong here:
+
+- operator scratchpad management
+- tracker-side run ownership policy
+
+### Operator loop
+
+Belongs here:
+
+- writing status, logs, scratchpad, and lock files under an instance-scoped operator-state root
+- exposing the selected workflow and operator-state root in loop status metadata
+- keeping the checked-in prompt aligned with the new instance-scoped local paths
+
+Does not belong here:
+
+- inventing a second instance-selection mechanism
+- moving runtime-owned artifacts into operator-local storage
+
+### Observability and docs
+
+Belongs here:
+
+- rendering the detached session name and selected operator-state root clearly enough for operators to diagnose which instance is being inspected
+- updating README/runbook/operator-skill text so the multi-instance contract is explicit
+
+Does not belong here:
+
+- broad self-hosting workflow redesign
+- unrelated TUI or report-schema changes
+
+## Slice Strategy And PR Seam
+
+This issue should land as one reviewable PR on one isolation seam:
+
+1. define one deterministic instance identity helper
+2. scope detached session naming and control inspection to that identity
+3. scope checked-in operator-loop generated state to that identity
+4. lock the behavior with focused tests and minimal doc updates
+
+Deferred from this PR:
+
+- same-tracker concurrent coordination policy across multiple instances
+- remote-host or distributed detached-session naming
+- per-instance operator UX beyond the generated-state partitioning needed for correctness
+- broader operator dashboard aggregation across many instances
+
+This seam is reviewable because it stays on local detached-runtime/operator isolation. It does not combine tracker edges, orchestrator retry state, or workflow-schema redesign in the same patch.
+
+## Instance Isolation Resolution Model
+
+This issue does not change orchestration retry or handoff states. The stateful surface here is local control/monitoring identity for a selected instance.
+
+### States
+
+1. `selector-resolved`
+   - a command or operator loop has a concrete selected workflow path, explicit or defaulted
+2. `instance-resolved`
+   - the workflow path resolves to typed instance paths
+3. `identity-derived`
+   - deterministic detached session identity and operator-state root are derived for that instance
+4. `isolated-surface-active`
+   - factory control and/or operator loop read and write only the targeted instance's session and generated files
+5. `identity-resolution-failed`
+   - required selected-instance facts cannot produce valid identity/path outputs
+
+### Allowed transitions
+
+- `selector-resolved -> instance-resolved`
+- `instance-resolved -> identity-derived`
+- `identity-derived -> isolated-surface-active`
+- `selector-resolved -> identity-resolution-failed`
+- `instance-resolved -> identity-resolution-failed`
+- `identity-derived -> identity-resolution-failed`
+
+### Contract rules
+
+- the selected workflow path remains the authoritative instance selector
+- detached session naming must be deterministic per instance and unique across distinct instance roots on the same host
+- detached control inspection/stop logic must only match the targeted instance's session identity
+- operator-local generated files must be partitioned by targeted instance, not shared globally across all instances in one engine checkout
+- runtime-owned `.tmp/` and `.var/` files remain instance-owned runtime state; operator-local generated files stay separate from them
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized instance facts available | Expected decision |
+| --- | --- | --- | --- |
+| Two instances launch detached runtimes from the same engine checkout | two selected workflow paths | two distinct instance roots and identity values | each instance gets a distinct detached session name; both can run concurrently |
+| `factory status --workflow <instance-a>` runs while instance B is also detached | selected workflow path, all `screen -ls` output | instance A identity | inspect only A's matching session; do not report B as degraded noise |
+| `factory stop --workflow <instance-a>` runs while instance B is healthy | selected workflow path, all live sessions/processes | instance A identity | stop only A's detached session and descendants; leave B untouched |
+| legacy global `symphony-factory` session exists from older code | matching sessions include legacy/global and/or scoped names | targeted instance identity | surface clear degraded or migration-safe behavior without silently killing another instance |
+| two operator loops target different instances from the same engine checkout | same operator repo root, two selected workflow paths | two distinct operator-state roots | lock/status/log/scratchpad files do not collide; each loop reports its own state |
+| operator loop omits `--workflow` inside an instance root | caller `cwd` | discovered selected instance and identity | preserve current local-default behavior but still write per-instance operator state |
+| provided workflow path is invalid | workflow path only | none | fail clearly before reading or writing session/operator files for any other instance |
+
+## Storage / Persistence Contract
+
+- detached runtime snapshots remain under the selected instance's existing instance-owned temp area:
+  - `<instance-root>/.tmp/status.json`
+  - `<instance-root>/.tmp/startup.json`
+  - `<instance-root>/.tmp/factory-main`
+- detached session identity becomes a deterministic derived value of the selected instance rather than one global constant
+- operator-local generated state stays under the operator checkout's `.ralph/`, but moves under an instance-scoped root such as:
+  - `<operator-repo-root>/.ralph/instances/<instance-key>/status.json`
+  - `<operator-repo-root>/.ralph/instances/<instance-key>/status.md`
+  - `<operator-repo-root>/.ralph/instances/<instance-key>/operator-scratchpad.md`
+  - `<operator-repo-root>/.ralph/instances/<instance-key>/logs/`
+  - `<operator-repo-root>/.ralph/instances/<instance-key>/operator-loop.lock`
+- no tracker-side persistence changes are introduced in this issue
+
+## Observability Requirements
+
+- `factory status` and related JSON output should expose the resolved detached session name for the targeted instance
+- operator-loop status JSON/Markdown should expose the selected workflow path and the instance-scoped operator-state root
+- degraded-control messages should stay explicit when collisions or legacy/global session leftovers are detected
+- docs should explain the difference between instance-owned runtime state and operator-local generated state
+
+## Implementation Steps
+
+1. Add a small shared instance-identity helper that derives:
+   - a stable instance key from resolved instance facts
+   - the detached session name for that instance
+   - the operator-state root for that instance
+2. Refactor `src/cli/factory-control.ts` so `resolveFactoryPaths()` exposes the targeted session identity and all start/status/stop/watch flows use that scoped name instead of the global constant.
+3. Update detached-control inspection and stop logic so session filtering is scoped to the targeted instance and collision/degraded reporting remains accurate.
+4. Refactor `skills/symphony-operator/operator-loop.sh` to derive or receive the targeted instance identity and write lock/status/log/scratchpad files under an instance-scoped generated directory.
+5. Update `skills/symphony-operator/operator-prompt.md`, `skills/symphony-operator/SKILL.md`, `README.md`, and the operator docs to describe:
+   - instance-scoped detached sessions
+   - instance-scoped operator generated state
+   - the continued separation between instance-owned `.tmp/.var` and operator-local `.ralph`
+6. Add regression tests for concurrent detached-control selection and concurrent operator-loop state isolation.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- instance-identity helper derives stable distinct identity values for two different instance roots
+- factory control derives a distinct detached session name per selected instance
+- `factory status` / `factory stop` only match sessions for the targeted instance when another instance's session is also present
+- operator-loop path derivation produces distinct lock/status/log/scratchpad roots for two selected workflow paths
+- operator-loop default selection still resolves one instance cleanly when launched from inside an instance root
+
+### Integration tests
+
+- two temp instances can each run factory-control inspection against distinct scoped sessions without cross-reporting
+- stopping one targeted instance leaves the other instance's mocked detached session alive
+- operator-loop `--once` run for instance A and instance B publishes state into separate per-instance generated directories under `.ralph/instances/`
+
+### End-to-end acceptance scenarios
+
+1. Given two target repositories with their own `WORKFLOW.md` files, when both detached factories are started from one engine checkout, then each uses a different deterministic screen session name and both remain inspectable.
+2. Given both detached factories are running, when an operator runs `symphony factory stop --workflow <instance-a>/WORKFLOW.md`, then only instance A stops and instance B remains healthy.
+3. Given two operator loops target two different instances from one engine checkout, when each writes status/log/scratchpad state, then the files remain isolated and inspectable per instance.
+4. Given the operator inspects one selected instance, when control output is rendered, then the session name and operator-local state path make it clear which instance is being observed.
+
+## Exit Criteria
+
+- detached factory sessions are deterministic and instance-scoped instead of globally named
+- detached-control inspection/start/stop/watch isolate the targeted instance cleanly when multiple instances exist
+- checked-in operator-loop generated state is instance-scoped and no longer assumes one shared repo-root singleton
+- docs explain the multi-instance local isolation contract clearly
+- focused tests cover concurrent detached-control and operator-state isolation scenarios
+
+## Deferred To Later Issues Or PRs
+
+- cross-instance coordination against the same tracker queue
+- distributed or multi-host detached-session identity
+- aggregated multi-instance operator dashboards
+- migration tooling beyond the minimal compatibility handling needed for this slice

--- a/docs/plans/216-multi-instance-detached-runtime-and-operator-state-isolation/plan.md
+++ b/docs/plans/216-multi-instance-detached-runtime-and-operator-state-isolation/plan.md
@@ -189,15 +189,15 @@ This issue does not change orchestration retry or handoff states. The stateful s
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized instance facts available | Expected decision |
-| --- | --- | --- | --- |
-| Two instances launch detached runtimes from the same engine checkout | two selected workflow paths | two distinct instance roots and identity values | each instance gets a distinct detached session name; both can run concurrently |
-| `factory status --workflow <instance-a>` runs while instance B is also detached | selected workflow path, all `screen -ls` output | instance A identity | inspect only A's matching session; do not report B as degraded noise |
-| `factory stop --workflow <instance-a>` runs while instance B is healthy | selected workflow path, all live sessions/processes | instance A identity | stop only A's detached session and descendants; leave B untouched |
-| legacy global `symphony-factory` session exists from older code | matching sessions include legacy/global and/or scoped names | targeted instance identity | surface clear degraded or migration-safe behavior without silently killing another instance |
-| two operator loops target different instances from the same engine checkout | same operator repo root, two selected workflow paths | two distinct operator-state roots | lock/status/log/scratchpad files do not collide; each loop reports its own state |
-| operator loop omits `--workflow` inside an instance root | caller `cwd` | discovered selected instance and identity | preserve current local-default behavior but still write per-instance operator state |
-| provided workflow path is invalid | workflow path only | none | fail clearly before reading or writing session/operator files for any other instance |
+| Observed condition                                                              | Local facts available                                       | Normalized instance facts available             | Expected decision                                                                           |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Two instances launch detached runtimes from the same engine checkout            | two selected workflow paths                                 | two distinct instance roots and identity values | each instance gets a distinct detached session name; both can run concurrently              |
+| `factory status --workflow <instance-a>` runs while instance B is also detached | selected workflow path, all `screen -ls` output             | instance A identity                             | inspect only A's matching session; do not report B as degraded noise                        |
+| `factory stop --workflow <instance-a>` runs while instance B is healthy         | selected workflow path, all live sessions/processes         | instance A identity                             | stop only A's detached session and descendants; leave B untouched                           |
+| legacy global `symphony-factory` session exists from older code                 | matching sessions include legacy/global and/or scoped names | targeted instance identity                      | surface clear degraded or migration-safe behavior without silently killing another instance |
+| two operator loops target different instances from the same engine checkout     | same operator repo root, two selected workflow paths        | two distinct operator-state roots               | lock/status/log/scratchpad files do not collide; each loop reports its own state            |
+| operator loop omits `--workflow` inside an instance root                        | caller `cwd`                                                | discovered selected instance and identity       | preserve current local-default behavior but still write per-instance operator state         |
+| provided workflow path is invalid                                               | workflow path only                                          | none                                            | fail clearly before reading or writing session/operator files for any other instance        |
 
 ## Storage / Persistence Contract
 

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -19,7 +19,8 @@ Supported repo-owned entry point:
 
 The checked-in loop and prompt live next to this skill under
 `skills/symphony-operator/`. `.ralph/` is local/generated-only state for the
-scratchpad, status snapshots, logs, and loop lock files.
+instance-scoped scratchpad, status snapshots, logs, and loop lock files under
+`.ralph/instances/<instance-key>/`.
 
 ## Scope
 
@@ -28,11 +29,12 @@ scratchpad, status snapshots, logs, and loop lock files.
 - Drive PRs through CI and automated review to a mergeable state.
 - Handle `plan-ready` issues: review plans, request changes when needed, and approve when ready.
 - Keep GitHub as a thin queue and rely on Symphony's own polling and concurrency.
-- Maintain a persistent local operator notebook in `.ralph/operator-scratchpad.md`.
+- Maintain a persistent local operator notebook in the selected instance's
+  `.ralph/instances/<instance-key>/operator-scratchpad.md`.
 
 ## Wake-Up Workflow
 
-1. Read `.ralph/operator-scratchpad.md` first so the latest operator context survives session loss and compaction.
+1. Read the selected instance's scratchpad first so the latest operator context survives session loss and compaction.
 2. Inspect the current repo state, open ready/running issues, open PRs, CI, and review comments.
 3. Use `pnpm tsx bin/symphony.ts factory status --json` as the primary factory-health check and determine whether the detached runtime is healthy, degraded, stopped, stuck, crashed, or misconfigured.
 4. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
@@ -61,7 +63,7 @@ scratchpad, status snapshots, logs, and loop lock files.
 - Treat `docs/guides/operator-runbook.md` as the canonical daily-use procedure and keep this skill focused on operator policy, checkpoints, and escalation.
 - Treat the factory-control surface as the primary local runtime contract; use ad hoc `screen`, `ps`, or `pkill` inspection only when the control command is unavailable or inconsistent.
 - In a wake-up cycle, favor short, bounded inspection commands over long-running watchers. If a secondary GitHub or watch-surface probe is slow or non-terminal, stop and continue from the latest successful control-surface read instead of waiting indefinitely.
-- Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring; do not use raw `screen -r symphony-factory` as the normal watch path because `Ctrl-C` there can kill the worker.
+- Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart` over manual `screen` and process cleanup.
 - Treat detached startup locale handling as repo-owned behavior: the supported factory-control path selects an installed UTF-8 locale, launches `screen -U`, and should fail clearly rather than relying on shell-local locale folklore.
@@ -122,10 +124,10 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 
 Before finishing each wake-up:
 
-1. update `.ralph/operator-scratchpad.md` with current state, open risks, and the next operator checks,
+1. update the selected instance scratchpad with current state, open risks, and the next operator checks,
 2. ask whether this cycle revealed something missing or ambiguous in this skill or the operator prompt,
 3. distinguish between:
    - durable process rules or generally correct operator behavior, which belong in this skill or the operator prompt,
-   - transient factory facts, temporary workarounds, and run-specific context, which belong in `.ralph/operator-scratchpad.md`,
+   - transient factory facts, temporary workarounds, and run-specific context, which belong in the selected instance scratchpad,
 4. if a durable rule needs to change, make the improvement through the normal PR flow,
 5. and record the result in the final status summary.

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -6,12 +6,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PROMPT_FILE="$SCRIPT_DIR/operator-prompt.md"
 RALPH_DIR="$REPO_ROOT/.ralph"
-LOG_DIR="$RALPH_DIR/logs"
-LOCK_DIR="$RALPH_DIR/operator-loop.lock"
-LOCK_INFO_FILE="$LOCK_DIR/owner"
-STATUS_JSON="$RALPH_DIR/status.json"
-STATUS_MD="$RALPH_DIR/status.md"
-SCRATCHPAD="$RALPH_DIR/operator-scratchpad.md"
+INSTANCE_STATE_RESOLVER="$REPO_ROOT/bin/resolve-operator-instance.ts"
+INSTANCE_KEY=""
+DETACHED_SESSION_NAME=""
+INSTANCE_STATE_ROOT=""
+LOG_DIR=""
+LOCK_DIR=""
+LOCK_INFO_FILE=""
+STATUS_JSON=""
+STATUS_MD=""
+SCRATCHPAD=""
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
 WORKFLOW_PATH="${SYMPHONY_OPERATOR_WORKFLOW_PATH:-}"
@@ -71,6 +75,41 @@ resolve_path() {
   node -p 'require("node:path").resolve(process.argv[1])' "$1"
 }
 
+resolve_instance_state() {
+  local metadata_json metadata_exports
+  metadata_json="$(
+    pnpm tsx "$INSTANCE_STATE_RESOLVER" \
+      --workflow "$WORKFLOW_PATH" \
+      --operator-repo-root "$REPO_ROOT"
+  )"
+  metadata_exports="$(
+    printf '%s' "$metadata_json" | node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const mappings = {
+  workflowPath: "WORKFLOW_PATH",
+  instanceKey: "INSTANCE_KEY",
+  detachedSessionName: "DETACHED_SESSION_NAME",
+  operatorStateRoot: "INSTANCE_STATE_ROOT",
+  logDir: "LOG_DIR",
+  lockDir: "LOCK_DIR",
+  lockInfoFile: "LOCK_INFO_FILE",
+  statusJsonPath: "STATUS_JSON",
+  statusMdPath: "STATUS_MD",
+  scratchpadPath: "SCRATCHPAD",
+};
+for (const [jsonKey, shellKey] of Object.entries(mappings)) {
+  const value = data[jsonKey];
+  if (typeof value !== "string") {
+    throw new Error(`Expected string for ${jsonKey}`);
+  }
+  console.log(`${shellKey}=${JSON.stringify(value)}`);
+}
+'
+  )"
+  eval "$metadata_exports"
+}
+
 pid_is_live() {
   local pid="${1:-}"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
@@ -90,6 +129,9 @@ write_status() {
   "message": "$(json_escape "$message")",
   "updatedAt": "$(json_escape "$updated_at")",
   "repoRoot": "$(json_escape "$REPO_ROOT")",
+  "instanceKey": "$(json_escape "$INSTANCE_KEY")",
+  "detachedSessionName": "$(json_escape "$DETACHED_SESSION_NAME")",
+  "operatorStateRoot": "$(json_escape "$INSTANCE_STATE_ROOT")",
   "pid": $$,
   "runOnce": $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'true'; else printf 'false'; fi),
   "intervalSeconds": $INTERVAL_SECONDS,
@@ -114,6 +156,9 @@ EOF
 - Message: $message
 - Updated: $updated_at
 - Repo root: $REPO_ROOT
+- Instance key: $INSTANCE_KEY
+- Detached session: $DETACHED_SESSION_NAME
+- Operator state root: $INSTANCE_STATE_ROOT
 - Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
 - Interval seconds: $INTERVAL_SECONDS
 - Selected workflow: ${WORKFLOW_PATH:-n/a}
@@ -211,6 +256,9 @@ run_cycle() {
     printf '== Symphony operator cycle ==\n'
     printf 'started_at=%s\n' "$LAST_CYCLE_STARTED_AT"
     printf 'repo_root=%s\n' "$REPO_ROOT"
+    printf 'instance_key=%s\n' "$INSTANCE_KEY"
+    printf 'detached_session=%s\n' "$DETACHED_SESSION_NAME"
+    printf 'operator_state_root=%s\n' "$INSTANCE_STATE_ROOT"
     printf 'selected_workflow=%s\n' "${WORKFLOW_PATH:-}"
     printf 'command=%s\n' "$OPERATOR_COMMAND"
     printf 'prompt=%s\n' "$PROMPT_FILE"
@@ -221,6 +269,9 @@ run_cycle() {
   (
     cd "$REPO_ROOT"
     export SYMPHONY_OPERATOR_REPO_ROOT="$REPO_ROOT"
+    export SYMPHONY_OPERATOR_INSTANCE_KEY="$INSTANCE_KEY"
+    export SYMPHONY_OPERATOR_DETACHED_SESSION_NAME="$DETACHED_SESSION_NAME"
+    export SYMPHONY_OPERATOR_STATE_ROOT="$INSTANCE_STATE_ROOT"
     export SYMPHONY_OPERATOR_SCRATCHPAD="$SCRATCHPAD"
     export SYMPHONY_OPERATOR_STATUS_JSON="$STATUS_JSON"
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
@@ -298,6 +349,11 @@ if [ ! -f "$PROMPT_FILE" ]; then
   exit 1
 fi
 
+if [ ! -f "$INSTANCE_STATE_RESOLVER" ]; then
+  echo "operator-loop: instance-state resolver not found: $INSTANCE_STATE_RESOLVER" >&2
+  exit 1
+fi
+
 if ! command -v node >/dev/null 2>&1; then
   echo "operator-loop: node not found in PATH; required for timestamp calculation" >&2
   exit 1
@@ -305,8 +361,11 @@ fi
 
 if [ -n "$WORKFLOW_PATH" ]; then
   WORKFLOW_PATH="$(resolve_path "$WORKFLOW_PATH")"
+else
+  WORKFLOW_PATH="$(resolve_path "$REPO_ROOT/WORKFLOW.md")"
 fi
 
+resolve_instance_state
 warn_default_command
 ensure_runtime_paths
 trap 'release_lock' EXIT

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -5,7 +5,7 @@ Run exactly one wake-up cycle, then stop.
 Required workflow:
 
 1. Read `skills/symphony-operator/SKILL.md`.
-2. Read `.ralph/operator-scratchpad.md` if it exists.
+2. Read the instance-scoped scratchpad at `SYMPHONY_OPERATOR_SCRATCHPAD` if it exists.
 3. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
 4. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
 5. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
@@ -17,7 +17,7 @@ Required workflow:
    - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
    - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 10. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-11. Update `.ralph/operator-scratchpad.md` before finishing the cycle.
+11. Update `SYMPHONY_OPERATOR_SCRATCHPAD` before finishing the cycle.
 
 Constraints:
 

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { loadWorkflowInstancePaths } from "../config/workflow.js";
+import { deriveSymphonyInstanceIdentity } from "../domain/instance-identity.js";
 import {
   deriveRuntimeInstancePaths,
   type RuntimeInstancePaths,
@@ -30,7 +31,6 @@ import {
 const execFile = promisify(execFileCallback);
 
 export const FACTORY_RUNTIME_DIRECTORY = path.join(".tmp", "factory-main");
-export const FACTORY_SCREEN_SESSION_NAME = "symphony-factory";
 export const FACTORY_RUN_GUARDRAILS_ACK_FLAG =
   "--i-understand-that-this-will-be-running-without-the-usual-guardrails";
 const START_TIMEOUT_MS = 15_000;
@@ -44,6 +44,10 @@ export interface FactoryPaths {
   readonly statusFilePath: string;
   readonly startupFilePath: string;
   readonly instance?: RuntimeInstancePaths;
+}
+
+interface ResolvedFactoryPaths extends FactoryPaths {
+  readonly sessionName: string;
 }
 
 export interface HostProcessSnapshot {
@@ -128,6 +132,7 @@ export interface FactoryControlDeps {
   readonly loadWorkflowInstancePaths?: (
     workflowPath: string,
   ) => Promise<RuntimeInstancePaths>;
+  readonly deriveSessionName?: (instance: RuntimeInstancePaths) => string;
   readonly readFile?: (filePath: string, encoding: "utf8") => Promise<string>;
   readonly listProcesses?: () => Promise<readonly HostProcessSnapshot[]>;
   readonly listScreenSessions?: () => Promise<readonly ScreenSessionSnapshot[]>;
@@ -148,12 +153,17 @@ export interface FactoryControlDeps {
 
 export async function resolveFactoryPaths(
   deps: FactoryControlDeps = {},
-): Promise<FactoryPaths> {
+): Promise<ResolvedFactoryPaths> {
   const cwd = deps.cwd ?? (() => process.cwd());
   const pathExists = deps.pathExists ?? defaultPathExists;
   const loadWorkspaceRoot = deps.loadWorkflowWorkspaceRoot;
   const loadInstancePaths =
     deps.loadWorkflowInstancePaths ?? loadWorkflowInstancePaths;
+  const deriveSessionName =
+    deps.deriveSessionName ??
+    ((instance: RuntimeInstancePaths) =>
+      deriveSymphonyInstanceIdentity(instance.instanceRoot)
+        .detachedSessionName);
 
   const workflowPath =
     deps.workflowPath === undefined || deps.workflowPath === null
@@ -185,6 +195,7 @@ export async function resolveFactoryPaths(
     repoRoot,
     runtimeRoot,
     workflowPath,
+    sessionName: deriveSessionName(instance),
     statusFilePath: deriveStatusFilePath(instance),
     startupFilePath: deriveStartupFilePath(instance),
     instance,
@@ -249,7 +260,7 @@ export async function startFactory(
 
   await launchScreenSession({
     runtimeRoot: paths.runtimeRoot,
-    sessionName: FACTORY_SCREEN_SESSION_NAME,
+    sessionName: paths.sessionName,
     command: createFactoryRunCommand(),
     env: launchEnvironment,
   });
@@ -456,7 +467,7 @@ export function collectDescendantProcessIds(
 }
 
 async function inspectFactoryControlAtPaths(
-  paths: FactoryPaths,
+  paths: ResolvedFactoryPaths,
   deps: FactoryControlDeps,
 ): Promise<FactoryControlStatusSnapshot> {
   const listProcesses = deps.listProcesses ?? defaultListProcesses;
@@ -472,7 +483,7 @@ async function inspectFactoryControlAtPaths(
   ]);
 
   const matchingSessions = sessions.filter(
-    (session) => session.name === FACTORY_SCREEN_SESSION_NAME,
+    (session) => session.name === paths.sessionName,
   );
   const liveSessions = matchingSessions.filter(
     (session) => !/^dead$/i.test(session.state),
@@ -487,7 +498,7 @@ async function inspectFactoryControlAtPaths(
 
   if (liveSessions.length > 1) {
     problems.push(
-      `multiple detached screen sessions match ${FACTORY_SCREEN_SESSION_NAME}`,
+      `multiple detached screen sessions match ${paths.sessionName}`,
     );
   }
   if (snapshotRead.error !== null) {
@@ -558,10 +569,19 @@ async function inspectFactoryControlAtPaths(
     }
   }
 
+  const publicPaths: FactoryPaths = {
+    repoRoot: paths.repoRoot,
+    runtimeRoot: paths.runtimeRoot,
+    workflowPath: paths.workflowPath,
+    statusFilePath: paths.statusFilePath,
+    startupFilePath: paths.startupFilePath,
+    ...(paths.instance === undefined ? {} : { instance: paths.instance }),
+  };
+
   return {
     controlState,
-    paths,
-    sessionName: FACTORY_SCREEN_SESSION_NAME,
+    paths: publicPaths,
+    sessionName: paths.sessionName,
     sessions: liveSessions,
     workerAlive,
     startup,
@@ -573,7 +593,7 @@ async function inspectFactoryControlAtPaths(
 }
 
 async function stopFactoryAtPaths(
-  paths: FactoryPaths,
+  paths: ResolvedFactoryPaths,
   deps: FactoryControlDeps,
 ): Promise<FactoryControlStopResult> {
   const listProcesses = deps.listProcesses ?? defaultListProcesses;

--- a/src/domain/instance-identity.ts
+++ b/src/domain/instance-identity.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { deriveInstanceRootFromWorkflowPath } from "./workflow.js";
+
+const DETACHED_SESSION_PREFIX = "symphony-factory";
+const OPERATOR_INSTANCES_DIRECTORY = path.join(".ralph", "instances");
+const MAX_INSTANCE_LABEL_LENGTH = 24;
+const INSTANCE_HASH_LENGTH = 10;
+
+export interface SymphonyInstanceIdentity {
+  readonly instanceKey: string;
+  readonly detachedSessionName: string;
+}
+
+export interface OperatorInstanceStatePaths {
+  readonly operatorStateRoot: string;
+  readonly logDir: string;
+  readonly lockDir: string;
+  readonly lockInfoFile: string;
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+  readonly scratchpadPath: string;
+}
+
+export function deriveSymphonyInstanceIdentity(
+  instanceRootOrWorkflowPath: string,
+): SymphonyInstanceIdentity {
+  const instanceRoot = normalizeInstanceRoot(instanceRootOrWorkflowPath);
+  const instanceKey = deriveSymphonyInstanceKey(instanceRoot);
+  return {
+    instanceKey,
+    detachedSessionName: `${DETACHED_SESSION_PREFIX}-${instanceKey}`,
+  };
+}
+
+export function deriveSymphonyInstanceKey(
+  instanceRootOrWorkflowPath: string,
+): string {
+  const instanceRoot = normalizeInstanceRoot(instanceRootOrWorkflowPath);
+  const instanceLabel = sanitizeInstanceLabel(path.basename(instanceRoot));
+  const instanceHash = createHash("sha256")
+    .update(instanceRoot)
+    .digest("hex")
+    .slice(0, INSTANCE_HASH_LENGTH);
+  return `${instanceLabel}-${instanceHash}`;
+}
+
+export function deriveOperatorInstanceStatePaths(args: {
+  readonly operatorRepoRoot: string;
+  readonly instanceKey: string;
+}): OperatorInstanceStatePaths {
+  const operatorStateRoot = path.join(
+    path.resolve(args.operatorRepoRoot),
+    OPERATOR_INSTANCES_DIRECTORY,
+    args.instanceKey,
+  );
+  const lockDir = path.join(operatorStateRoot, "operator-loop.lock");
+  return {
+    operatorStateRoot,
+    logDir: path.join(operatorStateRoot, "logs"),
+    lockDir,
+    lockInfoFile: path.join(lockDir, "owner"),
+    statusJsonPath: path.join(operatorStateRoot, "status.json"),
+    statusMdPath: path.join(operatorStateRoot, "status.md"),
+    scratchpadPath: path.join(operatorStateRoot, "operator-scratchpad.md"),
+  };
+}
+
+function normalizeInstanceRoot(instanceRootOrWorkflowPath: string): string {
+  const resolvedPath = path.resolve(instanceRootOrWorkflowPath);
+  return path.basename(resolvedPath) === "WORKFLOW.md"
+    ? deriveInstanceRootFromWorkflowPath(resolvedPath)
+    : resolvedPath;
+}
+
+function sanitizeInstanceLabel(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_INSTANCE_LABEL_LENGTH)
+    .replace(/-+$/g, "");
+  return normalized.length > 0 ? normalized : "instance";
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -3,48 +3,90 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceKey,
+} from "../../src/domain/instance-identity.js";
 import { createTempDir } from "../support/git.js";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = process.cwd();
-const ralphDir = path.join(repoRoot, ".ralph");
-const statusJsonPath = path.join(ralphDir, "status.json");
-const statusMdPath = path.join(ralphDir, "status.md");
-const scratchpadPath = path.join(ralphDir, "operator-scratchpad.md");
+const ralphInstancesRoot = path.join(repoRoot, ".ralph", "instances");
 
-interface FileBackup {
-  readonly existed: boolean;
-  readonly content: string | null;
+async function writeWorkflow(rootDir: string): Promise<string> {
+  const workflowPath = path.join(rootDir, "WORKFLOW.md");
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+workspace:
+  root: ./.tmp/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
 }
 
-async function backupFile(filePath: string): Promise<FileBackup> {
-  try {
-    return {
-      existed: true,
-      content: await fs.readFile(filePath, "utf8"),
+async function runOperatorLoop(workflowPath: string): Promise<{
+  readonly stateRoot: string;
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+  readonly scratchpadPath: string;
+  readonly logFile: string | null;
+}> {
+  await execFileAsync(
+    "bash",
+    [
+      path.join("skills", "symphony-operator", "operator-loop.sh"),
+      "--once",
+      "--workflow",
+      workflowPath,
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+      },
+    },
+  );
+
+  const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+  const paths = deriveOperatorInstanceStatePaths({
+    operatorRepoRoot: repoRoot,
+    instanceKey,
+  });
+  const statusJson = JSON.parse(
+    await fs.readFile(paths.statusJsonPath, "utf8"),
+  ) as {
+    readonly lastCycle: {
+      readonly logFile: string | null;
     };
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      return {
-        existed: false,
-        content: null,
-      };
-    }
-    throw error;
-  }
-}
+  };
 
-async function restoreFile(
-  filePath: string,
-  backup: FileBackup,
-): Promise<void> {
-  if (!backup.existed) {
-    await fs.rm(filePath, { force: true });
-    return;
-  }
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, backup.content ?? "", "utf8");
+  return {
+    stateRoot: paths.operatorStateRoot,
+    statusJsonPath: paths.statusJsonPath,
+    statusMdPath: paths.statusMdPath,
+    scratchpadPath: paths.scratchpadPath,
+    logFile: statusJson.lastCycle.logFile,
+  };
 }
 
 describe("operator loop workflow selection", () => {
@@ -52,66 +94,89 @@ describe("operator loop workflow selection", () => {
 
   afterEach(async () => {
     for (const filePath of createdPaths) {
-      await fs.rm(filePath, { force: true });
+      await fs.rm(filePath, { recursive: true, force: true });
     }
     createdPaths.clear();
   });
 
-  it("publishes the selected workflow path in loop status metadata", async () => {
+  it("publishes selected workflow metadata inside the instance-scoped operator state root", async () => {
     const tempDir = await createTempDir("symphony-operator-loop-");
-    const workflowPath = path.join(tempDir, "WORKFLOW.md");
-    await fs.writeFile(workflowPath, "tracker:\n  kind: github\n", "utf8");
-
-    const statusJsonBackup = await backupFile(statusJsonPath);
-    const statusMdBackup = await backupFile(statusMdPath);
-    const scratchpadBackup = await backupFile(scratchpadPath);
-    let createdLogFile: string | null = null;
+    const workflowPath = await writeWorkflow(tempDir);
 
     try {
-      await execFileAsync(
-        "bash",
-        [
-          path.join("skills", "symphony-operator", "operator-loop.sh"),
-          "--once",
-          "--workflow",
-          workflowPath,
-        ],
-        {
-          cwd: repoRoot,
-          env: {
-            ...process.env,
-            SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
-          },
-        },
-      );
+      const run = await runOperatorLoop(workflowPath);
+      createdPaths.add(tempDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
 
       const statusJson = JSON.parse(
-        await fs.readFile(statusJsonPath, "utf8"),
+        await fs.readFile(run.statusJsonPath, "utf8"),
       ) as {
         readonly state: string;
         readonly selectedWorkflowPath: string | null;
-        readonly lastCycle: {
-          readonly logFile: string | null;
-        };
+        readonly operatorStateRoot: string;
+        readonly scratchpad: string;
       };
-      const statusMd = await fs.readFile(statusMdPath, "utf8");
+      const statusMd = await fs.readFile(run.statusMdPath, "utf8");
 
-      createdLogFile = statusJson.lastCycle.logFile;
-      if (createdLogFile !== null) {
-        createdPaths.add(createdLogFile);
-      }
-
+      expect(run.stateRoot.startsWith(ralphInstancesRoot)).toBe(true);
       expect(statusJson.state).toBe("idle");
       expect(statusJson.selectedWorkflowPath).toBe(workflowPath);
+      expect(statusJson.operatorStateRoot).toBe(run.stateRoot);
+      expect(statusJson.scratchpad).toBe(run.scratchpadPath);
       expect(statusMd).toContain(`- Selected workflow: ${workflowPath}`);
+      expect(statusMd).toContain(`- Operator state root: ${run.stateRoot}`);
     } finally {
-      await restoreFile(statusJsonPath, statusJsonBackup);
-      await restoreFile(statusMdPath, statusMdBackup);
-      await restoreFile(scratchpadPath, scratchpadBackup);
       await fs.rm(tempDir, { recursive: true, force: true });
-      if (createdLogFile !== null) {
-        await fs.rm(createdLogFile, { force: true });
+    }
+  });
+
+  it("isolates operator-loop generated state per selected instance", async () => {
+    const firstDir = await createTempDir("symphony-operator-loop-a-");
+    const secondDir = await createTempDir("symphony-operator-loop-b-");
+    const firstWorkflow = await writeWorkflow(firstDir);
+    const secondWorkflow = await writeWorkflow(secondDir);
+
+    try {
+      const firstRun = await runOperatorLoop(firstWorkflow);
+      const secondRun = await runOperatorLoop(secondWorkflow);
+      createdPaths.add(firstDir);
+      createdPaths.add(secondDir);
+      createdPaths.add(firstRun.stateRoot);
+      createdPaths.add(secondRun.stateRoot);
+      if (firstRun.logFile !== null) {
+        createdPaths.add(firstRun.logFile);
       }
+      if (secondRun.logFile !== null) {
+        createdPaths.add(secondRun.logFile);
+      }
+
+      expect(firstRun.stateRoot).not.toBe(secondRun.stateRoot);
+      expect(await fs.readFile(firstRun.scratchpadPath, "utf8")).toContain(
+        "# Operator Scratchpad",
+      );
+      expect(await fs.readFile(secondRun.scratchpadPath, "utf8")).toContain(
+        "# Operator Scratchpad",
+      );
+
+      const firstStatus = JSON.parse(
+        await fs.readFile(firstRun.statusJsonPath, "utf8"),
+      ) as {
+        readonly selectedWorkflowPath: string | null;
+      };
+      const secondStatus = JSON.parse(
+        await fs.readFile(secondRun.statusJsonPath, "utf8"),
+      ) as {
+        readonly selectedWorkflowPath: string | null;
+      };
+
+      expect(firstStatus.selectedWorkflowPath).toBe(firstWorkflow);
+      expect(secondStatus.selectedWorkflowPath).toBe(secondWorkflow);
+    } finally {
+      await fs.rm(firstDir, { recursive: true, force: true });
+      await fs.rm(secondDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { deriveSymphonyInstanceIdentity } from "../../src/domain/instance-identity.js";
 import type { FactoryStatusSnapshot } from "../../src/observability/status.js";
 import type { StartupSnapshot } from "../../src/startup/service.js";
 import { deriveRuntimeInstancePaths } from "../../src/domain/workflow.js";
@@ -24,6 +25,8 @@ import {
   type ScreenSessionSnapshot,
 } from "../../src/cli/factory-control.js";
 import { createTempDir } from "../support/git.js";
+
+const LEGACY_TEST_SESSION_NAME = "symphony-factory";
 
 function createStatusSnapshot(
   workerPid: number,
@@ -128,6 +131,7 @@ function createControlDeps(
       ].includes(targetPath),
     loadWorkflowWorkspaceRoot: async () => instancePaths.workspaceRoot,
     loadWorkflowInstancePaths: async () => instancePaths,
+    deriveSessionName: () => LEGACY_TEST_SESSION_NAME,
     readFile: async (filePath) => {
       if (filePath === statusFilePath) {
         if (options.snapshot === null) {
@@ -448,6 +452,63 @@ Prompt body
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("derives a distinct detached session name per selected instance", async () => {
+    const firstDir = await createTempDir("symphony-factory-instance-a-");
+    const secondDir = await createTempDir("symphony-factory-instance-b-");
+    const workflowContent = `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+workspace:
+  root: ./.tmp/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`;
+
+    await fs.writeFile(
+      path.join(firstDir, "WORKFLOW.md"),
+      workflowContent,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(secondDir, "WORKFLOW.md"),
+      workflowContent,
+      "utf8",
+    );
+
+    try {
+      const first = await resolveFactoryPaths({
+        workflowPath: path.join(firstDir, "WORKFLOW.md"),
+      });
+      const second = await resolveFactoryPaths({
+        workflowPath: path.join(secondDir, "WORKFLOW.md"),
+      });
+
+      expect(first.sessionName).toBe(
+        deriveSymphonyInstanceIdentity(firstDir).detachedSessionName,
+      );
+      expect(second.sessionName).toBe(
+        deriveSymphonyInstanceIdentity(secondDir).detachedSessionName,
+      );
+      expect(first.sessionName).not.toBe(second.sessionName);
+    } finally {
+      await fs.rm(firstDir, { recursive: true, force: true });
+      await fs.rm(secondDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("process parsing helpers", () => {
@@ -739,6 +800,49 @@ describe("inspectFactoryControl", () => {
     expect(snapshot.controlState).toBe("degraded");
     expect(snapshot.snapshotFreshness.freshness).toBe("unavailable");
     expect(snapshot.snapshotFreshness.reason).toBe("startup-in-progress");
+  });
+
+  it("ignores another instance's detached session while inspecting the selected instance", async () => {
+    const snapshot = await inspectFactoryControl({
+      ...createControlDeps({
+        sessions: [
+          {
+            id: "9001.symphony-factory",
+            pid: 9001,
+            name: "symphony-factory",
+            state: "Detached",
+          },
+          {
+            id: "9101.symphony-factory-project-b-deadbeef01",
+            pid: 9101,
+            name: "symphony-factory-project-b-deadbeef01",
+            state: "Detached",
+          },
+        ],
+        processes: [
+          { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+          { pid: 9002, ppid: 9001, command: "pnpm tsx bin/symphony.ts run" },
+          {
+            pid: 9101,
+            ppid: 1,
+            command: "screen -dmS symphony-factory-project-b-deadbeef01",
+          },
+          { pid: 9102, ppid: 9101, command: "pnpm tsx bin/symphony.ts run" },
+        ],
+        snapshot: createStatusSnapshot(9002),
+      }),
+    });
+
+    expect(snapshot.controlState).toBe("running");
+    expect(snapshot.sessions).toEqual([
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+    ]);
+    expect(snapshot.processIds).toEqual([9001, 9002]);
   });
 
   it("reports offline startup snapshots as stale startup failures", async () => {
@@ -1531,6 +1635,112 @@ describe("stopFactory", () => {
         { pid: 9002, signal: "SIGTERM" },
         { pid: workerPid, signal: "SIGTERM" },
         { pid: 9102, signal: "SIGTERM" },
+      ]),
+    );
+    expect(result.kind).toBe("stopped");
+    expect(result.status.controlState).toBe("stopped");
+  });
+
+  it("stops only the selected instance when another detached session is healthy", async () => {
+    const workerPid = 9101;
+    const otherSessionName = "symphony-factory-project-b-deadbeef01";
+    const sessionsState: ScreenSessionSnapshot[] = [
+      {
+        id: "9001.symphony-factory",
+        pid: 9001,
+        name: "symphony-factory",
+        state: "Detached",
+      },
+      {
+        id: `9201.${otherSessionName}`,
+        pid: 9201,
+        name: otherSessionName,
+        state: "Detached",
+      },
+    ];
+    const processesState: HostProcessSnapshot[] = [
+      { pid: 9001, ppid: 1, command: "screen -dmS symphony-factory" },
+      { pid: 9002, ppid: 9001, command: "pnpm tsx bin/symphony.ts run" },
+      { pid: workerPid, ppid: 9002, command: "node bin/symphony.ts run" },
+      {
+        pid: 9201,
+        ppid: 1,
+        command: `screen -dmS ${otherSessionName}`,
+      },
+      { pid: 9202, ppid: 9201, command: "pnpm tsx bin/symphony.ts run" },
+    ];
+    const quitCalls: string[] = [];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await stopFactory({
+      ...createControlDeps({
+        sessions: sessionsState,
+        processes: processesState,
+        snapshot: createStatusSnapshot(workerPid),
+        quitScreenSession: async (sessionId) => {
+          quitCalls.push(sessionId);
+          const remainingSessions = sessionsState.filter(
+            (session) => session.id !== sessionId,
+          );
+          sessionsState.splice(0, sessionsState.length, ...remainingSessions);
+          const remainingProcesses = processesState.filter(
+            (processSnapshot) => processSnapshot.pid !== 9001,
+          );
+          processesState.splice(
+            0,
+            processesState.length,
+            ...remainingProcesses,
+          );
+        },
+        signalProcess: (pid, signal) => {
+          signals.push({ pid, signal });
+          const index = processesState.findIndex(
+            (processSnapshot) => processSnapshot.pid === pid,
+          );
+          if (index >= 0) {
+            processesState.splice(index, 1);
+          }
+        },
+      }),
+      listProcesses: async () => processesState,
+      listScreenSessions: async () => sessionsState,
+      readFile: async () => {
+        if (
+          processesState.some(
+            (processSnapshot) => processSnapshot.pid === workerPid,
+          )
+        ) {
+          return `${JSON.stringify(createStatusSnapshot(workerPid), null, 2)}\n`;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      isProcessAlive: (pid) =>
+        processesState.some((processSnapshot) => processSnapshot.pid === pid),
+      now: (() => {
+        let now = 0;
+        return () => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(quitCalls).toEqual(["9001.symphony-factory"]);
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        { pid: 9002, signal: "SIGTERM" },
+        { pid: workerPid, signal: "SIGTERM" },
+      ]),
+    );
+    expect(signals).not.toEqual(
+      expect.arrayContaining([{ pid: 9202, signal: "SIGTERM" }]),
+    );
+    expect(processesState).toEqual(
+      expect.arrayContaining([
+        { pid: 9201, ppid: 1, command: `screen -dmS ${otherSessionName}` },
+        { pid: 9202, ppid: 9201, command: "pnpm tsx bin/symphony.ts run" },
       ]),
     );
     expect(result.kind).toBe("stopped");

--- a/tests/unit/instance-identity.test.ts
+++ b/tests/unit/instance-identity.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+  deriveSymphonyInstanceKey,
+} from "../../src/domain/instance-identity.js";
+
+describe("instance identity helpers", () => {
+  it("derives stable distinct instance keys from different instance roots", () => {
+    const first = deriveSymphonyInstanceKey("/tmp/project-a");
+    const second = deriveSymphonyInstanceKey("/tmp/project-b");
+
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^project-a-[0-9a-f]{10}$/);
+    expect(second).toMatch(/^project-b-[0-9a-f]{10}$/);
+  });
+
+  it("derives detached session identity from a workflow path", () => {
+    const identity = deriveSymphonyInstanceIdentity(
+      "/tmp/project-a/WORKFLOW.md",
+    );
+
+    expect(identity.instanceKey).toMatch(/^project-a-[0-9a-f]{10}$/);
+    expect(identity.detachedSessionName).toBe(
+      `symphony-factory-${identity.instanceKey}`,
+    );
+  });
+
+  it("derives per-instance operator state roots under .ralph/instances", () => {
+    const instanceKey = deriveSymphonyInstanceKey("/tmp/project-a");
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: "/tmp/operator-checkout",
+      instanceKey,
+    });
+
+    expect(paths.operatorStateRoot).toBe(
+      path.join("/tmp/operator-checkout", ".ralph", "instances", instanceKey),
+    );
+    expect(paths.statusJsonPath).toBe(
+      path.join(paths.operatorStateRoot, "status.json"),
+    );
+    expect(paths.scratchpadPath).toBe(
+      path.join(paths.operatorStateRoot, "operator-scratchpad.md"),
+    );
+  });
+});


### PR DESCRIPTION
Closes #216

## Summary
- derive deterministic per-instance detached session identities and scope factory control to the selected instance
- isolate checked-in operator-loop generated state under `.ralph/instances/<instance-key>/` using the same shared instance identity
- add regression coverage for per-instance session naming, stop/status isolation, and operator-loop state isolation

## Verification
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
