### PR TITLE
Add pluggable reviewer-app adapters with normalized coverage and verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ tracker:
   approved_review_bot_logins:
     - greptile[bot]
     - bugbot[bot]
+  reviewer_apps:
+    devin:
+      accepted: true
+      required: true
   queue_priority:
     enabled: true
     project_number: 12
@@ -346,24 +350,26 @@ Workers should treat those summarized GitHub fields as untrusted context that
 helps explain the task, not as instructions that can override checked-in repo
 policy, code, docs, or local test evidence.
 
-| Field                            | Purpose                                                                                |
-| -------------------------------- | -------------------------------------------------------------------------------------- |
-| `tracker.repo`                   | GitHub repository to poll for labeled issues                                           |
-| `tracker.review_bot_logins`      | PR comment authors treated as actionable bot review                                    |
-| `polling.interval_ms`            | How often to check for new work                                                        |
-| `polling.max_concurrent_runs`    | Local concurrency cap                                                                  |
-| `workspace.root`                 | Where isolated workspaces are created                                                  |
-| `workspace.repo_url`             | Explicit clone source URL or local path; local paths resolve relative to `WORKFLOW.md` |
-| `workspace.branch_prefix`        | Issue branch naming prefix                                                             |
-| `workspace.worker_hosts.<name>`  | Optional SSH worker-host definitions for remote Codex execution                        |
-| `agent.runner.kind`              | Selects the logical runner provider (`codex`, `claude-code`, or `generic-command`)     |
-| `agent.runner.remote_execution`  | Optional remote execution selection for Codex (`kind: ssh`, `worker_host: <name>`)     |
-| `agent.command`                  | Runner command shape; Codex reuses its flags to launch `codex app-server`              |
-| `agent.prompt_transport`         | Sends the prompt over `stdin` or via a temp file path                                  |
-| `agent.timeout_ms`               | Max wall-clock time per runner turn                                                    |
-| `agent.max_turns`                | Max in-process continuation turns per worker run                                       |
-| `workspace.retention.on_success` | Terminal success workspace policy: `delete` or `retain` (default `delete`)             |
-| `workspace.retention.on_failure` | Terminal failure workspace policy: `delete` or `retain` (default `retain`)             |
+| Field                                | Purpose                                                                                |
+| ------------------------------------ | -------------------------------------------------------------------------------------- |
+| `tracker.repo`                       | GitHub repository to poll for labeled issues                                           |
+| `tracker.review_bot_logins`          | PR comment authors treated as actionable bot review                                    |
+| `tracker.approved_review_bot_logins` | Legacy reviewer-app identities whose current-head output must appear before landing    |
+| `tracker.reviewer_apps`              | First-class reviewer-app policy with explicit `accepted` and `required` semantics      |
+| `polling.interval_ms`                | How often to check for new work                                                        |
+| `polling.max_concurrent_runs`        | Local concurrency cap                                                                  |
+| `workspace.root`                     | Where isolated workspaces are created                                                  |
+| `workspace.repo_url`                 | Explicit clone source URL or local path; local paths resolve relative to `WORKFLOW.md` |
+| `workspace.branch_prefix`            | Issue branch naming prefix                                                             |
+| `workspace.worker_hosts.<name>`      | Optional SSH worker-host definitions for remote Codex execution                        |
+| `agent.runner.kind`                  | Selects the logical runner provider (`codex`, `claude-code`, or `generic-command`)     |
+| `agent.runner.remote_execution`      | Optional remote execution selection for Codex (`kind: ssh`, `worker_host: <name>`)     |
+| `agent.command`                      | Runner command shape; Codex reuses its flags to launch `codex app-server`              |
+| `agent.prompt_transport`             | Sends the prompt over `stdin` or via a temp file path                                  |
+| `agent.timeout_ms`                   | Max wall-clock time per runner turn                                                    |
+| `agent.max_turns`                    | Max in-process continuation turns per worker run                                       |
+| `workspace.retention.on_success`     | Terminal success workspace policy: `delete` or `retain` (default `delete`)             |
+| `workspace.retention.on_failure`     | Terminal failure workspace policy: `delete` or `retain` (default `retain`)             |
 
 `workspace.cleanup_on_success` remains accepted as a compatibility alias for
 `workspace.retention.on_success`.

--- a/docs/guides/workflow-frontmatter-reference.md
+++ b/docs/guides/workflow-frontmatter-reference.md
@@ -154,6 +154,49 @@ coverage policy. If you configure expected approved review bots, Symphony can
 block landing when none of them have produced qualifying output on the current
 PR head.
 
+##### `tracker.reviewer_apps`
+
+- Type: object
+- Required: no
+- Default: omitted
+
+Preferred first-class reviewer-app policy config for GitHub-backed trackers.
+Each key enables a built-in reviewer adapter and declares whether its verdict
+is accepted for actionable feedback and/or required before landing.
+
+Supported keys in this slice:
+
+- `devin`
+
+Example:
+
+```yaml
+tracker:
+  reviewer_apps:
+    devin:
+      accepted: true
+      required: true
+```
+
+###### `tracker.reviewer_apps.<key>.accepted`
+
+- Type: boolean
+- Required: no
+- Default: `true`
+
+When true, an explicit reviewer-app `issues-found` verdict counts as actionable
+feedback and can drive `rework-required`.
+
+###### `tracker.reviewer_apps.<key>.required`
+
+- Type: boolean
+- Required: no
+- Default: `false`
+
+When true, Symphony requires current-head reviewer coverage and an explicit
+`pass` verdict before the PR can become landable. `required: true` currently
+also requires `accepted: true`.
+
 ##### `tracker.queue_priority`
 
 - Type: object
@@ -652,6 +695,10 @@ tracker:
     - devin-ai-integration
   approved_review_bot_logins:
     - devin-ai-integration
+  reviewer_apps:
+    devin:
+      accepted: true
+      required: true
   queue_priority:
     enabled: true
     project_number: 7

