### PR TITLE
fix: count reviewer-app status contexts for coverage

### DIFF
--- a/src/tracker/pull-request-snapshot.ts
+++ b/src/tracker/pull-request-snapshot.ts
@@ -44,6 +44,17 @@ const NON_ACTIONABLE_BOT_COMMENT_MARKERS = {
   greptileSummaryHeading: /<h3\b[^>]*>\s*Greptile Summary\s*<\/h3>/i,
 } as const;
 
+const APPROVED_REVIEW_BOT_STATUS_CONTEXTS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "devin-ai-integration": ["Devin Review"],
+  "greptile-apps": ["Greptile Review"],
+  "greptile[bot]": ["Greptile Review"],
+  cursor: ["Cursor Bugbot"],
+  "cursor[bot]": ["Cursor Bugbot"],
+  "bugbot[bot]": ["Cursor Bugbot"],
+} as const;
+
 function isActionableBotReviewComment(body: string): boolean {
   const normalized = body.trim();
   return (
@@ -85,6 +96,29 @@ function isHumanLandingApprover(
       authorAssociation === "MEMBER" ||
       authorAssociation === "COLLABORATOR")
   );
+}
+
+function observedApprovedReviewBotLoginsFromChecks(
+  checks: readonly PullRequestCheck[],
+  approvedReviewBotLogins: ReadonlySet<string>,
+): readonly string[] {
+  if (approvedReviewBotLogins.size === 0) {
+    return [];
+  }
+
+  const successfulCheckNames = new Set(
+    checks
+      .filter((check) => check.status === "success")
+      .map((check) => check.name),
+  );
+
+  return [...approvedReviewBotLogins].filter((login) => {
+    const statusContexts = APPROVED_REVIEW_BOT_STATUS_CONTEXTS[login];
+    return (
+      statusContexts !== undefined &&
+      statusContexts.some((context) => successfulCheckNames.has(context))
+    );
+  });
 }
 
 export function createPullRequestSnapshot(input: {
@@ -234,6 +268,10 @@ export function createPullRequestSnapshot(input: {
                   );
                 })
                 .map((review) => review.author!.login),
+              ...observedApprovedReviewBotLoginsFromChecks(
+                input.checks,
+                approvedReviewBotLogins,
+              ),
             ].map((login) => login.toLowerCase()),
           ),
         ];

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -4,6 +4,7 @@ import type {
   PullRequestReviewState,
 } from "../../src/tracker/github-client.js";
 import { createPullRequestSnapshot } from "../../src/tracker/pull-request-snapshot.js";
+import type { PullRequestCheck } from "../../src/domain/pull-request.js";
 
 function createReviewState(
   comments: ReadonlyArray<{
@@ -82,6 +83,13 @@ const pullRequest: GitHubPullRequestResponse = {
     ref: "symphony/19",
     sha: "sha-1",
   },
+};
+
+const successfulDevinCheck: PullRequestCheck = {
+  name: "Devin Review",
+  status: "success",
+  conclusion: "success",
+  detailsUrl: "https://example.test/checks/devin",
 };
 
 describe("createPullRequestSnapshot", () => {
@@ -382,6 +390,87 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.observedApprovedReviewBotLogins).toEqual([
       "devin-ai-integration",
     ]);
+  });
+
+  it("records required approved bot review presence from a successful reviewer-app status context on the current head", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T02:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [
+            {
+              author: { login: "devin-ai-integration" },
+              body: "## ✅ Devin Review: No Issues Found",
+              submittedAt: "2026-03-06T01:00:00.000Z",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
+      approvedReviewBotLogins: ["devin-ai-integration"],
+    });
+
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
+    expect(snapshot.observedApprovedReviewBotLogins).toEqual([
+      "devin-ai-integration",
+    ]);
+  });
+
+  it("does not treat unrelated successful status contexts as approved reviewer coverage", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [
+        {
+          name: "check",
+          status: "success",
+          conclusion: "success",
+          detailsUrl: "https://example.test/checks/ci",
+        },
+      ],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T02:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
+      approvedReviewBotLogins: ["devin-ai-integration"],
+    });
+
+    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
+    expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
   });
 
   it("detects a human /land command on the current PR head", () => {


### PR DESCRIPTION
## Summary
- count successful reviewer-app status contexts toward approved review coverage for known bots
- keep stale review comments on old heads from blocking current-head reviewer-app coverage
- add regression tests for the current-head Devin status-context case

## Testing
- pnpm exec vitest run tests/unit/pull-request-snapshot.test.ts tests/unit/pull-request-policy.test.ts tests/unit/guarded-landing.test.ts tests/integration/github-bootstrap.test.ts
- pnpm typecheck
- pnpm lint

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
