### PR TITLE
Add safe full-TUI attach for detached factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Control or inspect the local detached factory runtime from the engine checkout:
 pnpm tsx bin/symphony.ts factory start --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory status --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory watch --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory attach --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory status --json --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory restart --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory stop --workflow ../target-repo/WORKFLOW.md
@@ -114,7 +115,8 @@ These commands target the checked-out runtime under `<instance-root>/.tmp/factor
 `status` when you want the raw runtime snapshot for a specific workflow path,
 and use `factory status` when you want the detached runtime control state plus
 the embedded status snapshot. Operators should generally start with
-`factory status`, then use `factory watch` for continuous monitoring.
+`factory status`, then use `factory watch` for continuous monitoring and
+`factory attach` when they need the full-screen TUI for a detached instance.
 
 The supported detached control path now normalizes the launched runtime to an
 installed UTF-8 locale and starts GNU Screen with `-U`. If the host does not
@@ -124,6 +126,8 @@ clearly instead of silently launching a mojibake-prone TUI.
 For detached monitoring, do not use raw `screen -r <instance-session-name>` as
 the normal watch path. Attaching that way gives your terminal the worker's
 foreground signal boundary, so an accidental `Ctrl-C` can stop the factory.
+Use `factory attach` instead when you need the full graphical TUI for a
+detached instance; it keeps `Ctrl-C` scoped to the foreground attach client.
 
 The status snapshot includes normalized runner visibility for active issues,
 including worker state, current phase, provider identity, execution transport,
@@ -566,35 +570,35 @@ Tests run in three layers: unit tests for pure logic, integration tests for adap
 
 This repository is in active construction, but the core local factory is already real. The table below is derived from the merged PR history in this repository and summarizes the capabilities that have actually landed so far.
 
-| Capability                                                                                                          | Status   |
-| ------------------------------------------------------------------------------------------------------------------- | -------- |
-| Local end-to-end GitHub issue -> branch -> PR -> merge loop                                                         | `done`   |
-| Human plan-review station before substantial implementation                                                         | `done`   |
-| Follows through on CI failures and review feedback until a PR is ready to land                                      | `done`   |
-| Human-controlled landing flow for merge-ready PRs                                                                   | `done`   |
-| Restart recovery and watchdog handling for stuck or interrupted runs                                                | `done`   |
-| Detached factory control CLI: `factory start`, `factory status`, `factory watch`, `factory restart`, `factory stop` | `done`   |
-| Status TUI with live runner/session context                                                                         | `done`   |
-| Per-issue reports from local runtime artifacts                                                                      | `done`   |
-| Campaign digest reporting across issues                                                                             | `done`   |
-| `factory-runs` archive publication for reports and logs                                                             | `done`   |
-| GitHub tracker adapter                                                                                              | `done`   |
-| Linear tracker adapter                                                                                              | `done`   |
-| Ready-queue prioritization from tracker metadata                                                                    | `done`   |
-| Generic command runner                                                                                              | `done`   |
-| Claude Code runner                                                                                                  | `done`   |
-| Codex runner                                                                                                        | `done`   |
-| Remote Codex execution over SSH                                                                                     | `done`   |
-| Multi-instance local factories from one Symphony engine checkout                                                    | `done`   |
-| Installed Symphony engine distribution support                                                                      | `done`   |
-| Self-hosting: Symphony works `symphony-ts` issues and opens PRs back here                                           | `done`   |
-| Beads tracker adapter and Beads workflow contract                                                                   | `coming` |
-| Detection/classification of stalled required checks instead of waiting forever                                      | `coming` |
-| Operator message injection into active or resumable worker sessions                                                 | `coming` |
-| Broader remote execution backends beyond current SSH Codex support                                                  | `coming` |
-| Automated QA review station and review-station pluggability                                                         | `coming` |
-| Context Library hook                                                                                                | `coming` |
-| Molecule-aware dispatch                                                                                             | `coming` |
+| Capability                                                                                                                            | Status   |
+| ------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Local end-to-end GitHub issue -> branch -> PR -> merge loop                                                                           | `done`   |
+| Human plan-review station before substantial implementation                                                                           | `done`   |
+| Follows through on CI failures and review feedback until a PR is ready to land                                                        | `done`   |
+| Human-controlled landing flow for merge-ready PRs                                                                                     | `done`   |
+| Restart recovery and watchdog handling for stuck or interrupted runs                                                                  | `done`   |
+| Detached factory control CLI: `factory start`, `factory status`, `factory watch`, `factory attach`, `factory restart`, `factory stop` | `done`   |
+| Status TUI with live runner/session context                                                                                           | `done`   |
+| Per-issue reports from local runtime artifacts                                                                                        | `done`   |
+| Campaign digest reporting across issues                                                                                               | `done`   |
+| `factory-runs` archive publication for reports and logs                                                                               | `done`   |
+| GitHub tracker adapter                                                                                                                | `done`   |
+| Linear tracker adapter                                                                                                                | `done`   |
+| Ready-queue prioritization from tracker metadata                                                                                      | `done`   |
+| Generic command runner                                                                                                                | `done`   |
+| Claude Code runner                                                                                                                    | `done`   |
+| Codex runner                                                                                                                          | `done`   |
+| Remote Codex execution over SSH                                                                                                       | `done`   |
+| Multi-instance local factories from one Symphony engine checkout                                                                      | `done`   |
+| Installed Symphony engine distribution support                                                                                        | `done`   |
+| Self-hosting: Symphony works `symphony-ts` issues and opens PRs back here                                                             | `done`   |
+| Beads tracker adapter and Beads workflow contract                                                                                     | `coming` |
+| Detection/classification of stalled required checks instead of waiting forever                                                        | `coming` |
+| Operator message injection into active or resumable worker sessions                                                                   | `coming` |
+| Broader remote execution backends beyond current SSH Codex support                                                                    | `coming` |
+| Automated QA review station and review-station pluggability                                                                           | `coming` |
+| Context Library hook                                                                                                                  | `coming` |
+| Molecule-aware dispatch                                                                                                               | `coming` |
 
 The highest-signal roadmap items currently tracked in GitHub Issues are:
 

--- a/docs/guides/failure-drills.md
+++ b/docs/guides/failure-drills.md
@@ -6,7 +6,7 @@ Use [`operator-runbook.md`](./operator-runbook.md) as the daily-use companion.
 
 ## Ground Rules
 
-- Start from the checked-in control path: `factory status`, `factory watch`, `factory start`, `factory restart`, `factory stop`.
+- Start from the checked-in control path: `factory status`, `factory watch`, `factory attach`, `factory start`, `factory restart`, `factory stop`.
 - Treat `factory status --json` as the primary evidence source.
 - Use retained workspaces and `.var/factory/issues/` artifacts to confirm what happened.
 - Do not normalize raw `screen` attachment or ad hoc process cleanup into the procedure unless the supported control path is broken.

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -11,6 +11,7 @@ pnpm tsx bin/symphony.ts factory start
 pnpm tsx bin/symphony.ts factory status
 pnpm tsx bin/symphony.ts factory status --json
 pnpm tsx bin/symphony.ts factory watch
+pnpm tsx bin/symphony.ts factory attach
 pnpm tsx bin/symphony.ts factory restart
 pnpm tsx bin/symphony.ts factory stop
 ```
@@ -21,6 +22,7 @@ selector:
 ```bash
 pnpm tsx bin/symphony.ts factory status --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory watch --workflow ../target-repo/WORKFLOW.md
+pnpm tsx bin/symphony.ts factory attach --workflow ../target-repo/WORKFLOW.md
 pnpm tsx bin/symphony.ts factory restart --workflow ../target-repo/WORKFLOW.md
 ```
 
@@ -51,6 +53,7 @@ Normal path rules:
 
 - Treat `factory status --json` as the primary source of truth.
 - Use `factory watch` as the supported live read-only monitor.
