### PR TITLE
Add deterministic operator runtime freshness checks

### DIFF
--- a/bin/check-factory-runtime-freshness.ts
+++ b/bin/check-factory-runtime-freshness.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { inspectFactoryControl } from "../src/cli/factory-control.js";
+import { collectFactoryRuntimeIdentity } from "../src/observability/runtime-identity.js";
+import { assessOperatorRuntimeFreshness } from "../src/observability/operator-runtime-freshness.js";
+
+interface Args {
+  readonly workflowPath?: string;
+  readonly operatorRepoRoot: string;
+  readonly json: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const workflowPath = readOptionalOptionValue(argv, "--workflow");
+  return {
+    ...(workflowPath === null ? {} : { workflowPath }),
+    operatorRepoRoot: path.resolve(
+      readOptionalOptionValue(argv, "--operator-repo-root") ?? process.cwd(),
+    ),
+    json: argv.includes("--json"),
+  };
+}
+
+function readOptionalOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function renderText(
+  result: ReturnType<typeof assessOperatorRuntimeFreshness>,
+): string {
+  return [
+    `Freshness: ${result.kind}`,
+    `Runtime head: ${result.runtimeHeadSha ?? "unavailable"}`,
+    `Engine head: ${result.engineHeadSha ?? "unavailable"}`,
+    `Control state: ${result.controlState}`,
+    `Factory state: ${result.factoryState ?? "unavailable"}`,
+    `Active issues: ${result.activeIssueCount.toString()}`,
+    `Should restart now: ${result.shouldRestart ? "yes" : "no"}`,
+    `Summary: ${result.summary}`,
+  ].join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const status = await inspectFactoryControl({
+    ...(args.workflowPath === undefined
+      ? {}
+      : { workflowPath: args.workflowPath }),
+  });
+  const engineRuntimeIdentity = await collectFactoryRuntimeIdentity(
+    args.operatorRepoRoot,
+  );
+  const result = assessOperatorRuntimeFreshness({
+    status,
+    engineRuntimeIdentity,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  process.stdout.write(`${renderText(result)}\n`);
+}
+
+main().catch((error: Error) => {
+  process.stderr.write(
+    error.stack ? `${error.stack}\n` : `${error.name}: ${error.message}\n`,
+  );
+  process.exit(1);
+});

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -37,7 +37,7 @@ instance-scoped scratchpad, status snapshots, logs, and loop lock files under
 1. Read the selected instance's scratchpad first so the latest operator context survives session loss and compaction.
 2. Inspect the current repo state, open ready/running issues, open PRs, CI, and review comments.
 3. Use `pnpm tsx bin/symphony.ts factory status --json` as the primary factory-health check and determine whether the detached runtime is healthy, degraded, stopped, stuck, crashed, or misconfigured.
-4. Immediately after the factory-health read, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root <operator-repo-root> --json` for the selected instance.
+4. Immediately after the factory-health read, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root <operator-repo-root> --json` for the selected instance, and append `--workflow <selected-workflow>` when operating on a non-default instance.
 5. If the freshness check reports `stale-idle`, refresh the operator repo checkout plus the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that fact in the instance scratchpad and defer restart until the next idle or post-merge checkpoint.
 6. Before any ordinary queue-advancement work after the freshness check is clear, run `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-repo-root> --json` for the selected instance and treat any `report-ready` or `review-blocked` entry as the first operator checkpoint after the factory-health read.
 7. For each pending completed-run report review:

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -37,30 +37,32 @@ instance-scoped scratchpad, status snapshots, logs, and loop lock files under
 1. Read the selected instance's scratchpad first so the latest operator context survives session loss and compaction.
 2. Inspect the current repo state, open ready/running issues, open PRs, CI, and review comments.
 3. Use `pnpm tsx bin/symphony.ts factory status --json` as the primary factory-health check and determine whether the detached runtime is healthy, degraded, stopped, stuck, crashed, or misconfigured.
-4. Before any ordinary queue-advancement work, run `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-repo-root> --json` for the selected instance and treat any `report-ready` or `review-blocked` entry as the first operator checkpoint after the factory-health read.
-5. For each pending completed-run report review:
+4. Immediately after the factory-health read, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root <operator-repo-root> --json` for the selected instance.
+5. If the freshness check reports `stale-idle`, refresh the operator repo checkout plus the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that fact in the instance scratchpad and defer restart until the next idle or post-merge checkpoint.
+6. Before any ordinary queue-advancement work after the freshness check is clear, run `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-repo-root> --json` for the selected instance and treat any `report-ready` or `review-blocked` entry as the first operator checkpoint after the factory-health read.
+7. For each pending completed-run report review:
    - read the generated report under `.var/reports/issues/<issue-number>/`
    - decide whether the report yields no tracked follow-up, a concrete follow-up issue, or a blocked review state
    - persist the decision through `symphony-report review-record` or `symphony-report review-follow-up`
    - and update the instance scratchpad with what the report taught the factory and what follow-up work was queued
-6. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
-7. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
-8. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
-   - any active issue waiting in `plan-ready` / `awaiting-human-handoff`
-   - any PR or active issue waiting in `awaiting-landing-command`
-9. If the factory is unhealthy, fix the concrete problem and restart it.
-10. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-11. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
-12. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
+8. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
+9. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
+10. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
+    - any active issue waiting in `plan-ready` / `awaiting-human-handoff`
+    - any PR or active issue waiting in `awaiting-landing-command`
+11. If the factory is unhealthy, fix the concrete problem and restart it.
+12. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
+13. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
+14. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
 
 - `Plan review: approved`
 - `Plan review: changes-requested`
 - `Plan review: waived` (record why in the comment)
 
-13. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
-14. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
-15. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
-16. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+15. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
+16. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
+17. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
+18. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
 

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -8,24 +8,26 @@ Required workflow:
 2. Read the instance-scoped scratchpad at `SYMPHONY_OPERATOR_SCRATCHPAD` if it exists.
 3. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
 4. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
-5. Immediately after the factory-health check, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-6. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
+5. Immediately after the factory-health check, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+6. If the freshness check reports `stale-idle`, refresh the operator repo checkout and the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint.
+7. Immediately after the freshness check is clear, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+8. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
    - read the report evidence under `.var/reports/issues/<issue-number>/`,
    - record a no-follow-up decision with `pnpm tsx bin/symphony-report.ts review-record --issue <number> --status reviewed-no-follow-up --summary <...>`,
    - or create a tracked follow-up issue with `pnpm tsx bin/symphony-report.ts review-follow-up --issue <number> --title <...> --body-file <...> --summary <...>`,
    - and update `SYMPHONY_OPERATOR_SCRATCHPAD` with what was learned and queued before moving on.
-7. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-8. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-9. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint is clear.
-10. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-11. As mandatory operator checkpoints for this wake-up, explicitly:
+9. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
+10. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+11. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint is clear.
+12. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+13. As mandatory operator checkpoints for this wake-up, explicitly:
 
 - review any active `plan-ready` / `awaiting-human-handoff` issue and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
 - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 
-12. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-13. Update `SYMPHONY_OPERATOR_SCRATCHPAD` before finishing the cycle.
+14. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+15. Update `SYMPHONY_OPERATOR_SCRATCHPAD` before finishing the cycle.
 
 Constraints:
 

--- a/src/observability/operator-runtime-freshness.ts
+++ b/src/observability/operator-runtime-freshness.ts
@@ -1,0 +1,116 @@
+import type {
+  FactoryControlState,
+  FactoryControlStatusSnapshot,
+} from "../cli/factory-control.js";
+import type { FactoryRuntimeIdentity } from "./runtime-identity.js";
+
+export type OperatorRuntimeFreshnessKind =
+  | "fresh"
+  | "stale-idle"
+  | "stale-busy"
+  | "stopped"
+  | "engine-head-unavailable"
+  | "runtime-head-unavailable";
+
+export interface OperatorRuntimeFreshnessSnapshot {
+  readonly kind: OperatorRuntimeFreshnessKind;
+  readonly shouldRestart: boolean;
+  readonly runtimeHeadSha: string | null;
+  readonly engineHeadSha: string | null;
+  readonly controlState: FactoryControlState;
+  readonly factoryState: string | null;
+  readonly activeIssueCount: number;
+  readonly summary: string;
+}
+
+export function assessOperatorRuntimeFreshness(args: {
+  readonly status: FactoryControlStatusSnapshot;
+  readonly engineRuntimeIdentity: FactoryRuntimeIdentity | null;
+}): OperatorRuntimeFreshnessSnapshot {
+  const runtimeHeadSha = args.status.startup?.runtimeIdentity?.headSha ?? null;
+  const engineHeadSha = args.engineRuntimeIdentity?.headSha ?? null;
+  const controlState = args.status.controlState;
+  const factoryState = args.status.statusSnapshot?.factoryState ?? null;
+  const activeIssueCount = args.status.statusSnapshot?.activeIssues.length ?? 0;
+
+  if (controlState !== "running") {
+    return {
+      kind: "stopped",
+      shouldRestart: false,
+      runtimeHeadSha,
+      engineHeadSha,
+      controlState,
+      factoryState,
+      activeIssueCount,
+      summary:
+        "Factory is not currently running; use the normal health-recovery flow before freshness restarts.",
+    };
+  }
+
+  if (engineHeadSha === null) {
+    return {
+      kind: "engine-head-unavailable",
+      shouldRestart: false,
+      runtimeHeadSha,
+      engineHeadSha,
+      controlState,
+      factoryState,
+      activeIssueCount,
+      summary:
+        "Could not determine the engine checkout head; investigate the operator repo checkout before applying freshness restarts.",
+    };
+  }
+
+  if (runtimeHeadSha === null) {
+    return {
+      kind: "runtime-head-unavailable",
+      shouldRestart: false,
+      runtimeHeadSha,
+      engineHeadSha,
+      controlState,
+      factoryState,
+      activeIssueCount,
+      summary:
+        "Could not determine the running factory head; investigate startup/runtime identity before applying freshness restarts.",
+    };
+  }
+
+  if (runtimeHeadSha === engineHeadSha) {
+    return {
+      kind: "fresh",
+      shouldRestart: false,
+      runtimeHeadSha,
+      engineHeadSha,
+      controlState,
+      factoryState,
+      activeIssueCount,
+      summary: "Factory runtime is already on the current engine head.",
+    };
+  }
+
+  if (factoryState === "idle") {
+    return {
+      kind: "stale-idle",
+      shouldRestart: true,
+      runtimeHeadSha,
+      engineHeadSha,
+      controlState,
+      factoryState,
+      activeIssueCount,
+      summary:
+        "Factory runtime is behind the current engine head and the instance is idle; restart it before ordinary queue work.",
+    };
+  }
+
+  return {
+    kind: "stale-busy",
+    shouldRestart: false,
+    runtimeHeadSha,
+    engineHeadSha,
+    controlState,
+    factoryState,
+    activeIssueCount,
+    summary:
+      "Factory runtime is behind the current engine head but the instance is busy; defer restart until the next idle or post-merge checkpoint.",
+  };
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -214,14 +214,20 @@ describe("operator loop workflow selection", () => {
       );
       createdPaths.add(tempDir);
       const prompt = await fs.readFile(promptCapture, "utf8");
+      const freshnessIndex = prompt.indexOf(
+        "bin/check-factory-runtime-freshness.ts",
+      );
       const reportReviewIndex = prompt.indexOf(
         "bin/symphony-report.ts review-pending",
       );
       const queueWorkIndex = prompt.indexOf("review any active `plan-ready`");
 
+      expect(freshnessIndex).toBeGreaterThanOrEqual(0);
       expect(reportReviewIndex).toBeGreaterThanOrEqual(0);
       expect(queueWorkIndex).toBeGreaterThanOrEqual(0);
+      expect(freshnessIndex).toBeLessThan(reportReviewIndex);
       expect(reportReviewIndex).toBeLessThan(queueWorkIndex);
+      expect(prompt).toContain("bin/check-factory-runtime-freshness.ts");
       expect(prompt).toContain("bin/symphony-report.ts review-pending");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/unit/operator-runtime-freshness.test.ts
+++ b/tests/unit/operator-runtime-freshness.test.ts
@@ -171,4 +171,69 @@ describe("assessOperatorRuntimeFreshness", () => {
     expect(result.shouldRestart).toBe(false);
     expect(result.activeIssueCount).toBe(1);
   });
+
+  it("reports stopped when factory control is not running", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus({
+        controlState: "stopped",
+      }),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "engine-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("stopped");
+    expect(result.shouldRestart).toBe(false);
+  });
+
+  it("reports engine-head-unavailable when the operator checkout head is unavailable", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus(),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: null,
+        committedAt: null,
+        isDirty: null,
+        source: "git-error",
+        detail: "git unavailable",
+      },
+    });
+
+    expect(result.kind).toBe("engine-head-unavailable");
+    expect(result.shouldRestart).toBe(false);
+  });
+
+  it("reports runtime-head-unavailable when the running factory head is unavailable", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus({
+        startup: {
+          ...buildStatus().startup!,
+          runtimeIdentity: {
+            checkoutPath: "/tmp/repo",
+            headSha: null,
+            committedAt: null,
+            isDirty: null,
+            source: "git-error",
+            detail: "runtime git unavailable",
+          },
+        },
+      }),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "engine-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("runtime-head-unavailable");
+    expect(result.shouldRestart).toBe(false);
+  });
 });

--- a/tests/unit/operator-runtime-freshness.test.ts
+++ b/tests/unit/operator-runtime-freshness.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import type { FactoryControlStatusSnapshot } from "../../src/cli/factory-control.js";
+import { assessOperatorRuntimeFreshness } from "../../src/observability/operator-runtime-freshness.js";
+
+function buildStatus(
+  overrides: Partial<FactoryControlStatusSnapshot> = {},
+): FactoryControlStatusSnapshot {
+  return {
+    controlState: "running",
+    paths: {
+      repoRoot: "/tmp/repo",
+      runtimeRoot: "/tmp/repo/.tmp/factory-main",
+      workflowPath: "/tmp/repo/WORKFLOW.md",
+      statusFilePath: "/tmp/repo/.tmp/status.json",
+      startupFilePath: "/tmp/repo/.tmp/startup.json",
+    },
+    sessionName: "test-session",
+    sessions: [],
+    workerAlive: true,
+    startup: {
+      state: "ready",
+      provider: "github-bootstrap/local-mirror",
+      summary: "ready",
+      updatedAt: "2026-03-30T00:00:00Z",
+      workerPid: 123,
+      workerAlive: true,
+      stale: false,
+      runtimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "runtime-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    },
+    snapshotFreshness: {
+      freshness: "fresh",
+      reason: "current-snapshot",
+      summary: "fresh",
+      workerAlive: true,
+      publicationState: "current",
+    },
+    statusSnapshot: {
+      version: 1,
+      generatedAt: "2026-03-30T00:00:00Z",
+      runtimeIdentity: null,
+      publication: { state: "current", detail: null },
+      dispatchPressure: null,
+      hostDispatch: null,
+      restartRecovery: {
+        state: "idle",
+        startedAt: null,
+        completedAt: null,
+        summary: null,
+        issues: [],
+      },
+      recoveryPosture: {
+        summary: { family: "healthy", summary: "healthy", issueCount: 0 },
+        entries: [],
+      },
+      factoryState: "idle",
+      worker: {
+        instanceId: "instance",
+        pid: 123,
+        startedAt: "2026-03-30T00:00:00Z",
+        pollIntervalMs: 30000,
+        maxConcurrentRuns: 1,
+      },
+      counts: {
+        ready: 0,
+        running: 0,
+        failed: 0,
+        activeLocalRuns: 0,
+        retries: 0,
+      },
+      lastAction: {
+        kind: "poll-started",
+        summary: "polling",
+        at: "2026-03-30T00:00:00Z",
+        issueNumber: null,
+      },
+      activeIssues: [],
+      readyQueue: [],
+      retries: [],
+    },
+    processIds: [],
+    problems: [],
+    ...overrides,
+  };
+}
+
+describe("assessOperatorRuntimeFreshness", () => {
+  it("reports fresh when runtime and engine heads match", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus(),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "runtime-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("fresh");
+    expect(result.shouldRestart).toBe(false);
+  });
+
+  it("requests restart when runtime is stale and idle", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus(),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "engine-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("stale-idle");
+    expect(result.shouldRestart).toBe(true);
+  });
+
+  it("defers restart when runtime is stale and busy", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus({
+        statusSnapshot: {
+          ...buildStatus().statusSnapshot!,
+          factoryState: "running",
+          activeIssues: [
+            {
+              issueNumber: 1,
+              issueIdentifier: "repo#1",
+              title: "active",
+              source: "running",
+              runSequence: 1,
+              status: "running",
+              summary: "running",
+              workspacePath: null,
+              branchName: "branch",
+              runSessionId: null,
+              executionOwner: null,
+              ownerPid: 123,
+              runnerPid: null,
+              startedAt: null,
+              updatedAt: "2026-03-30T00:00:00Z",
+              pullRequest: null,
+              checks: { pendingNames: [], failingNames: [] },
+              review: { actionableCount: 0, unresolvedThreadCount: 0 },
+              blockedReason: null,
+              runnerVisibility: null,
+            },
+          ],
+        },
+      }),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "engine-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("stale-busy");
+    expect(result.shouldRestart).toBe(false);
+    expect(result.activeIssueCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic operator helper that compares the selected factory runtime head to the current engine checkout head
- classify freshness as fresh, stale-idle, stale-busy, or unavailable so wake-ups can restart only when it is safe
- make the operator prompt and skill require this check before ordinary queue work, with regression coverage

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
