### PR TITLE
chore: run tests in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,7 @@ pnpm lint || { echo "❌ Lint failed"; exit 1; }
 echo "→ format:check"
 pnpm format:check || { echo "❌ Format check failed"; exit 1; }
 
+echo "→ test"
+pnpm test || { echo "❌ Test suite failed"; exit 1; }
+
 echo "✓ All pre-push checks passed"


### PR DESCRIPTION
Closes #243

## Summary
- add `pnpm test` to the Husky `pre-push` hook
- keep the existing typecheck, lint, and format checks in place
- fail pushes locally when the test suite regresses

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