+- Use `factory attach` when you need the full-screen TUI for a detached instance.
 - Do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can stop the detached worker.
 - Prefer `factory start|stop|restart` over ad hoc `screen`, `ps`, or `pkill`.
 
@@ -60,12 +63,13 @@ Run this sequence at the start of each operator pass:
 
 1. Inspect `pnpm tsx bin/symphony.ts factory status --json`, appending `--workflow <path>` whenever the operator checkout is not the target instance root.
 2. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
-3. Check for operator-gated work the factory cannot clear by itself:
+3. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
+4. Check for operator-gated work the factory cannot clear by itself:
    - active issues in `awaiting-human-handoff`
    - active issues or PRs in `awaiting-landing-command`
-4. If the detached runtime is stopped or degraded, repair that first.
-5. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
-6. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
+5. If the detached runtime is stopped or degraded, repair that first.
+6. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
+7. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
 
@@ -97,6 +101,15 @@ Watch the live surface with:
 ```bash
 pnpm tsx bin/symphony.ts factory watch
 ```
+
+Recover the full-screen TUI safely with:
+
+```bash
+pnpm tsx bin/symphony.ts factory attach
+```
+
+`factory attach` is richer than `factory watch`, but it is still brokered:
+`Ctrl-C` exits the attach client without stopping the detached worker.
 
 Stop only through the supported command:
 

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -125,7 +125,8 @@ right now?"; for detached control it refers to `<instance-root>/.tmp/factory-mai
 operator checkout you are typing in.
 
 For self-hosting operations, prefer `factory status` first, then `factory watch`
-when you want a live read-only monitor.
+when you want a live read-only monitor, and `factory attach` when you need the
+full-screen TUI for a detached instance.
 
 The supported detached control path owns the UTF-8 terminal contract for the
 factory runtime: it selects an installed UTF-8 locale for detached startup,
@@ -136,9 +137,14 @@ Do not use raw `screen -r <instance-session-name>` as the normal watch path. Tha
 attach path gives your terminal direct foreground ownership of the worker, so
 an accidental `Ctrl-C` can stop the detached factory.
 
+Use `factory attach` instead when you need the full graphical TUI after a
+detached start. That attach path keeps `Ctrl-C` scoped to the foreground attach
+client instead of the worker.
+
 The operator loop sits above those factory-control commands; it should inspect
 and supervise the detached runtime through `factory status` / `factory watch`
-rather than reimplementing scheduler or runner logic.
+rather than reimplementing scheduler or runner logic. `factory attach` is for
+human deep inspection, not for automation.
 
 ### 5. Watch the issue lifecycle
 