--- a/docs/plans/242-reviewer-app-adapters/plan.md
+++ b/docs/plans/242-reviewer-app-adapters/plan.md
@@ -1,0 +1,325 @@
+# Issue 242 Plan: Add Pluggable Reviewer-App Adapters With Normalized Coverage And Verdicts
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Introduce a GitHub-edge reviewer-app adapter seam that normalizes per-app current-head coverage, run status, verdict, actionable feedback, and unresolved-feedback facts so PR lifecycle and guarded landing can make deterministic decisions without hardcoded app-specific parsing in generic snapshot policy.
+
+## Scope
+
+- add a normalized reviewer-app snapshot contract derived from raw GitHub PR review surfaces
+- add a pluggable GitHub-side reviewer-app adapter registry that owns app-specific parsing rules
+- add a first real adapter for `devin`
+- add a compatibility adapter path that preserves current generic review-bot and approved-bot behavior while policy migrates to the normalized snapshot seam
+- update PR lifecycle and guarded landing policy to consume normalized reviewer-app snapshots for required reviewer coverage, explicit pass/issues-found verdicts, and unresolved reviewer feedback
+- add operator-visible reviewer-app posture projection where needed to debug coverage/verdict decisions
+- add unit, integration, and e2e coverage for current-head, stale-head, missing, running, pass, and issues-found reviewer-app outcomes
+
+## Non-goals
+
+- full adapter rollout for every existing or future reviewer app in this PR
+- Linear or other non-GitHub tracker parity
+- redesigning human review policy or plan review workflow
+- changing the overall PR lifecycle topology beyond replacing brittle reviewer-app inference with normalized reviewer facts
+- remote reviewer orchestration, retry triggering, or bot command APIs
+- introducing one-of/all-of reviewer quorum policy beyond the narrow seam needed for this issue
+
+## Current Gaps
+
+- `src/tracker/pull-request-snapshot.ts` mixes transport-derived review surfaces, app-specific string heuristics, and policy-oriented gating facts in one module
+- current state only partially distinguishes reviewer-app concepts:
+  - generic actionable bot feedback via `reviewBotLogins`
+  - required reviewer presence via `approvedReviewBotLogins`
+  - ad hoc status-context matching via `APPROVED_REVIEW_BOT_STATUS_CONTEXTS`
+- the current snapshot does not model coverage, running/completed status, verdict, and unresolved/actionable feedback separately per reviewer app
+- policy can still treat a PR as landable when a reviewer app clearly reported issues outside the currently recognized unresolved-thread or classified-comment paths
+- app-specific evidence and debugging facts are not carried through a dedicated normalized surface for observability
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: deterministic rules for when required reviewer apps count as covered, when explicit `issues-found` verdicts require rework, and when landing needs explicit `pass`
+  - does not belong: Devin-specific strings, GitHub comment/review object traversal, or status-context parsing
+- Configuration Layer
+  - belongs: typed workflow config for stable reviewer-app keys and the minimum accepted/required policy flags needed for this slice
+  - does not belong: PR lifecycle evaluation or adapter parsing logic
+- Coordination Layer
+  - belongs: consume normalized lifecycle and landing-blocked outcomes derived from reviewer-app snapshots
+  - does not belong: GitHub review surface parsing or app-specific heuristics
+- Execution Layer
+  - belongs: no workspace or runner changes in this slice
+  - does not belong: reviewer-app normalization or landing policy
+- Integration Layer
+  - belongs: GitHub transport reads, raw-surface aggregation, reviewer-app adapter registry, per-app parsing, normalized reviewer snapshot creation
+  - does not belong: orchestrator retry policy, operator command sequencing, or TUI-only presentation logic
+- Observability Layer
+  - belongs: project normalized reviewer coverage/verdict/unresolved posture into status and report surfaces when needed for operator debugging
+  - does not belong: re-parsing raw GitHub comments/reviews/checks to rediscover reviewer-app state
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts` and `src/config/workflow.ts`
+  - add the narrowest repo-owned config seam for named reviewer apps and required/accepted policy in GitHub-compatible trackers
+- `src/tracker/`
+  - separate reviewer-app transport aggregation, normalization, and policy
+  - introduce:
+    - a raw GitHub review-surface input shape for adapters
+    - a normalized reviewer-app snapshot contract
+    - an adapter registry/factory
+    - a `devin` adapter
+    - a compatibility adapter for existing generic bot-login behavior
+  - update PR snapshot composition to embed normalized reviewer-app facts rather than scattered booleans and hardcoded login/status matching
+- `src/tracker/pull-request-policy.ts` and `src/tracker/guarded-landing.ts`
+  - consume normalized reviewer-app coverage/verdict/unresolved state
+- `src/tracker/service.ts` and any affected domain types
+  - carry precise blocked/waiting reasons from the normalized reviewer state
+- observability/docs/tests
+  - expose enough reviewer-app posture to explain why a PR is waiting, degraded, or in rework
+
+### Does not belong in this issue
+
+- runner prompt changes
+- workspace or orchestration retry refactors
+- GraphQL transport rewrites beyond what the normalized adapter seam immediately needs
+- broad lifecycle-domain renaming unrelated to reviewer-app semantics
+- full removal of existing bot-login compatibility if that would broaden the PR beyond one slice
+
+## Layering Notes
+
+- `config/workflow`
+  - owns stable reviewer-app configuration
+  - should not encode GitHub parsing rules or landing decisions
+- `tracker`
+  - owns raw GitHub review-surface aggregation plus reviewer-app normalization
+  - should keep transport, adapter parsing, and PR policy in separate modules
+- `workspace`
+  - unchanged
+- `runner`
+  - unchanged
+- `orchestrator`
+  - consumes normalized lifecycle kinds and blocked reasons only
+  - must not inspect reviewer keys, bot logins, review bodies, or status contexts directly
+- `observability`
+  - renders normalized reviewer posture and evidence summaries
+  - must not infer reviewer state from raw tracker payloads outside the normalized snapshot
+
+## Slice Strategy And PR Seam
+
+Keep this as one reviewable PR focused on a single tracker-boundary seam:
+
+1. add a normalized reviewer-app snapshot contract and GitHub adapter registry
+2. ship one real `devin` adapter plus one compatibility adapter for existing generic bot-login behavior
+3. migrate PR lifecycle and guarded landing to consume normalized reviewer-app facts
+4. update docs/status/tests to explain the new deterministic reviewer posture
+
+Deferred:
+
+- native adapters for Greptile, Cursor Bugbot, or other reviewer apps beyond compatibility fallback
+- richer reviewer policy such as one-of/all-of quorum, optional-but-observed apps, or weighted reviewers
+- non-GitHub tracker implementations of reviewer-app normalization
+- dedicated reviewer-app dashboards beyond the minimum operator-visible posture needed for debugging this slice
+
+This seam is reviewable because it isolates reviewer-app semantics at the integration edge while preserving the rest of the orchestration lifecycle model and existing runner/workspace behavior.
+
+## Runtime State Model
+
+This issue changes stateful PR handoff behavior, so reviewer-app state must be explicit.
+
+### Per-reviewer normalized states
+
+For each configured reviewer app on the current PR head:
+
+1. `missing`
+   - no current-head evidence that the reviewer app ran
+2. `running`
+   - current-head evidence indicates the reviewer app has started but not reached a terminal verdict
+3. `completed-pass`
+   - current-head evidence shows the reviewer app completed with an explicit pass / no-issues verdict
+4. `completed-issues-found`
+   - current-head evidence shows the reviewer app completed with an explicit issues-found verdict
+5. `completed-unknown`
+   - current-head evidence shows the reviewer app ran, but the adapter cannot classify a deterministic pass/fail verdict
+
+Each normalized reviewer snapshot also carries:
+
+- `coverage`: `missing | observed`
+- `status`: `running | completed | unknown`
+- `verdict`: `pass | issues-found | unknown`
+- `actionableFeedback`
+- `unresolvedFeedbackIds`
+- evidence facts for debugging
+
+### Aggregate policy states relevant to this issue
+
+- `awaiting-system-checks`
+  - CI or reviewer app execution is still naturally pending
+- `degraded-review-infrastructure`
+  - required reviewer coverage for the current head is still missing after the normal check surface has settled
+- `awaiting-human-review`
+  - human review debt remains without automated reviewer-app issues forcing a follow-up run
+- `rework-required`
+  - a reviewer app explicitly found issues on the current head, or actionable reviewer feedback remains
+- `awaiting-landing-command`
+  - required reviewer apps have explicit current-head pass coverage and no reviewer-app/human blockers remain
+- `awaiting-landing`
+  - `/land` observed; guarded landing still re-checks normalized reviewer-app facts
+- `handoff-ready`
+  - merge observed
+
+### Allowed transitions relevant to this issue
+
+- `awaiting-system-checks` -> `degraded-review-infrastructure`
+  - normal check stabilization has completed and a required reviewer app is still `missing`
+- `awaiting-system-checks` -> `rework-required`
+  - a required or accepted reviewer app reaches `completed-issues-found`
+- `awaiting-system-checks` -> `awaiting-landing-command`
+  - required reviewer apps reach `completed-pass`, all checks are green, and no actionable feedback remains
+- `degraded-review-infrastructure` -> `awaiting-system-checks`
+  - a reviewer app is now observed but still `running`
+- `degraded-review-infrastructure` -> `rework-required`
+  - a reviewer app later completes with `issues-found`
+- `degraded-review-infrastructure` -> `awaiting-landing-command`
+  - a reviewer app later completes with explicit `pass`
+- `awaiting-landing-command` -> `rework-required`
+  - a new head or fresh reviewer result introduces issues-found or actionable feedback
+- `awaiting-landing-command` -> `degraded-review-infrastructure`
+  - a new head invalidates stale reviewer coverage and no current-head required reviewer evidence exists
+- `awaiting-landing` -> `rework-required`
+  - guarded landing re-check observes `issues-found` or actionable feedback
+- `awaiting-landing` -> `degraded-review-infrastructure`
+  - guarded landing re-check observes required reviewer coverage missing on the approved/current head
+- `awaiting-landing` -> `handoff-ready`
+  - guarded landing succeeds and merge is observed
+
+### Coordination Decision Rules
+
+- policy must treat reviewer-app coverage, run status, verdict, and unresolved/actionable feedback as separate normalized inputs
+- a successful non-reviewer CI status must never satisfy reviewer coverage or verdict
+- required reviewer apps must have current-head `coverage=observed`, terminal `status=completed`, explicit `verdict=pass`, and no unresolved/actionable reviewer feedback before landing is eligible
+- stale reviewer evidence from prior heads must never satisfy current-head policy
+- keep orchestrator logic tracker-neutral by exposing only normalized lifecycle kinds and summaries above the tracker boundary
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Required reviewer app has no current-head evidence and checks are still pending or in no-check stabilization | no landing attempt active | reviewer coverage = `missing`; check surface unsettled | stay in `awaiting-system-checks` |
+| Required reviewer app has no current-head evidence after checks settle | no landing attempt active | reviewer coverage = `missing`; check surface settled | report `degraded-review-infrastructure` |
+| Required reviewer app has a current-head running status/check but no terminal verdict yet | no landing attempt active | reviewer coverage = `observed`; status = `running`; verdict = `unknown` | stay in `awaiting-system-checks` |
+| Required reviewer app explicitly reports pass on current head | no landing attempt active | coverage = `observed`; status = `completed`; verdict = `pass`; unresolved feedback = none | allow `awaiting-landing-command` when other gates pass |
+| Required reviewer app explicitly reports issues on current head through a top-level review/comment without unresolved thread objects | no landing attempt active | coverage = `observed`; verdict = `issues-found`; actionable feedback > 0 or verdict gate fail | enter `rework-required` |
+| Reviewer app ran only on an older head, then a new commit landed | no landing attempt active or stale `/land` exists | current-head reviewer coverage = `missing` | fall back to waiting/degraded based on check-settled posture |
+| `/land` exists, but guarded landing re-check still sees required reviewer app `missing` or `completed-unknown` | landing approval recorded | required reviewer landing gate unsatisfied | block landing and return degraded/waiting lifecycle consistent with normalized state |
+| Compatibility adapter sees generic approved-bot review evidence but no explicit app-specific adapter configured | no landing attempt active | compatibility reviewer snapshot satisfies current policy | preserve current behavior while new adapter seam is adopted |
+
+## Storage / Persistence Contract
+
+- no new durable store is introduced
+- workflow config remains the source of truth for named reviewer-app policy
+- normalized reviewer-app snapshots remain ephemeral tracker state derived from GitHub review surfaces for the current head
+- operator artifacts/status may persist normalized reviewer summaries/evidence references, but not raw GitHub-authored payloads as the primary contract
+
+## Observability Requirements
+
+- status and report surfaces should be able to show, at minimum:
+  - which reviewer apps are configured and required
+  - whether each required reviewer app is missing, running, pass, issues-found, or unknown on the current head
+  - whether blocked/rework decisions came from coverage, verdict, or unresolved/actionable feedback
+- summaries should distinguish:
+  - ordinary system-check waiting
+  - degraded reviewer coverage because a required app never produced current-head output
+  - explicit reviewer-app issues requiring rework
+  - landing-ready posture with current-head pass coverage
+- operator docs should explain that reviewer-app semantics now come from normalized adapters at the tracker edge
+
+## Decision Notes
+
+- Introduce a new additive reviewer-app config seam now instead of overloading `review_bot_logins` and `approved_review_bot_logins` further. Those fields describe author classes, not stable reviewer-app identities or policy.
+- Keep a compatibility adapter in the first slice so this PR can land without forcing immediate native adapters for every existing reviewer app.
+- Make `devin` the first explicit adapter because the issue specifically calls out top-level review-summary semantics that the current generic surface handles poorly.
+- Prefer a dedicated raw-review-surface input shape for adapters so app-specific parsers do not depend directly on GitHub client response types across the codebase.
+
+## Implementation Steps
+
+1. Add typed workflow/domain config for named reviewer apps in GitHub-compatible trackers, including the minimum policy flags needed for this slice.
+2. Introduce a tracker-side normalized reviewer-app snapshot contract plus a raw GitHub reviewer-surface input shape.
+3. Extract current reviewer-app parsing out of `src/tracker/pull-request-snapshot.ts` into:
+   - adapter interfaces/types
+   - adapter registry/factory
+   - compatibility adapter for existing generic bot-login behavior
+   - `devin` adapter
+4. Update PR snapshot creation to aggregate per-app reviewer snapshots and derive policy-oriented aggregate facts from that normalized collection instead of scattered booleans and hardcoded status-context tables.
+5. Update `src/tracker/pull-request-policy.ts` to consume normalized reviewer-app snapshots for:
+   - waiting on running reviewer apps
+   - degraded required coverage when reviewer apps remain missing after checks settle
+   - rework when a reviewer app explicitly reports issues or unresolved reviewer feedback
+   - landing eligibility only after explicit required-app pass coverage
+6. Update guarded landing and tracker service result types so landing uses the same normalized reviewer-app gate and summary vocabulary.
+7. Thread reviewer-app posture through any affected observability/report/status surfaces without leaking raw GitHub parsing upward.
+8. Update workflow docs/README/operator docs for the new reviewer-app config seam and deterministic landing policy.
+9. Add targeted tests across unit, integration, and e2e layers using shared fixtures/builders where reviewer-app surface setup repeats.
+10. Run local self-review and repository gates before PR update/open:
+   - `pnpm format:check`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+   - `codex review --base origin/main` if available and reliable
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- reviewer-app adapter registry selects `devin` and compatibility adapters deterministically from config
+- `devin` adapter classifies current-head results as `missing`, `running`, `pass`, `issues-found`, and `unknown`
+- stale prior-head reviewer evidence does not satisfy current-head coverage or verdict
+- policy maps:
+  - required reviewer `missing` after check stabilization -> `degraded-review-infrastructure`
+  - required reviewer `running` -> `awaiting-system-checks`
+  - required reviewer `issues-found` -> `rework-required`
+  - required reviewer `pass` with no other blockers -> `awaiting-landing-command`
+- guarded landing blocks when required reviewer apps are `missing`, `running`, or `unknown`
+
+### Integration
+
+- `GitHubTracker.inspectIssueHandoff()` reports `awaiting-system-checks` while Devin is still running on the current head
+- `GitHubTracker.inspectIssueHandoff()` reports `degraded-review-infrastructure` when required Devin coverage is still missing after checks settle
+- `GitHubTracker.inspectIssueHandoff()` reports `rework-required` when Devin leaves a current-head summary that explicitly says issues were found, even if no unresolved thread objects exist
+- `GitHubTracker.inspectIssueHandoff()` reports `awaiting-landing-command` when Devin explicitly passes on the current head and all other gates are green
+- `GitHubTracker.executeLanding()` fail-closes when stale or unknown reviewer-app posture makes landing non-deterministic
+
+### End-to-End
+
+- factory run opens a PR, CI turns green, required Devin output never appears, and the run stays visibly degraded instead of becoming landable
+- factory run opens a PR, Devin reports issues on the current head via summary review/comment, and Symphony schedules rework rather than waiting for `/land`
+- factory run opens a PR, Devin initially runs, later emits an explicit current-head pass, and the run advances to `awaiting-landing-command`
+- after a follow-up push, prior-head Devin pass evidence no longer satisfies the new head until new current-head reviewer output arrives
+
+### Acceptance Scenarios
+
+1. Devin is configured as required, CI is green, and Devin never produces current-head output; Symphony reports degraded reviewer infrastructure instead of landing-ready posture.
+2. Devin is configured as required and reports a current-head running status; Symphony keeps waiting rather than degrading or landing.
+3. Devin is configured as required and reports `found 3 potential issues` on the current head; Symphony enters `rework-required` even without unresolved thread objects.
+4. Devin is configured as required and reports `No Issues Found` on the current head; Symphony can advance to `/land` once other gates are green.
+5. After a new push, only stale prior-head Devin evidence exists; Symphony falls back to waiting/degraded until new current-head reviewer output appears.
+
+## Exit Criteria
+
+1. reviewer-app semantics are parsed through a pluggable tracker-edge adapter seam rather than hardcoded inside generic PR snapshot logic
+2. `devin` is modeled through that seam with deterministic current-head coverage and verdict handling
+3. required landing policy depends on normalized reviewer-app coverage, explicit pass verdicts, and unresolved/actionable reviewer feedback
+4. a PR cannot become landable when a required reviewer app explicitly reported issues on the current head
+5. status/docs/tests make current-head reviewer coverage and verdict posture inspectable
+6. `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass
+
+## Deferred To Later Issues Or PRs
+
+- native adapters for additional reviewer apps beyond `devin` and the compatibility fallback
+- richer reviewer policy such as all-of/one-of groups, quorum counts, or optional accepted-only reviewer classes
+- non-GitHub reviewer-app normalization
+- automatic reviewer reruns, escalation comments, or recovery automation when reviewer coverage is missing
+- broader cleanup that fully removes legacy bot-login fields after native adapter migration is complete

--- a/docs/plans/242-reviewer-app-adapters/plan.md
+++ b/docs/plans/242-reviewer-app-adapters/plan.md
@@ -206,16 +206,16 @@ Each normalized reviewer snapshot also carries:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Required reviewer app has no current-head evidence and checks are still pending or in no-check stabilization | no landing attempt active | reviewer coverage = `missing`; check surface unsettled | stay in `awaiting-system-checks` |
-| Required reviewer app has no current-head evidence after checks settle | no landing attempt active | reviewer coverage = `missing`; check surface settled | report `degraded-review-infrastructure` |
-| Required reviewer app has a current-head running status/check but no terminal verdict yet | no landing attempt active | reviewer coverage = `observed`; status = `running`; verdict = `unknown` | stay in `awaiting-system-checks` |
-| Required reviewer app explicitly reports pass on current head | no landing attempt active | coverage = `observed`; status = `completed`; verdict = `pass`; unresolved feedback = none | allow `awaiting-landing-command` when other gates pass |
-| Required reviewer app explicitly reports issues on current head through a top-level review/comment without unresolved thread objects | no landing attempt active | coverage = `observed`; verdict = `issues-found`; actionable feedback > 0 or verdict gate fail | enter `rework-required` |
-| Reviewer app ran only on an older head, then a new commit landed | no landing attempt active or stale `/land` exists | current-head reviewer coverage = `missing` | fall back to waiting/degraded based on check-settled posture |
-| `/land` exists, but guarded landing re-check still sees required reviewer app `missing` or `completed-unknown` | landing approval recorded | required reviewer landing gate unsatisfied | block landing and return degraded/waiting lifecycle consistent with normalized state |
-| Compatibility adapter sees generic approved-bot review evidence but no explicit app-specific adapter configured | no landing attempt active | compatibility reviewer snapshot satisfies current policy | preserve current behavior while new adapter seam is adopted |
+| Observed condition                                                                                                                   | Local facts available                             | Normalized tracker facts available                                                            | Expected decision                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Required reviewer app has no current-head evidence and checks are still pending or in no-check stabilization                         | no landing attempt active                         | reviewer coverage = `missing`; check surface unsettled                                        | stay in `awaiting-system-checks`                                                     |
+| Required reviewer app has no current-head evidence after checks settle                                                               | no landing attempt active                         | reviewer coverage = `missing`; check surface settled                                          | report `degraded-review-infrastructure`                                              |
+| Required reviewer app has a current-head running status/check but no terminal verdict yet                                            | no landing attempt active                         | reviewer coverage = `observed`; status = `running`; verdict = `unknown`                       | stay in `awaiting-system-checks`                                                     |
+| Required reviewer app explicitly reports pass on current head                                                                        | no landing attempt active                         | coverage = `observed`; status = `completed`; verdict = `pass`; unresolved feedback = none     | allow `awaiting-landing-command` when other gates pass                               |
+| Required reviewer app explicitly reports issues on current head through a top-level review/comment without unresolved thread objects | no landing attempt active                         | coverage = `observed`; verdict = `issues-found`; actionable feedback > 0 or verdict gate fail | enter `rework-required`                                                              |
+| Reviewer app ran only on an older head, then a new commit landed                                                                     | no landing attempt active or stale `/land` exists | current-head reviewer coverage = `missing`                                                    | fall back to waiting/degraded based on check-settled posture                         |
+| `/land` exists, but guarded landing re-check still sees required reviewer app `missing` or `completed-unknown`                       | landing approval recorded                         | required reviewer landing gate unsatisfied                                                    | block landing and return degraded/waiting lifecycle consistent with normalized state |
+| Compatibility adapter sees generic approved-bot review evidence but no explicit app-specific adapter configured                      | no landing attempt active                         | compatibility reviewer snapshot satisfies current policy                                      | preserve current behavior while new adapter seam is adopted                          |
 
 ## Storage / Persistence Contract
 
@@ -264,11 +264,12 @@ Each normalized reviewer snapshot also carries:
 8. Update workflow docs/README/operator docs for the new reviewer-app config seam and deterministic landing policy.
 9. Add targeted tests across unit, integration, and e2e layers using shared fixtures/builders where reviewer-app surface setup repeats.
 10. Run local self-review and repository gates before PR update/open:
-   - `pnpm format:check`
-   - `pnpm lint`
-   - `pnpm typecheck`
-   - `pnpm test`
-   - `codex review --base origin/main` if available and reliable
+
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `codex review --base origin/main` if available and reliable
 
 ## Tests And Acceptance Scenarios
 

