### PR TITLE
fix: block /land when GitHub reports merge conflicts

### DIFF
--- a/docs/plans/267-conflicting-prs-must-not-await-land/plan.md
+++ b/docs/plans/267-conflicting-prs-must-not-await-land/plan.md
@@ -1,0 +1,66 @@
+# Issue 267 Plan: Conflicting PRs Must Not Await `/land`
+
+## Scope
+
+Prevent GitHub PRs with merge conflicts or other non-passing mergeability states from entering `awaiting-landing-command`.
+
+## Non-goals
+
+- No reviewer-app policy redesign.
+- No landing execution changes beyond the pre-landing lifecycle gate.
+- No new handoff lifecycle kind in this slice.
+
+## Current gap
+
+- `executeLanding()` already blocks non-mergeable PRs.
+- `inspectIssueHandoff()` can still classify a PR as `awaiting-landing-command` before a human `/land`, even when GitHub reports `mergeable=false` or `mergeable_state=dirty`.
+- That solicits `/land` too early and makes the factory appear merge-ready when it is not.
+
+## Layer map
+
+- Policy: tighten the normalized PR lifecycle gate for merge conflicts.
+- Configuration: none.
+- Coordination: none.
+- Execution: none.
+- Integration: carry GitHub mergeability facts into the normalized PR snapshot.
+- Observability: status/handoff summaries should explain the mergeability blocker.
+
+## Architecture boundaries
+
+- Keep the fix inside tracker normalization/policy:
+  - `src/tracker/pull-request-snapshot.ts`
+  - `src/tracker/pull-request-policy.ts`
+- Reuse existing lifecycle kinds instead of inventing a new conflict-only lifecycle in this slice.
+
+## Implementation steps
+
+1. Extend normalized PR snapshots to include GitHub mergeability facts needed by lifecycle policy.
+2. Update PR lifecycle evaluation so:
+   - `mergeable === null` waits for mergeability to settle
+   - conflicting / non-passing merge states return a blocked non-landing lifecycle
+3. Add unit coverage for conflicting and unknown-mergeability PRs.
+4. Add integration coverage for a green-check PR whose merge gate is `dirty`.
+
+## Tests
+
+- `tests/unit/pull-request-policy.test.ts`
+- `tests/integration/github-bootstrap.test.ts`
+- repo validation:
+  - `pnpm typecheck`
+  - `pnpm lint`
+  - `pnpm test`
+
+## Acceptance scenarios
+
+1. A PR with green checks and satisfied review state but `mergeable=false` / `mergeable_state=dirty` does not surface `awaiting-landing-command`.
+2. A PR whose mergeability is still unknown waits rather than looking landable.
+3. Conflicting PRs remain clearly blocked in the status surface.
+
+## Exit criteria
+
+- Conflicting PRs no longer solicit `/land`.
+- Tests cover the normalized snapshot + lifecycle path that regressed on `#261`.
+
+## Deferred
+
+- A dedicated lifecycle/status kind for merge conflicts, if we later want something more specific than `rework-required`.

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -53,6 +53,9 @@ interface GitHubPullRequestListResponse {
 export interface GitHubPullRequestResponse extends GitHubPullRequestListResponse {
   readonly landingState: "open" | "merged";
   readonly mergedAt: string | null;
+  readonly mergeable?: boolean | null;
+  readonly mergeable_state?: string | null;
+  readonly draft?: boolean;
 }
 
 export interface GitHubPullRequestDetailsResponse extends GitHubPullRequestListResponse {
@@ -726,8 +729,9 @@ export class GitHubClient {
     const matchingPulls = pulls.filter((pull) => pull.head.ref === headBranch);
     const openPull = matchingPulls.find((pull) => pull.state === "open");
     if (openPull) {
+      const details = await this.getPullRequest(openPull.number);
       return {
-        ...openPull,
+        ...details,
         landingState: "open",
         mergedAt: null,
       };

--- a/src/tracker/pull-request-policy.ts
+++ b/src/tracker/pull-request-policy.ts
@@ -11,6 +11,8 @@ export interface PullRequestPolicyResult {
   readonly nextNoCheckObservation: NoCheckObservation | null;
 }
 
+const PASSING_MERGE_STATES = new Set(["clean", "has_hooks"]);
+
 function summarizeLifecycle(
   intro: string,
   url: string,
@@ -236,6 +238,48 @@ export function evaluatePullRequestLifecycle(
         actionableReviewFeedback: [],
         unresolvedThreadIds: [],
         summary: `Degraded external review infrastructure for ${snapshot.pullRequest.url}; required reviewer-app output was observed on the current head but no explicit pass verdict was normalized.`,
+      },
+      nextNoCheckObservation: previousNoCheckObservation ?? null,
+    };
+  }
+
+  if (snapshot.mergeable === null) {
+    return {
+      lifecycle: {
+        kind: "awaiting-system-checks",
+        branchName: snapshot.branchName,
+        pullRequest: snapshot.pullRequest,
+        checks: snapshot.checks,
+        pendingCheckNames: snapshot.pendingCheckNames,
+        failingCheckNames: snapshot.failingCheckNames,
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        summary: `Waiting for GitHub mergeability to settle on ${snapshot.pullRequest.url}`,
+      },
+      nextNoCheckObservation: previousNoCheckObservation ?? null,
+    };
+  }
+
+  if (
+    snapshot.mergeable !== true ||
+    (snapshot.mergeStateStatus !== null &&
+      !PASSING_MERGE_STATES.has(snapshot.mergeStateStatus))
+  ) {
+    const mergeStateSummary =
+      snapshot.mergeable !== true
+        ? "GitHub does not consider the pull request mergeable"
+        : `GitHub reports merge state '${snapshot.mergeStateStatus}'`;
+    return {
+      lifecycle: {
+        kind: "rework-required",
+        branchName: snapshot.branchName,
+        pullRequest: snapshot.pullRequest,
+        checks: snapshot.checks,
+        pendingCheckNames: snapshot.pendingCheckNames,
+        failingCheckNames: snapshot.failingCheckNames,
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        summary: `${mergeStateSummary} for ${snapshot.pullRequest.url}`,
       },
       nextNoCheckObservation: previousNoCheckObservation ?? null,
     };

--- a/src/tracker/pull-request-snapshot.ts
+++ b/src/tracker/pull-request-snapshot.ts
@@ -6,6 +6,7 @@ import type {
 } from "../domain/pull-request.js";
 import type { GitHubReviewerAppConfig } from "../domain/workflow.js";
 import type {
+  GitHubPullRequestDetailsResponse,
   GitHubPullRequestResponse,
   PullRequestReviewState,
 } from "./github-client.js";
@@ -24,6 +25,8 @@ export interface PullRequestSnapshot {
   readonly branchName: string;
   readonly pullRequest: PullRequestHandle;
   readonly landingState: "open" | "merged";
+  readonly mergeable: boolean | null;
+  readonly mergeStateStatus: string | null;
   readonly hasLandingCommand: boolean;
   readonly checks: readonly PullRequestCheck[];
   readonly pendingCheckNames: readonly string[];
@@ -34,6 +37,16 @@ export interface PullRequestSnapshot {
   readonly reviewerApps: readonly ReviewerAppSnapshot[];
   readonly requiredReviewerState: RequiredReviewerState;
   readonly observedReviewerKeys: readonly string[];
+}
+
+function hasMergeabilityFields(
+  pullRequest: GitHubPullRequestResponse,
+): pullRequest is GitHubPullRequestResponse & GitHubPullRequestDetailsResponse {
+  return (
+    "mergeable" in pullRequest &&
+    "mergeable_state" in pullRequest &&
+    "draft" in pullRequest
+  );
 }
 
 function isAfter(left: string, right: string | null): boolean {
@@ -185,6 +198,12 @@ export function createPullRequestSnapshot(input: {
       latestCommitAt,
     },
     landingState: input.pullRequest.landingState,
+    mergeable: hasMergeabilityFields(input.pullRequest)
+      ? input.pullRequest.mergeable
+      : null,
+    mergeStateStatus: hasMergeabilityFields(input.pullRequest)
+      ? (input.pullRequest.mergeable_state?.toLowerCase() ?? null)
+      : null,
     hasLandingCommand,
     checks: input.checks,
     pendingCheckNames,

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -795,6 +795,31 @@ describe("GitHubTracker", () => {
     });
   });
 
+  it("does not report awaiting landing command when the pull request is conflicting", async () => {
+    const tracker = createTracker(server);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.setPullRequestMergeGate("symphony/7", {
+      mergeable: false,
+      mergeableState: "dirty",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("rework-required");
+    expect(lifecycle.summary).toMatch(
+      /does not consider the pull request mergeable/i,
+    );
+  });
+
   it("reports merged when the pull request is already merged before landing executes", async () => {
     const tracker = createTracker(server);
 

--- a/tests/unit/pull-request-policy.test.ts
+++ b/tests/unit/pull-request-policy.test.ts
@@ -15,6 +15,8 @@ function createSnapshot(
       latestCommitAt: "2026-03-06T00:00:00.000Z",
     },
     landingState: "open",
+    mergeable: true,
+    mergeStateStatus: "clean",
     hasLandingCommand: false,
     checks: [],
     pendingCheckNames: [],
@@ -188,6 +190,50 @@ describe("pull-request-policy", () => {
 
     expect(lifecycle.kind).toBe("degraded-review-infrastructure");
     expect(lifecycle.summary).toMatch(/explicit pass verdict/i);
+  });
+
+  it("does not surface /land when GitHub mergeability is still unknown", () => {
+    const lifecycle = evaluatePullRequestLifecycle(
+      createSnapshot({
+        checks: [
+          {
+            name: "CI",
+            status: "success",
+            conclusion: "success",
+            detailsUrl: null,
+          },
+        ],
+        mergeable: null,
+        mergeStateStatus: "unknown",
+      }),
+      undefined,
+    ).lifecycle;
+
+    expect(lifecycle.kind).toBe("awaiting-system-checks");
+    expect(lifecycle.summary).toMatch(/mergeability to settle/i);
+  });
+
+  it("requires rework instead of /land when GitHub reports conflicts", () => {
+    const lifecycle = evaluatePullRequestLifecycle(
+      createSnapshot({
+        checks: [
+          {
+            name: "CI",
+            status: "success",
+            conclusion: "success",
+            detailsUrl: null,
+          },
+        ],
+        mergeable: false,
+        mergeStateStatus: "dirty",
+      }),
+      undefined,
+    ).lifecycle;
+
+    expect(lifecycle.kind).toBe("rework-required");
+    expect(lifecycle.summary).toMatch(
+      /not consider the pull request mergeable/i,
+    );
   });
 
   it("requires rework for failing checks or bot feedback", () => {


### PR DESCRIPTION
Closes #267

## Summary
- fetch full PR details during lifecycle inspection so mergeability is available before landing
- block `awaiting-landing-command` when GitHub still reports unknown or conflicting mergeability
- cover the lifecycle gate with unit and github-bootstrap integration tests

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