--- a/docs/plans/232-safe-full-tui-attach/plan.md
+++ b/docs/plans/232-safe-full-tui-attach/plan.md
@@ -199,16 +199,16 @@ This issue does not change the detached factory runtime state machine. It adds a
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Detached-control facts available | Expected decision |
-| --- | --- | --- | --- |
-| Target instance has one healthy detached session | selected workflow path, local TTY, attach helper/backend available | `factory status` equivalent reports one matching session | start brokered attach and render the full TUI |
-| Target instance is stopped | selected workflow path, local TTY | no matching session / stopped control state | fail clearly and direct the operator to `factory start` or `factory status` |
-| Target instance is degraded with multiple matching sessions | selected workflow path | degraded control snapshot with multiple matching sessions | fail clearly; require operator cleanup through existing control path rather than attaching ambiguously |
-| Operator presses `Ctrl-C` while attached | local client receives interrupt byte/signal | worker session remains otherwise healthy | detach the client, restore terminal state, leave detached runtime alive |
-| Operator terminal resizes while attached | local width/height change | active detached session | propagate resize through the broker so the foreground TUI reflows |
-| Attach helper/PTY wrapper is unavailable on host | host command/path probe fails | detached session may still be healthy | fail clearly with actionable local-host guidance; do not fall back to unsafe raw attach |
-| Attach child exits unexpectedly while worker remains alive | attach subprocess exit status / EOF | detached control still shows live session | report attach failure locally; do not stop the worker |
-| Local terminal restoration fails during detach | raw-mode / stdio restore error | detached worker may still be healthy | report degraded local cleanup clearly while prioritizing worker safety |
+| Observed condition                                          | Local facts available                                              | Detached-control facts available                          | Expected decision                                                                                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Target instance has one healthy detached session            | selected workflow path, local TTY, attach helper/backend available | `factory status` equivalent reports one matching session  | start brokered attach and render the full TUI                                                          |
+| Target instance is stopped                                  | selected workflow path, local TTY                                  | no matching session / stopped control state               | fail clearly and direct the operator to `factory start` or `factory status`                            |
+| Target instance is degraded with multiple matching sessions | selected workflow path                                             | degraded control snapshot with multiple matching sessions | fail clearly; require operator cleanup through existing control path rather than attaching ambiguously |
+| Operator presses `Ctrl-C` while attached                    | local client receives interrupt byte/signal                        | worker session remains otherwise healthy                  | detach the client, restore terminal state, leave detached runtime alive                                |
+| Operator terminal resizes while attached                    | local width/height change                                          | active detached session                                   | propagate resize through the broker so the foreground TUI reflows                                      |
+| Attach helper/PTY wrapper is unavailable on host            | host command/path probe fails                                      | detached session may still be healthy                     | fail clearly with actionable local-host guidance; do not fall back to unsafe raw attach                |
+| Attach child exits unexpectedly while worker remains alive  | attach subprocess exit status / EOF                                | detached control still shows live session                 | report attach failure locally; do not stop the worker                                                  |
+| Local terminal restoration fails during detach              | raw-mode / stdio restore error                                     | detached worker may still be healthy                      | report degraded local cleanup clearly while prioritizing worker safety                                 |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/232-safe-full-tui-attach/plan.md
+++ b/docs/plans/232-safe-full-tui-attach/plan.md
@@ -1,0 +1,290 @@
+# Issue 232 Plan: Safe Full-TUI Attach For Detached Factory Instances
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a supported way to recover the live full-screen Symphony TUI for an already-running detached factory instance without handing the operator terminal directly to the worker-owned `screen` session.
+
+This slice should preserve the existing detached-control model:
+
+- `factory status --json` remains the canonical source of truth
+- `factory watch` remains the supported read-only live monitor
+- the new attach path becomes the explicit richer foreground-TUI recovery tool when operators need the real full-screen dashboard instead of the summarized watch surface
+
+## Scope
+
+- add a first-class `symphony factory attach` command for a selected instance
+- broker a safe attach boundary between the operator terminal and the detached runtime session so operator interrupt keys detach the client instead of stopping the worker
+- resolve attach targets through the existing instance-scoped detached session identity contract
+- keep the attach path limited to local detached runtime integration and operator-facing docs/tests
+- add focused unit and integration coverage for attach-session resolution, signal handling, terminal cleanup, and degraded-control cases
+- update operator docs and skills to distinguish `factory status`, `factory watch`, and `factory attach`
+
+## Non-goals
+
+- changing tracker transport, normalization, or lifecycle policy
+- changing orchestrator retry, continuation, reconciliation, lease, or handoff behavior
+- replacing GNU Screen as the detached-runtime backend
+- redesigning the dashboard/TUI layout
+- introducing a remote terminal protocol or hosted attach service
+- making `factory attach` the new canonical source of truth over `factory status --json`
+- broadening this issue into operator-loop packaging or dashboard aggregation work
+
+## Current Gaps
+
+- the supported detached observation path today is `factory watch`, which is intentionally safe but does not expose the actual full-screen foreground TUI
+- the only practical way to recover the real TUI today is raw `screen -r` against the detached session, which is explicitly unsupported because the operator terminal shares the worker's direct terminal boundary
+- current factory-control code can resolve and inspect the detached `screen` session safely, but it has no brokered attach client
+- CLI parsing and docs currently expose only `start`, `stop`, `restart`, `status`, and `watch`
+- tests cover the safe watch client but not a richer attach path with explicit signal isolation and terminal restoration rules
+
+## Decision Notes
+
+- Keep `factory attach` as an explicit, opt-in operator command instead of overloading `factory watch`. The two commands have different contracts: read-only snapshot polling versus richer live TUI recovery.
+- Keep the attach boundary local and brokered. Do not normalize raw `screen -r` back into the operator procedure.
+- Reuse the existing selected-instance contract and detached session naming from `#216`; this issue should not reopen multi-instance identity design.
+- Prefer a PTY-broker attach client that can intercept local control keys and terminal signals before they reach the detached worker. Do not assume GNU Screen alone can provide the required safety boundary.
+- If host-specific terminal helpers are required, isolate them behind a small attach-integration helper so the command contract stays testable.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the abstraction mapping in `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the repo-owned rule that full-TUI recovery for a detached instance must go through a safe brokered attach path rather than raw worker-terminal attach
+  - belongs: the rule that `factory status --json` remains canonical and `factory watch` remains the default safe live monitor
+  - does not belong: `screen` argv details, PTY plumbing, or OS signal wiring
+- Configuration Layer
+  - belongs: fixed CLI-level attach defaults and any small typed attach options that stay internal to the command contract for this slice
+  - does not belong: new `WORKFLOW.md` settings unless implementation proves a persistent repo-owned config seam is necessary
+- Coordination Layer
+  - belongs: selecting the targeted detached session for the chosen instance and defining how the attach client starts, detaches, and reports degraded conditions
+  - does not belong: orchestrator polling, dispatch, retries, review-loop policy, or runtime-state redesign
+- Execution Layer
+  - belongs: launching the local attach broker, allocating the child terminal boundary, forwarding resize/input/output, and preventing client interrupts from reaching the worker session
+  - does not belong: workspace lifecycle or runner behavior changes
+- Integration Layer
+  - belongs: GNU Screen attach invocation, host terminal capability probing if needed, and any local PTY helper integration used to broker the attach safely
+  - does not belong: tracker API changes or mixed tracker/runtime policy
+- Observability Layer
+  - belongs: clear operator-facing output for attach failures, degraded session selection, and docs that position attach relative to status/watch
+  - does not belong: canonical snapshot schema changes unless the attach UX proves an actual read-model gap
+
+## Architecture Boundaries
+
+### CLI / factory-control seam
+
+Belongs here:
+
+- `factory attach` argument parsing and dispatch
+- selected-instance resolution using the existing factory-control path helpers
+- attach preflight checks against current detached control state
+
+Does not belong here:
+
+- raw PTY event loops embedded inline inside unrelated start/stop/status logic
+- tracker or orchestrator policy
+
+### Attach broker seam
+
+Belongs here:
+
+- one focused attach client module that owns:
+  - child attach process creation
+  - local terminal mode setup and restoration
+  - input/output forwarding
+  - resize propagation
+  - interception of local detach/interrupt keys and signals
+- explicit distinction between "client detached" and "worker stopped"
+
+Does not belong here:
+
+- detached-runtime lifecycle management beyond attach preflight
+- snapshot rendering logic already owned by `factory watch` / status surfaces
+
+### Screen / host integration seam
+
+Belongs here:
+
+- constructing the attach command for the resolved detached session
+- encapsulating host-specific PTY-wrapper details when a raw child process cannot safely own the operator terminal directly
+- surfacing actionable errors when the attach helper or `screen` backend is unavailable
+
+Does not belong here:
+
+- attach policy decisions
+- repo-wide terminal abstraction unrelated to this feature
+
+### Observability and docs seam
+
+Belongs here:
+
+- documenting when to use `factory status`, `factory watch`, and `factory attach`
+- explaining that `factory attach` is richer than `watch` but still brokered so `Ctrl-C` detaches the client only
+- making degraded attach failure modes explicit in CLI output and docs
+
+Does not belong here:
+
+- TUI redesign
+- unrelated operator-loop behavior changes
+
+### Tracker / workspace / runner seams
+
+Untouched for this slice:
+
+- tracker adapters should not learn about attach
+- workspace code should not absorb attach plumbing
+- runner implementations should continue to see the same runtime environment as today
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR on one detached-runtime operator seam:
+
+1. add one explicit `factory attach` command
+2. implement one isolated brokered attach client
+3. reuse existing instance-scoped detached session resolution
+4. lock the behavior with focused tests and operator docs
+
+Deferred from this PR:
+
+- replacing Screen with another session backend
+- richer interactive attach controls beyond safe detach and resize handling
+- remote attach or web-based TUI access
+- broader operator loop/dashboard changes
+- any orchestrator-side TUI state publication redesign
+
+This seam is reviewable because it stays in CLI/factory-control, a small attach helper, host integration, tests, and docs. It does not mix tracker edges, orchestrator retry state, or broad TUI redesign.
+
+## Attach Client Runtime State Model
+
+This issue does not change the detached factory runtime state machine. It adds a brokered attach-client state model.
+
+### States
+
+1. `preflight`
+   - resolve the selected instance and inspect detached control state
+2. `attach-ready`
+   - exactly one healthy target session is available for brokered attach
+3. `attaching`
+   - the local attach broker launches the child attach boundary
+4. `attached`
+   - full-screen TUI bytes and resize/input events flow through the broker
+5. `detaching`
+   - the operator requests local detach or the client receives an interrupt/termination signal
+6. `detached`
+   - the client exits after restoring the local terminal without stopping the worker
+7. `attach-failed`
+   - preflight, child attach launch, or terminal restoration fails clearly
+
+### Allowed transitions
+
+- `preflight -> attach-ready`
+- `preflight -> attach-failed`
+- `attach-ready -> attaching`
+- `attaching -> attached`
+- `attaching -> attach-failed`
+- `attached -> detaching`
+- `detaching -> detached`
+- `attached -> attach-failed`
+
+### Contract rules
+
+- attach targets exactly one selected instance's detached session
+- `Ctrl-C`, `SIGINT`, and local terminal teardown must detach the client without intentionally forwarding those control signals to the worker-owned session
+- the attach client must restore local terminal state on all normal detach paths
+- degraded preflight states remain explicit; the command should not guess across multiple matching sessions or silently fall back to raw `screen -r`
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Detached-control facts available | Expected decision |
+| --- | --- | --- | --- |
+| Target instance has one healthy detached session | selected workflow path, local TTY, attach helper/backend available | `factory status` equivalent reports one matching session | start brokered attach and render the full TUI |
+| Target instance is stopped | selected workflow path, local TTY | no matching session / stopped control state | fail clearly and direct the operator to `factory start` or `factory status` |
+| Target instance is degraded with multiple matching sessions | selected workflow path | degraded control snapshot with multiple matching sessions | fail clearly; require operator cleanup through existing control path rather than attaching ambiguously |
+| Operator presses `Ctrl-C` while attached | local client receives interrupt byte/signal | worker session remains otherwise healthy | detach the client, restore terminal state, leave detached runtime alive |
+| Operator terminal resizes while attached | local width/height change | active detached session | propagate resize through the broker so the foreground TUI reflows |
+| Attach helper/PTY wrapper is unavailable on host | host command/path probe fails | detached session may still be healthy | fail clearly with actionable local-host guidance; do not fall back to unsafe raw attach |
+| Attach child exits unexpectedly while worker remains alive | attach subprocess exit status / EOF | detached control still shows live session | report attach failure locally; do not stop the worker |
+| Local terminal restoration fails during detach | raw-mode / stdio restore error | detached worker may still be healthy | report degraded local cleanup clearly while prioritizing worker safety |
+
+## Storage / Persistence Contract
+
+- no new durable runtime files are required for this slice
+- no tracker-side or orchestrator durable state changes are introduced
+- attach state is process-local to the brokered client and exits with that client
+- existing detached status/startup snapshots remain the canonical read-side evidence before and after attach
+
+## Observability Requirements
+
+- `factory attach` must fail with explicit, operator-readable messages when the target instance is stopped, degraded, ambiguous, or unsupported on the current host
+- docs must state that `factory status --json` remains canonical, `factory watch` remains the supported read-only monitor, and `factory attach` is the richer foreground TUI recovery tool
+- tests must prove that local detach/interrupt paths do not invoke factory stop behavior
+- if the attach client prints a local banner or detach hint, keep it minimal so it does not obscure the full-screen TUI
+
+## Implementation Steps
+
+1. Extend CLI parsing and dispatch to accept `symphony factory attach [--workflow <path>]`.
+2. Add a focused attach module near factory-control that:
+   - resolves the selected instance through the existing factory-control helpers
+   - performs detached-control preflight
+   - launches a brokered child attach boundary for the resolved `screen` session
+   - owns local terminal mode setup, resize forwarding, detach/interrupt handling, and cleanup
+3. Add a small host integration helper for the brokered attach path so tests can stub:
+   - child attach process creation
+   - local terminal raw-mode interactions
+   - resize and signal listeners
+4. Keep `factory watch` unchanged as the polling read-only surface; do not collapse the two contracts.
+5. Update README and operator docs/skills to explain the three supported detached observation modes:
+   - `factory status --json` for truth
+   - `factory watch` for safe read-only monitoring
+   - `factory attach` for safe full-TUI recovery
+6. Add regression coverage for command parsing, attach preflight, safe detach-on-`Ctrl-C`, resize forwarding, and terminal restoration.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+- `parseArgs()` accepts `symphony factory attach`
+- CLI dispatch calls the new attach command without changing existing start/stop/status/watch behavior
+- attach preflight rejects stopped and degraded multi-session control states
+- attach client intercepts local `SIGINT` / detach key handling and does not call `stopFactory()`
+- attach client restores local terminal state on normal detach and child-exit paths
+- attach client forwards resize events to the child attach boundary
+
+### Integration tests
+
+- a mocked healthy detached session can be attached through the broker with the resolved instance-scoped session name
+- interrupting the attach client leaves detached control healthy and does not terminate the worker-owned session
+- attach startup fails clearly when the host helper or backend is unavailable
+
+### End-to-end acceptance scenarios
+
+1. Given a detached factory is already running, when the operator runs `pnpm tsx bin/symphony.ts factory attach --workflow <path>`, then the real full-screen TUI appears through the supported brokered path.
+2. Given the operator is attached through `factory attach`, when they press `Ctrl-C`, then the attach client exits and a subsequent `factory status` still shows the detached runtime alive.
+3. Given two detached instances exist, when the operator attaches to one selected workflow, then only that instance's detached session is targeted.
+4. Given detached control is degraded or ambiguous, when the operator runs `factory attach`, then the command refuses unsafe attach and points the operator back to `factory status` / cleanup.
+
+## Exit Criteria
+
+- a supported `factory attach` command exists for detached instances
+- attach uses the selected instance-scoped detached session identity and refuses ambiguous/degraded targets
+- local detach/interrupt handling does not stop the detached worker
+- local terminal cleanup is reliable and tested
+- docs clearly distinguish canonical status, safe watch, and safe full-TUI attach
+
+## Deferred
+
+- replacing Screen
+- read/write permission models inside Screen itself
+- remote or browser-based TUI attach
+- richer interactive attach shortcuts beyond the minimum safe detach contract
+- broader observability redesign or dashboard feature work
+
+## Decision Notes
+
+- Prefer one explicit attach command over telling operators to use raw `screen -r`. The product gap is not "operators need to remember a shell incantation"; it is that the supported control surface lacks a safe foreground-TUI recovery path.
+- Prefer a brokered attach client over claiming Screen alone provides the needed safety boundary. The repo should own the safety contract in code and tests.
+- Keep the initial attach slice narrow. Solving safe full-TUI recovery does not require tracker changes, orchestrator redesign, or a new supervisor architecture.

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -63,7 +63,7 @@ instance-scoped scratchpad, status snapshots, logs, and loop lock files under
 - Treat `docs/guides/operator-runbook.md` as the canonical daily-use procedure and keep this skill focused on operator policy, checkpoints, and escalation.
 - Treat the factory-control surface as the primary local runtime contract; use ad hoc `screen`, `ps`, or `pkill` inspection only when the control command is unavailable or inconsistent.
 - In a wake-up cycle, favor short, bounded inspection commands over long-running watchers. If a secondary GitHub or watch-surface probe is slow or non-terminal, stop and continue from the latest successful control-surface read instead of waiting indefinitely.
-- Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
+- Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring and `pnpm tsx bin/symphony.ts factory attach` when you need the full-screen TUI; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart` over manual `screen` and process cleanup.
 - Treat detached startup locale handling as repo-owned behavior: the supported factory-control path selects an installed UTF-8 locale, launches `screen -U`, and should fail clearly rather than relying on shell-local locale folklore.
