### PR TITLE
Fix detached third-party factory start

### DIFF
--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { loadWorkflowInstancePaths } from "../config/workflow.js";
 import { deriveSymphonyInstanceIdentity } from "../domain/instance-identity.js";
@@ -33,6 +34,11 @@ const execFile = promisify(execFileCallback);
 export const FACTORY_RUNTIME_DIRECTORY = path.join(".tmp", "factory-main");
 export const FACTORY_RUN_GUARDRAILS_ACK_FLAG =
   "--i-understand-that-this-will-be-running-without-the-usual-guardrails";
+const ENGINE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
 const START_TIMEOUT_MS = 15_000;
 const STOP_TIMEOUT_MS = 15_000;
 const POLL_INTERVAL_MS = 250;
@@ -139,6 +145,7 @@ export interface FactoryControlDeps {
   readonly listAvailableLocales?: () => Promise<readonly string[]>;
   readonly launchScreenSession?: (options: {
     readonly runtimeRoot: string;
+    readonly launchCwd: string;
     readonly sessionName: string;
     readonly command: readonly string[];
     readonly env: NodeJS.ProcessEnv;
@@ -146,6 +153,7 @@ export interface FactoryControlDeps {
   readonly quitScreenSession?: (sessionId: string) => Promise<void>;
   readonly signalProcess?: (pid: number, signal: NodeJS.Signals) => void;
   readonly removeFile?: (filePath: string) => Promise<void>;
+  readonly ensureDirectory?: (directoryPath: string) => Promise<void>;
   readonly isProcessAlive?: (pid: number) => boolean;
   readonly sleep?: (ms: number) => Promise<void>;
   readonly now?: () => number;
@@ -243,6 +251,7 @@ export async function startFactory(
   const listAvailableLocales =
     deps.listAvailableLocales ?? defaultListAvailableLocales;
   const removeFile = deps.removeFile ?? defaultRemoveFile;
+  const ensureDirectory = deps.ensureDirectory ?? defaultEnsureDirectory;
   const sleep = deps.sleep ?? defaultSleep;
   const now = deps.now ?? (() => Date.now());
   const launchEnvironment = createFactoryLaunchEnvironment(
@@ -255,13 +264,15 @@ export async function startFactory(
     }),
   );
 
+  await ensureDirectory(paths.runtimeRoot);
   await removeFile(paths.statusFilePath);
   await removeFile(paths.startupFilePath);
 
   await launchScreenSession({
     runtimeRoot: paths.runtimeRoot,
+    launchCwd: ENGINE_ROOT,
     sessionName: paths.sessionName,
-    command: createFactoryRunCommand(),
+    command: createFactoryRunCommand(paths.workflowPath),
     env: launchEnvironment,
   });
 
@@ -1008,6 +1019,7 @@ async function defaultListAvailableLocales(): Promise<readonly string[]> {
 
 async function defaultLaunchScreenSession(options: {
   readonly runtimeRoot: string;
+  readonly launchCwd: string;
   readonly sessionName: string;
   readonly command: readonly string[];
   readonly env: NodeJS.ProcessEnv;
@@ -1016,7 +1028,7 @@ async function defaultLaunchScreenSession(options: {
     "screen",
     createFactoryScreenLaunchCommand(options.sessionName, options.command),
     {
-      cwd: options.runtimeRoot,
+      cwd: options.launchCwd,
       env: options.env,
       timeout: 5_000,
     },
@@ -1035,6 +1047,10 @@ async function defaultSleep(ms: number): Promise<void> {
 
 async function defaultRemoveFile(filePath: string): Promise<void> {
   await fs.rm(filePath, { force: true });
+}
+
+async function defaultEnsureDirectory(directoryPath: string): Promise<void> {
+  await fs.mkdir(directoryPath, { recursive: true });
 }
 
 function assessStartupSnapshot(
@@ -1095,12 +1111,16 @@ function isMissingScreenSessionError(error: unknown): boolean {
   );
 }
 
-export function createFactoryRunCommand(): readonly string[] {
+export function createFactoryRunCommand(
+  workflowPath: string,
+): readonly string[] {
   return [
     "pnpm",
     "tsx",
-    "bin/symphony.ts",
+    path.join(ENGINE_ROOT, "bin", "symphony.ts"),
     "run",
+    "--workflow",
+    workflowPath,
     FACTORY_RUN_GUARDRAILS_ACK_FLAG,
   ];
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   createActiveRunExecutionOwner,
@@ -336,9 +335,11 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#livenessProbe = livenessProbe ?? null;
     this.#runtimeIdentity = Promise.resolve(
       runtimeIdentity ??
-        // `workflowPath` resolves to `<runtime-checkout>/symphony.yml` in the
-        // detached factory layout, so its parent is the live runtime checkout root.
-        collectFactoryRuntimeIdentity(path.dirname(config.workflowPath)),
+        // The running process cwd identifies the code checkout that launched the
+        // current worker. This may differ from the repository that owns
+        // WORKFLOW.md when one shared engine checkout targets a separate
+        // project-local instance.
+        collectFactoryRuntimeIdentity(process.cwd()),
     );
   }
 

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -165,12 +165,10 @@ export async function runStartupPreparation(options: {
   const instance = getConfigInstancePaths(options.config);
   const workerPid = options.workerPid ?? process.pid;
   const artifactPath = deriveStartupFilePath(instance);
-  // The workflow file may be loaded from either the instance root or the live
-  // runtime checkout; the workflow file's parent identifies the code checkout
-  // that is actually running right now.
-  const runtimeIdentity = await collectFactoryRuntimeIdentity(
-    path.dirname(options.config.workflowPath),
-  );
+  // The running process cwd identifies the code checkout that launched the
+  // current worker. This may differ from the repository that owns WORKFLOW.md
+  // when one shared engine checkout targets a separate project-local instance.
+  const runtimeIdentity = await collectFactoryRuntimeIdentity(process.cwd());
 
   options.logger.info("Startup preparation started", {
     provider: preparer.id,

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -102,6 +102,7 @@ function createControlDeps(
     readonly quitScreenSession?: FactoryControlDeps["quitScreenSession"];
     readonly signalProcess?: FactoryControlDeps["signalProcess"];
     readonly sleep?: FactoryControlDeps["sleep"];
+    readonly ensureDirectory?: FactoryControlDeps["ensureDirectory"];
   } = {},
 ): FactoryControlDeps {
   const repoRoot = "/repo";
@@ -180,6 +181,7 @@ function createControlDeps(
     listAvailableLocales: async () =>
       options.availableLocales ?? ["en_US.UTF-8", "C", "POSIX"],
     removeFile: options.removeFile ?? (async () => {}),
+    ensureDirectory: options.ensureDirectory ?? (async () => {}),
     sleep: options.sleep ?? (async () => {}),
     isProcessAlive: (pid) =>
       (options.processes ?? []).some(
@@ -998,11 +1000,13 @@ describe("inspectFactoryControl", () => {
 
 describe("createFactoryRunCommand", () => {
   it("builds the detached run command with the required guardrails acknowledgment", () => {
-    expect(createFactoryRunCommand()).toEqual([
+    expect(createFactoryRunCommand("/tmp/target/WORKFLOW.md")).toEqual([
       "pnpm",
       "tsx",
-      "bin/symphony.ts",
+      expect.stringMatching(/bin\/symphony\.ts$/u),
       "run",
+      "--workflow",
+      "/tmp/target/WORKFLOW.md",
       "--i-understand-that-this-will-be-running-without-the-usual-guardrails",
     ]);
   });
@@ -1011,7 +1015,7 @@ describe("createFactoryRunCommand", () => {
     expect(
       createFactoryScreenLaunchCommand(
         "symphony-factory",
-        createFactoryRunCommand(),
+        createFactoryRunCommand("/tmp/target/WORKFLOW.md"),
       ),
     ).toEqual([
       "-U",
@@ -1019,8 +1023,10 @@ describe("createFactoryRunCommand", () => {
       "symphony-factory",
       "pnpm",
       "tsx",
-      "bin/symphony.ts",
+      expect.stringMatching(/bin\/symphony\.ts$/u),
       "run",
+      "--workflow",
+      "/tmp/target/WORKFLOW.md",
       "--i-understand-that-this-will-be-running-without-the-usual-guardrails",
     ]);
   });
@@ -1058,6 +1064,7 @@ describe("startFactory", () => {
     let currentSnapshot: FactoryStatusSnapshot | null = null;
     const launched: Array<{
       runtimeRoot: string;
+      launchCwd: string;
       sessionName: string;
       command: readonly string[];
       env: NodeJS.ProcessEnv;
@@ -1112,8 +1119,9 @@ describe("startFactory", () => {
     expect(launched).toHaveLength(1);
     expect(launched[0]).toEqual({
       runtimeRoot: "/repo/.tmp/factory-main",
+      launchCwd: expect.stringMatching(/symphony-ts$/u),
       sessionName: "symphony-factory",
-      command: createFactoryRunCommand(),
+      command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
       env: expect.objectContaining({
         LANG: "en_US.UTF-8",
         LC_ALL: "en_US.UTF-8",
@@ -1122,6 +1130,98 @@ describe("startFactory", () => {
     });
     expect(result.kind).toBe("started");
     expect(result.status.controlState).toBe("running");
+  });
+
+  it("launches a third-party instance from the engine checkout with an explicit workflow path", async () => {
+    const launched: Array<{
+      runtimeRoot: string;
+      launchCwd: string;
+      sessionName: string;
+      command: readonly string[];
+      env: NodeJS.ProcessEnv;
+    }> = [];
+    let statusPublished = false;
+
+    const result = await startFactory({
+      workflowPath: "/target-project/WORKFLOW.md",
+      cwd: () => "/engine-checkout",
+      pathExists: async () => true,
+      loadWorkflowInstancePaths: async () =>
+        deriveRuntimeInstancePaths({
+          workflowPath: "/target-project/WORKFLOW.md",
+          workspaceRoot: "/target-project/.tmp/workspaces",
+        }),
+      deriveSessionName: () => "symphony-factory-target-project",
+      readFile: async (filePath) => {
+        if (
+          filePath === "/target-project/.tmp/status.json" &&
+          statusPublished
+        ) {
+          return `${JSON.stringify(
+            createStatusSnapshot(9101, {
+              factoryState: "running",
+            }),
+            null,
+            2,
+          )}\n`;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      listProcesses: async () =>
+        statusPublished
+          ? [
+              {
+                pid: 9101,
+                ppid: 9002,
+                command: "node /engine-checkout/bin/symphony.ts run",
+              },
+            ]
+          : [],
+      listScreenSessions: async () =>
+        statusPublished
+          ? [
+              {
+                id: "9001.symphony-factory-target-project",
+                pid: 9001,
+                name: "symphony-factory-target-project",
+                state: "Detached",
+              },
+            ]
+          : [],
+      listAvailableLocales: async () => ["en_US.UTF-8", "C"],
+      ensureDirectory: async () => {},
+      removeFile: async () => {},
+      launchScreenSession: async (options) => {
+        launched.push(options);
+        statusPublished = true;
+      },
+      isProcessAlive: () => true,
+      now: (() => {
+        let now = 0;
+        return () => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(launched).toEqual([
+      {
+        runtimeRoot: "/target-project/.tmp/factory-main",
+        launchCwd: expect.stringMatching(/symphony-ts$/u),
+        sessionName: "symphony-factory-target-project",
+        command: createFactoryRunCommand("/target-project/WORKFLOW.md"),
+        env: expect.objectContaining({
+          LANG: "en_US.UTF-8",
+          LC_ALL: "en_US.UTF-8",
+          LC_CTYPE: "en_US.UTF-8",
+        }),
+      },
+    ]);
+    expect(result.kind).toBe("started");
+    expect(result.status.paths.repoRoot).toBe("/target-project");
   });
 
   it("keeps waiting while the restarted runtime only has an initializing snapshot", async () => {
@@ -1455,6 +1555,7 @@ describe("startFactory", () => {
   it("times out when the detached runtime never becomes healthy after launch", async () => {
     const launched: Array<{
       runtimeRoot: string;
+      launchCwd: string;
       sessionName: string;
       command: readonly string[];
       env: NodeJS.ProcessEnv;
@@ -1476,8 +1577,9 @@ describe("startFactory", () => {
     expect(launched).toEqual([
       {
         runtimeRoot: "/repo/.tmp/factory-main",
+        launchCwd: expect.stringMatching(/symphony-ts$/u),
         sessionName: "symphony-factory",
-        command: createFactoryRunCommand(),
+        command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({
           LANG: "en_US.UTF-8",
           LC_ALL: "en_US.UTF-8",
@@ -1490,6 +1592,7 @@ describe("startFactory", () => {
   it("normalizes a bad inherited locale before launching the detached runtime", async () => {
     const launched: Array<{
       runtimeRoot: string;
+      launchCwd: string;
       sessionName: string;
       command: readonly string[];
       env: NodeJS.ProcessEnv;
@@ -1517,8 +1620,9 @@ describe("startFactory", () => {
     expect(launched).toEqual([
       {
         runtimeRoot: "/repo/.tmp/factory-main",
+        launchCwd: expect.stringMatching(/symphony-ts$/u),
         sessionName: "symphony-factory",
-        command: createFactoryRunCommand(),
+        command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({
           TERM: "screen-256color",
           LANG: "en_US.UTF-8",
@@ -1966,6 +2070,7 @@ describe("factory restart launch contract", () => {
     let currentSnapshot: FactoryStatusSnapshot | null = null;
     const launches: Array<{
       runtimeRoot: string;
+      launchCwd: string;
       sessionName: string;
       command: readonly string[];
       env: NodeJS.ProcessEnv;
@@ -2050,7 +2155,7 @@ describe("factory restart launch contract", () => {
     expect(launches).toHaveLength(2);
     expect(launches).toEqual([
       expect.objectContaining({
-        command: createFactoryRunCommand(),
+        command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({
           LANG: "en_US.UTF-8",
           LC_ALL: "en_US.UTF-8",
@@ -2058,7 +2163,7 @@ describe("factory restart launch contract", () => {
         }),
       }),
       expect.objectContaining({
-        command: createFactoryRunCommand(),
+        command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({
           LANG: "en_US.UTF-8",
           LC_ALL: "en_US.UTF-8",

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -169,7 +169,7 @@ describe("startup service", () => {
         workerPid: 3210,
         provider: "github-bootstrap/local-mirror",
         runtimeIdentity: {
-          checkoutPath: runtimeRoot,
+          checkoutPath: process.cwd(),
         },
       });
     } finally {
@@ -312,7 +312,7 @@ describe("startup service", () => {
         provider: "github-bootstrap/test-failure",
         summary: "Mirror refresh failed.",
         runtimeIdentity: {
-          checkoutPath: tempDir,
+          checkoutPath: process.cwd(),
         },
       });
     } finally {
@@ -350,7 +350,7 @@ describe("startup service", () => {
         workerPid: 9876,
         provider: "github-bootstrap/test-abort",
         runtimeIdentity: {
-          checkoutPath: tempDir,
+          checkoutPath: process.cwd(),
         },
       });
     } finally {


### PR DESCRIPTION
## Summary
- launch detached factory runs from the active Symphony engine checkout with an explicit --workflow target
- create the instance runtime root before launch instead of assuming it already exists
- record runtime identity from the running engine checkout and add regression coverage for third-party detached starts

## Verification
- pnpm exec vitest run tests/unit/factory-control.test.ts tests/unit/cli.test.ts
- pnpm typecheck
- pnpm lint
- manual verification: Factory already running.
{
  "controlState": "running",
  "paths": {
    "repoRoot": "/Users/jessmartin/Documents/code/context-library",
    "runtimeRoot": "/Users/jessmartin/Documents/code/context-library/.tmp/factory-main",
    "workflowPath": "/Users/jessmartin/Documents/code/context-library/WORKFLOW.md",
    "statusFilePath": "/Users/jessmartin/Documents/code/context-library/.tmp/status.json",
    "startupFilePath": "/Users/jessmartin/Documents/code/context-library/.tmp/startup.json",
    "instance": {
      "instanceRoot": "/Users/jessmartin/Documents/code/context-library",
      "workflowRoot": "/Users/jessmartin/Documents/code/context-library",
      "tempRoot": "/Users/jessmartin/Documents/code/context-library/.tmp",
      "varRoot": "/Users/jessmartin/Documents/code/context-library/.var",
      "runtimeRoot": "/Users/jessmartin/Documents/code/context-library/.tmp/factory-main",
      "runtimeWorkflowPath": "/Users/jessmartin/Documents/code/context-library/.tmp/factory-main/WORKFLOW.md",
      "workspaceRoot": "/Users/jessmartin/Documents/code/context-library/.tmp/workspaces",
      "statusFilePath": "/Users/jessmartin/Documents/code/context-library/.tmp/status.json",
      "startupFilePath": "/Users/jessmartin/Documents/code/context-library/.tmp/startup.json",
      "githubMirrorPath": "/Users/jessmartin/Documents/code/context-library/.tmp/github/upstream",
      "factoryArtifactsRoot": "/Users/jessmartin/Documents/code/context-library/.var/factory",
      "issueArtifactsRoot": "/Users/jessmartin/Documents/code/context-library/.var/factory/issues",
      "reportsRoot": "/Users/jessmartin/Documents/code/context-library/.var/reports",
      "issueReportsRoot": "/Users/jessmartin/Documents/code/context-library/.var/reports/issues",
      "campaignReportsRoot": "/Users/jessmartin/Documents/code/context-library/.var/reports/campaigns"
    }
  },
  "sessionName": "symphony-factory-context-library-418d516765",
  "sessions": [
    {
      "id": "62057.symphony-factory-context-library-418d516765",
      "pid": 62057,
      "name": "symphony-factory-context-library-418d516765",
      "state": "Attached"
    }
  ],
  "workerAlive": true,
  "startup": {
    "state": "ready",
    "provider": "github-bootstrap/local-mirror",
    "summary": "GitHub bootstrap mirror created at /Users/jessmartin/Documents/code/context-library/.tmp/github/upstream.",
    "updatedAt": "2026-03-24T03:13:53.435Z",
    "workerPid": 62164,
    "workerAlive": true,
    "stale": false,
    "runtimeIdentity": {
      "checkoutPath": "/Users/jessmartin/Documents/code/symphony-ts",
      "headSha": "55e1defa598cd733a1efffe5500f7e7021e4c549",
      "committedAt": "2026-03-23T18:42:11-04:00",
      "isDirty": true,
      "source": "git",
      "detail": null
    }
  },
  "snapshotFreshness": {
    "freshness": "fresh",
    "reason": "current-snapshot",
    "summary": "The snapshot belongs to the live factory runtime.",
    "workerAlive": true,
    "publicationState": "current"
  },
  "statusSnapshot": {
    "version": 1,
    "generatedAt": "2026-03-24T03:15:24.834Z",
    "runtimeIdentity": {
      "checkoutPath": "/Users/jessmartin/Documents/code/symphony-ts",
      "headSha": "55e1defa598cd733a1efffe5500f7e7021e4c549",
      "committedAt": "2026-03-23T18:42:11-04:00",
      "isDirty": true,
      "source": "git",
      "detail": null
    },
    "publication": {
      "state": "current",
      "detail": null
    },
    "dispatchPressure": null,
    "hostDispatch": null,
    "restartRecovery": {
      "state": "ready",
      "startedAt": "2026-03-24T03:13:54.132Z",
      "completedAt": "2026-03-24T03:15:24.833Z",
      "summary": "Restart recovery completed successfully.",
      "issues": []
    },
    "recoveryPosture": {
      "summary": {
        "family": "restart-recovery",
        "summary": "Restart recovery completed successfully.",
        "issueCount": 0
      },
      "entries": [
        {
          "family": "restart-recovery",
          "issueNumber": null,
          "issueIdentifier": null,
          "title": null,
          "source": "restart-recovery",
          "summary": "Restart recovery completed successfully.",
          "observedAt": "2026-03-24T03:15:24.833Z"
        }
      ]
    },
    "factoryState": "idle",
    "worker": {
      "instanceId": "b10a75ca-92d1-4e35-93d4-f9189191857e",
      "pid": 62164,
      "startedAt": "2026-03-24T03:13:53.439Z",
      "pollIntervalMs": 30000,
      "maxConcurrentRuns": 1
    },
    "counts": {
      "ready": 0,
      "running": 0,
      "failed": 0,
      "activeLocalRuns": 0,
      "retries": 0
    },
    "lastAction": {
      "kind": "poll-fetched",
      "summary": "Found 0 ready, 0 running, 0 failed issues",
      "at": "2026-03-24T03:15:24.834Z",
      "issueNumber": null
    },
    "activeIssues": [],
    "readyQueue": [],
    "retries": []
  },
  "processIds": [
    62057,
    62164,
    62074,
    62092,
    62124
  ],
  "problems": []
} now starts a healthy detached runtime for a brand-new external instance

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