--- a/docs/plans/242-reviewer-app-adapters/plan.md
+++ b/docs/plans/242-reviewer-app-adapters/plan.md
@@ -1,0 +1,258 @@
+# Issue 242 Plan: Add Pluggable Reviewer-App Adapters With Normalized Coverage And Verdicts
+
+## Status
+
+- approved
+
+## Goal
+
+Introduce a pluggable GitHub reviewer-app adapter seam so Symphony evaluates reviewer coverage, run status, verdict, and unresolved reviewer feedback from normalized per-app snapshots instead of inferring landing readiness from mixed raw PR surfaces.
+
+## Scope
+
+- add a typed GitHub `reviewer_apps` workflow contract with explicit `accepted` and `required` policy flags
+- add a normalized reviewer-app snapshot contract at the tracker integration edge
+- add a GitHub reviewer-app registry with one real `devin` adapter and one legacy compatibility adapter for the current bot-login behavior
+- migrate PR lifecycle and guarded landing policy to normalized reviewer-app snapshots
+- update tests and docs for missing, running, pass, issues-found, stale-head, and unknown-verdict reviewer outcomes
+
+## Non-goals
+
+- implementing every existing reviewer bot as a first-class adapter in this slice
+- redesigning the overall landing topology, human `/land` protocol, or review-loop retry policy
+- changing Linear or non-GitHub tracker behavior
+- adding reviewer-app retriggering, timer-based escalation, or remote reviewer orchestration
+- building a broad operator dashboard redesign beyond the normalized facts needed for this issue
+
+## Current Gaps
+
+- `src/tracker/pull-request-snapshot.ts` still mixes top-level comments, reviews, review threads, and status checks into a small set of booleans and feedback lists
+- reviewer-app-specific parsing rules such as Devin verdict strings do not live behind a stable integration seam
+- current policy can count reviewer coverage without an explicit pass verdict, and can miss explicit issues-found output when it is not represented as unresolved threads or classified comments
+- legacy config fields `review_bot_logins` and `approved_review_bot_logins` overload several policy concepts and cannot express accepted-vs-required reviewer semantics cleanly
+- reviewer-app behavior is hard to test deterministically because coverage, verdict, and unresolved feedback are not modeled separately
+
+## Spec Alignment By Abstraction Level
+
+- Policy Layer
+  - belongs: require explicit pass verdicts from required reviewer apps before landing, and treat issues-found verdicts as actionable rework
+  - does not belong: Devin-specific strings, GitHub GraphQL field mapping, or check-status transport details
+- Configuration Layer
+  - belongs: typed `tracker.reviewer_apps` parsing plus compatibility with the legacy bot-login fields
+  - does not belong: reviewer verdict parsing or lifecycle transitions
+- Coordination Layer
+  - belongs: consume normalized lifecycle outcomes such as waiting, rework-required, degraded reviewer infrastructure, and awaiting landing
+  - does not belong: app-specific review parsing or raw GitHub review/comment inspection
+- Execution Layer
+  - belongs: no workspace or runner changes in this slice
+  - does not belong: reviewer-app normalization or landing policy
+- Integration Layer
+  - belongs: reviewer-app adapter registry, per-app coverage/status/verdict parsing, and compatibility normalization for legacy bot-login behavior
+  - does not belong: orchestrator retry budgeting or operator rendering policy
+- Observability Layer
+  - belongs: summaries and artifacts that reflect normalized reviewer-app gating reasons
+  - does not belong: reverse-engineering reviewer-app state from raw GitHub payloads outside the tracker
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts` and `src/config/workflow.ts`
+  - add the typed `tracker.reviewer_apps` config seam and preserve backward compatibility with existing bot-login fields
+- `src/tracker/`
+  - add reviewer-app snapshot types plus a registry that keeps app-specific parsing at the integration edge
+  - add one real `devin` adapter for current-head coverage, running detection, verdict parsing, and actionable feedback extraction
+  - add a legacy compatibility adapter so existing review-bot and approved-review-bot behavior still works while the new seam lands
+  - update PR lifecycle and guarded landing policy to consume normalized reviewer-app snapshots
+- tests and docs
+  - extend unit, integration, and e2e coverage plus workflow docs/examples for the new config and policy surface
+
+### Does not belong in this issue
+
+- tracker transport rewrites unrelated to reviewer-app surfaces
+- broad refactors across orchestrator state, runner control, or workspace lifecycle
+- Linear parity or multi-tracker reviewer-app abstractions
+- a second configuration system for human review policy
+
+## Layering Notes
+
+- `config/workflow`
+  - owns parsing and validation for reviewer-app policy declarations
+  - must not parse reviewer verdict text
+- `tracker`
+  - owns GitHub review/check normalization and reviewer-app parsing
+  - must keep transport, normalization, and policy in distinct modules
+- `workspace`
+  - unchanged
+- `runner`
+  - unchanged
+- `orchestrator`
+  - reacts only to normalized lifecycle and landing-blocked reasons
+  - must not inspect reviewer-app logins, review text, or check names directly
+- `observability`
+  - renders the normalized lifecycle summaries
+  - must not re-derive reviewer coverage or verdict from tracker payload side effects
+
+## Slice Strategy And PR Seam
+
+Keep this issue to one tracker-boundary PR:
+
+1. add the reviewer-app config and normalized snapshot contract
+2. land the adapter registry with `devin` plus a legacy compatibility adapter
+3. migrate lifecycle/landing policy and regression coverage to the normalized seam
+
+Deferred:
+
+- additional first-class reviewer-app adapters beyond Devin
+- richer quorum rules such as one-of vs all-of reviewer requirements
+- dedicated status/TUI reviewer-app tables beyond the summaries already fed by tracker lifecycle results
+
+This stays reviewable because it moves app-specific semantics to one integration seam without reopening runner, orchestration, or broader tracker transport design.
+
+## Runtime State Model
+
+### Per-app reviewer states
+
+Each configured reviewer app produces a current-head snapshot with:
+
+1. `coverage`
+   - `missing`
+   - `observed`
+2. `status`
+   - `running`
+   - `completed`
+   - `unknown`
+3. `verdict`
+   - `pass`
+   - `issues-found`
+   - `unknown`
+
+Each snapshot also carries:
+
+- `actionableFeedback`
+- `unresolvedFeedbackIds`
+- evidence pointers for debugging
+
+### Aggregate required-reviewer gate states
+
+1. `not-required`
+   - no required reviewer apps are configured
+2. `running`
+   - at least one required reviewer app is still running on the current head
+3. `missing`
+   - required reviewer output is absent after the normal check surface has settled
+4. `unknown`
+   - required reviewer output was observed, but no explicit pass/fail verdict could be normalized
+5. `satisfied`
+   - every required reviewer app has current-head coverage and an explicit `pass` verdict
+
+### Lifecycle transitions relevant to this issue
+
+- `awaiting-system-checks` -> `rework-required`
+  - an accepted reviewer app reports `issues-found` or emits actionable unresolved feedback
+- `awaiting-system-checks` -> `degraded-review-infrastructure`
+  - required reviewer coverage is missing after checks settle, or verdict remains unknown
+- `awaiting-system-checks` -> `awaiting-landing-command`
+  - checks are settled, all required reviewer apps explicitly pass, and no actionable feedback remains
+- `awaiting-landing` -> `degraded-review-infrastructure`
+  - guarded landing re-check sees missing or ambiguous required reviewer results on the current head
+- `awaiting-landing` -> `handoff-ready`
+  - merge succeeds after the normalized reviewer gate passes
+
+## Failure-Class Matrix
+
+| Observed condition                                                                 | Local facts available     | Normalized reviewer facts available                       | Expected decision                                                           |
+| ---------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Required reviewer check is pending on the current head                             | no landing attempt active | required reviewer state = `running`                       | stay in `awaiting-system-checks`                                            |
+| Required reviewer never emitted current-head output after checks settled           | no landing attempt active | required reviewer state = `missing`                       | return `degraded-review-infrastructure`                                     |
+| Required reviewer emitted current-head output but no explicit pass/fail was parsed | no landing attempt active | required reviewer state = `unknown`                       | return `degraded-review-infrastructure`                                     |
+| Devin reports `No Issues Found` on the current head                                | no landing attempt active | Devin coverage observed, status completed, verdict `pass` | allow `awaiting-landing-command` when other gates pass                      |
+| Devin reports `found N potential issues` on the current head                       | no landing attempt active | Devin verdict `issues-found`, actionable feedback present | return `rework-required`                                                    |
+| Legacy bot comment/thread feedback exists on the current head                      | no landing attempt active | compatibility adapter actionable feedback present         | return `rework-required`                                                    |
+| Prior-head reviewer output exists but Symphony pushed a new commit                 | no landing attempt active | current-head coverage missing or running for the new head | do not count stale reviewer evidence; keep waiting or degrade appropriately |
+| `/land` exists but guarded landing re-check sees ambiguous required reviewer pass  | landing approval recorded | required reviewer state = `unknown`                       | block landing fail-closed                                                   |
+
+## Storage / Persistence Contract
+
+- no new durable store is introduced
+- workflow config becomes the source of truth for explicit reviewer-app policy declarations
+- reviewer-app snapshots remain normalized ephemeral tracker facts derived from the current PR head
+- issue artifacts and landing-blocked events should preserve normalized reviewer gating summaries rather than raw GitHub review payloads
+
+## Observability Requirements
+
+- lifecycle summaries must distinguish:
+  - reviewer still running
+  - required reviewer missing
+  - required reviewer verdict unknown
+  - reviewer issues-found / actionable feedback
+  - explicit pass with landing now awaiting `/land`
+- the normalized reviewer-app seam must be testable directly in unit coverage
+- docs/examples should show the preferred `tracker.reviewer_apps` configuration
+
+## Decision Notes
+
+- Keep a legacy compatibility adapter in this slice so the new seam lands without forcing a one-shot migration for every bot-specific rule.
+- Treat required reviewer verdict `unknown` as fail-closed degraded infrastructure. Coverage alone is not sufficient for deterministic landing under this issue.
+- Keep app-specific parsing in dedicated adapter modules. `pull-request-policy.ts` and `guarded-landing.ts` should never inspect Devin strings directly.
+
+## Implementation Steps
+
+1. Restore the checked-in issue plan path referenced by the approved issue handoff.
+2. Add the typed `tracker.reviewer_apps` workflow contract and validation for supported GitHub reviewer-app keys.
+3. Add normalized reviewer-app snapshot types plus a GitHub reviewer-app registry seam.
+4. Implement the `devin` adapter for:
+   - current-head coverage detection
+   - running detection from the current-head check surface
+   - explicit pass / issues-found verdict parsing
+   - actionable feedback extraction from top-level review artifacts
+5. Implement a legacy compatibility adapter that preserves the current bot-login behavior for existing `review_bot_logins` / `approved_review_bot_logins` workflows.
+6. Update `createPullRequestSnapshot()` to aggregate normalized reviewer-app snapshots into lifecycle inputs without mixing app-specific parsing into policy.
+7. Update PR lifecycle and guarded landing policy to require explicit pass verdicts for required reviewer apps and to fail closed on missing or ambiguous required reviewer results.
+8. Update docs/examples and add regression coverage across workflow parsing, unit, integration, and e2e layers.
+9. Run local self-review and repository gates before opening/updating the PR:
+   - `pnpm format:check`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+   - `codex review --base origin/main` if available and reliable
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- workflow parsing accepts `tracker.reviewer_apps.devin` and rejects invalid reviewer-app configs
+- reviewer snapshot normalization marks Devin current-head `pass`, `issues-found`, `running`, `missing`, and `unknown` cases correctly
+- stale prior-head reviewer evidence does not satisfy current-head coverage
+- lifecycle policy returns degraded infrastructure when required reviewer coverage is missing or verdict is unknown
+- guarded landing blocks when required reviewer verdict is missing or unknown
+
+### Integration
+
+- `GitHubTracker.inspectIssueHandoff()` treats current-head Devin `No Issues Found` as landing-eligible when other gates are green
+- `GitHubTracker.inspectIssueHandoff()` treats current-head Devin `found N potential issues` as `rework-required`
+- `GitHubTracker.inspectIssueHandoff()` stays non-landable while a required Devin check is still pending
+- `GitHubTracker.executeLanding()` fails closed when required reviewer coverage is missing or verdict remains unknown
+
+### End-to-end
+
+- factory run opens a PR, CI turns green, required reviewer output is missing, and the run remains visibly degraded instead of landable
+- factory run opens a PR, required Devin output reports issues on the current head, and the run enters rework instead of awaiting `/land`
+- after a follow-up push, stale prior-head reviewer output no longer satisfies the new head
+
+## Exit Criteria
+
+1. reviewer-app parsing lives behind a pluggable tracker-edge seam
+2. Devin is implemented through that seam
+3. landing requires explicit pass verdicts from required reviewer apps
+4. a PR cannot become landable when Devin explicitly reports issues on the current head
+5. legacy bot-login behavior still works through a compatibility adapter
+6. docs and tests reflect the new `tracker.reviewer_apps` contract
+7. `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass
+
+## Deferred To Later Issues Or PRs
+
+- additional first-class reviewer-app adapters such as Greptile or Cursor-specific verdict parsers
+- richer reviewer quorum policy and per-app retry/retrigger semantics
+- tracker-agnostic reviewer-app abstractions for Linear or future backends
+- dedicated reviewer-app tables in TUI/status surfaces beyond the lifecycle summaries in this slice

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -19,6 +19,7 @@ import type {
   CodexRemoteExecutionConfig,
   GitHubCompatibleTrackerConfig,
   GitHubQueuePriorityConfig,
+  GitHubReviewerAppConfig,
   LinearTrackerConfig,
   ObservabilityConfig,
   PromptBuilder,
@@ -74,8 +75,11 @@ const SUPPORTED_AGENT_RUNNER_KINDS = [
   "generic-command",
   "claude-code",
 ] as const;
+const SUPPORTED_GITHUB_REVIEWER_APP_KEYS = ["devin"] as const;
 type SupportedTrackerKind = (typeof SUPPORTED_TRACKER_KINDS)[number];
 type SupportedAgentRunnerKind = (typeof SUPPORTED_AGENT_RUNNER_KINDS)[number];
+type SupportedGitHubReviewerAppKey =
+  (typeof SUPPORTED_GITHUB_REVIEWER_APP_KEYS)[number];
 
 interface PromptRenderInput {
   readonly issue: PromptIssueContext;
@@ -312,6 +316,74 @@ function isSupportedAgentRunnerKind(
   value: string,
 ): value is SupportedAgentRunnerKind {
   return (SUPPORTED_AGENT_RUNNER_KINDS as readonly string[]).includes(value);
+}
+
+function resolveGitHubReviewerApps(
+  value: unknown,
+): readonly GitHubReviewerAppConfig[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ConfigError("Expected object for tracker.reviewer_apps");
+  }
+
+  const reviewerApps: GitHubReviewerAppConfig[] = [];
+  for (const [key, rawConfig] of Object.entries(value).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (
+      !SUPPORTED_GITHUB_REVIEWER_APP_KEYS.includes(
+        key as SupportedGitHubReviewerAppKey,
+      )
+    ) {
+      throw new ConfigError(
+        `Unsupported tracker.reviewer_apps key '${key}'. Supported reviewer apps: ${SUPPORTED_GITHUB_REVIEWER_APP_KEYS.join(", ")}`,
+      );
+    }
+    if (
+      rawConfig === null ||
+      typeof rawConfig !== "object" ||
+      Array.isArray(rawConfig)
+    ) {
+      throw new ConfigError(`Expected object for tracker.reviewer_apps.${key}`);
+    }
+
+    const appConfig = rawConfig as Record<string, unknown>;
+    const accepted =
+      appConfig["accepted"] === undefined
+        ? true
+        : requireBoolean(
+            appConfig["accepted"],
+            `tracker.reviewer_apps.${key}.accepted`,
+          );
+    const required =
+      appConfig["required"] === undefined
+        ? false
+        : requireBoolean(
+            appConfig["required"],
+            `tracker.reviewer_apps.${key}.required`,
+          );
+
+    if (!accepted && !required) {
+      throw new ConfigError(
+        `tracker.reviewer_apps.${key} must enable accepted, required, or both`,
+      );
+    }
+    if (required && !accepted) {
+      throw new ConfigError(
+        `tracker.reviewer_apps.${key}.required cannot be true when accepted is false`,
+      );
+    }
+
+    reviewerApps.push({
+      key,
+      accepted,
+      required,
+    });
+  }
+
+  return reviewerApps;
 }
 
 function parseFrontMatter(raw: string): {
@@ -1029,6 +1101,7 @@ function resolveGitHubTrackerConfig<
             tracker["approved_review_bot_logins"],
             "tracker.approved_review_bot_logins",
           ),
+    reviewerApps: resolveGitHubReviewerApps(tracker["reviewer_apps"]),
     queuePriority: resolveGitHubQueuePriorityConfig(
       tracker["queue_priority"],
       "tracker.queue_priority",

--- a/src/domain/handoff.ts
+++ b/src/domain/handoff.ts
@@ -26,7 +26,10 @@ export interface PullRequestCheck {
   readonly detailsUrl: string | null;
 }
 
-export type ReviewFeedbackKind = "review-thread" | "issue-comment";
+export type ReviewFeedbackKind =
+  | "review-thread"
+  | "issue-comment"
+  | "pull-request-review";
 
 export interface ReviewFeedback {
   readonly id: string;

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -13,6 +13,12 @@ export interface GitHubQueuePriorityConfig extends QueuePriorityConfig {
   readonly optionRankMap?: Readonly<Record<string, number>> | undefined;
 }
 
+export interface GitHubReviewerAppConfig {
+  readonly key: string;
+  readonly accepted: boolean;
+  readonly required: boolean;
+}
+
 export interface WatchdogConfig {
   readonly enabled: boolean;
   readonly checkIntervalMs: number;
@@ -34,6 +40,7 @@ interface BaseGitHubTrackerConfig {
   readonly successComment: string;
   readonly reviewBotLogins: readonly string[];
   readonly approvedReviewBotLogins?: readonly string[] | undefined;
+  readonly reviewerApps?: readonly GitHubReviewerAppConfig[] | undefined;
   readonly queuePriority?: GitHubQueuePriorityConfig | undefined;
 }
 

--- a/src/templates/third-party-workflow.ts
+++ b/src/templates/third-party-workflow.ts
@@ -31,6 +31,7 @@ export function renderThirdPartyWorkflowTemplate(
     "  failed_label: symphony:failed",
     "  success_comment: Symphony completed this issue successfully.",
     "  review_bot_logins: []",
+    "  reviewer_apps: {}",
     "polling:",
     "  interval_ms: 30000",
     "  max_concurrent_runs: 1",

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -200,8 +200,10 @@ interface PullRequestReviewThreadsConnection {
 
 interface PullRequestReviewsConnection {
   readonly nodes: Array<{
+    readonly id: string;
     readonly body: string;
     readonly submittedAt: string;
+    readonly url: string;
     readonly author: {
       readonly login: string;
     } | null;
@@ -303,8 +305,10 @@ const PULL_REQUEST_REVIEW_STATE_QUERY = `
         }
         reviews(first: 100) {
           nodes {
+            id
             body
             submittedAt
+            url
             author {
               login
             }

--- a/src/tracker/github.ts
+++ b/src/tracker/github.ts
@@ -14,12 +14,14 @@ import {
   type NoCheckObservation,
 } from "./pull-request-policy.js";
 import { createPullRequestSnapshot } from "./pull-request-snapshot.js";
+import { getConfiguredReviewerAppLogins } from "./reviewer-apps.js";
 import type { LandingExecutionResult, Tracker } from "./service.js";
 
 export class GitHubTracker implements Tracker {
   readonly #config: GitHubCompatibleTrackerConfig;
   readonly #logger: Logger;
   readonly #client: GitHubClient;
+  readonly #reviewerAppLogins: ReadonlySet<string>;
   #ensureLabelsPromise: Promise<void> | null = null;
   readonly #noCheckObservations = new Map<string, NoCheckObservation>();
   readonly #planReviewObservations = new Map<
@@ -43,6 +45,7 @@ export class GitHubTracker implements Tracker {
     this.#config = config;
     this.#logger = logger;
     this.#client = new GitHubClient(config, logger);
+    this.#reviewerAppLogins = getConfiguredReviewerAppLogins(config);
   }
 
   subject(): string {
@@ -53,9 +56,7 @@ export class GitHubTracker implements Tracker {
     if (authorLogin === null) {
       return false;
     }
-    return !this.#config.reviewBotLogins
-      .map((login) => login.toLowerCase())
-      .includes(authorLogin.toLowerCase());
+    return !this.#reviewerAppLogins.has(authorLogin.toLowerCase());
   }
 
   async ensureLabels(): Promise<void> {
@@ -155,6 +156,7 @@ export class GitHubTracker implements Tracker {
       reviewState: reviewStateData,
       reviewBotLogins: this.#config.reviewBotLogins,
       approvedReviewBotLogins: this.#config.approvedReviewBotLogins ?? [],
+      reviewerApps: this.#config.reviewerApps ?? [],
     });
     const result = evaluatePullRequestLifecycle(
       snapshot,
@@ -203,6 +205,7 @@ export class GitHubTracker implements Tracker {
       reviewState,
       reviewBotLogins: this.#config.reviewBotLogins,
       approvedReviewBotLogins: this.#config.approvedReviewBotLogins ?? [],
+      reviewerApps: this.#config.reviewerApps ?? [],
     });
     const gateSnapshot: GuardedLandingSnapshot = {
       approvedHeadSha: pullRequest.headSha,
@@ -220,7 +223,7 @@ export class GitHubTracker implements Tracker {
           feedback.kind === "review-thread" &&
           !this.#isBotReviewFeedback(feedback.authorLogin),
       ).length,
-      requiredApprovedReviewCoverage: snapshot.requiredApprovedReviewCoverage,
+      requiredReviewerState: snapshot.requiredReviewerState,
     };
     const decision = evaluateGuardedLanding(gateSnapshot);
     if (decision.kind === "blocked") {
@@ -294,9 +297,7 @@ export class GitHubTracker implements Tracker {
     if (authorLogin === null) {
       return false;
     }
-    return this.#config.reviewBotLogins
-      .map((login) => login.toLowerCase())
-      .includes(authorLogin.toLowerCase());
+    return this.#reviewerAppLogins.has(authorLogin.toLowerCase());
   }
 
   async #isStaleMergedPullRequest(

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -144,6 +144,15 @@ export function evaluateGuardedLanding(
     };
   }
 
+  if (snapshot.requiredReviewerState === "running") {
+    return {
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because a required reviewer app is still running on the current head.`,
+    };
+  }
+
   return {
     kind: "requested",
     summary: `Landing requested for ${formatPullRequest(snapshot)}.`,

--- a/src/tracker/guarded-landing.ts
+++ b/src/tracker/guarded-landing.ts
@@ -15,7 +15,7 @@ export interface GuardedLandingSnapshot {
   readonly failingCheckNames: readonly string[];
   readonly botActionableReviewFeedback: PullRequestSnapshot["botActionableReviewFeedback"];
   readonly unresolvedReviewThreadCount: number;
-  readonly requiredApprovedReviewCoverage: PullRequestSnapshot["requiredApprovedReviewCoverage"];
+  readonly requiredReviewerState: PullRequestSnapshot["requiredReviewerState"];
 }
 
 // Fail closed: GitHub can report "unstable" when only non-required checks fail,
@@ -126,12 +126,21 @@ export function evaluateGuardedLanding(
     };
   }
 
-  if (snapshot.requiredApprovedReviewCoverage === "missing") {
+  if (snapshot.requiredReviewerState === "missing") {
     return {
       kind: "blocked",
       reason: "required-bot-review-missing",
       lifecycleKind: "degraded-review-infrastructure",
       summary: `Landing blocked for ${formatPullRequest(snapshot)} because expected reviewer-app output has not been observed on the current head and external review coverage is degraded.`,
+    };
+  }
+
+  if (snapshot.requiredReviewerState === "unknown") {
+    return {
+      kind: "blocked",
+      reason: "required-reviewer-verdict-unknown",
+      lifecycleKind: "degraded-review-infrastructure",
+      summary: `Landing blocked for ${formatPullRequest(snapshot)} because required reviewer-app output on the current head did not produce an explicit pass verdict.`,
     };
   }
 

--- a/src/tracker/pull-request-policy.ts
+++ b/src/tracker/pull-request-policy.ts
@@ -146,6 +146,23 @@ export function evaluatePullRequestLifecycle(
     };
   }
 
+  if (snapshot.requiredReviewerState === "running") {
+    return {
+      lifecycle: {
+        kind: "awaiting-system-checks",
+        branchName: snapshot.branchName,
+        pullRequest: snapshot.pullRequest,
+        checks: snapshot.checks,
+        pendingCheckNames: snapshot.pendingCheckNames,
+        failingCheckNames: snapshot.failingCheckNames,
+        actionableReviewFeedback: snapshot.actionableReviewFeedback,
+        unresolvedThreadIds: [],
+        summary: `Waiting for reviewer apps to finish on ${snapshot.pullRequest.url}`,
+      },
+      nextNoCheckObservation: null,
+    };
+  }
+
   if (snapshot.actionableReviewFeedback.length > 0) {
     return {
       lifecycle: {
@@ -190,7 +207,7 @@ export function evaluatePullRequestLifecycle(
     }
   }
 
-  if (snapshot.requiredApprovedReviewCoverage === "missing") {
+  if (snapshot.requiredReviewerState === "missing") {
     return {
       lifecycle: {
         kind: "degraded-review-infrastructure",
@@ -202,6 +219,23 @@ export function evaluatePullRequestLifecycle(
         actionableReviewFeedback: [],
         unresolvedThreadIds: [],
         summary: `Degraded external review infrastructure for ${snapshot.pullRequest.url}; expected reviewer-app output has not been observed on the current head.`,
+      },
+      nextNoCheckObservation: previousNoCheckObservation ?? null,
+    };
+  }
+
+  if (snapshot.requiredReviewerState === "unknown") {
+    return {
+      lifecycle: {
+        kind: "degraded-review-infrastructure",
+        branchName: snapshot.branchName,
+        pullRequest: snapshot.pullRequest,
+        checks: snapshot.checks,
+        pendingCheckNames: snapshot.pendingCheckNames,
+        failingCheckNames: snapshot.failingCheckNames,
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        summary: `Degraded external review infrastructure for ${snapshot.pullRequest.url}; required reviewer-app output was observed on the current head but no explicit pass verdict was normalized.`,
       },
       nextNoCheckObservation: previousNoCheckObservation ?? null,
     };

--- a/src/tracker/pull-request-snapshot.ts
+++ b/src/tracker/pull-request-snapshot.ts
@@ -4,11 +4,21 @@ import type {
   PullRequestHandle,
   ReviewFeedback,
 } from "../domain/pull-request.js";
+import type { GitHubReviewerAppConfig } from "../domain/workflow.js";
 import type {
   GitHubPullRequestResponse,
   PullRequestReviewState,
 } from "./github-client.js";
 import { parseLandingCommandSignal } from "./landing-command-signal.js";
+import {
+  createReviewerAppSnapshots,
+  evaluateRequiredReviewerState,
+  getConfiguredReviewerAppLogins,
+  type CurrentHeadIssueComment,
+  type CurrentHeadPullRequestReview,
+  type RequiredReviewerState,
+} from "./reviewer-apps.js";
+import type { ReviewerAppSnapshot } from "./reviewer-app-types.js";
 
 export interface PullRequestSnapshot {
   readonly branchName: string;
@@ -21,11 +31,9 @@ export interface PullRequestSnapshot {
   readonly actionableReviewFeedback: readonly ReviewFeedback[];
   readonly botActionableReviewFeedback: readonly ReviewFeedback[];
   readonly unresolvedThreadIds: readonly string[];
-  readonly requiredApprovedReviewCoverage:
-    | "not-required"
-    | "satisfied"
-    | "missing";
-  readonly observedApprovedReviewBotLogins: readonly string[];
+  readonly reviewerApps: readonly ReviewerAppSnapshot[];
+  readonly requiredReviewerState: RequiredReviewerState;
+  readonly observedReviewerKeys: readonly string[];
 }
 
 function isAfter(left: string, right: string | null): boolean {
@@ -35,90 +43,22 @@ function isAfter(left: string, right: string | null): boolean {
   return Date.parse(left) > Date.parse(right);
 }
 
-const NON_ACTIONABLE_BOT_COMMENT_MARKERS = {
-  // Keep these in sync with the summary comment templates emitted by known bots.
-  cursorSummary: "<!-- CURSOR_SUMMARY -->",
-  cursorTakingALook: /^Taking a look!\s*/i,
-  cursorAgentLinks:
-    /cursor\.com\/(agents\/|background-agent\?|assets\/images\/open-in-(web|cursor))/i,
-  greptileSummaryHeading: /<h3\b[^>]*>\s*Greptile Summary\s*<\/h3>/i,
-} as const;
-
-const APPROVED_REVIEW_BOT_STATUS_CONTEXTS: Readonly<
-  Record<string, readonly string[]>
-> = {
-  "devin-ai-integration": ["Devin Review"],
-  "greptile-apps": ["Greptile Review"],
-  "greptile[bot]": ["Greptile Review"],
-  cursor: ["Cursor Bugbot"],
-  "cursor[bot]": ["Cursor Bugbot"],
-  "bugbot[bot]": ["Cursor Bugbot"],
-} as const;
-
-function isActionableBotReviewComment(body: string): boolean {
-  const normalized = body.trim();
-  return (
-    normalized.length > 0 &&
-    !normalized.includes(NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorSummary) &&
-    !(
-      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorTakingALook.test(normalized) &&
-      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorAgentLinks.test(normalized)
-    ) &&
-    !NON_ACTIONABLE_BOT_COMMENT_MARKERS.greptileSummaryHeading.test(normalized)
-  );
-}
-
-function isQualifyingApprovedReviewBody(body: string): boolean {
-  const normalized = body.trim();
-  return (
-    normalized.length > 0 &&
-    !normalized.includes(NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorSummary) &&
-    !(
-      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorTakingALook.test(normalized) &&
-      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorAgentLinks.test(normalized)
-    )
-  );
-}
-
 function isHumanLandingApprover(
   authorLogin: string | null,
   authorAssociation: string,
-  reviewBotLogins: ReadonlySet<string>,
+  reviewerAppLogins: ReadonlySet<string>,
 ): boolean {
   if (authorLogin === null) {
     return false;
   }
   const normalized = authorLogin.toLowerCase();
   return (
-    !reviewBotLogins.has(normalized) &&
+    !reviewerAppLogins.has(normalized) &&
     !normalized.endsWith("[bot]") &&
     (authorAssociation === "OWNER" ||
       authorAssociation === "MEMBER" ||
       authorAssociation === "COLLABORATOR")
   );
-}
-
-function observedApprovedReviewBotLoginsFromChecks(
-  checks: readonly PullRequestCheck[],
-  approvedReviewBotLogins: ReadonlySet<string>,
-): readonly string[] {
-  if (approvedReviewBotLogins.size === 0) {
-    return [];
-  }
-
-  const successfulCheckNames = new Set(
-    checks
-      .filter((check) => check.status === "success")
-      .map((check) => check.name),
-  );
-
-  return [...approvedReviewBotLogins].filter((login) => {
-    const statusContexts = APPROVED_REVIEW_BOT_STATUS_CONTEXTS[login];
-    return (
-      statusContexts !== undefined &&
-      statusContexts.some((context) => successfulCheckNames.has(context))
-    );
-  });
 }
 
 export function createPullRequestSnapshot(input: {
@@ -128,15 +68,15 @@ export function createPullRequestSnapshot(input: {
   reviewState: PullRequestReviewState;
   reviewBotLogins: readonly string[];
   approvedReviewBotLogins?: readonly string[] | undefined;
+  reviewerApps?: readonly GitHubReviewerAppConfig[] | undefined;
 }): PullRequestSnapshot {
   const latestCommitAt =
     input.reviewState.commits.nodes[0]?.commit.committedDate ?? null;
-  const reviewBotLogins = new Set(
-    input.reviewBotLogins.map((login) => login.toLowerCase()),
-  );
-  const approvedReviewBotLogins = new Set(
-    (input.approvedReviewBotLogins ?? []).map((login) => login.toLowerCase()),
-  );
+  const reviewerAppLogins = getConfiguredReviewerAppLogins({
+    reviewBotLogins: input.reviewBotLogins,
+    approvedReviewBotLogins: input.approvedReviewBotLogins ?? [],
+    reviewerApps: input.reviewerApps ?? [],
+  });
 
   const unresolvedThreads = input.reviewState.reviewThreads.nodes
     .filter((thread) => !thread.isResolved && !thread.isOutdated)
@@ -162,60 +102,63 @@ export function createPullRequestSnapshot(input: {
       };
       return feedback;
     });
-
-  const actionableBotComments =
-    reviewBotLogins.size === 0
-      ? []
-      : input.reviewState.comments.nodes
-          .filter((comment) => {
-            const authorLogin = comment.author?.login;
-            return (
-              typeof authorLogin === "string" &&
-              reviewBotLogins.has(authorLogin.toLowerCase())
-            );
-          })
-          .filter((comment) => isActionableBotReviewComment(comment.body))
-          .filter((comment) => isAfter(comment.createdAt, latestCommitAt))
-          .map<ReviewFeedback>((comment) => ({
-            id: comment.id,
-            kind: "issue-comment",
-            threadId: null,
-            authorLogin: comment.author?.login ?? null,
-            body: comment.body,
-            createdAt: comment.createdAt,
-            url: comment.url,
-            path: null,
-            line: null,
-          }));
+  const currentHeadIssueComments: CurrentHeadIssueComment[] =
+    input.reviewState.comments.nodes
+      .filter((comment) => isAfter(comment.createdAt, latestCommitAt))
+      .map((comment) => ({
+        id: comment.id,
+        authorLogin: comment.author?.login ?? null,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        url: comment.url,
+        authorAssociation: comment.authorAssociation,
+      }));
+  const currentHeadPullRequestReviews: CurrentHeadPullRequestReview[] = (
+    input.reviewState.reviews?.nodes ?? []
+  )
+    .filter((review) => isAfter(review.submittedAt, latestCommitAt))
+    .map((review) => ({
+      id: review.id,
+      authorLogin: review.author?.login ?? null,
+      body: review.body,
+      submittedAt: review.submittedAt,
+      url: review.url,
+    }));
+  const reviewerApps = createReviewerAppSnapshots({
+    config: {
+      reviewBotLogins: input.reviewBotLogins,
+      approvedReviewBotLogins: input.approvedReviewBotLogins ?? [],
+      reviewerApps: input.reviewerApps ?? [],
+    },
+    checks: input.checks,
+    currentHeadIssueComments,
+    currentHeadPullRequestReviews,
+    unresolvedReviewThreads: unresolvedThreads,
+  });
 
   const hasLandingCommand =
     latestCommitAt !== null &&
-    input.reviewState.comments.nodes.some((comment) => {
-      const authorLogin = comment.author?.login ?? null;
+    currentHeadIssueComments.some((comment) => {
       return (
         isHumanLandingApprover(
-          authorLogin,
+          comment.authorLogin,
           comment.authorAssociation,
-          reviewBotLogins,
-        ) &&
-        isAfter(comment.createdAt, latestCommitAt) &&
-        parseLandingCommandSignal(comment.body)
+          reviewerAppLogins,
+        ) && parseLandingCommandSignal(comment.body)
       );
     });
-
-  const actionableReviewFeedback = [
-    ...unresolvedThreads,
-    ...actionableBotComments,
-  ];
-  const botActionableReviewFeedback = actionableReviewFeedback.filter(
-    (feedback) => {
-      const authorLogin = feedback.authorLogin;
-      return (
-        typeof authorLogin === "string" &&
-        reviewBotLogins.has(authorLogin.toLowerCase())
-      );
-    },
+  const botActionableReviewFeedback = reviewerApps
+    .filter((reviewer) => reviewer.accepted)
+    .flatMap((reviewer) => reviewer.actionableFeedback);
+  const botActionableFeedbackIds = new Set(
+    botActionableReviewFeedback.map((feedback) => feedback.id),
   );
+  const actionableReviewFeedback = [
+    ...unresolvedThreads.filter(
+      (feedback) => !botActionableFeedbackIds.has(feedback.id),
+    ),
+    ...botActionableReviewFeedback,
+  ];
 
   const pendingCheckNames = input.checks
     .filter((check) => check.status === "pending")
@@ -227,60 +170,10 @@ export function createPullRequestSnapshot(input: {
     .filter((feedback) => feedback.kind === "review-thread")
     .map((feedback) => feedback.threadId)
     .filter((threadId): threadId is string => threadId !== null);
-  const observedApprovedReviewBotLogins =
-    approvedReviewBotLogins.size === 0
-      ? []
-      : [
-          ...new Set(
-            [
-              ...input.reviewState.comments.nodes
-                .filter((comment) => {
-                  const authorLogin = comment.author?.login;
-                  return (
-                    typeof authorLogin === "string" &&
-                    approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
-                    isQualifyingApprovedReviewBody(comment.body) &&
-                    isAfter(comment.createdAt, latestCommitAt)
-                  );
-                })
-                .map((comment) => comment.author!.login),
-              ...input.reviewState.reviewThreads.nodes
-                .map((thread) => thread.originComments.nodes[0])
-                .filter((comment) => comment !== undefined)
-                .filter((comment) => {
-                  const authorLogin = comment.author?.login;
-                  return (
-                    typeof authorLogin === "string" &&
-                    approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
-                    isQualifyingApprovedReviewBody(comment.body) &&
-                    isAfter(comment.createdAt, latestCommitAt)
-                  );
-                })
-                .map((comment) => comment.author!.login),
-              ...(input.reviewState.reviews?.nodes ?? [])
-                .filter((review) => {
-                  const authorLogin = review.author?.login;
-                  return (
-                    typeof authorLogin === "string" &&
-                    approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
-                    isQualifyingApprovedReviewBody(review.body) &&
-                    isAfter(review.submittedAt, latestCommitAt)
-                  );
-                })
-                .map((review) => review.author!.login),
-              ...observedApprovedReviewBotLoginsFromChecks(
-                input.checks,
-                approvedReviewBotLogins,
-              ),
-            ].map((login) => login.toLowerCase()),
-          ),
-        ];
-  const requiredApprovedReviewCoverage =
-    approvedReviewBotLogins.size === 0
-      ? "not-required"
-      : observedApprovedReviewBotLogins.length > 0
-        ? "satisfied"
-        : "missing";
+  const requiredReviewerState = evaluateRequiredReviewerState(reviewerApps);
+  const observedReviewerKeys = reviewerApps
+    .filter((reviewer) => reviewer.coverage === "observed")
+    .map((reviewer) => reviewer.reviewerKey);
 
   return {
     branchName: input.branchName,
@@ -299,7 +192,8 @@ export function createPullRequestSnapshot(input: {
     actionableReviewFeedback,
     botActionableReviewFeedback,
     unresolvedThreadIds,
-    requiredApprovedReviewCoverage,
-    observedApprovedReviewBotLogins,
+    reviewerApps,
+    requiredReviewerState,
+    observedReviewerKeys,
   };
 }

--- a/src/tracker/reviewer-app-devin.ts
+++ b/src/tracker/reviewer-app-devin.ts
@@ -168,7 +168,7 @@ export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
         : (latestArtifact?.verdict ?? "unknown");
     const actionableFeedback = [
       ...unresolvedThreads,
-      ...(verdict === "issues-found" && latestArtifact !== null
+      ...(latestArtifact !== null && latestArtifact.verdict === "issues-found"
         ? [latestArtifact.feedback]
         : []),
     ];

--- a/src/tracker/reviewer-app-devin.ts
+++ b/src/tracker/reviewer-app-devin.ts
@@ -66,6 +66,10 @@ function createPullRequestReviewFeedback(
   };
 }
 
+function isDevinAuthoredFeedback(feedback: ReviewFeedback): boolean {
+  return feedback.authorLogin?.toLowerCase() === DEVIN_LOGIN;
+}
+
 function latestRecognizedArtifact(
   comments: readonly CurrentHeadIssueComment[],
   reviews: readonly CurrentHeadPullRequestReview[],
@@ -128,6 +132,9 @@ export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
     config: GitHubReviewerAppConfig,
     input: ReviewerAppAdapterInput,
   ): ReviewerAppSnapshot {
+    const unresolvedThreads = input.unresolvedReviewThreads.filter(
+      isDevinAuthoredFeedback,
+    );
     const comments = input.currentHeadIssueComments.filter(
       (comment) => comment.authorLogin?.toLowerCase() === DEVIN_LOGIN,
     );
@@ -140,6 +147,7 @@ export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
       hasMatchingCheck(input.checks, "success") ||
       hasMatchingCheck(input.checks, "failure");
     const coverage =
+      unresolvedThreads.length > 0 ||
       comments.length > 0 ||
       reviews.length > 0 ||
       hasRunningCheck ||
@@ -148,14 +156,22 @@ export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
         : "missing";
     const status = hasRunningCheck
       ? "running"
-      : comments.length > 0 || reviews.length > 0 || hasCompletedCheck
+      : unresolvedThreads.length > 0 ||
+          comments.length > 0 ||
+          reviews.length > 0 ||
+          hasCompletedCheck
         ? "completed"
         : "unknown";
-    const verdict = latestArtifact?.verdict ?? "unknown";
-    const actionableFeedback =
-      verdict === "issues-found" && latestArtifact !== null
+    const verdict =
+      unresolvedThreads.length > 0
+        ? "issues-found"
+        : (latestArtifact?.verdict ?? "unknown");
+    const actionableFeedback = [
+      ...unresolvedThreads,
+      ...(verdict === "issues-found" && latestArtifact !== null
         ? [latestArtifact.feedback]
-        : [];
+        : []),
+    ];
 
     return {
       reviewerKey: config.key,
@@ -189,6 +205,13 @@ export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
           createdAt: review.submittedAt,
           url: review.url,
           summary: summarizeBody(review.body),
+        })),
+        ...unresolvedThreads.map((thread) => ({
+          id: thread.id,
+          kind: "review-thread" as const,
+          createdAt: thread.createdAt,
+          url: thread.url,
+          summary: summarizeBody(thread.body),
         })),
       ],
     };

--- a/src/tracker/reviewer-app-devin.ts
+++ b/src/tracker/reviewer-app-devin.ts
@@ -1,0 +1,196 @@
+import type { GitHubReviewerAppConfig } from "../domain/workflow.js";
+import type {
+  PullRequestCheck,
+  ReviewFeedback,
+} from "../domain/pull-request.js";
+import type { ReviewerAppSnapshot } from "./reviewer-app-types.js";
+import type {
+  CurrentHeadIssueComment,
+  CurrentHeadPullRequestReview,
+  GitHubReviewerAppAdapter,
+  ReviewerAppAdapterInput,
+} from "./reviewer-apps.js";
+
+const DEVIN_LOGIN = "devin-ai-integration";
+const DEVIN_CHECK_NAME = "Devin Review";
+
+function summarizeBody(body: string): string {
+  const normalized = body.trim().replace(/\s+/gu, " ");
+  return normalized.length <= 120
+    ? normalized
+    : `${normalized.slice(0, 117)}...`;
+}
+
+function parseDevinVerdict(body: string): "pass" | "issues-found" | "unknown" {
+  if (/devin review:?\s*no issues found/i.test(body)) {
+    return "pass";
+  }
+  if (
+    /devin review:?.*found\s+\d+\s+potential issues/i.test(body) ||
+    /devin review:?.*issues found/i.test(body)
+  ) {
+    return "issues-found";
+  }
+  return "unknown";
+}
+
+function createIssueCommentFeedback(
+  comment: CurrentHeadIssueComment,
+): ReviewFeedback {
+  return {
+    id: comment.id,
+    kind: "issue-comment",
+    threadId: null,
+    authorLogin: comment.authorLogin,
+    body: comment.body,
+    createdAt: comment.createdAt,
+    url: comment.url,
+    path: null,
+    line: null,
+  };
+}
+
+function createPullRequestReviewFeedback(
+  review: CurrentHeadPullRequestReview,
+): ReviewFeedback {
+  return {
+    id: review.id,
+    kind: "pull-request-review",
+    threadId: null,
+    authorLogin: review.authorLogin,
+    body: review.body,
+    createdAt: review.submittedAt,
+    url: review.url,
+    path: null,
+    line: null,
+  };
+}
+
+function latestRecognizedArtifact(
+  comments: readonly CurrentHeadIssueComment[],
+  reviews: readonly CurrentHeadPullRequestReview[],
+): {
+  readonly createdAt: string;
+  readonly verdict: "pass" | "issues-found";
+  readonly feedback: ReviewFeedback;
+} | null {
+  const recognized = [
+    ...comments
+      .map((comment) => ({
+        createdAt: comment.createdAt,
+        verdict: parseDevinVerdict(comment.body),
+        feedback: createIssueCommentFeedback(comment),
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          readonly createdAt: string;
+          readonly verdict: "pass" | "issues-found";
+          readonly feedback: ReviewFeedback;
+        } => entry.verdict !== "unknown",
+      ),
+    ...reviews
+      .map((review) => ({
+        createdAt: review.submittedAt,
+        verdict: parseDevinVerdict(review.body),
+        feedback: createPullRequestReviewFeedback(review),
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          readonly createdAt: string;
+          readonly verdict: "pass" | "issues-found";
+          readonly feedback: ReviewFeedback;
+        } => entry.verdict !== "unknown",
+      ),
+  ].sort(
+    (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
+  );
+
+  return recognized[0] ?? null;
+}
+
+function hasMatchingCheck(
+  checks: readonly PullRequestCheck[],
+  status: PullRequestCheck["status"],
+): boolean {
+  return checks.some(
+    (check) => check.name === DEVIN_CHECK_NAME && check.status === status,
+  );
+}
+
+export const devinReviewerAppAdapter: GitHubReviewerAppAdapter = {
+  key: "devin",
+  handledLogins: [DEVIN_LOGIN],
+  evaluate(
+    config: GitHubReviewerAppConfig,
+    input: ReviewerAppAdapterInput,
+  ): ReviewerAppSnapshot {
+    const comments = input.currentHeadIssueComments.filter(
+      (comment) => comment.authorLogin?.toLowerCase() === DEVIN_LOGIN,
+    );
+    const reviews = input.currentHeadPullRequestReviews.filter(
+      (review) => review.authorLogin?.toLowerCase() === DEVIN_LOGIN,
+    );
+    const latestArtifact = latestRecognizedArtifact(comments, reviews);
+    const hasRunningCheck = hasMatchingCheck(input.checks, "pending");
+    const hasCompletedCheck =
+      hasMatchingCheck(input.checks, "success") ||
+      hasMatchingCheck(input.checks, "failure");
+    const coverage =
+      comments.length > 0 ||
+      reviews.length > 0 ||
+      hasRunningCheck ||
+      hasCompletedCheck
+        ? "observed"
+        : "missing";
+    const status = hasRunningCheck
+      ? "running"
+      : comments.length > 0 || reviews.length > 0 || hasCompletedCheck
+        ? "completed"
+        : "unknown";
+    const verdict = latestArtifact?.verdict ?? "unknown";
+    const actionableFeedback =
+      verdict === "issues-found" && latestArtifact !== null
+        ? [latestArtifact.feedback]
+        : [];
+
+    return {
+      reviewerKey: config.key,
+      accepted: config.accepted,
+      required: config.required,
+      coverage,
+      status,
+      verdict,
+      actionableFeedback,
+      unresolvedFeedbackIds: actionableFeedback.map((feedback) => feedback.id),
+      evidence: [
+        ...input.checks
+          .filter((check) => check.name === DEVIN_CHECK_NAME)
+          .map((check) => ({
+            id: `check:${check.name}:${check.status}`,
+            kind: "check" as const,
+            createdAt: null,
+            url: check.detailsUrl,
+            summary: `${check.name} is ${check.status}`,
+          })),
+        ...comments.map((comment) => ({
+          id: comment.id,
+          kind: "issue-comment" as const,
+          createdAt: comment.createdAt,
+          url: comment.url,
+          summary: summarizeBody(comment.body),
+        })),
+        ...reviews.map((review) => ({
+          id: review.id,
+          kind: "pull-request-review" as const,
+          createdAt: review.submittedAt,
+          url: review.url,
+          summary: summarizeBody(review.body),
+        })),
+      ],
+    };
+  },
+};

--- a/src/tracker/reviewer-app-legacy.ts
+++ b/src/tracker/reviewer-app-legacy.ts
@@ -1,0 +1,257 @@
+import type { ReviewFeedback } from "../domain/pull-request.js";
+import type { ReviewerAppSnapshot } from "./reviewer-app-types.js";
+import type { PullRequestCheck } from "../domain/pull-request.js";
+
+const NON_ACTIONABLE_BOT_COMMENT_MARKERS = {
+  cursorSummary: "<!-- CURSOR_SUMMARY -->",
+  cursorTakingALook: /^Taking a look!\s*/i,
+  cursorAgentLinks:
+    /cursor\.com\/(agents\/|background-agent\?|assets\/images\/open-in-(web|cursor))/i,
+  greptileSummaryHeading: /<h3\b[^>]*>\s*Greptile Summary\s*<\/h3>/i,
+} as const;
+
+const APPROVED_REVIEW_BOT_STATUS_CONTEXTS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "greptile-apps": ["Greptile Review"],
+  "greptile[bot]": ["Greptile Review"],
+  cursor: ["Cursor Bugbot"],
+  "cursor[bot]": ["Cursor Bugbot"],
+  "bugbot[bot]": ["Cursor Bugbot"],
+} as const;
+
+function summarizeBody(body: string): string {
+  const normalized = body.trim().replace(/\s+/gu, " ");
+  return normalized.length <= 120
+    ? normalized
+    : `${normalized.slice(0, 117)}...`;
+}
+
+function isQualifyingApprovedReviewBody(body: string): boolean {
+  const normalized = body.trim();
+  return (
+    normalized.length > 0 &&
+    !normalized.includes(NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorSummary) &&
+    !(
+      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorTakingALook.test(normalized) &&
+      NON_ACTIONABLE_BOT_COMMENT_MARKERS.cursorAgentLinks.test(normalized)
+    )
+  );
+}
+
+function observedApprovedReviewBotLoginsFromChecks(
+  checks: readonly PullRequestCheck[],
+  approvedReviewBotLogins: ReadonlySet<string>,
+): readonly string[] {
+  const successfulCheckNames = new Set(
+    checks
+      .filter((check) => check.status === "success")
+      .map((check) => check.name),
+  );
+
+  return [...approvedReviewBotLogins].filter((login) => {
+    const statusContexts = APPROVED_REVIEW_BOT_STATUS_CONTEXTS[login];
+    return (
+      statusContexts !== undefined &&
+      statusContexts.some((context) => successfulCheckNames.has(context))
+    );
+  });
+}
+
+function hasPendingApprovedReviewCheck(
+  checks: readonly PullRequestCheck[],
+  approvedReviewBotLogins: ReadonlySet<string>,
+): boolean {
+  const pendingCheckNames = new Set(
+    checks
+      .filter((check) => check.status === "pending")
+      .map((check) => check.name),
+  );
+
+  return [...approvedReviewBotLogins].some((login) => {
+    const statusContexts = APPROVED_REVIEW_BOT_STATUS_CONTEXTS[login];
+    return (
+      statusContexts !== undefined &&
+      statusContexts.some((context) => pendingCheckNames.has(context))
+    );
+  });
+}
+
+export function createLegacyReviewerAppSnapshot(input: {
+  reviewBotLogins: readonly string[];
+  approvedReviewBotLogins: readonly string[];
+  checks: readonly PullRequestCheck[];
+  currentHeadIssueComments: readonly {
+    readonly id: string;
+    readonly authorLogin: string | null;
+    readonly body: string;
+    readonly createdAt: string;
+    readonly url: string;
+  }[];
+  currentHeadPullRequestReviews: readonly {
+    readonly id: string;
+    readonly authorLogin: string | null;
+    readonly body: string;
+    readonly submittedAt: string;
+    readonly url: string;
+  }[];
+  unresolvedReviewThreads: readonly ReviewFeedback[];
+}): ReviewerAppSnapshot | null {
+  if (
+    input.reviewBotLogins.length === 0 &&
+    input.approvedReviewBotLogins.length === 0
+  ) {
+    return null;
+  }
+
+  const reviewBotLogins = new Set(
+    input.reviewBotLogins.map((login) => login.toLowerCase()),
+  );
+  const approvedReviewBotLogins = new Set(
+    input.approvedReviewBotLogins.map((login) => login.toLowerCase()),
+  );
+  const actionableFeedback = [
+    ...input.unresolvedReviewThreads.filter((feedback) => {
+      const authorLogin = feedback.authorLogin;
+      return (
+        typeof authorLogin === "string" &&
+        reviewBotLogins.has(authorLogin.toLowerCase())
+      );
+    }),
+    ...input.currentHeadIssueComments
+      .filter((comment) => {
+        const authorLogin = comment.authorLogin;
+        return (
+          typeof authorLogin === "string" &&
+          reviewBotLogins.has(authorLogin.toLowerCase()) &&
+          isQualifyingApprovedReviewBody(comment.body) &&
+          !NON_ACTIONABLE_BOT_COMMENT_MARKERS.greptileSummaryHeading.test(
+            comment.body.trim(),
+          )
+        );
+      })
+      .map<ReviewFeedback>((comment) => ({
+        id: comment.id,
+        kind: "issue-comment",
+        threadId: null,
+        authorLogin: comment.authorLogin,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        url: comment.url,
+        path: null,
+        line: null,
+      })),
+  ];
+  const observedApprovedReviewBotLogins = [
+    ...new Set([
+      ...input.currentHeadIssueComments
+        .filter((comment) => {
+          const authorLogin = comment.authorLogin;
+          return (
+            typeof authorLogin === "string" &&
+            approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
+            isQualifyingApprovedReviewBody(comment.body)
+          );
+        })
+        .map((comment) => comment.authorLogin!.toLowerCase()),
+      ...input.currentHeadPullRequestReviews
+        .filter((review) => {
+          const authorLogin = review.authorLogin;
+          return (
+            typeof authorLogin === "string" &&
+            approvedReviewBotLogins.has(authorLogin.toLowerCase()) &&
+            isQualifyingApprovedReviewBody(review.body)
+          );
+        })
+        .map((review) => review.authorLogin!.toLowerCase()),
+      ...observedApprovedReviewBotLoginsFromChecks(
+        input.checks,
+        approvedReviewBotLogins,
+      ),
+    ]),
+  ];
+  const hasPendingApprovedReview =
+    approvedReviewBotLogins.size > 0 &&
+    hasPendingApprovedReviewCheck(input.checks, approvedReviewBotLogins);
+  const coverage =
+    observedApprovedReviewBotLogins.length > 0 || actionableFeedback.length > 0
+      ? "observed"
+      : "missing";
+  const status = hasPendingApprovedReview
+    ? "running"
+    : coverage === "observed"
+      ? "completed"
+      : "unknown";
+  const verdict =
+    actionableFeedback.length > 0
+      ? "issues-found"
+      : observedApprovedReviewBotLogins.length > 0
+        ? "pass"
+        : "unknown";
+
+  return {
+    reviewerKey: "legacy-bot-review",
+    accepted: reviewBotLogins.size > 0,
+    required: approvedReviewBotLogins.size > 0,
+    coverage,
+    status,
+    verdict,
+    actionableFeedback,
+    unresolvedFeedbackIds: actionableFeedback.map((feedback) => feedback.id),
+    evidence: [
+      ...actionableFeedback.map((feedback) => ({
+        id: feedback.id,
+        kind: feedback.kind,
+        createdAt: feedback.createdAt,
+        url: feedback.url,
+        summary: summarizeBody(feedback.body),
+      })),
+      ...input.checks
+        .filter((check) =>
+          [...approvedReviewBotLogins].some((login) =>
+            (APPROVED_REVIEW_BOT_STATUS_CONTEXTS[login] ?? []).includes(
+              check.name,
+            ),
+          ),
+        )
+        .map((check) => ({
+          id: `check:${check.name}:${check.status}`,
+          kind: "check" as const,
+          createdAt: null,
+          url: check.detailsUrl,
+          summary: `${check.name} is ${check.status}`,
+        })),
+      ...input.currentHeadIssueComments
+        .filter((comment) => {
+          const authorLogin = comment.authorLogin;
+          return (
+            typeof authorLogin === "string" &&
+            (reviewBotLogins.has(authorLogin.toLowerCase()) ||
+              approvedReviewBotLogins.has(authorLogin.toLowerCase()))
+          );
+        })
+        .map((comment) => ({
+          id: comment.id,
+          kind: "issue-comment" as const,
+          createdAt: comment.createdAt,
+          url: comment.url,
+          summary: summarizeBody(comment.body),
+        })),
+      ...input.currentHeadPullRequestReviews
+        .filter((review) => {
+          const authorLogin = review.authorLogin;
+          return (
+            typeof authorLogin === "string" &&
+            approvedReviewBotLogins.has(authorLogin.toLowerCase())
+          );
+        })
+        .map((review) => ({
+          id: review.id,
+          kind: "pull-request-review" as const,
+          createdAt: review.submittedAt,
+          url: review.url,
+          summary: summarizeBody(review.body),
+        })),
+    ],
+  };
+}

--- a/src/tracker/reviewer-app-legacy.ts
+++ b/src/tracker/reviewer-app-legacy.ts
@@ -13,6 +13,7 @@ const NON_ACTIONABLE_BOT_COMMENT_MARKERS = {
 const APPROVED_REVIEW_BOT_STATUS_CONTEXTS: Readonly<
   Record<string, readonly string[]>
 > = {
+  "devin-ai-integration": ["Devin Review"],
   "greptile-apps": ["Greptile Review"],
   "greptile[bot]": ["Greptile Review"],
   cursor: ["Cursor Bugbot"],

--- a/src/tracker/reviewer-app-legacy.ts
+++ b/src/tracker/reviewer-app-legacy.ts
@@ -111,12 +111,17 @@ export function createLegacyReviewerAppSnapshot(input: {
   const approvedReviewBotLogins = new Set(
     input.approvedReviewBotLogins.map((login) => login.toLowerCase()),
   );
+  const acceptedBotLogins = new Set([
+    ...reviewBotLogins,
+    ...approvedReviewBotLogins,
+  ]);
+  const accepted = reviewBotLogins.size > 0 || approvedReviewBotLogins.size > 0;
   const actionableFeedback = [
     ...input.unresolvedReviewThreads.filter((feedback) => {
       const authorLogin = feedback.authorLogin;
       return (
         typeof authorLogin === "string" &&
-        reviewBotLogins.has(authorLogin.toLowerCase())
+        acceptedBotLogins.has(authorLogin.toLowerCase())
       );
     }),
     ...input.currentHeadIssueComments
@@ -124,7 +129,7 @@ export function createLegacyReviewerAppSnapshot(input: {
         const authorLogin = comment.authorLogin;
         return (
           typeof authorLogin === "string" &&
-          reviewBotLogins.has(authorLogin.toLowerCase()) &&
+          acceptedBotLogins.has(authorLogin.toLowerCase()) &&
           isQualifyingApprovedReviewBody(comment.body) &&
           !NON_ACTIONABLE_BOT_COMMENT_MARKERS.greptileSummaryHeading.test(
             comment.body.trim(),
@@ -192,7 +197,7 @@ export function createLegacyReviewerAppSnapshot(input: {
 
   return {
     reviewerKey: "legacy-bot-review",
-    accepted: reviewBotLogins.size > 0,
+    accepted,
     required: approvedReviewBotLogins.size > 0,
     coverage,
     status,

--- a/src/tracker/reviewer-app-types.ts
+++ b/src/tracker/reviewer-app-types.ts
@@ -1,0 +1,31 @@
+import type { ReviewFeedback } from "../domain/pull-request.js";
+
+export type ReviewerAppCoverage = "missing" | "observed";
+export type ReviewerAppStatus = "running" | "completed" | "unknown";
+export type ReviewerAppVerdict = "pass" | "issues-found" | "unknown";
+
+export type ReviewerAppEvidenceKind =
+  | "check"
+  | "issue-comment"
+  | "review-thread"
+  | "pull-request-review";
+
+export interface ReviewerAppEvidence {
+  readonly id: string;
+  readonly kind: ReviewerAppEvidenceKind;
+  readonly createdAt: string | null;
+  readonly url: string | null;
+  readonly summary: string;
+}
+
+export interface ReviewerAppSnapshot {
+  readonly reviewerKey: string;
+  readonly accepted: boolean;
+  readonly required: boolean;
+  readonly coverage: ReviewerAppCoverage;
+  readonly status: ReviewerAppStatus;
+  readonly verdict: ReviewerAppVerdict;
+  readonly actionableFeedback: readonly ReviewFeedback[];
+  readonly unresolvedFeedbackIds: readonly string[];
+  readonly evidence: readonly ReviewerAppEvidence[];
+}

--- a/src/tracker/reviewer-apps.ts
+++ b/src/tracker/reviewer-apps.ts
@@ -1,0 +1,148 @@
+import type {
+  ReviewFeedback,
+  PullRequestCheck,
+} from "../domain/pull-request.js";
+import type {
+  GitHubCompatibleTrackerConfig,
+  GitHubReviewerAppConfig,
+} from "../domain/workflow.js";
+import { devinReviewerAppAdapter } from "./reviewer-app-devin.js";
+import { createLegacyReviewerAppSnapshot } from "./reviewer-app-legacy.js";
+import type { ReviewerAppSnapshot } from "./reviewer-app-types.js";
+
+export interface CurrentHeadIssueComment {
+  readonly id: string;
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly url: string;
+  readonly authorAssociation: string;
+}
+
+export interface CurrentHeadPullRequestReview {
+  readonly id: string;
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly submittedAt: string;
+  readonly url: string;
+}
+
+export interface ReviewerAppAdapterInput {
+  readonly checks: readonly PullRequestCheck[];
+  readonly currentHeadIssueComments: readonly CurrentHeadIssueComment[];
+  readonly currentHeadPullRequestReviews: readonly CurrentHeadPullRequestReview[];
+  readonly unresolvedReviewThreads: readonly ReviewFeedback[];
+}
+
+export interface GitHubReviewerAppAdapter {
+  readonly key: string;
+  readonly handledLogins: readonly string[];
+  evaluate(
+    config: GitHubReviewerAppConfig,
+    input: ReviewerAppAdapterInput,
+  ): ReviewerAppSnapshot;
+}
+
+const REVIEWER_APP_ADAPTERS = new Map<string, GitHubReviewerAppAdapter>([
+  [devinReviewerAppAdapter.key, devinReviewerAppAdapter],
+]);
+
+export type RequiredReviewerState =
+  | "not-required"
+  | "running"
+  | "missing"
+  | "unknown"
+  | "satisfied";
+
+export function getConfiguredReviewerAppLogins(
+  config: Pick<
+    GitHubCompatibleTrackerConfig,
+    "reviewBotLogins" | "approvedReviewBotLogins" | "reviewerApps"
+  >,
+): ReadonlySet<string> {
+  const logins = new Set<string>();
+  for (const login of config.reviewBotLogins) {
+    logins.add(login.toLowerCase());
+  }
+  for (const login of config.approvedReviewBotLogins ?? []) {
+    logins.add(login.toLowerCase());
+  }
+  for (const reviewerApp of config.reviewerApps ?? []) {
+    const adapter = REVIEWER_APP_ADAPTERS.get(reviewerApp.key);
+    for (const login of adapter?.handledLogins ?? []) {
+      logins.add(login.toLowerCase());
+    }
+  }
+  return logins;
+}
+
+export function evaluateRequiredReviewerState(
+  reviewerApps: readonly ReviewerAppSnapshot[],
+): RequiredReviewerState {
+  const requiredReviewerApps = reviewerApps.filter(
+    (reviewer) => reviewer.required,
+  );
+  if (requiredReviewerApps.length === 0) {
+    return "not-required";
+  }
+  if (requiredReviewerApps.some((reviewer) => reviewer.status === "running")) {
+    return "running";
+  }
+  if (
+    requiredReviewerApps.some((reviewer) => reviewer.coverage === "missing")
+  ) {
+    return "missing";
+  }
+  if (requiredReviewerApps.some((reviewer) => reviewer.verdict !== "pass")) {
+    return "unknown";
+  }
+  return "satisfied";
+}
+
+export function createReviewerAppSnapshots(input: {
+  config: Pick<
+    GitHubCompatibleTrackerConfig,
+    "reviewBotLogins" | "approvedReviewBotLogins" | "reviewerApps"
+  >;
+  checks: readonly PullRequestCheck[];
+  currentHeadIssueComments: readonly CurrentHeadIssueComment[];
+  currentHeadPullRequestReviews: readonly CurrentHeadPullRequestReview[];
+  unresolvedReviewThreads: readonly ReviewFeedback[];
+}): readonly ReviewerAppSnapshot[] {
+  const explicitReviewerApps = input.config.reviewerApps ?? [];
+  const handledLogins = new Set<string>();
+  const snapshots: ReviewerAppSnapshot[] = [];
+
+  for (const reviewerApp of explicitReviewerApps) {
+    const adapter = REVIEWER_APP_ADAPTERS.get(reviewerApp.key);
+    if (adapter === undefined) {
+      continue;
+    }
+    for (const login of adapter.handledLogins) {
+      handledLogins.add(login.toLowerCase());
+    }
+    snapshots.push(
+      adapter.evaluate(reviewerApp, {
+        checks: input.checks,
+        currentHeadIssueComments: input.currentHeadIssueComments,
+        currentHeadPullRequestReviews: input.currentHeadPullRequestReviews,
+        unresolvedReviewThreads: input.unresolvedReviewThreads,
+      }),
+    );
+  }
+
+  const legacySnapshot = createLegacyReviewerAppSnapshot({
+    reviewBotLogins: input.config.reviewBotLogins.filter(
+      (login) => !handledLogins.has(login.toLowerCase()),
+    ),
+    approvedReviewBotLogins: (
+      input.config.approvedReviewBotLogins ?? []
+    ).filter((login) => !handledLogins.has(login.toLowerCase())),
+    checks: input.checks,
+    currentHeadIssueComments: input.currentHeadIssueComments,
+    currentHeadPullRequestReviews: input.currentHeadPullRequestReviews,
+    unresolvedReviewThreads: input.unresolvedReviewThreads,
+  });
+
+  return legacySnapshot === null ? snapshots : [...snapshots, legacySnapshot];
+}

--- a/src/tracker/service.ts
+++ b/src/tracker/service.ts
@@ -8,6 +8,7 @@ export type LandingBlockedReason =
   | "checks-not-green"
   | "review-threads-unresolved"
   | "required-bot-review-missing"
+  | "required-reviewer-verdict-unknown"
   | "actionable-review-feedback"
   | "merge-request-refused";
 

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -78,6 +78,13 @@ async function writeWorkflow(options: {
       }
     | undefined;
   approvedReviewBotLogins?: readonly string[] | undefined;
+  reviewerApps?:
+    | readonly {
+        readonly key: string;
+        readonly accepted: boolean;
+        readonly required: boolean;
+      }[]
+    | undefined;
 }): Promise<string> {
   const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
   const workerHostsBlock =
@@ -139,6 +146,19 @@ ${
     ? ""
     : `  approved_review_bot_logins:
 ${options.approvedReviewBotLogins!.map((login) => `    - ${login}`).join("\n")}
+`
+}
+${
+  (options.reviewerApps ?? []).length === 0
+    ? ""
+    : `  reviewer_apps:
+${options
+  .reviewerApps!.map(
+    (reviewerApp) => `    ${reviewerApp.key}:
+      accepted: ${reviewerApp.accepted ? "true" : "false"}
+      required: ${reviewerApp.required ? "true" : "false"}`,
+  )
+  .join("\n")}
 `
 }
 polling:
@@ -1123,6 +1143,52 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       issueNumber: 207,
       status: "awaiting-landing-command",
     });
+  });
+
+  it("treats a Devin issues-found verdict as rework-required", async () => {
+    server.seedIssue({
+      number: 242,
+      title: "Normalize Devin reviewer verdicts",
+      body: "Do not treat explicit reviewer-app issues as landable.",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success-unique.sh"),
+      reviewerApps: [{ key: "devin", accepted: true, required: true }],
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/242", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestReview({
+      head: "symphony/242",
+      authorLogin: "devin-ai-integration",
+      body: "## Devin Review: Found 3 potential issues",
+      submittedAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    await orchestrator.runOnce();
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.activeIssues[0]).toMatchObject({
+      issueNumber: 242,
+      status: "rework-required",
+    });
+    expect(status.activeIssues[0]?.summary).toMatch(/rework required/i);
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      242,
+    );
+    expect(artifactSummary.currentOutcome).toBe("rework-required");
   });
 
   it("records landing-failed when the merge request throws before dispatch completes", async () => {

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -22,6 +22,11 @@ function createTracker(
     optionRankMap?: Readonly<Record<string, number>>;
   },
   approvedReviewBotLogins?: readonly string[],
+  reviewerApps?: readonly {
+    key: string;
+    accepted: boolean;
+    required: boolean;
+  }[],
 ): GitHubTracker {
   return new GitHubTracker(
     {
@@ -34,6 +39,7 @@ function createTracker(
       successComment: "done",
       reviewBotLogins: ["greptile[bot]", "bugbot[bot]"],
       approvedReviewBotLogins: approvedReviewBotLogins ?? [],
+      reviewerApps: reviewerApps ?? [],
       queuePriority,
     },
     logger,
@@ -1022,7 +1028,12 @@ describe("GitHubTracker", () => {
   });
 
   it("treats a clean top-level bot review as satisfying required approved bot review", async () => {
-    const tracker = createTracker(server, undefined, ["devin-ai-integration"]);
+    const tracker = createTracker(
+      server,
+      undefined,
+      [],
+      [{ key: "devin", accepted: true, required: true }],
+    );
 
     await server.recordPullRequest({
       title: "PR for issue 7",
@@ -1043,6 +1054,39 @@ describe("GitHubTracker", () => {
     const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
 
     expect(lifecycle.kind).toBe("awaiting-landing-command");
+  });
+
+  it("treats a Devin issues-found verdict as rework-required", async () => {
+    const tracker = createTracker(
+      server,
+      undefined,
+      [],
+      [{ key: "devin", accepted: true, required: true }],
+    );
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestReview({
+      head: "symphony/7",
+      authorLogin: "devin-ai-integration",
+      body: "## Devin Review: Found 2 potential issues",
+      submittedAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("rework-required");
+    expect(lifecycle.actionableReviewFeedback).toHaveLength(1);
+    expect(lifecycle.actionableReviewFeedback[0]?.kind).toBe(
+      "pull-request-review",
+    );
   });
 
   it("blocks guarded landing when required approved bot review is missing", async () => {

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -50,9 +50,11 @@ interface MockPullRequestComment {
 }
 
 interface MockPullRequestReview {
+  readonly id: string;
   readonly authorLogin: string | null;
   readonly body: string;
   readonly submittedAt: string;
+  readonly url: string;
 }
 
 interface MockReviewThread {
@@ -545,10 +547,13 @@ export class MockGitHubServer {
     submittedAt?: string;
   }): void {
     const pullRequest = this.#requirePullRequestByHead(input.head);
+    const reviewId = randomUUID();
     pullRequest.reviews.push({
+      id: reviewId,
       authorLogin: input.authorLogin,
       body: input.body,
       submittedAt: input.submittedAt ?? new Date().toISOString(),
+      url: `${pullRequest.html_url}#pullrequestreview-${reviewId}`,
     });
   }
 
@@ -1033,8 +1038,10 @@ export class MockGitHubServer {
               },
               reviews: {
                 nodes: pullRequest.reviews.map((review) => ({
+                  id: review.id,
                   body: review.body,
                   submittedAt: review.submittedAt,
+                  url: review.url,
                   author:
                     review.authorLogin === null
                       ? null

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -27,6 +27,7 @@ import {
 import { createTempDir } from "../support/git.js";
 
 const LEGACY_TEST_SESSION_NAME = "symphony-factory";
+const ENGINE_ROOT_PATH_PATTERN = /\/symphony-ts(?:\/|$)/u;
 
 function createStatusSnapshot(
   workerPid: number,
@@ -1119,7 +1120,7 @@ describe("startFactory", () => {
     expect(launched).toHaveLength(1);
     expect(launched[0]).toEqual({
       runtimeRoot: "/repo/.tmp/factory-main",
-      launchCwd: expect.stringMatching(/symphony-ts$/u),
+      launchCwd: expect.stringMatching(ENGINE_ROOT_PATH_PATTERN),
       sessionName: "symphony-factory",
       command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
       env: expect.objectContaining({
@@ -1210,7 +1211,7 @@ describe("startFactory", () => {
     expect(launched).toEqual([
       {
         runtimeRoot: "/target-project/.tmp/factory-main",
-        launchCwd: expect.stringMatching(/symphony-ts$/u),
+        launchCwd: expect.stringMatching(ENGINE_ROOT_PATH_PATTERN),
         sessionName: "symphony-factory-target-project",
         command: createFactoryRunCommand("/target-project/WORKFLOW.md"),
         env: expect.objectContaining({
@@ -1577,7 +1578,7 @@ describe("startFactory", () => {
     expect(launched).toEqual([
       {
         runtimeRoot: "/repo/.tmp/factory-main",
-        launchCwd: expect.stringMatching(/symphony-ts$/u),
+        launchCwd: expect.stringMatching(ENGINE_ROOT_PATH_PATTERN),
         sessionName: "symphony-factory",
         command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({
@@ -1620,7 +1621,7 @@ describe("startFactory", () => {
     expect(launched).toEqual([
       {
         runtimeRoot: "/repo/.tmp/factory-main",
-        launchCwd: expect.stringMatching(/symphony-ts$/u),
+        launchCwd: expect.stringMatching(ENGINE_ROOT_PATH_PATTERN),
         sessionName: "symphony-factory",
         command: createFactoryRunCommand("/repo/.tmp/factory-main/WORKFLOW.md"),
         env: expect.objectContaining({

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -206,6 +206,21 @@ describe("evaluateGuardedLanding", () => {
     });
   });
 
+  it("rejects landing when a required reviewer app is still running", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        requiredReviewerState: "running",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "checks-not-green",
+      lifecycleKind: "awaiting-system-checks",
+      summary: expect.stringContaining("still running"),
+    });
+  });
+
   it("rejects already merged pull requests explicitly", () => {
     const result = evaluateGuardedLanding(
       createSnapshot({

--- a/tests/unit/guarded-landing.test.ts
+++ b/tests/unit/guarded-landing.test.ts
@@ -24,7 +24,7 @@ function createSnapshot(
     failingCheckNames: [],
     botActionableReviewFeedback: [],
     unresolvedReviewThreadCount: 0,
-    requiredApprovedReviewCoverage: "satisfied",
+    requiredReviewerState: "satisfied",
     ...overrides,
   };
 }
@@ -181,13 +181,27 @@ describe("evaluateGuardedLanding", () => {
   it("rejects landing when required approved bot review is missing", () => {
     const result = evaluateGuardedLanding(
       createSnapshot({
-        requiredApprovedReviewCoverage: "missing",
+        requiredReviewerState: "missing",
       }),
     );
 
     expect(result).toMatchObject({
       kind: "blocked",
       reason: "required-bot-review-missing",
+      lifecycleKind: "degraded-review-infrastructure",
+    });
+  });
+
+  it("rejects landing when required reviewer verdict is unknown", () => {
+    const result = evaluateGuardedLanding(
+      createSnapshot({
+        requiredReviewerState: "unknown",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "blocked",
+      reason: "required-reviewer-verdict-unknown",
       lifecycleKind: "degraded-review-infrastructure",
     });
   });

--- a/tests/unit/pull-request-policy.test.ts
+++ b/tests/unit/pull-request-policy.test.ts
@@ -22,8 +22,9 @@ function createSnapshot(
     actionableReviewFeedback: [],
     botActionableReviewFeedback: [],
     unresolvedThreadIds: [],
-    requiredApprovedReviewCoverage: "satisfied",
-    observedApprovedReviewBotLogins: [],
+    reviewerApps: [],
+    requiredReviewerState: "satisfied",
+    observedReviewerKeys: [],
     ...overrides,
   };
 }
@@ -115,7 +116,7 @@ describe("pull-request-policy", () => {
             detailsUrl: null,
           },
         ],
-        requiredApprovedReviewCoverage: "missing",
+        requiredReviewerState: "missing",
       }),
       undefined,
     ).lifecycle;
@@ -128,7 +129,7 @@ describe("pull-request-policy", () => {
 
   it("preserves no-check stabilization while required approved bot review is missing", () => {
     const snapshot = createSnapshot({
-      requiredApprovedReviewCoverage: "missing",
+      requiredReviewerState: "missing",
     });
 
     const first = evaluatePullRequestLifecycle(snapshot, undefined);
@@ -146,6 +147,47 @@ describe("pull-request-policy", () => {
     expect(second.nextNoCheckObservation).toEqual(first.nextNoCheckObservation);
     expect(third.lifecycle.kind).toBe("degraded-review-infrastructure");
     expect(third.nextNoCheckObservation).toEqual(first.nextNoCheckObservation);
+  });
+
+  it("waits while a required reviewer app is still running", () => {
+    const lifecycle = evaluatePullRequestLifecycle(
+      createSnapshot({
+        checks: [
+          {
+            name: "Devin Review",
+            status: "pending",
+            conclusion: null,
+            detailsUrl: null,
+          },
+        ],
+        pendingCheckNames: [],
+        requiredReviewerState: "running",
+      }),
+      undefined,
+    ).lifecycle;
+
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
+    expect(lifecycle.summary).toMatch(/reviewer apps to finish/i);
+  });
+
+  it("degrades when required reviewer verdict is unknown", () => {
+    const lifecycle = evaluatePullRequestLifecycle(
+      createSnapshot({
+        checks: [
+          {
+            name: "CI",
+            status: "success",
+            conclusion: "success",
+            detailsUrl: null,
+          },
+        ],
+        requiredReviewerState: "unknown",
+      }),
+      undefined,
+    ).lifecycle;
+
+    expect(lifecycle.kind).toBe("degraded-review-infrastructure");
+    expect(lifecycle.summary).toMatch(/explicit pass verdict/i);
   });
 
   it("requires rework for failing checks or bot feedback", () => {

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../src/tracker/github-client.js";
 import { createPullRequestSnapshot } from "../../src/tracker/pull-request-snapshot.js";
 import type { PullRequestCheck } from "../../src/domain/pull-request.js";
+import type { GitHubReviewerAppConfig } from "../../src/domain/workflow.js";
 
 function createReviewState(
   comments: ReadonlyArray<{
@@ -91,6 +92,14 @@ const successfulDevinCheck: PullRequestCheck = {
   conclusion: "success",
   detailsUrl: "https://example.test/checks/devin",
 };
+
+const devinReviewerApps: readonly GitHubReviewerAppConfig[] = [
+  {
+    key: "devin",
+    accepted: true,
+    required: true,
+  },
+];
 
 describe("createPullRequestSnapshot", () => {
   it("keeps a bot-owned thread actionable when a human replies", () => {
@@ -200,7 +209,7 @@ describe("createPullRequestSnapshot", () => {
               id: "comment-1",
               authorAssociation: "NONE",
               author: { login: "devin-ai-integration" },
-              body: "Automated review found a shutdown edge case.",
+              body: "## Devin Review: Found 1 potential issues",
               createdAt: "2026-03-06T01:00:00.000Z",
               url: "https://example.test/pr/24#comment-1",
             },
@@ -213,7 +222,8 @@ describe("createPullRequestSnapshot", () => {
           nodes: [],
         },
       },
-      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
     });
 
     expect(snapshot.actionableReviewFeedback).toHaveLength(1);
@@ -221,6 +231,10 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.botActionableReviewFeedback[0]?.authorLogin).toBe(
       "devin-ai-integration",
     );
+    expect(snapshot.reviewerApps[0]).toMatchObject({
+      reviewerKey: "devin",
+      verdict: "issues-found",
+    });
   });
 
   it("records required approved bot review presence from a clean summary comment", () => {
@@ -261,8 +275,8 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["greptile-apps"],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual(["greptile-apps"]);
+    expect(snapshot.requiredReviewerState).toBe("satisfied");
+    expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
   });
 
   it("ignores stale required approved bot review from before the current head commit", () => {
@@ -303,8 +317,8 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["greptile-apps"],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
+    expect(snapshot.requiredReviewerState).toBe("missing");
+    expect(snapshot.observedReviewerKeys).toEqual([]);
   });
 
   it("ignores cursor acknowledgement noise for required approved bot review presence", () => {
@@ -347,8 +361,8 @@ describe("createPullRequestSnapshot", () => {
       approvedReviewBotLogins: ["cursor[bot]"],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
+    expect(snapshot.requiredReviewerState).toBe("missing");
+    expect(snapshot.observedReviewerKeys).toEqual([]);
   });
 
   it("records required approved bot review presence from a top-level PR review", () => {
@@ -372,9 +386,11 @@ describe("createPullRequestSnapshot", () => {
         reviews: {
           nodes: [
             {
+              id: "review-1",
               author: { login: "devin-ai-integration" },
               body: "## ✅ Devin Review: No Issues Found",
               submittedAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#review-1",
             },
           ],
         },
@@ -382,14 +398,12 @@ describe("createPullRequestSnapshot", () => {
           nodes: [],
         },
       },
-      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
-      approvedReviewBotLogins: ["devin-ai-integration"],
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual([
-      "devin-ai-integration",
-    ]);
+    expect(snapshot.requiredReviewerState).toBe("satisfied");
+    expect(snapshot.observedReviewerKeys).toEqual(["devin"]);
   });
 
   it("records required approved bot review presence from a successful reviewer-app status context on the current head", () => {
@@ -413,9 +427,11 @@ describe("createPullRequestSnapshot", () => {
         reviews: {
           nodes: [
             {
+              id: "review-1",
               author: { login: "devin-ai-integration" },
               body: "## ✅ Devin Review: No Issues Found",
-              submittedAt: "2026-03-06T01:00:00.000Z",
+              submittedAt: "2026-03-06T03:00:00.000Z",
+              url: "https://example.test/pr/24#review-1",
             },
           ],
         },
@@ -423,14 +439,45 @@ describe("createPullRequestSnapshot", () => {
           nodes: [],
         },
       },
-      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
-      approvedReviewBotLogins: ["devin-ai-integration"],
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("satisfied");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual([
-      "devin-ai-integration",
-    ]);
+    expect(snapshot.requiredReviewerState).toBe("satisfied");
+    expect(snapshot.observedReviewerKeys).toEqual(["devin"]);
+  });
+
+  it("treats reviewer-app check success without a current-head verdict as unknown", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T02:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
+    });
+
+    expect(snapshot.requiredReviewerState).toBe("unknown");
+    expect(snapshot.observedReviewerKeys).toEqual(["devin"]);
   });
 
   it("does not treat unrelated successful status contexts as approved reviewer coverage", () => {
@@ -465,12 +512,12 @@ describe("createPullRequestSnapshot", () => {
           nodes: [],
         },
       },
-      reviewBotLogins: ["greptile-apps", "cursor", "devin-ai-integration"],
-      approvedReviewBotLogins: ["devin-ai-integration"],
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
     });
 
-    expect(snapshot.requiredApprovedReviewCoverage).toBe("missing");
-    expect(snapshot.observedApprovedReviewBotLogins).toEqual([]);
+    expect(snapshot.requiredReviewerState).toBe("missing");
+    expect(snapshot.observedReviewerKeys).toEqual([]);
   });
 
   it("detects a human /land command on the current PR head", () => {

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -279,6 +279,39 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
   });
 
+  it("preserves legacy devin check coverage for approved review bot configs", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["devin-ai-integration"],
+      approvedReviewBotLogins: ["devin-ai-integration"],
+    });
+
+    expect(snapshot.requiredReviewerState).toBe("satisfied");
+    expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
+  });
+
   it("ignores stale required approved bot review from before the current head commit", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -313,6 +313,97 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.observedReviewerKeys).toEqual(["devin"]);
   });
 
+  it("does not surface a passing devin review as actionable feedback when unresolved threads already require rework", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [
+            {
+              id: "review-1",
+              author: { login: "devin-ai-integration" },
+              body: "## ✅ Devin Review: No Issues Found",
+              submittedAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#review-1",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [
+            {
+              id: "thread-1",
+              isResolved: false,
+              isOutdated: false,
+              originComments: {
+                nodes: [
+                  {
+                    id: "comment-1",
+                    body: "Please update this condition.",
+                    createdAt: "2026-03-06T01:02:00.000Z",
+                    url: "https://example.test/thread/1#comment-1",
+                    path: "src/index.ts",
+                    line: 10,
+                    author: { login: "devin-ai-integration" },
+                  },
+                ],
+              },
+              latestComments: {
+                nodes: [
+                  {
+                    id: "comment-1",
+                    body: "Please update this condition.",
+                    createdAt: "2026-03-06T01:02:00.000Z",
+                    url: "https://example.test/thread/1#comment-1",
+                    path: "src/index.ts",
+                    line: 10,
+                    author: { login: "devin-ai-integration" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
+    });
+
+    const devinSnapshot = snapshot.reviewerApps.find(
+      (reviewer) => reviewer.reviewerKey === "devin",
+    );
+
+    expect(devinSnapshot).toMatchObject({
+      reviewerKey: "devin",
+      verdict: "issues-found",
+    });
+    expect(devinSnapshot?.actionableFeedback).toHaveLength(1);
+    expect(devinSnapshot?.actionableFeedback[0]).toMatchObject({
+      id: "comment-1",
+      kind: "review-thread",
+      threadId: "thread-1",
+    });
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]).toMatchObject({
+      id: "comment-1",
+      kind: "review-thread",
+      threadId: "thread-1",
+    });
+  });
+
   it("preserves legacy devin check coverage for approved review bot configs", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",
@@ -344,6 +435,62 @@ describe("createPullRequestSnapshot", () => {
 
     expect(snapshot.requiredReviewerState).toBe("satisfied");
     expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
+  });
+
+  it("treats legacy approved review bot findings as accepted actionable feedback", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              authorAssociation: "NONE",
+              author: { login: "greptile[bot]" },
+              body: "Please fix this before merging.",
+              createdAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#comment-1",
+            },
+          ],
+        },
+        reviews: {
+          nodes: [],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: [],
+      approvedReviewBotLogins: ["greptile[bot]"],
+    });
+
+    const legacySnapshot = snapshot.reviewerApps.find(
+      (reviewer) => reviewer.reviewerKey === "legacy-bot-review",
+    );
+
+    expect(legacySnapshot).toMatchObject({
+      reviewerKey: "legacy-bot-review",
+      accepted: true,
+      required: true,
+      verdict: "issues-found",
+    });
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]).toMatchObject({
+      id: "comment-1",
+      kind: "issue-comment",
+      authorLogin: "greptile[bot]",
+    });
   });
 
   it("ignores stale required approved bot review from before the current head commit", () => {

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -279,6 +279,40 @@ describe("createPullRequestSnapshot", () => {
     expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
   });
 
+  it("keeps devin-owned review threads actionable after migrating to reviewer_apps", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [],
+      reviewState: createReviewState([
+        {
+          id: "comment-1",
+          authorLogin: "devin-ai-integration",
+          body: "Please update this condition.",
+          createdAt: "2026-03-06T01:00:00.000Z",
+          url: "https://example.test/thread/1#comment-1",
+        },
+      ]),
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: ["devin-ai-integration"],
+    });
+
+    expect(snapshot.reviewerApps).toContainEqual(
+      expect.objectContaining({
+        reviewerKey: "devin",
+        verdict: "issues-found",
+      }),
+    );
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]).toMatchObject({
+      kind: "review-thread",
+      threadId: "thread-1",
+      authorLogin: "devin-ai-integration",
+    });
+    expect(snapshot.unresolvedThreadIds).toEqual(["thread-1"]);
+    expect(snapshot.observedReviewerKeys).toEqual(["devin"]);
+  });
+
   it("preserves legacy devin check coverage for approved review bot configs", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -130,6 +130,43 @@ ${buildSharedWorkflowSections()}`,
     expect(rendered).toContain("sociotechnica-org/symphony-ts");
   });
 
+  it("loads explicit reviewer app policy for GitHub trackers", async () => {
+    const dir = await createTempDir("workflow-reviewer-apps-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+  reviewer_apps:
+    devin:
+      accepted: true
+      required: true
+${buildSharedWorkflowSections()}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    if (
+      workflow.config.tracker.kind === "github" ||
+      workflow.config.tracker.kind === "github-bootstrap"
+    ) {
+      expect(workflow.config.tracker.reviewerApps).toEqual([
+        {
+          key: "devin",
+          accepted: true,
+          required: true,
+        },
+      ]);
+    }
+  });
+
   it("preserves the authoritative resolved instance paths", async () => {
     const instanceRoot = "/srv/instances/project-a";
     const workflowPath = path.join(instanceRoot, "WORKFLOW.md");


### PR DESCRIPTION
Closes #242

## Summary
- add first-class `tracker.reviewer_apps` config and a reviewer-app adapter seam that normalizes coverage, status, verdict, evidence, and actionable feedback
- implement the initial `devin` adapter while preserving legacy `review_bot_logins` and `approved_review_bot_logins` behavior behind a compatibility snapshot
- update PR lifecycle and guarded landing policy to use normalized reviewer-app state, then cover the new behavior across unit, integration, and e2e tests

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`

## Notes
- local self-review: `codex review --base origin/main` plus manual diff review; no actionable findings remained after fixing the workspace-checkout cwd test expectation
- the branch preserves the reviewed issue plan history from `docs/plans/242-reviewer-app-adapters/plan.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