@@ -115,6 +115,7 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 - Detached `screen` sessions have been more reliable for unattended local operation than short-lived interactive exec sessions.
 - `pnpm tsx bin/symphony.ts factory status --json` is the fastest trustworthy read of detached runtime health, embedded status snapshot state, and degraded-control problems.
 - `pnpm tsx bin/symphony.ts factory watch` is the supported live watch surface for the detached factory; it should absorb operator `Ctrl-C` without stopping the worker.
+- `pnpm tsx bin/symphony.ts factory attach` is the supported way to recover the full-screen TUI for a detached factory instance; `Ctrl-C` should exit the attach client without stopping the worker.
 - The TUI/watch surface is an operator view, not the source of truth. On each wake-up, compare it against `factory status --json`; if issue stage, checks, review counts, session/event text, or token display drift materially, treat that as a product bug rather than hand-waving it away.
 - A closed issue plus an open PR usually means the factory reached the PR stage; inspect the PR before restarting anything.
 - If the factory has no `symphony:ready` issues, idle is healthy.

--- a/src/cli/factory-attach.ts
+++ b/src/cli/factory-attach.ts
@@ -1,0 +1,337 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  inspectFactoryControl,
+  type FactoryControlStatusSnapshot,
+} from "./factory-control.js";
+
+const LOCAL_DETACH_BYTES = new Set([0x03]);
+
+export interface FactoryAttachTerminal {
+  readonly stdin: {
+    readonly isTTY?: boolean;
+    setRawMode?: (mode: boolean) => void;
+    resume: () => void;
+    pause: () => void;
+    on: (event: "data", listener: (chunk: Buffer) => void) => void;
+    off: (event: "data", listener: (chunk: Buffer) => void) => void;
+  };
+  readonly stdout: {
+    readonly isTTY?: boolean;
+    write: (chunk: string | Uint8Array) => boolean;
+  };
+  readonly stderr: {
+    write: (chunk: string | Uint8Array) => boolean;
+  };
+}
+
+export interface FactoryAttachInput {
+  write: (chunk: string | Uint8Array) => boolean;
+}
+
+export interface FactoryAttachOutput {
+  on: (event: "data", listener: (chunk: Buffer) => void) => void;
+}
+
+export interface FactoryAttachChild {
+  readonly pid: number | undefined;
+  readonly stdin: FactoryAttachInput | null;
+  readonly stdout: FactoryAttachOutput | null;
+  readonly stderr: FactoryAttachOutput | null;
+  readonly waitForExit: () => Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+  readonly kill: (signal?: NodeJS.Signals) => void;
+}
+
+export interface FactoryAttachDeps {
+  readonly workflowPath?: string | null;
+  readonly inspectFactoryControl?: (options?: {
+    readonly workflowPath?: string | null;
+  }) => Promise<FactoryControlStatusSnapshot>;
+  readonly launchAttachChild?: (sessionId: string) => FactoryAttachChild;
+  readonly terminal?: FactoryAttachTerminal;
+  readonly onSignal?: (signal: NodeJS.Signals, listener: () => void) => void;
+  readonly offSignal?: (signal: NodeJS.Signals, listener: () => void) => void;
+  readonly onResize?: (listener: () => void) => void;
+  readonly offResize?: (listener: () => void) => void;
+  readonly killChild?: (
+    child: FactoryAttachChild,
+    signal?: NodeJS.Signals,
+  ) => void;
+  readonly platform?: NodeJS.Platform;
+}
+
+export async function attachFactory(
+  deps: FactoryAttachDeps = {},
+): Promise<void> {
+  const inspect = deps.inspectFactoryControl ?? inspectFactoryControl;
+  const terminal = deps.terminal ?? defaultTerminal();
+  const onSignal =
+    deps.onSignal ?? ((signal, listener) => process.on(signal, listener));
+  const offSignal =
+    deps.offSignal ?? ((signal, listener) => process.off(signal, listener));
+  const onResize =
+    deps.onResize ?? ((listener) => process.on("SIGWINCH", listener));
+  const offResize =
+    deps.offResize ?? ((listener) => process.off("SIGWINCH", listener));
+  const killChild =
+    deps.killChild ?? ((child, signal = "SIGTERM") => child.kill(signal));
+  const platform = deps.platform ?? process.platform;
+  const launchAttachChild =
+    deps.launchAttachChild ??
+    ((sessionId) => defaultLaunchAttachChild(sessionId, platform));
+
+  if (!terminal.stdin.isTTY || !terminal.stdout.isTTY) {
+    throw new Error(
+      "Factory attach requires an interactive TTY on stdin and stdout.",
+    );
+  }
+  if (typeof terminal.stdin.setRawMode !== "function") {
+    throw new Error(
+      "Factory attach requires terminal raw-mode support on stdin.",
+    );
+  }
+
+  const inspectOptions =
+    deps.workflowPath === undefined
+      ? undefined
+      : { workflowPath: deps.workflowPath };
+  const status = await inspect(inspectOptions);
+  const targetSession = resolveAttachSession(status);
+
+  terminal.stderr.write(
+    "Factory attach: Ctrl-C exits this attach client only.\n",
+  );
+
+  const child = launchAttachChild(targetSession.id);
+  const stdout = child.stdout;
+  const stderr = child.stderr;
+  const childStdin = child.stdin;
+
+  if (stdout !== null) {
+    stdout.on("data", (chunk) => {
+      terminal.stdout.write(chunk);
+    });
+  }
+  if (stderr !== null) {
+    stderr.on("data", (chunk) => {
+      terminal.stderr.write(chunk);
+    });
+  }
+
+  let detachedLocally = false;
+  let terminalRestored = false;
+  const restoreErrors: Error[] = [];
+
+  const restoreTerminal = (): void => {
+    if (terminalRestored) {
+      return;
+    }
+    terminalRestored = true;
+    try {
+      terminal.stdin.off("data", onStdinData);
+      terminal.stdin.setRawMode?.(false);
+      terminal.stdin.pause();
+    } catch (error) {
+      restoreErrors.push(error as Error);
+    }
+    offSignal("SIGINT", onInterruptSignal);
+    offSignal("SIGTERM", onInterruptSignal);
+    offResize(onResizeSignal);
+  };
+
+  const detachLocalClient = (): void => {
+    if (detachedLocally) {
+      return;
+    }
+    detachedLocally = true;
+    restoreTerminal();
+    killChild(child, "SIGTERM");
+  };
+
+  const onInterruptSignal = (): void => {
+    detachLocalClient();
+  };
+
+  const onResizeSignal = (): void => {
+    if (child.pid !== undefined) {
+      try {
+        process.kill(child.pid, "SIGWINCH");
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ESRCH") {
+          throw error;
+        }
+      }
+    }
+  };
+
+  const onStdinData = (chunk: Buffer): void => {
+    if (containsLocalDetachByte(chunk)) {
+      detachLocalClient();
+      return;
+    }
+    if (childStdin !== null) {
+      childStdin.write(chunk);
+    }
+  };
+
+  onSignal("SIGINT", onInterruptSignal);
+  onSignal("SIGTERM", onInterruptSignal);
+  onResize(onResizeSignal);
+
+  terminal.stdin.setRawMode(true);
+  terminal.stdin.resume();
+  terminal.stdin.on("data", onStdinData);
+
+  try {
+    const { code, signal } = await child.waitForExit();
+    restoreTerminal();
+    if (restoreErrors.length > 0) {
+      throw new Error(
+        `Factory attach restored the worker safely but failed to restore the local terminal cleanly: ${restoreErrors[0]!.message}`,
+        { cause: restoreErrors[0] },
+      );
+    }
+    if (code === 0 || signal === "SIGTERM") {
+      return;
+    }
+    throw new Error(
+      `Factory attach ended unexpectedly${renderExitDetail(code, signal)}.`,
+    );
+  } finally {
+    restoreTerminal();
+  }
+}
+
+export function createFactoryAttachCommand(
+  sessionId: string,
+  platform: NodeJS.Platform,
+): {
+  readonly command: string;
+  readonly args: readonly string[];
+} {
+  if (platform === "darwin") {
+    return {
+      command: "script",
+      args: ["-q", "/dev/null", "screen", "-x", sessionId],
+    };
+  }
+  if (platform === "linux") {
+    return {
+      command: "script",
+      args: [
+        "-q",
+        "-f",
+        "-e",
+        "-c",
+        escapeShellCommand(["screen", "-x", sessionId]),
+        "/dev/null",
+      ],
+    };
+  }
+  throw new Error(
+    `Factory attach is only supported on macOS and Linux today; got ${platform}.`,
+  );
+}
+
+export function resolveAttachSession(
+  snapshot: FactoryControlStatusSnapshot,
+): FactoryControlStatusSnapshot["sessions"][number] {
+  if (snapshot.controlState === "running" && snapshot.sessions.length === 1) {
+    const session = snapshot.sessions[0];
+    if (session !== undefined) {
+      return session;
+    }
+  }
+
+  const detail =
+    snapshot.problems.length > 0
+      ? ` Problems: ${snapshot.problems.join(" | ")}`
+      : "";
+  if (snapshot.controlState === "stopped") {
+    throw new Error(
+      `Factory attach requires a running detached runtime for ${snapshot.paths.workflowPath}, but factory control is stopped. Use 'symphony factory start' or inspect with 'symphony factory status'.`,
+    );
+  }
+  throw new Error(
+    `Factory attach requires one healthy detached runtime for ${snapshot.paths.workflowPath}, but factory control is ${snapshot.controlState}.${detail}`,
+  );
+}
+
+function defaultTerminal(): FactoryAttachTerminal {
+  return {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  };
+}
+
+function defaultLaunchAttachChild(
+  sessionId: string,
+  platform: NodeJS.Platform,
+): FactoryAttachChild {
+  const { command, args } = createFactoryAttachCommand(sessionId, platform);
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = spawn(command, [...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+  } catch (error) {
+    throw wrapAttachLaunchError(error as Error);
+  }
+  return {
+    pid: child.pid,
+    stdin: child.stdin,
+    stdout: child.stdout,
+    stderr: child.stderr,
+    waitForExit: () =>
+      new Promise((resolve, reject) => {
+        child.once("error", (error) => {
+          reject(wrapAttachLaunchError(error));
+        });
+        child.once("exit", (code, signal) => {
+          resolve({ code, signal });
+        });
+      }),
+    kill: (signal) => {
+      child.kill(signal);
+    },
+  };
+}
+
+function containsLocalDetachByte(chunk: Buffer): boolean {
+  return [...chunk].some((byte) => LOCAL_DETACH_BYTES.has(byte));
+}
+
+function escapeShellCommand(args: readonly string[]): string {
+  return args.map((value) => `'${value.replace(/'/g, `'\\''`)}'`).join(" ");
+}
+
+function wrapAttachLaunchError(error: Error): Error {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "ENOENT" || code === "ENOEXEC") {
+    return new Error(
+      "Factory attach requires the local 'script' terminal helper. Install a Unix 'script' command before using 'symphony factory attach'.",
+      { cause: error },
+    );
+  }
+  return new Error("Factory attach could not start the local attach broker.", {
+    cause: error,
+  });
+}
+
+function renderExitDetail(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): string {
+  if (signal !== null) {
+    return ` (signal ${signal})`;
+  }
+  if (code !== null) {
+    return ` (exit ${code.toString()})`;
+  }
+  return "";
+}

--- a/src/cli/factory-attach.ts
+++ b/src/cli/factory-attach.ts
@@ -59,6 +59,7 @@ export interface FactoryAttachDeps {
     child: FactoryAttachChild,
     signal?: NodeJS.Signals,
   ) => void;
+  readonly signalProcess?: (pid: number, signal: NodeJS.Signals) => void;
   readonly platform?: NodeJS.Platform;
 }
 
@@ -77,6 +78,8 @@ export async function attachFactory(
     deps.offResize ?? ((listener) => process.off("SIGWINCH", listener));
   const killChild =
     deps.killChild ?? ((child, signal = "SIGTERM") => child.kill(signal));
+  const signalProcess =
+    deps.signalProcess ?? ((pid, signal) => process.kill(pid, signal));
   const platform = deps.platform ?? process.platform;
   const launchAttachChild =
     deps.launchAttachChild ??
@@ -157,7 +160,7 @@ export async function attachFactory(
   const onResizeSignal = (): void => {
     if (child.pid !== undefined) {
       try {
-        process.kill(child.pid, "SIGWINCH");
+        signalProcess(child.pid, "SIGWINCH");
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
         if (code !== "ESRCH") {
@@ -168,12 +171,13 @@ export async function attachFactory(
   };
 
   const onStdinData = (chunk: Buffer): void => {
+    const forwardChunk = takeForwardChunkBeforeDetach(chunk);
+    if (forwardChunk !== null && childStdin !== null) {
+      childStdin.write(forwardChunk);
+    }
     if (containsLocalDetachByte(chunk)) {
       detachLocalClient();
       return;
-    }
-    if (childStdin !== null) {
-      childStdin.write(chunk);
     }
   };
 
@@ -255,6 +259,11 @@ export function resolveAttachSession(
       `Factory attach requires a running detached runtime for ${snapshot.paths.workflowPath}, but factory control is stopped. Use 'symphony factory start' or inspect with 'symphony factory status'.`,
     );
   }
+  if (snapshot.controlState === "running") {
+    throw new Error(
+      `Factory attach expected exactly one detached session for ${snapshot.paths.workflowPath}, but found ${snapshot.sessions.length.toString()} while factory control reported running.`,
+    );
+  }
   throw new Error(
     `Factory attach requires one healthy detached runtime for ${snapshot.paths.workflowPath}, but factory control is ${snapshot.controlState}.${detail}`,
   );
@@ -289,12 +298,19 @@ function defaultLaunchAttachChild(
     stderr: child.stderr,
     waitForExit: () =>
       new Promise((resolve, reject) => {
-        child.once("error", (error) => {
+        const onError = (error: Error): void => {
+          child.off("exit", onExit);
           reject(wrapAttachLaunchError(error));
-        });
-        child.once("exit", (code, signal) => {
+        };
+        const onExit = (
+          code: number | null,
+          signal: NodeJS.Signals | null,
+        ): void => {
+          child.off("error", onError);
           resolve({ code, signal });
-        });
+        };
+        child.once("error", onError);
+        child.once("exit", onExit);
       }),
     kill: (signal) => {
       child.kill(signal);
@@ -304,6 +320,17 @@ function defaultLaunchAttachChild(
 
 function containsLocalDetachByte(chunk: Buffer): boolean {
   return [...chunk].some((byte) => LOCAL_DETACH_BYTES.has(byte));
+}
+
+function takeForwardChunkBeforeDetach(chunk: Buffer): Buffer | null {
+  const detachOffset = chunk.findIndex((byte) => LOCAL_DETACH_BYTES.has(byte));
+  if (detachOffset === -1) {
+    return chunk;
+  }
+  if (detachOffset === 0) {
+    return null;
+  }
+  return chunk.subarray(0, detachOffset);
 }
 
 function escapeShellCommand(args: readonly string[]): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ import {
   startFactory,
   stopFactory,
 } from "./factory-control.js";
+import { attachFactory } from "./factory-attach.js";
 import { watchFactory } from "./factory-watch.js";
 import { scaffoldWorkflow, renderScaffoldWorkflowResult } from "./init.js";
 import {
@@ -66,6 +67,12 @@ export type CliArgs =
   | {
       readonly command: "factory";
       readonly action: "watch";
+      readonly format: "human";
+      readonly workflowPath: string | null;
+    }
+  | {
+      readonly command: "factory";
+      readonly action: "attach";
       readonly format: "human";
       readonly workflowPath: string | null;
     }
@@ -163,6 +170,17 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         workflowPath: resolvedWorkflowPath,
       };
     }
+    if (action === "attach") {
+      if (args.includes("--json")) {
+        throw new Error("Usage: symphony factory attach [--workflow <path>]");
+      }
+      return {
+        command: "factory",
+        action: "attach",
+        format: "human",
+        workflowPath: resolvedWorkflowPath,
+      };
+    }
     if (action === "status") {
       return {
         command: "factory",
@@ -172,7 +190,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
       };
     }
     throw new Error(
-      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory <watch|attach> [--workflow <path>]",
     );
   }
 
@@ -316,6 +334,10 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 
         case "watch":
           await watchFactory({ workflowPath: args.workflowPath });
+          return;
+
+        case "attach":
+          await attachFactory({ workflowPath: args.workflowPath });
           return;
       }
       return;

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -309,6 +309,16 @@ describe("parseArgs", () => {
     });
   });
 
+  it("parses the factory attach command", () => {
+    const args = parseArgs(["node", "symphony", "factory", "attach"]);
+    expect(args).toEqual({
+      command: "factory",
+      action: "attach",
+      format: "human",
+      workflowPath: null,
+    });
+  });
+
   it("parses the factory start and stop commands", () => {
     expect(parseArgs(["node", "symphony", "factory", "start"])).toEqual({
       command: "factory",
@@ -399,16 +409,31 @@ describe("parseArgs", () => {
       format: "human",
       workflowPath,
     });
+    expect(
+      parseArgs([
+        "node",
+        "symphony",
+        "factory",
+        "attach",
+        "--workflow",
+        "/tmp/project/WORKFLOW.md",
+      ]),
+    ).toEqual({
+      command: "factory",
+      action: "attach",
+      format: "human",
+      workflowPath,
+    });
   });
 
   it("shows factory-specific usage for missing or unknown factory actions", () => {
     expect(() => parseArgs(["node", "symphony", "factory"])).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory <watch|attach> [--workflow <path>]",
     );
     expect(() =>
       parseArgs(["node", "symphony", "factory", "deploy"]),
     ).toThrowError(
-      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory watch [--workflow <path>]",
+      "Usage: symphony factory <start|stop|restart|status> [--json] [--workflow <path>]\n       symphony factory <watch|attach> [--workflow <path>]",
     );
   });
 
@@ -416,6 +441,12 @@ describe("parseArgs", () => {
     expect(() =>
       parseArgs(["node", "symphony", "factory", "watch", "--json"]),
     ).toThrowError("Usage: symphony factory watch [--workflow <path>]");
+  });
+
+  it("rejects --json for factory attach", () => {
+    expect(() =>
+      parseArgs(["node", "symphony", "factory", "attach", "--json"]),
+    ).toThrowError("Usage: symphony factory attach [--workflow <path>]");
   });
 });
 
@@ -1384,6 +1415,30 @@ describe("runCli factory", () => {
     expect(watchFactory).toHaveBeenCalledWith({ workflowPath: null });
   });
 
+  it("dispatches the factory attach command", async () => {
+    vi.resetModules();
+    const attachFactory = vi.fn(async () => {});
+
+    vi.doMock("../../src/cli/factory-control.js", () => ({
+      inspectFactoryControl: vi.fn(),
+      renderFactoryControlStatus: vi.fn(),
+      startFactory: vi.fn(),
+      stopFactory: vi.fn(),
+    }));
+    vi.doMock("../../src/cli/factory-watch.js", () => ({
+      watchFactory: vi.fn(),
+    }));
+    vi.doMock("../../src/cli/factory-attach.js", () => ({
+      attachFactory,
+    }));
+
+    const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
+
+    await mockedRunCli(["node", "symphony", "factory", "attach"]);
+
+    expect(attachFactory).toHaveBeenCalledWith({ workflowPath: null });
+  });
+
   it("forwards explicit workflow selection to factory control and watch commands", async () => {
     vi.resetModules();
     const workflowPath = "/tmp/project/WORKFLOW.md";
@@ -1400,6 +1455,7 @@ describe("runCli factory", () => {
       createFactoryControlSnapshot("stopped"),
     );
     const watchFactory = vi.fn(async () => {});
+    const attachFactory = vi.fn(async () => {});
 
     vi.doMock("../../src/cli/factory-control.js", () => ({
       inspectFactoryControl,
@@ -1409,6 +1465,9 @@ describe("runCli factory", () => {
     }));
     vi.doMock("../../src/cli/factory-watch.js", () => ({
       watchFactory,
+    }));
+    vi.doMock("../../src/cli/factory-attach.js", () => ({
+      attachFactory,
     }));
 
     const { runCli: mockedRunCli } = await import("../../src/cli/index.js");
@@ -1445,10 +1504,19 @@ describe("runCli factory", () => {
       "--workflow",
       workflowPath,
     ]);
+    await mockedRunCli([
+      "node",
+      "symphony",
+      "factory",
+      "attach",
+      "--workflow",
+      workflowPath,
+    ]);
 
     expect(startFactory).toHaveBeenCalledWith({ workflowPath });
     expect(stopFactory).toHaveBeenCalledWith({ workflowPath });
     expect(inspectFactoryControl).toHaveBeenCalledWith({ workflowPath });
     expect(watchFactory).toHaveBeenCalledWith({ workflowPath });
+    expect(attachFactory).toHaveBeenCalledWith({ workflowPath });
   });
 });

--- a/tests/unit/factory-attach.test.ts
+++ b/tests/unit/factory-attach.test.ts
@@ -175,6 +175,17 @@ describe("resolveAttachSession", () => {
       /factory control is degraded/,
     );
   });
+
+  it("fails clearly if running control reports an unexpected session count", () => {
+    const snapshot = {
+      ...createSnapshot(),
+      sessions: [],
+    } satisfies FactoryControlStatusSnapshot;
+
+    expect(() => resolveAttachSession(snapshot)).toThrowError(
+      /expected exactly one detached session/,
+    );
+  });
 });
 
 describe("attachFactory", () => {
@@ -247,10 +258,38 @@ describe("attachFactory", () => {
     expect(child.stdin.writes).toEqual([Buffer.from("a")]);
   });
 
+  it("forwards bytes before Ctrl-C and then detaches locally", async () => {
+    const { terminal, stdin } = createTerminal();
+    const child = new MockAttachChild();
+    const killChild = vi.fn(
+      (target: FactoryAttachChild, signal?: NodeJS.Signals) => {
+        target.kill(signal);
+      },
+    );
+
+    const attachPromise = attachFactory({
+      inspectFactoryControl: async () => createSnapshot(),
+      terminal,
+      launchAttachChild: () => child,
+      onSignal: vi.fn(),
+      offSignal: vi.fn(),
+      onResize: vi.fn(),
+      offResize: vi.fn(),
+      killChild,
+    });
+
+    await waitForAsyncSetup();
+    stdin.emit("data", Buffer.from([0x61, 0x62, 0x03, 0x63]));
+    await attachPromise;
+
+    expect(child.stdin.writes).toEqual([Buffer.from("ab")]);
+    expect(killChild).toHaveBeenCalledWith(child, "SIGTERM");
+  });
+
   it("forwards SIGWINCH to the local attach child", async () => {
     const { terminal } = createTerminal();
     const child = new MockAttachChild();
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const signalProcess = vi.fn(() => true);
     let resizeListener: (() => void) | undefined;
 
     const attachPromise = attachFactory({
@@ -263,6 +302,7 @@ describe("attachFactory", () => {
         resizeListener = listener;
       },
       offResize: vi.fn(),
+      signalProcess,
       killChild: vi.fn((target, signal) => {
         target.kill(signal);
       }),
@@ -273,7 +313,38 @@ describe("attachFactory", () => {
     child.emit("exit", 0, null);
     await attachPromise;
 
-    expect(killSpy).toHaveBeenCalledWith(child.pid, "SIGWINCH");
+    expect(signalProcess).toHaveBeenCalledWith(child.pid, "SIGWINCH");
+  });
+
+  it("ignores resize forwarding after the attach child exits", async () => {
+    const { terminal } = createTerminal();
+    const child = new MockAttachChild();
+    const signalProcess = vi.fn(() => true);
+    let resizeListener: (() => void) | undefined;
+
+    const attachPromise = attachFactory({
+      inspectFactoryControl: async () => createSnapshot(),
+      terminal,
+      launchAttachChild: () => child,
+      onSignal: vi.fn(),
+      offSignal: vi.fn(),
+      onResize: (listener) => {
+        resizeListener = listener;
+      },
+      offResize: vi.fn(),
+      signalProcess,
+      killChild: vi.fn((target, signal) => {
+        target.kill(signal);
+      }),
+    });
+
+    await waitForAsyncSetup();
+    child.pid = undefined;
+    resizeListener?.();
+    child.emit("exit", 0, null);
+    await attachPromise;
+
+    expect(signalProcess).not.toHaveBeenCalled();
   });
 
   it("requires an interactive terminal", async () => {

--- a/tests/unit/factory-attach.test.ts
+++ b/tests/unit/factory-attach.test.ts
@@ -1,0 +1,301 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FactoryControlStatusSnapshot } from "../../src/cli/factory-control.js";
+import {
+  attachFactory,
+  createFactoryAttachCommand,
+  resolveAttachSession,
+  type FactoryAttachChild,
+  type FactoryAttachTerminal,
+} from "../../src/cli/factory-attach.js";
+
+class MockStream extends EventEmitter {
+  isTTY = true;
+  readonly writes: Array<string | Uint8Array> = [];
+
+  write(chunk: string | Uint8Array): boolean {
+    this.writes.push(chunk);
+    return true;
+  }
+}
+
+class MockInput extends EventEmitter {
+  isTTY = true;
+  rawModes: boolean[] = [];
+  resumed = false;
+  paused = false;
+
+  setRawMode(mode: boolean): void {
+    this.rawModes.push(mode);
+  }
+
+  resume(): void {
+    this.resumed = true;
+  }
+
+  pause(): void {
+    this.paused = true;
+  }
+}
+
+class MockAttachChild extends EventEmitter implements FactoryAttachChild {
+  readonly stdin = new MockStream();
+  readonly stdout = new MockStream();
+  readonly stderr = new MockStream();
+  readonly kills: Array<NodeJS.Signals | undefined> = [];
+  pid: number | undefined = 4242;
+
+  async waitForExit(): Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }> {
+    return await new Promise((resolve) => {
+      this.once("exit", (code: number | null, signal: NodeJS.Signals | null) =>
+        resolve({ code, signal }),
+      );
+      this.once("error", (error: Error) => {
+        throw error;
+      });
+    });
+  }
+
+  kill(signal?: NodeJS.Signals): void {
+    this.kills.push(signal);
+    this.emit("exit", null, signal ?? null);
+  }
+}
+
+function createSnapshot(
+  controlState: "running" | "stopped" | "degraded" = "running",
+): FactoryControlStatusSnapshot {
+  return {
+    controlState,
+    paths: {
+      repoRoot: "/repo",
+      runtimeRoot: "/repo/.tmp/factory-main",
+      workflowPath: "/repo/WORKFLOW.md",
+      statusFilePath: "/repo/.tmp/status.json",
+      startupFilePath: "/repo/.tmp/startup.json",
+    },
+    sessionName: "symphony-factory-instance",
+    sessions:
+      controlState === "running"
+        ? [
+            {
+              id: "1234.symphony-factory-instance",
+              pid: 1234,
+              name: "symphony-factory-instance",
+              state: "Detached",
+            },
+          ]
+        : [],
+    workerAlive: controlState === "running",
+    startup: null,
+    snapshotFreshness: {
+      freshness: controlState === "running" ? "fresh" : "unavailable",
+      reason:
+        controlState === "running" ? "current-snapshot" : "missing-snapshot",
+      summary:
+        controlState === "running"
+          ? "The snapshot belongs to the live factory runtime."
+          : "No runtime snapshot is available.",
+      workerAlive: controlState === "running" ? true : null,
+      publicationState: controlState === "running" ? "current" : null,
+    },
+    statusSnapshot: null,
+    processIds: controlState === "degraded" ? [1234] : [],
+    problems:
+      controlState === "degraded" ? ["multiple detached screen sessions"] : [],
+  };
+}
+
+function createTerminal(): {
+  readonly terminal: FactoryAttachTerminal;
+  readonly stdin: MockInput;
+  readonly stdout: MockStream;
+  readonly stderr: MockStream;
+} {
+  const stdin = new MockInput();
+  const stdout = new MockStream();
+  const stderr = new MockStream();
+  return {
+    terminal: { stdin, stdout, stderr },
+    stdin,
+    stdout,
+    stderr,
+  };
+}
+
+async function waitForAsyncSetup(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createFactoryAttachCommand", () => {
+  it("builds a macOS script wrapper", () => {
+    expect(createFactoryAttachCommand("1234.session", "darwin")).toEqual({
+      command: "script",
+      args: ["-q", "/dev/null", "screen", "-x", "1234.session"],
+    });
+  });
+
+  it("builds a Linux script wrapper", () => {
+    expect(createFactoryAttachCommand("1234.session", "linux")).toEqual({
+      command: "script",
+      args: [
+        "-q",
+        "-f",
+        "-e",
+        "-c",
+        "'screen' '-x' '1234.session'",
+        "/dev/null",
+      ],
+    });
+  });
+});
+
+describe("resolveAttachSession", () => {
+  it("returns the single healthy session for running control", () => {
+    expect(resolveAttachSession(createSnapshot())).toMatchObject({
+      id: "1234.symphony-factory-instance",
+    });
+  });
+
+  it("fails clearly for stopped control", () => {
+    expect(() => resolveAttachSession(createSnapshot("stopped"))).toThrowError(
+      /requires a running detached runtime/,
+    );
+  });
+
+  it("fails clearly for degraded control", () => {
+    expect(() => resolveAttachSession(createSnapshot("degraded"))).toThrowError(
+      /factory control is degraded/,
+    );
+  });
+});
+
+describe("attachFactory", () => {
+  it("intercepts Ctrl-C locally and does not forward it to the child session", async () => {
+    const { terminal, stdin, stderr } = createTerminal();
+    const child = new MockAttachChild();
+    const inspected = vi.fn(async () => createSnapshot());
+    const killChild = vi.fn(
+      (target: FactoryAttachChild, signal?: NodeJS.Signals) => {
+        target.kill(signal);
+      },
+    );
+    const signals = new Map<NodeJS.Signals, () => void>();
+
+    const attachPromise = attachFactory({
+      workflowPath: "/repo/WORKFLOW.md",
+      inspectFactoryControl: inspected,
+      terminal,
+      launchAttachChild: () => child,
+      killChild,
+      onSignal: (signal, listener) => {
+        signals.set(signal, listener);
+      },
+      offSignal: (signal) => {
+        signals.delete(signal);
+      },
+      onResize: vi.fn(),
+      offResize: vi.fn(),
+    });
+
+    await waitForAsyncSetup();
+    stdin.emit("data", Buffer.from([0x03]));
+    await attachPromise;
+
+    expect(inspected).toHaveBeenCalledWith({
+      workflowPath: "/repo/WORKFLOW.md",
+    });
+    expect(killChild).toHaveBeenCalledWith(child, "SIGTERM");
+    expect(child.stdin.writes).toEqual([]);
+    expect(stdin.rawModes).toEqual([true, false]);
+    expect(stdin.paused).toBe(true);
+    expect(signals.size).toBe(0);
+    expect(String(stderr.writes[0])).toContain(
+      "Ctrl-C exits this attach client only.",
+    );
+  });
+
+  it("forwards normal input bytes to the attach child", async () => {
+    const { terminal, stdin } = createTerminal();
+    const child = new MockAttachChild();
+
+    const attachPromise = attachFactory({
+      inspectFactoryControl: async () => createSnapshot(),
+      terminal,
+      launchAttachChild: () => child,
+      onSignal: vi.fn(),
+      offSignal: vi.fn(),
+      onResize: vi.fn(),
+      offResize: vi.fn(),
+      killChild: vi.fn((target, signal) => {
+        target.kill(signal);
+      }),
+    });
+
+    await waitForAsyncSetup();
+    stdin.emit("data", Buffer.from("a"));
+    child.emit("exit", 0, null);
+    await attachPromise;
+
+    expect(child.stdin.writes).toEqual([Buffer.from("a")]);
+  });
+
+  it("forwards SIGWINCH to the local attach child", async () => {
+    const { terminal } = createTerminal();
+    const child = new MockAttachChild();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    let resizeListener: (() => void) | undefined;
+
+    const attachPromise = attachFactory({
+      inspectFactoryControl: async () => createSnapshot(),
+      terminal,
+      launchAttachChild: () => child,
+      onSignal: vi.fn(),
+      offSignal: vi.fn(),
+      onResize: (listener) => {
+        resizeListener = listener;
+      },
+      offResize: vi.fn(),
+      killChild: vi.fn((target, signal) => {
+        target.kill(signal);
+      }),
+    });
+
+    await waitForAsyncSetup();
+    resizeListener?.();
+    child.emit("exit", 0, null);
+    await attachPromise;
+
+    expect(killSpy).toHaveBeenCalledWith(child.pid, "SIGWINCH");
+  });
+
+  it("requires an interactive terminal", async () => {
+    const { terminal, stdin } = createTerminal();
+    stdin.isTTY = false;
+
+    await expect(
+      attachFactory({
+        inspectFactoryControl: async () => createSnapshot(),
+        terminal,
+      }),
+    ).rejects.toThrowError(/requires an interactive TTY/);
+  });
+
+  it("fails clearly when attach preflight is not healthy", async () => {
+    const { terminal } = createTerminal();
+
+    await expect(
+      attachFactory({
+        inspectFactoryControl: async () => createSnapshot("stopped"),
+        terminal,
+      }),
+    ).rejects.toThrowError(/requires a running detached runtime/);
+  });
+});


### PR DESCRIPTION
Closes #232

## Summary
- add `symphony factory attach` as a supported detached full-TUI attach path
- broker attach through a local terminal helper so `Ctrl-C` exits the client instead of stopping the worker
- document the supported `status` / `watch` / `attach` split and add focused unit coverage

## Checks
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test