### PR TITLE
Split CI checks and avoid duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,3 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-
-  check:
-    runs-on: ubuntu-latest
-    needs: [static, test]
-    steps:
-      - run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main, "**"]
+    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
-  check:
+  static:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,4 +20,15 @@ jobs:
       - run: pnpm format:check
       - run: pnpm lint
       - run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+
+  check:
+    runs-on: ubuntu-latest
+    needs: [static, test]
+    steps:
+      - run: true


### PR DESCRIPTION
This updates the CI workflow so PR branches do not run duplicate `push` and `pull_request` checks for the same commit.
It also splits the single `CI / check` job into separate `CI / static` and `CI / test` jobs for clearer status reporting.
Pre-push `typecheck`, `lint`, and `format:check` passed locally.
A separate `pnpm test` run in this workspace still has existing unrelated failures in `tests/unit/factory-control.test.ts` around `launchCwd` expectations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
