### PR TITLE
Automate terminal issue report publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Generate a per-issue report from local artifacts:
 pnpm tsx bin/symphony-report.ts issue --issue 44
 ```
 
+Symphony now runs this generation step automatically after a terminal issue
+outcome is recorded. Successful runs generate reports after merge is observed;
+failed runs generate reports after the terminal failure is recorded. The manual
+command remains available for ad hoc regeneration.
+
 Inspect pending completed-run report reviews for the selected operator
 instance:
 
@@ -227,6 +232,10 @@ worktree:
 ```bash
 pnpm tsx bin/symphony-report.ts publish --issue 44 --archive-root ../factory-runs
 ```
+
+If `WORKFLOW.md` sets `observability.issue_reports.archive_root`, Symphony also
+attempts this publication step automatically after each terminal run. Local
+artifacts remain canonical if archive publication is blocked or partial.
 
 Archive publication stays detached from `symphony run` and `symphony-ts` CI. It
 copies the already-canonical local `report.json`, `report.md`, and available
@@ -276,7 +285,7 @@ If expected reviewer apps are configured and never produce qualifying output on 
 
 If a run fails, Symphony retries. After retries are exhausted, it marks the issue `symphony:failed`.
 
-Active run ownership is persisted locally as a transport-aware execution-owner record. On restart, Symphony reconciles `symphony:running` issues against local state, recovers orphaned runs, and resumes or fails them cleanly without assuming every execution owns a local runner PID. Per-issue reporting artifacts are written to `.var/factory/issues/` so they survive workspace cleanup. Generated per-issue reports are written under `.var/reports/issues/<issue-number>/` when the report command is run.
+Active run ownership is persisted locally as a transport-aware execution-owner record. On restart, Symphony reconciles `symphony:running` issues against local state, recovers orphaned runs, and resumes or fails them cleanly without assuming every execution owns a local runner PID. Per-issue reporting artifacts are written to `.var/factory/issues/` so they survive workspace cleanup. Symphony records automatic report-generation/publication receipts in `.var/factory/issues/<issue-number>/terminal-reporting.json` and writes generated per-issue reports under `.var/reports/issues/<issue-number>/`.
 Those paths are instance-owned: for any given run they live under the repository that owns the active `WORKFLOW.md`, not under a shared engine-global temp root.
 
 ## Configuration

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -75,6 +75,11 @@ agent:
   timeout_ms: 5400000
   max_turns: 20
   env: {}
+observability:
+  # Optional automatic archive publication for terminal issue reports.
+  # Relative paths resolve from the repository that owns this WORKFLOW.md.
+  # issue_reports:
+  #   archive_root: ../factory-runs
 ---
 
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.

--- a/docs/guides/workflow-frontmatter-reference.md
+++ b/docs/guides/workflow-frontmatter-reference.md
@@ -650,6 +650,29 @@ The parser accepts:
 - Required: no
 - Default: `16`
 
+#### `observability.issue_reports`
+
+- Type: object
+- Required: no
+- Default: omitted
+
+Controls automatic per-issue report generation and optional archive
+publication after terminal issue outcomes.
+
+##### `observability.issue_reports.archive_root`
+
+- Type: string
+- Required: no
+- Default: omitted
+
+When configured, Symphony attempts to publish each terminal issue report into
+the checked-out `factory-runs` archive rooted at this path after generating or
+refreshing the local report. Relative paths resolve from the repository that
+owns `WORKFLOW.md`.
+
+If omitted, Symphony still generates the local terminal issue report
+automatically, but publication stays manual through `symphony-report publish`.
+
 ## Minimal GitHub Example
 
 ```yaml

--- a/docs/plans/250-automatic-terminal-run-report-publication/plan.md
+++ b/docs/plans/250-automatic-terminal-run-report-publication/plan.md
@@ -267,16 +267,16 @@ One reporting subject is a terminal issue keyed by:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Issue reaches terminal success/failure, no receipt exists yet | current terminal issue artifacts and session/log pointers | issue is already terminal | create `pending-generation`, generate report immediately, then continue to publish or finalize |
-| Terminal issue has current report and no archive root configured | current report exists, no publish config | issue is terminal | mark/report `report-generated` with explicit “publication not configured” note |
-| Terminal issue has current report and configured archive root | current report exists, publish config resolves | issue is terminal | move to `pending-publication` and publish immediately |
-| Report generation fails (artifact parse error, write failure, stale invariant) | terminal artifacts plus error | issue is terminal | record `blocked` at generation stage; keep issue terminal and surface blocker |
-| Publication fails because archive root is missing/unwritable | current report exists plus publish error | issue is terminal | record `blocked` at publication stage with explicit archive-root error |
-| Publication succeeds with referenced/unavailable logs only | current report plus partial publish metadata | issue is terminal | record `publication-partial`; do not treat as blocked if required files landed |
-| Factory restarts and finds terminal issue with stale/missing receipt | terminal issue artifacts and maybe stale receipt | issue is terminal | reconcile: rerun only the missing step for the current terminal receipt |
-| Factory restarts and finds already-published current receipt | current report receipt and publish metadata | issue is terminal | do nothing; keep published/partial status visible |
+| Observed condition                                                             | Local facts available                                     | Normalized tracker facts available | Expected decision                                                                              |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Issue reaches terminal success/failure, no receipt exists yet                  | current terminal issue artifacts and session/log pointers | issue is already terminal          | create `pending-generation`, generate report immediately, then continue to publish or finalize |
+| Terminal issue has current report and no archive root configured               | current report exists, no publish config                  | issue is terminal                  | mark/report `report-generated` with explicit “publication not configured” note                 |
+| Terminal issue has current report and configured archive root                  | current report exists, publish config resolves            | issue is terminal                  | move to `pending-publication` and publish immediately                                          |
+| Report generation fails (artifact parse error, write failure, stale invariant) | terminal artifacts plus error                             | issue is terminal                  | record `blocked` at generation stage; keep issue terminal and surface blocker                  |
+| Publication fails because archive root is missing/unwritable                   | current report exists plus publish error                  | issue is terminal                  | record `blocked` at publication stage with explicit archive-root error                         |
+| Publication succeeds with referenced/unavailable logs only                     | current report plus partial publish metadata              | issue is terminal                  | record `publication-partial`; do not treat as blocked if required files landed                 |
+| Factory restarts and finds terminal issue with stale/missing receipt           | terminal issue artifacts and maybe stale receipt          | issue is terminal                  | reconcile: rerun only the missing step for the current terminal receipt                        |
+| Factory restarts and finds already-published current receipt                   | current report receipt and publish metadata               | issue is terminal                  | do nothing; keep published/partial status visible                                              |
 
 ## Storage And Persistence Contract
 

--- a/docs/plans/250-automatic-terminal-run-report-publication/plan.md
+++ b/docs/plans/250-automatic-terminal-run-report-publication/plan.md
@@ -1,0 +1,365 @@
+# Issue 250 Plan: Automatic Terminal-Run Report Publication
+
+## Status
+
+`plan-ready`
+
+## Goal
+
+Make per-issue report generation a standard post-terminal step for successful and failed issue runs, and add an optional workflow-owned archive-publication path so a configured `factory-runs` checkout is updated automatically without requiring manual `symphony-report` follow-up commands.
+
+## Scope
+
+This slice covers:
+
+1. automatic per-issue report generation after terminal success/failure
+2. an explicit workflow/config contract for optional automatic `factory-runs` publication
+3. a small, typed post-terminal reporting state/receipt contract that records generation and publication outcomes per issue
+4. coordinator-owned triggering plus restart-time reconciliation for terminal issues whose reporting work is missing or blocked
+5. operator/status surfacing so missing archive config, successful publication, partial publication, and blocked publication are inspectable
+6. focused unit, integration, and end-to-end coverage for successful and failed runs plus restart recovery of blocked publication work
+7. docs updates for the new runtime behavior and workflow config
+
+## Non-goals
+
+This slice does not include:
+
+1. making archive publication mandatory for all workflows
+2. pushing, committing, or opening PRs in the `factory-runs` repository
+3. campaign-level archive automation or digest publication
+4. redesigning the existing issue-report schema beyond the additive state/receipt metadata needed for automation
+5. moving tracker, runner, or workspace policy into the report/publication services
+6. turning operator review state into the canonical source of terminal reporting truth
+
+## Current Gaps
+
+Today the repo has the required detached building blocks but no normal runtime automation:
+
+1. `writeIssueReport()` exists, but the orchestrator does not invoke it automatically when an issue becomes terminal
+2. `publishIssueToFactoryRuns()` exists, but publication only happens through the detached CLI
+3. there is no workflow-owned config for a default archive root
+4. there is no durable per-issue reporting receipt that tells operators whether automatic generation/publication ran, was skipped, or failed
+5. restart recovery does not reconcile terminal issues that are missing reports or blocked on publication
+6. the operator/report surfaces can discover completed reports later, but they do not show whether the standard terminal automation succeeded
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that report generation is a standard terminal step for both success and failure
+2. the rule that archive publication is optional and enabled only when configured
+3. the rule that missing archive configuration is explicit and inspectable rather than silently treated as success
+4. the rule that terminal issue completion remains tracker truth even if reporting/publication is blocked
+
+Does not belong here:
+
+1. raw file-copy mechanics
+2. tracker transport details
+3. hidden operator-only conventions for whether publication ran
+
+### Configuration Layer
+
+Belongs here:
+
+1. a typed `WORKFLOW.md` contract for optional automatic archive publication
+2. path resolution for the configured archive root relative to the owning workflow/instance root
+3. parser validation and docs for the new observability/reporting config surface
+
+Does not belong here:
+
+1. inline publication logic
+2. status rendering rules
+3. coordinator retry state encoded only in prompt text
+
+### Coordination Layer
+
+Belongs here:
+
+1. triggering post-terminal reporting work from the terminal success/failure seam
+2. explicit runtime-state transitions for whether a terminal issue still needs report generation/publication work
+3. restart-time reconciliation of missing or blocked reporting work for already-terminal issues
+4. keeping reporting failures observable without reopening tracker lifecycle policy
+
+Does not belong here:
+
+1. tracker-specific archive behavior
+2. report rendering details
+3. file-copy code for `factory-runs`
+
+### Execution Layer
+
+Belongs here:
+
+1. no new runner/workspace responsibilities beyond existing raw artifacts consumed by report generation
+
+Does not belong here:
+
+1. archive publication policy
+2. post-terminal report state ownership
+3. ad hoc workspace retention changes created only for publication
+
+### Integration Layer
+
+Belongs here:
+
+1. optional `factory-runs` publication using the configured archive root
+2. normalization of publication outcomes into a stable receipt/status shape for the coordinator
+3. idempotent publish behavior when restart reconciliation re-runs a terminal publication
+
+Does not belong here:
+
+1. orchestrator dispatch or retry policy
+2. issue-report derivation logic
+3. operator review-state bookkeeping
+
+### Observability Layer
+
+Belongs here:
+
+1. automatic report generation over canonical issue artifacts
+2. the durable per-issue reporting receipt/state contract
+3. status-facing summaries of report/publication state
+4. read/write helpers for the receipt contract and any additive artifact pointers
+
+Does not belong here:
+
+1. tracker mutations
+2. archive git operations beyond local publication results
+3. retry/backoff logic that belongs to the coordinator
+
+## Architecture Boundaries
+
+### `src/orchestrator/`
+
+Owns:
+
+1. detecting terminal issue transitions and invoking post-terminal reporting automation
+2. explicit transition logic for pending/generated/published/blocked reporting work
+3. restart reconciliation for terminal reporting receipts
+
+Does not own:
+
+1. report composition internals
+2. archive directory layout policy
+3. operator review-ledger state
+
+### `src/observability/`
+
+Owns:
+
+1. `writeIssueReport()` reuse for automatic generation
+2. a typed reporting receipt/state document stored with instance-owned issue artifacts
+3. status-friendly summaries for the latest generation/publication outcome
+
+Does not own:
+
+1. tracker completion/failure transitions
+2. archive-root config parsing
+3. `factory-runs` worktree validation logic
+
+### `src/integration/`
+
+Owns:
+
+1. `factory-runs` publication and normalized publication result details
+2. resolving publication status as `published`, `partial`, or blocked with factual notes
+
+Does not own:
+
+1. whether publication should run
+2. report-generation fallback policy
+3. coordinator restart decisions
+
+### `src/config/` and docs
+
+Own:
+
+1. the new optional workflow field for archive publication
+2. parser validation and path resolution
+3. README/frontmatter docs updates
+
+Do not own:
+
+1. publication state mutations
+2. report rendering
+3. operator runtime decisions
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR by staying on one post-terminal reporting seam:
+
+1. add a narrow workflow/config contract for optional publication
+2. add a focused terminal-reporting receipt/service seam in observability/integration
+3. wire the coordinator to trigger and reconcile that seam after terminal issue transitions
+4. update status/operator docs and tests around that one runtime behavior
+
+This PR deliberately defers:
+
+1. campaign/archive automation beyond the per-issue terminal path
+2. remote git publication from the archive checkout
+3. broader operator-loop redesign or follow-up issue filing changes
+4. any redesign of the canonical report schema beyond what the receipt/status seam strictly needs
+
+Why this seam is reviewable:
+
+1. it preserves the existing report-generation and `factory-runs` publication services as the core workhorses
+2. it keeps tracker policy, report rendering, and archive file-copy code in their existing layers
+3. it limits coordination changes to one explicit terminal follow-through path instead of broad run-loop refactors
+
+## Runtime State Model
+
+This issue changes post-terminal orchestration behavior, so the reporting follow-through state must be explicit rather than inferred from ad hoc file existence checks.
+
+### Reporting subject
+
+One reporting subject is a terminal issue keyed by:
+
+1. issue number
+2. terminal issue update timestamp / observed terminal transition
+3. current report generation timestamp when present
+4. configured archive root identity when publication is enabled
+
+### Receipt states
+
+1. `pending-generation`
+   - the issue is terminal, but the current terminal report has not been generated yet
+2. `report-generated`
+   - the current terminal report exists and publication is not configured
+3. `pending-publication`
+   - the current terminal report exists and archive publication is configured but not yet completed for the current receipt
+4. `published`
+   - the current terminal report was generated and publication completed
+5. `publication-partial`
+   - required report files were published, but some log-copy outcomes were partial
+6. `blocked`
+   - report generation or publication failed for the current terminal receipt and needs reconciliation
+
+### Allowed transitions
+
+1. `pending-generation -> report-generated`
+2. `pending-generation -> pending-publication`
+3. `pending-generation -> blocked`
+4. `report-generated -> pending-publication`
+   - only if config changes to enable publication and the existing report remains current
+5. `pending-publication -> published`
+6. `pending-publication -> publication-partial`
+7. `pending-publication -> blocked`
+8. `publication-partial -> published`
+   - on a later successful republish
+9. `publication-partial -> blocked`
+10. `blocked -> pending-generation`
+    - when the blocker was report generation and the coordinator retries on restart/poll
+11. `blocked -> pending-publication`
+    - when the report exists and only publication needs another attempt
+12. any terminal receipt state -> `pending-generation`
+    - when the issue reaches a newer terminal update that makes the stored report stale
+
+### Coordinator rules
+
+1. tracker completion/failure remains the terminal source of truth even when the receipt is `blocked`
+2. the coordinator should run reporting work after terminal artifact persistence so report generation reads the current canonical facts
+3. restart reconciliation should examine terminal issues plus the receipt document and resume only the missing blocked step for the current terminal receipt
+4. reporting follow-through must not consume the issue retry budget used for coding-agent failures
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Issue reaches terminal success/failure, no receipt exists yet | current terminal issue artifacts and session/log pointers | issue is already terminal | create `pending-generation`, generate report immediately, then continue to publish or finalize |
+| Terminal issue has current report and no archive root configured | current report exists, no publish config | issue is terminal | mark/report `report-generated` with explicit “publication not configured” note |
+| Terminal issue has current report and configured archive root | current report exists, publish config resolves | issue is terminal | move to `pending-publication` and publish immediately |
+| Report generation fails (artifact parse error, write failure, stale invariant) | terminal artifacts plus error | issue is terminal | record `blocked` at generation stage; keep issue terminal and surface blocker |
+| Publication fails because archive root is missing/unwritable | current report exists plus publish error | issue is terminal | record `blocked` at publication stage with explicit archive-root error |
+| Publication succeeds with referenced/unavailable logs only | current report plus partial publish metadata | issue is terminal | record `publication-partial`; do not treat as blocked if required files landed |
+| Factory restarts and finds terminal issue with stale/missing receipt | terminal issue artifacts and maybe stale receipt | issue is terminal | reconcile: rerun only the missing step for the current terminal receipt |
+| Factory restarts and finds already-published current receipt | current report receipt and publish metadata | issue is terminal | do nothing; keep published/partial status visible |
+
+## Storage And Persistence Contract
+
+This slice adds a durable per-issue reporting receipt under the instance-owned artifact tree. The exact filename can be chosen during implementation, but the contract should live with the issue artifacts, not in operator-only state.
+
+Contract rules:
+
+1. the receipt is additive to existing canonical issue artifacts and generated reports
+2. it records the current terminal issue identity, report generation facts, publication facts, stage-specific notes, and timestamps
+3. it distinguishes `not configured`, `blocked`, `partial`, and `published` explicitly instead of overloading one summary string
+4. it points back to canonical generated report paths and published archive paths when available
+5. it is rewritten atomically so restart reconciliation never reads truncated state
+
+## Observability Requirements
+
+1. terminal issue status/output should expose whether the current report is pending, generated only, published, partial, or blocked
+2. missing archive configuration must be visible as an explicit state/note rather than indistinguishable from successful publication
+3. blocked reporting/publication must include the stage and a factual error summary
+4. operator-facing docs must describe where to inspect the receipt and published outputs
+5. generated report/publication automation should remain attributable to the current terminal issue state and not depend on operator scratchpads
+
+## Implementation Steps
+
+1. Add a typed workflow/config contract for optional archive publication under `observability`, including parser validation and path resolution relative to the instance root/workflow owner.
+2. Add a small observability-side reporting receipt/state module that can read/write the per-issue terminal-reporting state atomically.
+3. Extract or wrap the existing report-generation/publication calls behind a focused service that:
+   - generates the current report
+   - optionally publishes it
+   - returns a normalized receipt update with stage, notes, and output paths
+4. Wire the coordinator terminal success/failure seam so the service runs after terminal artifact persistence in both `#completeIssue` and `#failIssue`.
+5. Add restart/poll reconciliation for terminal issues whose reporting receipt is missing, stale, or blocked, keeping this logic separate from runner retry budgeting.
+6. Extend status/operator-facing surfaces to project the current reporting/publication outcome for terminal issues.
+7. Update README and workflow-frontmatter docs for the new automatic behavior and optional archive-publication config.
+8. Add focused tests and then one realistic end-to-end run that proves reports are emitted automatically without manual CLI invocation.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. config parsing resolves the optional archive root and rejects malformed values
+2. reporting receipt transitions are explicit for generated-only, published, partial, and blocked outcomes
+3. restart reconciliation chooses the missing step correctly for stale or blocked receipts
+
+### Integration
+
+1. terminal success automatically generates `report.json` and `report.md` without invoking `symphony-report issue`
+2. terminal failure does the same and preserves explicit failure/report status
+3. configured archive publication writes into `factory-runs` automatically and records the published receipt
+4. missing or unwritable archive roots produce a blocked publication receipt with a factual note
+5. partial log publication records `publication-partial` rather than pretending the issue was fully published
+
+### End-to-end
+
+1. a representative successful factory run ends with generated per-issue reports present under `.var/reports/issues/<issue-number>/`
+2. the same run publishes into a configured local `factory-runs` checkout without manual report CLI commands
+3. a representative failed run also emits the report automatically and leaves an inspectable receipt/state
+4. a restarted runtime resumes a previously blocked publication path and converges once the archive root becomes valid
+
+## Acceptance Scenarios
+
+1. Given a successful issue run with no archive root configured, when the issue becomes terminal, then Symphony writes the per-issue report automatically and surfaces that publication was skipped because it was not configured.
+2. Given a failed issue run with an archive root configured, when the issue becomes terminal, then Symphony writes the per-issue report automatically and publishes it into `factory-runs`.
+3. Given a terminal issue whose archive publication failed, when the factory restarts after the archive root is repaired, then Symphony retries the missing publication step and records the converged success/partial result.
+4. Given a terminal issue whose report generation fails, when an operator inspects status/artifacts, then the blocked stage and factual error are visible without reopening tracker lifecycle state.
+
+## Exit Criteria
+
+1. terminal success and exhausted terminal failure both trigger automatic per-issue report generation
+2. archive publication is automatic only when configured through the workflow contract
+3. operators can inspect whether the current terminal issue report is generated, published, partial, or blocked
+4. restart reconciliation converges missing/blocked terminal reporting work without piggybacking on agent retry counters
+5. docs and parser-aligned config references describe the new behavior accurately
+6. relevant unit, integration, and end-to-end tests pass
+
+## Deferred To Later Issues Or PRs
+
+1. automatic campaign digest publication
+2. archive-repo commit/push/PR automation
+3. broader operator-loop behavior changes beyond consuming the surfaced receipt/status
+4. any archive backlog backfill command for historical runs predating this receipt contract
+
+## Decision Notes
+
+1. Keep automatic report generation/publication as a coordinator-triggered follow-through path, not a pure operator-loop concern, because the issue goal is standard terminal behavior and should not depend on whether the operator wakes up.
+2. Keep the receipt contract under instance-owned issue artifacts rather than `.ralph/` so terminal reporting truth remains part of runtime evidence, while operator review state remains a separate consumer.
+3. Treat publication as optional config but generation as mandatory terminal follow-through so the repo always preserves local evidence even when no archive checkout exists.

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -512,10 +512,16 @@ function isScpStyleRepoUrl(repoUrl: string): boolean {
 
 function resolveObservabilityConfig(
   raw: Readonly<Record<string, unknown>>,
+  instanceRoot: string,
 ): ObservabilityConfig {
   const dashboardEnabled = raw["dashboard_enabled"];
   const refreshMs = raw["refresh_ms"];
   const renderIntervalMs = raw["render_interval_ms"];
+  const issueReports = raw["issue_reports"];
+  const resolvedIssueReports =
+    issueReports === undefined
+      ? { archiveRoot: null }
+      : resolveIssueReportsConfig(issueReports, instanceRoot);
   return {
     dashboardEnabled:
       dashboardEnabled === undefined
@@ -531,6 +537,28 @@ function resolveObservabilityConfig(
       renderIntervalMs === undefined
         ? 16
         : requireNumber(renderIntervalMs, "observability.render_interval_ms"),
+    issueReports: resolvedIssueReports,
+  };
+}
+
+function resolveIssueReportsConfig(
+  raw: unknown,
+  instanceRoot: string,
+): ObservabilityConfig["issueReports"] {
+  const issueReports = coerceOptionalObject(raw, "observability.issue_reports");
+  const archiveRootRaw = issueReports["archive_root"];
+  const archiveRoot =
+    archiveRootRaw === undefined
+      ? null
+      : path.resolve(
+          instanceRoot,
+          requireString(
+            archiveRootRaw,
+            "observability.issue_reports.archive_root",
+          ),
+        );
+  return {
+    archiveRoot,
   };
 }
 
@@ -671,7 +699,7 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
         ...(repo !== undefined ? { GITHUB_REPO: repo } : {}),
       },
     },
-    observability: resolveObservabilityConfig(observabilityRaw),
+    observability: resolveObservabilityConfig(observabilityRaw, instanceRoot),
   };
 
   if (!["stdin", "file"].includes(resolved.agent.promptTransport)) {

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -147,6 +147,9 @@ export interface ObservabilityConfig {
   readonly dashboardEnabled: boolean;
   readonly refreshMs: number;
   readonly renderIntervalMs: number;
+  readonly issueReports: {
+    readonly archiveRoot: string | null;
+  };
 }
 
 export interface RuntimeInstancePaths {

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -626,9 +626,7 @@ export function renderFactoryStatusSnapshot(
       lines.push(`    Summary: ${issue.summary}`);
       lines.push(`    Branch: ${issue.branchName}`);
       lines.push(`    Observed: ${issue.observedAt}`);
-      lines.push(
-        `    Workspace retention: ${issue.workspaceRetentionState}`,
-      );
+      lines.push(`    Workspace retention: ${issue.workspaceRetentionState}`);
       lines.push(
         `    Reporting: ${issue.reportingState ?? "unavailable"}${
           issue.reportingSummary === null ? "" : ` - ${issue.reportingSummary}`
@@ -1495,7 +1493,11 @@ function parseTerminalIssue(
 ): FactoryTerminalIssueSnapshot {
   const issue = expectObject(value, filePath, field);
   return {
-    issueNumber: expectInteger(issue.issueNumber, filePath, `${field}.issueNumber`),
+    issueNumber: expectInteger(
+      issue.issueNumber,
+      filePath,
+      `${field}.issueNumber`,
+    ),
     issueIdentifier: expectString(
       issue.issueIdentifier,
       filePath,

--- a/src/observability/status.ts
+++ b/src/observability/status.ts
@@ -185,6 +185,36 @@ export interface FactoryReadyQueueIssueSnapshot {
   readonly queuePriorityLabel: string | null;
 }
 
+export interface FactoryTerminalIssueSnapshot {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly branchName: string;
+  readonly terminalOutcome: "success" | "failure";
+  readonly summary: string;
+  readonly observedAt: string;
+  readonly workspaceRetentionState:
+    | "retry-retained"
+    | "terminal-retained"
+    | "cleanup-succeeded"
+    | "cleanup-failed"
+    | "unknown";
+  readonly reportingState:
+    | "pending-generation"
+    | "report-generated"
+    | "pending-publication"
+    | "published"
+    | "publication-partial"
+    | "blocked"
+    | null;
+  readonly reportingSummary: string | null;
+  readonly reportingReceiptFile: string | null;
+  readonly reportJsonFile: string | null;
+  readonly reportMarkdownFile: string | null;
+  readonly publicationRoot: string | null;
+  readonly blockedStage: "report-generation" | "publication" | null;
+}
+
 export interface FactoryHostDispatchHostSnapshot {
   readonly name: string;
   readonly occupiedByIssueNumber: number | null;
@@ -246,6 +276,7 @@ export interface FactoryStatusSnapshot {
   readonly counts: FactoryStatusCounts;
   readonly lastAction: FactoryStatusAction | null;
   readonly activeIssues: readonly FactoryActiveIssueSnapshot[];
+  readonly terminalIssues?: readonly FactoryTerminalIssueSnapshot[];
   readonly readyQueue?: readonly FactoryReadyQueueIssueSnapshot[];
   readonly retries: readonly FactoryRetrySnapshot[];
 }
@@ -584,6 +615,44 @@ export function renderFactoryStatusSnapshot(
   }
 
   lines.push("");
+  lines.push("Terminal issues:");
+  if ((snapshot.terminalIssues ?? []).length === 0) {
+    lines.push("  none");
+  } else {
+    for (const issue of snapshot.terminalIssues ?? []) {
+      lines.push(
+        `  #${issue.issueNumber.toString()} ${issue.title} [${issue.terminalOutcome}]`,
+      );
+      lines.push(`    Summary: ${issue.summary}`);
+      lines.push(`    Branch: ${issue.branchName}`);
+      lines.push(`    Observed: ${issue.observedAt}`);
+      lines.push(
+        `    Workspace retention: ${issue.workspaceRetentionState}`,
+      );
+      lines.push(
+        `    Reporting: ${issue.reportingState ?? "unavailable"}${
+          issue.reportingSummary === null ? "" : ` - ${issue.reportingSummary}`
+        }`,
+      );
+      if (issue.reportingReceiptFile !== null) {
+        lines.push(`    Reporting receipt: ${issue.reportingReceiptFile}`);
+      }
+      if (issue.reportJsonFile !== null) {
+        lines.push(`    report.json: ${issue.reportJsonFile}`);
+      }
+      if (issue.reportMarkdownFile !== null) {
+        lines.push(`    report.md: ${issue.reportMarkdownFile}`);
+      }
+      if (issue.publicationRoot !== null) {
+        lines.push(`    Published at: ${issue.publicationRoot}`);
+      }
+      if (issue.blockedStage !== null) {
+        lines.push(`    Blocked stage: ${issue.blockedStage}`);
+      }
+    }
+  }
+
+  lines.push("");
   lines.push("Ready queue:");
   if (readyQueue.length === 0) {
     lines.push("  none");
@@ -849,6 +918,21 @@ function parseFactoryStatusSnapshot(
       (entry, index) =>
         parseActiveIssue(entry, filePath, `activeIssues[${index.toString()}]`),
     ),
+    ...(snapshot.terminalIssues === undefined
+      ? {}
+      : {
+          terminalIssues: expectArray(
+            snapshot.terminalIssues,
+            filePath,
+            "terminalIssues",
+            (entry, index) =>
+              parseTerminalIssue(
+                entry,
+                filePath,
+                `terminalIssues[${index.toString()}]`,
+              ),
+          ),
+        }),
     readyQueue: expectArray(
       snapshot.readyQueue ?? [],
       filePath,
@@ -1400,6 +1484,88 @@ function parseActiveIssue(
       issue.runnerVisibility,
       filePath,
       `${field}.runnerVisibility`,
+    ),
+  };
+}
+
+function parseTerminalIssue(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryTerminalIssueSnapshot {
+  const issue = expectObject(value, filePath, field);
+  return {
+    issueNumber: expectInteger(issue.issueNumber, filePath, `${field}.issueNumber`),
+    issueIdentifier: expectString(
+      issue.issueIdentifier,
+      filePath,
+      `${field}.issueIdentifier`,
+    ),
+    title: expectString(issue.title, filePath, `${field}.title`),
+    branchName: expectString(issue.branchName, filePath, `${field}.branchName`),
+    terminalOutcome: expectEnum(
+      issue.terminalOutcome,
+      ["success", "failure"],
+      filePath,
+      `${field}.terminalOutcome`,
+    ),
+    summary: expectString(issue.summary, filePath, `${field}.summary`),
+    observedAt: expectString(issue.observedAt, filePath, `${field}.observedAt`),
+    workspaceRetentionState: expectEnum(
+      issue.workspaceRetentionState,
+      [
+        "retry-retained",
+        "terminal-retained",
+        "cleanup-succeeded",
+        "cleanup-failed",
+        "unknown",
+      ],
+      filePath,
+      `${field}.workspaceRetentionState`,
+    ),
+    reportingState: expectNullableEnum(
+      issue.reportingState,
+      [
+        "pending-generation",
+        "report-generated",
+        "pending-publication",
+        "published",
+        "publication-partial",
+        "blocked",
+      ],
+      filePath,
+      `${field}.reportingState`,
+    ),
+    reportingSummary: expectNullableString(
+      issue.reportingSummary,
+      filePath,
+      `${field}.reportingSummary`,
+    ),
+    reportingReceiptFile: expectNullableString(
+      issue.reportingReceiptFile,
+      filePath,
+      `${field}.reportingReceiptFile`,
+    ),
+    reportJsonFile: expectNullableString(
+      issue.reportJsonFile,
+      filePath,
+      `${field}.reportJsonFile`,
+    ),
+    reportMarkdownFile: expectNullableString(
+      issue.reportMarkdownFile,
+      filePath,
+      `${field}.reportMarkdownFile`,
+    ),
+    publicationRoot: expectNullableString(
+      issue.publicationRoot,
+      filePath,
+      `${field}.publicationRoot`,
+    ),
+    blockedStage: expectNullableEnum(
+      issue.blockedStage,
+      ["report-generation", "publication"],
+      filePath,
+      `${field}.blockedStage`,
     ),
   };
 }

--- a/src/observability/terminal-reporting.ts
+++ b/src/observability/terminal-reporting.ts
@@ -132,50 +132,7 @@ export async function listTerminalIssues(
   const completed = await Promise.all(
     entries
       .filter((entry) => entry.isDirectory())
-      .map(async (entry) => {
-        const issueFile = path.join(
-          resolvedInstance.issueArtifactsRoot,
-          entry.name,
-          "issue.json",
-        );
-        let parsed: Record<string, unknown>;
-        try {
-          parsed = JSON.parse(await fs.readFile(issueFile, "utf8")) as Record<
-            string,
-            unknown
-          >;
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-            return null;
-          }
-          throw error;
-        }
-        const currentOutcome = parsed["currentOutcome"];
-        if (currentOutcome !== "succeeded" && currentOutcome !== "failed") {
-          return null;
-        }
-        const issueNumber = parsed["issueNumber"];
-        const issueIdentifier = parsed["issueIdentifier"];
-        const title = parsed["title"];
-        const lastUpdatedAt = parsed["lastUpdatedAt"];
-        if (
-          typeof issueNumber !== "number" ||
-          typeof issueIdentifier !== "string" ||
-          typeof title !== "string" ||
-          typeof lastUpdatedAt !== "string"
-        ) {
-          throw new ObservabilityError(
-            `Malformed terminal issue summary at ${issueFile}; expected completed issue fields.`,
-          );
-        }
-        return {
-          issueNumber,
-          issueIdentifier,
-          title,
-          currentOutcome,
-          lastUpdatedAt,
-        } satisfies TerminalIssueSummary;
-      }),
+      .map((entry) => readTerminalIssue(resolvedInstance, Number(entry.name))),
   );
   return completed
     .filter((entry): entry is TerminalIssueSummary => entry !== null)
@@ -185,6 +142,53 @@ export async function listTerminalIssues(
       }
       return right.issueNumber - left.issueNumber;
     });
+}
+
+export async function readTerminalIssue(
+  instance: RuntimeInstanceInput,
+  issueNumber: number,
+): Promise<TerminalIssueSummary | null> {
+  const resolvedInstance = coerceRuntimeInstancePaths(instance);
+  const issueFile = path.join(
+    resolvedInstance.issueArtifactsRoot,
+    issueNumber.toString(),
+    "issue.json",
+  );
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(await fs.readFile(issueFile, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  const currentOutcome = parsed["currentOutcome"];
+  if (currentOutcome !== "succeeded" && currentOutcome !== "failed") {
+    return null;
+  }
+  const issueIdentifier = parsed["issueIdentifier"];
+  const title = parsed["title"];
+  const lastUpdatedAt = parsed["lastUpdatedAt"];
+  if (
+    typeof issueIdentifier !== "string" ||
+    typeof title !== "string" ||
+    typeof lastUpdatedAt !== "string"
+  ) {
+    throw new ObservabilityError(
+      `Malformed terminal issue summary at ${issueFile}; expected completed issue fields.`,
+    );
+  }
+  return {
+    issueNumber,
+    issueIdentifier,
+    title,
+    currentOutcome,
+    lastUpdatedAt,
+  } satisfies TerminalIssueSummary;
 }
 
 export async function reconcileTerminalIssueReporting(args: {
@@ -396,6 +400,31 @@ export function isIssueReportStale(
     Number.isFinite(reportTimestamp) &&
     Number.isFinite(issueTimestamp) &&
     reportTimestamp < issueTimestamp
+  );
+}
+
+export function shouldReconcileTerminalIssue(args: {
+  readonly issue: TerminalIssueSummary;
+  readonly receipt: TerminalIssueReportingReceipt | null;
+  readonly archiveRoot: string | null;
+}): boolean {
+  const { archiveRoot, issue, receipt } = args;
+  if (receipt === null) {
+    return true;
+  }
+  if (receipt.issueUpdatedAt !== issue.lastUpdatedAt) {
+    return true;
+  }
+  if (receipt.archiveRoot !== archiveRoot) {
+    return true;
+  }
+
+  if (archiveRoot === null) {
+    return receipt.state !== "report-generated";
+  }
+
+  return (
+    receipt.state !== "published" && receipt.state !== "publication-partial"
   );
 }
 

--- a/src/observability/terminal-reporting.ts
+++ b/src/observability/terminal-reporting.ts
@@ -1,0 +1,460 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
+import type { RuntimeInstanceInput } from "../domain/workflow.js";
+import { coerceRuntimeInstancePaths } from "../domain/workflow.js";
+import { publishIssueToFactoryRuns } from "../integration/factory-runs.js";
+import { createDefaultIssueReportEnrichers } from "../runner/codex-report-enricher.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
+import {
+  deriveIssueReportPaths,
+  readIssueReportDocument,
+  writeIssueReport,
+} from "./issue-report.js";
+
+export const TERMINAL_ISSUE_REPORTING_SCHEMA_VERSION = 1 as const;
+
+export type TerminalIssueReportingState =
+  | "pending-generation"
+  | "report-generated"
+  | "pending-publication"
+  | "published"
+  | "publication-partial"
+  | "blocked";
+
+export type TerminalIssueReportingBlockedStage =
+  | "report-generation"
+  | "publication";
+
+export interface TerminalIssueSummary {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly currentOutcome: "succeeded" | "failed";
+  readonly lastUpdatedAt: string;
+}
+
+export interface TerminalIssueReportingReceiptPaths {
+  readonly issueRoot: string;
+  readonly receiptFile: string;
+}
+
+export interface TerminalIssueReportingReceipt {
+  readonly version: typeof TERMINAL_ISSUE_REPORTING_SCHEMA_VERSION;
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly issueTitle: string;
+  readonly terminalOutcome: "succeeded" | "failed";
+  readonly issueUpdatedAt: string;
+  readonly state: TerminalIssueReportingState;
+  readonly summary: string;
+  readonly note: string | null;
+  readonly blockedStage: TerminalIssueReportingBlockedStage | null;
+  readonly archiveRoot: string | null;
+  readonly reportGeneratedAt: string | null;
+  readonly reportJsonFile: string | null;
+  readonly reportMarkdownFile: string | null;
+  readonly publicationId: string | null;
+  readonly publicationRoot: string | null;
+  readonly publicationMetadataFile: string | null;
+  readonly publishedAt: string | null;
+  readonly updatedAt: string;
+}
+
+export interface ReconcileTerminalIssueReportingResult {
+  readonly receipt: TerminalIssueReportingReceipt;
+  readonly changed: boolean;
+}
+
+export function deriveTerminalIssueReportingReceiptPaths(
+  instance: RuntimeInstanceInput,
+  issueNumber: number,
+): TerminalIssueReportingReceiptPaths {
+  const resolvedInstance = coerceRuntimeInstancePaths(instance);
+  const issueRoot = path.join(
+    resolvedInstance.issueArtifactsRoot,
+    issueNumber.toString(),
+  );
+  return {
+    issueRoot,
+    receiptFile: path.join(issueRoot, "terminal-reporting.json"),
+  };
+}
+
+export async function readTerminalIssueReportingReceipt(
+  instance: RuntimeInstanceInput,
+  issueNumber: number,
+): Promise<TerminalIssueReportingReceipt | null> {
+  const paths = deriveTerminalIssueReportingReceiptPaths(instance, issueNumber);
+  try {
+    const raw = await fs.readFile(paths.receiptFile, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (parsed["version"] !== TERMINAL_ISSUE_REPORTING_SCHEMA_VERSION) {
+      throw new ObservabilityError(
+        `Unsupported terminal issue reporting receipt schema in ${paths.receiptFile}`,
+      );
+    }
+    return parsed as unknown as TerminalIssueReportingReceipt;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function writeTerminalIssueReportingReceipt(
+  instance: RuntimeInstanceInput,
+  receipt: TerminalIssueReportingReceipt,
+): Promise<void> {
+  const paths = deriveTerminalIssueReportingReceiptPaths(
+    instance,
+    receipt.issueNumber,
+  );
+  await fs.mkdir(paths.issueRoot, { recursive: true });
+  await writeJsonFileAtomic(paths.receiptFile, receipt, {
+    tempPrefix: ".terminal-reporting",
+  });
+}
+
+export async function listTerminalIssues(
+  instance: RuntimeInstanceInput,
+): Promise<readonly TerminalIssueSummary[]> {
+  const resolvedInstance = coerceRuntimeInstancePaths(instance);
+  const entries = await fs
+    .readdir(resolvedInstance.issueArtifactsRoot, { withFileTypes: true })
+    .catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+  const completed = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const issueFile = path.join(
+          resolvedInstance.issueArtifactsRoot,
+          entry.name,
+          "issue.json",
+        );
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(await fs.readFile(issueFile, "utf8")) as Record<
+            string,
+            unknown
+          >;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return null;
+          }
+          throw error;
+        }
+        const currentOutcome = parsed["currentOutcome"];
+        if (currentOutcome !== "succeeded" && currentOutcome !== "failed") {
+          return null;
+        }
+        const issueNumber = parsed["issueNumber"];
+        const issueIdentifier = parsed["issueIdentifier"];
+        const title = parsed["title"];
+        const lastUpdatedAt = parsed["lastUpdatedAt"];
+        if (
+          typeof issueNumber !== "number" ||
+          typeof issueIdentifier !== "string" ||
+          typeof title !== "string" ||
+          typeof lastUpdatedAt !== "string"
+        ) {
+          throw new ObservabilityError(
+            `Malformed terminal issue summary at ${issueFile}; expected completed issue fields.`,
+          );
+        }
+        return {
+          issueNumber,
+          issueIdentifier,
+          title,
+          currentOutcome,
+          lastUpdatedAt,
+        } satisfies TerminalIssueSummary;
+      }),
+  );
+  return completed
+    .filter((entry): entry is TerminalIssueSummary => entry !== null)
+    .sort((left, right) => {
+      if (left.lastUpdatedAt !== right.lastUpdatedAt) {
+        return right.lastUpdatedAt.localeCompare(left.lastUpdatedAt);
+      }
+      return right.issueNumber - left.issueNumber;
+    });
+}
+
+export async function reconcileTerminalIssueReporting(args: {
+  readonly instance: RuntimeInstanceInput;
+  readonly issue: TerminalIssueSummary;
+  readonly archiveRoot: string | null;
+}): Promise<ReconcileTerminalIssueReportingResult> {
+  const resolvedInstance = coerceRuntimeInstancePaths(args.instance);
+  const receiptBefore = await readTerminalIssueReportingReceipt(
+    resolvedInstance,
+    args.issue.issueNumber,
+  );
+  const now = new Date().toISOString();
+  const reportPaths = deriveIssueReportPaths(
+    resolvedInstance,
+    args.issue.issueNumber,
+  );
+  let changed = false;
+
+  const reportDocument = await readIssueReportDocument(
+    resolvedInstance,
+    args.issue.issueNumber,
+  ).catch(() => null);
+  const hasCurrentReport =
+    reportDocument !== null &&
+    !isIssueReportStale(reportDocument.report.generatedAt, args.issue);
+
+  if (!hasCurrentReport) {
+    await writeTerminalIssueReportingReceipt(
+      resolvedInstance,
+      buildReceipt({
+        issue: args.issue,
+        state: "pending-generation",
+        archiveRoot: args.archiveRoot,
+        summary: "Generating the current terminal issue report.",
+        updatedAt: now,
+        reportJsonFile: reportPaths.reportJsonFile,
+        reportMarkdownFile: reportPaths.reportMarkdownFile,
+      }),
+    );
+    changed = true;
+    try {
+      const generated = await writeIssueReport(
+        resolvedInstance,
+        args.issue.issueNumber,
+        {
+          enrichers: createDefaultIssueReportEnrichers(),
+        },
+      );
+      if (args.archiveRoot === null) {
+        const receipt = buildReceipt({
+          issue: args.issue,
+          state: "report-generated",
+          archiveRoot: null,
+          summary:
+            "Generated the current terminal issue report. Archive publication is not configured.",
+          note: "Archive publication is not configured for this workflow.",
+          updatedAt: new Date().toISOString(),
+          reportGeneratedAt: generated.report.generatedAt,
+          reportJsonFile: generated.outputPaths.reportJsonFile,
+          reportMarkdownFile: generated.outputPaths.reportMarkdownFile,
+        });
+        await writeTerminalIssueReportingReceipt(resolvedInstance, receipt);
+        return {
+          receipt,
+          changed: true,
+        };
+      }
+    } catch (error) {
+      const receipt = buildReceipt({
+        issue: args.issue,
+        state: "blocked",
+        archiveRoot: args.archiveRoot,
+        summary: "Terminal issue report generation is blocked.",
+        note: error instanceof Error ? error.message : String(error),
+        blockedStage: "report-generation",
+        updatedAt: new Date().toISOString(),
+        reportJsonFile: reportPaths.reportJsonFile,
+        reportMarkdownFile: reportPaths.reportMarkdownFile,
+      });
+      await writeTerminalIssueReportingReceipt(resolvedInstance, receipt);
+      return {
+        receipt,
+        changed: true,
+      };
+    }
+  }
+
+  const currentReport = await readIssueReportDocument(
+    resolvedInstance,
+    args.issue.issueNumber,
+  );
+  if (args.archiveRoot === null) {
+    const nextReceipt = buildReceipt({
+      issue: args.issue,
+      state: "report-generated",
+      archiveRoot: null,
+      summary:
+        "Generated the current terminal issue report. Archive publication is not configured.",
+      note: "Archive publication is not configured for this workflow.",
+      updatedAt: new Date().toISOString(),
+      reportGeneratedAt: currentReport.report.generatedAt,
+      reportJsonFile: currentReport.outputPaths.reportJsonFile,
+      reportMarkdownFile: currentReport.outputPaths.reportMarkdownFile,
+    });
+    const equivalent =
+      receiptBefore !== null && areReceiptsEquivalent(receiptBefore, nextReceipt);
+    if (!equivalent) {
+      await writeTerminalIssueReportingReceipt(resolvedInstance, nextReceipt);
+      changed = true;
+    }
+    return {
+      receipt: nextReceipt,
+      changed,
+    };
+  }
+
+  if (
+    receiptBefore !== null &&
+    receiptBefore.issueUpdatedAt === args.issue.lastUpdatedAt &&
+    receiptBefore.archiveRoot === args.archiveRoot &&
+    receiptBefore.reportGeneratedAt === currentReport.report.generatedAt &&
+    (receiptBefore.state === "published" ||
+      receiptBefore.state === "publication-partial")
+  ) {
+    return {
+      receipt: receiptBefore,
+      changed,
+    };
+  }
+
+  await writeTerminalIssueReportingReceipt(
+    resolvedInstance,
+    buildReceipt({
+      issue: args.issue,
+      state: "pending-publication",
+      archiveRoot: args.archiveRoot,
+      summary: "Publishing the current terminal issue report to factory-runs.",
+      updatedAt: new Date().toISOString(),
+      reportGeneratedAt: currentReport.report.generatedAt,
+      reportJsonFile: currentReport.outputPaths.reportJsonFile,
+      reportMarkdownFile: currentReport.outputPaths.reportMarkdownFile,
+    }),
+  );
+  changed = true;
+
+  try {
+    const published = await publishIssueToFactoryRuns({
+      instance: resolvedInstance,
+      sourceRoot: resolvedInstance.workflowRoot,
+      archiveRoot: args.archiveRoot,
+      issueNumber: args.issue.issueNumber,
+    });
+    const receipt = buildReceipt({
+      issue: args.issue,
+      state:
+        published.status === "complete" ? "published" : "publication-partial",
+      archiveRoot: args.archiveRoot,
+      summary:
+        published.status === "complete"
+          ? "Generated and published the current terminal issue report."
+          : "Generated and published the current terminal issue report with partial log publication.",
+      note:
+        published.status === "complete"
+          ? null
+          : "Publication completed, but one or more session logs were referenced or unavailable.",
+      updatedAt: new Date().toISOString(),
+      reportGeneratedAt: currentReport.report.generatedAt,
+      reportJsonFile: currentReport.outputPaths.reportJsonFile,
+      reportMarkdownFile: currentReport.outputPaths.reportMarkdownFile,
+      publicationId: published.publicationId,
+      publicationRoot: published.paths.publicationRoot,
+      publicationMetadataFile: published.paths.metadataFile,
+      publishedAt: published.metadata.publishedAt,
+    });
+    await writeTerminalIssueReportingReceipt(resolvedInstance, receipt);
+    return {
+      receipt,
+      changed: true,
+    };
+  } catch (error) {
+    const receipt = buildReceipt({
+      issue: args.issue,
+      state: "blocked",
+      archiveRoot: args.archiveRoot,
+      summary: "Terminal issue report publication is blocked.",
+      note: error instanceof Error ? error.message : String(error),
+      blockedStage: "publication",
+      updatedAt: new Date().toISOString(),
+      reportGeneratedAt: currentReport.report.generatedAt,
+      reportJsonFile: currentReport.outputPaths.reportJsonFile,
+      reportMarkdownFile: currentReport.outputPaths.reportMarkdownFile,
+    });
+    await writeTerminalIssueReportingReceipt(resolvedInstance, receipt);
+    return {
+      receipt,
+      changed: true,
+    };
+  }
+}
+
+export function isIssueReportStale(
+  reportGeneratedAt: string,
+  issue: TerminalIssueSummary,
+): boolean {
+  const reportTimestamp = Date.parse(reportGeneratedAt);
+  const issueTimestamp = Date.parse(issue.lastUpdatedAt);
+  return (
+    Number.isFinite(reportTimestamp) &&
+    Number.isFinite(issueTimestamp) &&
+    reportTimestamp < issueTimestamp
+  );
+}
+
+function buildReceipt(args: {
+  readonly issue: TerminalIssueSummary;
+  readonly state: TerminalIssueReportingState;
+  readonly archiveRoot: string | null;
+  readonly summary: string;
+  readonly updatedAt: string;
+  readonly note?: string | null | undefined;
+  readonly blockedStage?: TerminalIssueReportingBlockedStage | null | undefined;
+  readonly reportGeneratedAt?: string | null | undefined;
+  readonly reportJsonFile?: string | null | undefined;
+  readonly reportMarkdownFile?: string | null | undefined;
+  readonly publicationId?: string | null | undefined;
+  readonly publicationRoot?: string | null | undefined;
+  readonly publicationMetadataFile?: string | null | undefined;
+  readonly publishedAt?: string | null | undefined;
+}): TerminalIssueReportingReceipt {
+  return {
+    version: TERMINAL_ISSUE_REPORTING_SCHEMA_VERSION,
+    issueNumber: args.issue.issueNumber,
+    issueIdentifier: args.issue.issueIdentifier,
+    issueTitle: args.issue.title,
+    terminalOutcome: args.issue.currentOutcome,
+    issueUpdatedAt: args.issue.lastUpdatedAt,
+    state: args.state,
+    summary: args.summary,
+    note: args.note ?? null,
+    blockedStage: args.blockedStage ?? null,
+    archiveRoot: args.archiveRoot,
+    reportGeneratedAt: args.reportGeneratedAt ?? null,
+    reportJsonFile: args.reportJsonFile ?? null,
+    reportMarkdownFile: args.reportMarkdownFile ?? null,
+    publicationId: args.publicationId ?? null,
+    publicationRoot: args.publicationRoot ?? null,
+    publicationMetadataFile: args.publicationMetadataFile ?? null,
+    publishedAt: args.publishedAt ?? null,
+    updatedAt: args.updatedAt,
+  };
+}
+
+function areReceiptsEquivalent(
+  left: TerminalIssueReportingReceipt,
+  right: TerminalIssueReportingReceipt,
+): boolean {
+  return (
+    left.issueUpdatedAt === right.issueUpdatedAt &&
+    left.state === right.state &&
+    left.summary === right.summary &&
+    left.note === right.note &&
+    left.blockedStage === right.blockedStage &&
+    left.archiveRoot === right.archiveRoot &&
+    left.reportGeneratedAt === right.reportGeneratedAt &&
+    left.reportJsonFile === right.reportJsonFile &&
+    left.reportMarkdownFile === right.reportMarkdownFile &&
+    left.publicationId === right.publicationId &&
+    left.publicationRoot === right.publicationRoot &&
+    left.publicationMetadataFile === right.publicationMetadataFile &&
+    left.publishedAt === right.publishedAt
+  );
+}

--- a/src/observability/terminal-reporting.ts
+++ b/src/observability/terminal-reporting.ts
@@ -295,7 +295,8 @@ export async function reconcileTerminalIssueReporting(args: {
       reportMarkdownFile: currentReport.outputPaths.reportMarkdownFile,
     });
     const equivalent =
-      receiptBefore !== null && areReceiptsEquivalent(receiptBefore, nextReceipt);
+      receiptBefore !== null &&
+      areReceiptsEquivalent(receiptBefore, nextReceipt);
     if (!equivalent) {
       await writeTerminalIssueReportingReceipt(resolvedInstance, nextReceipt);
       changed = true;

--- a/src/orchestrator/recovery-posture.ts
+++ b/src/orchestrator/recovery-posture.ts
@@ -47,6 +47,20 @@ export interface RuntimeTerminalCleanupPosture {
   readonly summary: string;
   readonly observedAt: string;
   readonly workspaceRetention: WorkspaceRetentionOutcome;
+  readonly reportingState:
+    | "pending-generation"
+    | "report-generated"
+    | "pending-publication"
+    | "published"
+    | "publication-partial"
+    | "blocked"
+    | null;
+  readonly reportingSummary: string | null;
+  readonly reportingReceiptFile: string | null;
+  readonly reportJsonFile: string | null;
+  readonly reportMarkdownFile: string | null;
+  readonly publicationRoot: string | null;
+  readonly blockedStage: "report-generation" | "publication" | null;
 }
 
 export function noteTerminalCleanupPosture(
@@ -202,7 +216,10 @@ export function projectRecoveryPosture(input: {
       issueIdentifier: issue.issueIdentifier,
       title: issue.title,
       source: "terminal-cleanup",
-      summary: issue.summary,
+      summary:
+        issue.reportingSummary === null
+          ? issue.summary
+          : `${issue.summary} Reporting: ${issue.reportingSummary}`,
       observedAt: issue.observedAt,
     });
   }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -163,6 +163,7 @@ import {
   setReadyQueue,
   setRestartRecoveryState,
   setTrackerIssueCounts,
+  upsertTerminalIssue,
   upsertActiveIssue,
 } from "./status-state.js";
 import { decideRestartRecovery } from "./restart-recovery.js";
@@ -180,6 +181,12 @@ import {
   extractRateLimitsSnapshot,
   extractTransientFailureSignal,
 } from "../runner/transient-failure.js";
+import {
+  deriveTerminalIssueReportingReceiptPaths,
+  listTerminalIssues,
+  reconcileTerminalIssueReporting,
+  type TerminalIssueReportingReceipt,
+} from "../observability/terminal-reporting.js";
 import {
   classifyWorkspaceCleanupFailure,
   classifyWorkspaceCleanupSuccess,
@@ -686,6 +693,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     this.#state.polling.checkingNow = false;
     this.#notifyDashboard();
     await this.#persistStatusSnapshot();
+    await this.#reconcileTerminalIssueReporting();
 
     if (availableSlots <= 0) {
       return;
@@ -707,6 +715,75 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
 
     await Promise.all(runs);
+  }
+
+  async #reconcileTerminalIssueReporting(): Promise<void> {
+    const terminalIssues = await listTerminalIssues(getConfigInstancePaths(this.#config));
+    for (const issue of terminalIssues) {
+      try {
+        const result = await reconcileTerminalIssueReporting({
+          instance: getConfigInstancePaths(this.#config),
+          issue,
+          archiveRoot: this.#config.observability.issueReports.archiveRoot,
+        });
+        const existingTerminal = this.#state.status.terminalIssues.find(
+          (entry) => entry.issueNumber === issue.issueNumber,
+        );
+        this.#upsertTerminalReportingStatus(
+          {
+            number: issue.issueNumber,
+            identifier: issue.issueIdentifier,
+            title: issue.title,
+          },
+          {
+            branchName: existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+            terminalOutcome:
+              issue.currentOutcome === "succeeded" ? "success" : "failure",
+            observedAt: issue.lastUpdatedAt,
+            workspaceRetentionState:
+              existingTerminal?.workspaceRetention.state ?? "unknown",
+            summary:
+              existingTerminal?.summary ??
+              `Terminal issue state recorded for ${issue.issueIdentifier}.`,
+            receipt: result.receipt,
+          },
+        );
+        if (result.changed) {
+          await this.#persistStatusSnapshot();
+        }
+      } catch (error) {
+        const normalizedError = this.#normalizeFailure(error as Error);
+        this.#logger.error("Terminal issue reporting reconciliation failed", {
+          issueNumber: issue.issueNumber,
+          error: normalizedError,
+        });
+        const existingTerminal = this.#state.status.terminalIssues.find(
+          (entry) => entry.issueNumber === issue.issueNumber,
+        );
+        this.#upsertTerminalReportingStatus(
+          {
+            number: issue.issueNumber,
+            identifier: issue.issueIdentifier,
+            title: issue.title,
+          },
+          {
+            branchName: existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+            terminalOutcome:
+              issue.currentOutcome === "succeeded" ? "success" : "failure",
+            observedAt: issue.lastUpdatedAt,
+            workspaceRetentionState:
+              existingTerminal?.workspaceRetention.state ?? "unknown",
+            summary:
+              existingTerminal?.summary ??
+              `Terminal issue state recorded for ${issue.issueIdentifier}.`,
+            receipt: null,
+            fallbackReportingSummary: normalizedError,
+            fallbackBlockedStage: "report-generation",
+          },
+        );
+        await this.#persistStatusSnapshot();
+      }
+    }
   }
 
   async runLoop(signal?: AbortSignal): Promise<void> {
@@ -1995,6 +2072,13 @@ export class BootstrapOrchestrator implements Orchestrator {
         workspaceRetention,
       }),
     );
+    await this.#runTerminalIssueReporting(issue, {
+      terminalOutcome: "success",
+      branchName: options?.branchName ?? this.#branchName(issue.number),
+      observedAt,
+      workspaceRetention,
+      summary,
+    });
   }
 
   async #refreshLifecycle(branchName: string): Promise<HandoffLifecycle> {
@@ -2609,6 +2693,65 @@ export class BootstrapOrchestrator implements Orchestrator {
         workspaceRetention,
       }),
     );
+    await this.#runTerminalIssueReporting(issue, {
+      terminalOutcome: "failure",
+      branchName: options?.branchName ?? this.#branchName(issue.number),
+      observedAt,
+      workspaceRetention,
+      summary,
+    });
+  }
+
+  async #runTerminalIssueReporting(
+    issue: RuntimeIssue,
+    options: {
+      readonly terminalOutcome: "success" | "failure";
+      readonly branchName: string;
+      readonly observedAt: string;
+      readonly workspaceRetention: WorkspaceRetentionOutcome;
+      readonly summary: string;
+    },
+  ): Promise<void> {
+    try {
+      const { receipt } = await reconcileTerminalIssueReporting({
+        instance: getConfigInstancePaths(this.#config),
+        issue: {
+          issueNumber: issue.number,
+          issueIdentifier: issue.identifier,
+          title: issue.title,
+          currentOutcome:
+            options.terminalOutcome === "success" ? "succeeded" : "failed",
+          lastUpdatedAt: options.observedAt,
+        },
+        archiveRoot: this.#config.observability.issueReports.archiveRoot,
+      });
+      this.#upsertTerminalReportingStatus(issue, {
+        branchName: options.branchName,
+        terminalOutcome: options.terminalOutcome,
+        observedAt: options.observedAt,
+        workspaceRetentionState: options.workspaceRetention.state,
+        summary: options.summary,
+        receipt,
+      });
+      await this.#persistStatusSnapshot();
+    } catch (error) {
+      const normalizedError = this.#normalizeFailure(error as Error);
+      this.#logger.error("Terminal issue reporting failed", {
+        issueNumber: issue.number,
+        error: normalizedError,
+      });
+      this.#upsertTerminalReportingStatus(issue, {
+        branchName: options.branchName,
+        terminalOutcome: options.terminalOutcome,
+        observedAt: options.observedAt,
+        workspaceRetentionState: options.workspaceRetention.state,
+        summary: options.summary,
+        receipt: null,
+        fallbackReportingSummary: normalizedError,
+        fallbackBlockedStage: "report-generation",
+      });
+      await this.#persistStatusSnapshot();
+    }
   }
 
   async #applyTerminalWorkspacePolicy(
@@ -2672,6 +2815,54 @@ export class BootstrapOrchestrator implements Orchestrator {
     retention: WorkspaceRetentionOutcome,
   ): string {
     return `${summary}; ${this.#summarizeWorkspaceRetention(retention)}`;
+  }
+
+  #upsertTerminalReportingStatus(
+    issue: RuntimeIssue | { number: number; identifier: string; title: string },
+    options: {
+      readonly branchName: string;
+      readonly terminalOutcome: "success" | "failure";
+      readonly observedAt: string;
+      readonly workspaceRetentionState:
+        | "retry-retained"
+        | "terminal-retained"
+        | "cleanup-succeeded"
+        | "cleanup-failed"
+        | "unknown";
+      readonly summary: string;
+      readonly receipt: TerminalIssueReportingReceipt | null;
+      readonly fallbackReportingSummary?: string | undefined;
+      readonly fallbackBlockedStage?: "report-generation" | "publication";
+    },
+  ): void {
+    const receiptPaths = deriveTerminalIssueReportingReceiptPaths(
+      getConfigInstancePaths(this.#config),
+      issue.number,
+    );
+    const reportingSummary =
+      options.receipt === null
+        ? (options.fallbackReportingSummary ?? null)
+        : options.receipt.note === null
+          ? options.receipt.summary
+          : `${options.receipt.summary} ${options.receipt.note}`;
+    upsertTerminalIssue(this.#state.status, {
+      issueNumber: issue.number,
+      issueIdentifier: issue.identifier,
+      title: issue.title,
+      branchName: options.branchName,
+      terminalOutcome: options.terminalOutcome,
+      summary: options.summary,
+      observedAt: options.observedAt,
+      workspaceRetentionState: options.workspaceRetentionState,
+      reportingState: options.receipt?.state ?? "blocked",
+      reportingSummary,
+      reportingReceiptFile: receiptPaths.receiptFile,
+      reportJsonFile: options.receipt?.reportJsonFile ?? null,
+      reportMarkdownFile: options.receipt?.reportMarkdownFile ?? null,
+      publicationRoot: options.receipt?.publicationRoot ?? null,
+      blockedStage:
+        options.receipt?.blockedStage ?? options.fallbackBlockedStage ?? null,
+    });
   }
 
   #summarizeRetryScheduled(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -774,7 +774,8 @@ export class BootstrapOrchestrator implements Orchestrator {
           },
           {
             branchName:
-              existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+              existingTerminal?.branchName ??
+              this.#branchName(issue.issueNumber),
             terminalOutcome:
               issue.currentOutcome === "succeeded" ? "success" : "failure",
             observedAt: issue.lastUpdatedAt,
@@ -835,7 +836,9 @@ export class BootstrapOrchestrator implements Orchestrator {
             title: issue.title,
           },
           {
-            branchName: existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+            branchName:
+              existingTerminal?.branchName ??
+              this.#branchName(issue.issueNumber),
             terminalOutcome:
               issue.currentOutcome === "succeeded" ? "success" : "failure",
             observedAt: issue.lastUpdatedAt,
@@ -892,7 +895,9 @@ export class BootstrapOrchestrator implements Orchestrator {
             title: issue.title,
           },
           {
-            branchName: existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+            branchName:
+              existingTerminal?.branchName ??
+              this.#branchName(issue.issueNumber),
             terminalOutcome:
               issue.currentOutcome === "succeeded" ? "success" : "failure",
             observedAt: issue.lastUpdatedAt,
@@ -906,11 +911,14 @@ export class BootstrapOrchestrator implements Orchestrator {
             fallbackBlockedStage: "report-generation",
           },
         );
-        scheduleTerminalIssueReportingRetry(this.#state.terminalIssueReporting, {
-          issueNumber: issue.issueNumber,
-          baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
-          maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
-        });
+        scheduleTerminalIssueReportingRetry(
+          this.#state.terminalIssueReporting,
+          {
+            issueNumber: issue.issueNumber,
+            baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+            maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+          },
+        );
         statusChanged = true;
       }
     }
@@ -2882,11 +2890,14 @@ export class BootstrapOrchestrator implements Orchestrator {
         })
       ) {
         if (receipt.state === "blocked") {
-          scheduleTerminalIssueReportingRetry(this.#state.terminalIssueReporting, {
-            issueNumber: issue.number,
-            baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
-            maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
-          });
+          scheduleTerminalIssueReportingRetry(
+            this.#state.terminalIssueReporting,
+            {
+              issueNumber: issue.number,
+              baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+              maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+            },
+          );
         } else {
           enqueueTerminalIssueReporting(
             this.#state.terminalIssueReporting,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -116,6 +116,13 @@ import {
   getActiveDispatchPressure,
 } from "./dispatch-pressure-state.js";
 import {
+  clearTerminalIssueReportingState,
+  enqueueTerminalIssueReporting,
+  isTerminalIssueReportingDue,
+  scheduleTerminalIssueReportingRetry,
+  seedTerminalIssueReportingBackoff,
+} from "./terminal-reporting-state.js";
+import {
   bindHostReservationToRunSession,
   claimHostForIssue,
   clearPreferredHost,
@@ -724,7 +731,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     const instance = getConfigInstancePaths(this.#config);
     const archiveRoot = this.#config.observability.issueReports.archiveRoot;
 
-    if (!this.#state.terminalIssueReportingBacklogScanned) {
+    if (!this.#state.terminalIssueReporting.backlogScanned) {
       const terminalIssues = await listTerminalIssues(instance);
       for (const issue of terminalIssues) {
         const receipt = await readTerminalIssueReportingReceipt(
@@ -738,7 +745,21 @@ export class BootstrapOrchestrator implements Orchestrator {
             archiveRoot,
           })
         ) {
-          this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+          if (receipt?.state === "blocked") {
+            seedTerminalIssueReportingBackoff(
+              this.#state.terminalIssueReporting,
+              {
+                issueNumber: issue.issueNumber,
+                updatedAt: receipt.updatedAt,
+                baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+              },
+            );
+          } else {
+            enqueueTerminalIssueReporting(
+              this.#state.terminalIssueReporting,
+              issue.issueNumber,
+            );
+          }
           continue;
         }
 
@@ -766,21 +787,35 @@ export class BootstrapOrchestrator implements Orchestrator {
           },
         );
       }
-      this.#state.terminalIssueReportingBacklogScanned = true;
+      this.#state.terminalIssueReporting.backlogScanned = true;
       if (terminalIssues.length > 0) {
         await this.#persistStatusSnapshot();
       }
     }
 
-    if (this.#state.terminalIssueReportingQueue.size === 0) {
+    if (this.#state.terminalIssueReporting.queuedIssueNumbers.size === 0) {
       return;
     }
 
     let statusChanged = false;
-    for (const issueNumber of [...this.#state.terminalIssueReportingQueue]) {
+    for (const issueNumber of [
+      ...this.#state.terminalIssueReporting.queuedIssueNumbers,
+    ]) {
+      if (
+        !isTerminalIssueReportingDue(
+          this.#state.terminalIssueReporting,
+          issueNumber,
+        )
+      ) {
+        continue;
+      }
+
       const issue = await readTerminalIssue(instance, issueNumber);
       if (issue === null) {
-        this.#state.terminalIssueReportingQueue.delete(issueNumber);
+        clearTerminalIssueReportingState(
+          this.#state.terminalIssueReporting,
+          issueNumber,
+        );
         continue;
       }
 
@@ -819,9 +854,26 @@ export class BootstrapOrchestrator implements Orchestrator {
             archiveRoot,
           })
         ) {
-          this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+          if (result.receipt.state === "blocked") {
+            scheduleTerminalIssueReportingRetry(
+              this.#state.terminalIssueReporting,
+              {
+                issueNumber: issue.issueNumber,
+                baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+                maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+              },
+            );
+          } else {
+            enqueueTerminalIssueReporting(
+              this.#state.terminalIssueReporting,
+              issue.issueNumber,
+            );
+          }
         } else {
-          this.#state.terminalIssueReportingQueue.delete(issue.issueNumber);
+          clearTerminalIssueReportingState(
+            this.#state.terminalIssueReporting,
+            issue.issueNumber,
+          );
         }
         statusChanged = statusChanged || result.changed;
       } catch (error) {
@@ -854,7 +906,11 @@ export class BootstrapOrchestrator implements Orchestrator {
             fallbackBlockedStage: "report-generation",
           },
         );
-        this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+        scheduleTerminalIssueReportingRetry(this.#state.terminalIssueReporting, {
+          issueNumber: issue.issueNumber,
+          baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+          maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+        });
         statusChanged = true;
       }
     }
@@ -2825,9 +2881,23 @@ export class BootstrapOrchestrator implements Orchestrator {
           archiveRoot: this.#config.observability.issueReports.archiveRoot,
         })
       ) {
-        this.#state.terminalIssueReportingQueue.add(issue.number);
+        if (receipt.state === "blocked") {
+          scheduleTerminalIssueReportingRetry(this.#state.terminalIssueReporting, {
+            issueNumber: issue.number,
+            baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+            maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+          });
+        } else {
+          enqueueTerminalIssueReporting(
+            this.#state.terminalIssueReporting,
+            issue.number,
+          );
+        }
       } else {
-        this.#state.terminalIssueReportingQueue.delete(issue.number);
+        clearTerminalIssueReportingState(
+          this.#state.terminalIssueReporting,
+          issue.number,
+        );
       }
       await this.#persistStatusSnapshot();
     } catch (error) {
@@ -2846,9 +2916,27 @@ export class BootstrapOrchestrator implements Orchestrator {
         fallbackReportingSummary: normalizedError,
         fallbackBlockedStage: "report-generation",
       });
-      this.#state.terminalIssueReportingQueue.add(issue.number);
+      scheduleTerminalIssueReportingRetry(this.#state.terminalIssueReporting, {
+        issueNumber: issue.number,
+        baseBackoffMs: this.#terminalIssueReportingBaseBackoffMs(),
+        maxBackoffMs: this.#terminalIssueReportingMaxBackoffMs(),
+      });
       await this.#persistStatusSnapshot();
     }
+  }
+
+  #terminalIssueReportingBaseBackoffMs(): number {
+    return Math.max(
+      this.#config.polling.intervalMs * 2,
+      this.#config.polling.retry.backoffMs,
+    );
+  }
+
+  #terminalIssueReportingMaxBackoffMs(): number {
+    return Math.max(
+      this.#terminalIssueReportingBaseBackoffMs(),
+      this.#config.polling.intervalMs * 16,
+    );
   }
 
   async #applyTerminalWorkspacePolicy(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -184,7 +184,10 @@ import {
 import {
   deriveTerminalIssueReportingReceiptPaths,
   listTerminalIssues,
+  readTerminalIssue,
+  readTerminalIssueReportingReceipt,
   reconcileTerminalIssueReporting,
+  shouldReconcileTerminalIssue,
   type TerminalIssueReportingReceipt,
 } from "../observability/terminal-reporting.js";
 import {
@@ -718,13 +721,74 @@ export class BootstrapOrchestrator implements Orchestrator {
   }
 
   async #reconcileTerminalIssueReporting(): Promise<void> {
-    const terminalIssues = await listTerminalIssues(getConfigInstancePaths(this.#config));
-    for (const issue of terminalIssues) {
+    const instance = getConfigInstancePaths(this.#config);
+    const archiveRoot = this.#config.observability.issueReports.archiveRoot;
+
+    if (!this.#state.terminalIssueReportingBacklogScanned) {
+      const terminalIssues = await listTerminalIssues(instance);
+      for (const issue of terminalIssues) {
+        const receipt = await readTerminalIssueReportingReceipt(
+          instance,
+          issue.issueNumber,
+        );
+        if (
+          shouldReconcileTerminalIssue({
+            issue,
+            receipt,
+            archiveRoot,
+          })
+        ) {
+          this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+          continue;
+        }
+
+        const existingTerminal = this.#state.status.terminalIssues.find(
+          (entry) => entry.issueNumber === issue.issueNumber,
+        );
+        this.#upsertTerminalReportingStatus(
+          {
+            number: issue.issueNumber,
+            identifier: issue.issueIdentifier,
+            title: issue.title,
+          },
+          {
+            branchName:
+              existingTerminal?.branchName ?? this.#branchName(issue.issueNumber),
+            terminalOutcome:
+              issue.currentOutcome === "succeeded" ? "success" : "failure",
+            observedAt: issue.lastUpdatedAt,
+            workspaceRetentionState:
+              existingTerminal?.workspaceRetention.state ?? "unknown",
+            summary:
+              existingTerminal?.summary ??
+              `Terminal issue state recorded for ${issue.issueIdentifier}.`,
+            receipt,
+          },
+        );
+      }
+      this.#state.terminalIssueReportingBacklogScanned = true;
+      if (terminalIssues.length > 0) {
+        await this.#persistStatusSnapshot();
+      }
+    }
+
+    if (this.#state.terminalIssueReportingQueue.size === 0) {
+      return;
+    }
+
+    let statusChanged = false;
+    for (const issueNumber of [...this.#state.terminalIssueReportingQueue]) {
+      const issue = await readTerminalIssue(instance, issueNumber);
+      if (issue === null) {
+        this.#state.terminalIssueReportingQueue.delete(issueNumber);
+        continue;
+      }
+
       try {
         const result = await reconcileTerminalIssueReporting({
-          instance: getConfigInstancePaths(this.#config),
+          instance,
           issue,
-          archiveRoot: this.#config.observability.issueReports.archiveRoot,
+          archiveRoot,
         });
         const existingTerminal = this.#state.status.terminalIssues.find(
           (entry) => entry.issueNumber === issue.issueNumber,
@@ -748,9 +812,18 @@ export class BootstrapOrchestrator implements Orchestrator {
             receipt: result.receipt,
           },
         );
-        if (result.changed) {
-          await this.#persistStatusSnapshot();
+        if (
+          shouldReconcileTerminalIssue({
+            issue,
+            receipt: result.receipt,
+            archiveRoot,
+          })
+        ) {
+          this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+        } else {
+          this.#state.terminalIssueReportingQueue.delete(issue.issueNumber);
         }
+        statusChanged = statusChanged || result.changed;
       } catch (error) {
         const normalizedError = this.#normalizeFailure(error as Error);
         this.#logger.error("Terminal issue reporting reconciliation failed", {
@@ -781,8 +854,13 @@ export class BootstrapOrchestrator implements Orchestrator {
             fallbackBlockedStage: "report-generation",
           },
         );
-        await this.#persistStatusSnapshot();
+        this.#state.terminalIssueReportingQueue.add(issue.issueNumber);
+        statusChanged = true;
       }
+    }
+
+    if (statusChanged) {
+      await this.#persistStatusSnapshot();
     }
   }
 
@@ -2733,6 +2811,24 @@ export class BootstrapOrchestrator implements Orchestrator {
         summary: options.summary,
         receipt,
       });
+      if (
+        shouldReconcileTerminalIssue({
+          issue: {
+            issueNumber: issue.number,
+            issueIdentifier: issue.identifier,
+            title: issue.title,
+            currentOutcome:
+              options.terminalOutcome === "success" ? "succeeded" : "failed",
+            lastUpdatedAt: options.observedAt,
+          },
+          receipt,
+          archiveRoot: this.#config.observability.issueReports.archiveRoot,
+        })
+      ) {
+        this.#state.terminalIssueReportingQueue.add(issue.number);
+      } else {
+        this.#state.terminalIssueReportingQueue.delete(issue.number);
+      }
       await this.#persistStatusSnapshot();
     } catch (error) {
       const normalizedError = this.#normalizeFailure(error as Error);
@@ -2750,6 +2846,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         fallbackReportingSummary: normalizedError,
         fallbackBlockedStage: "report-generation",
       });
+      this.#state.terminalIssueReportingQueue.add(issue.number);
       await this.#persistStatusSnapshot();
     }
   }

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -44,6 +44,7 @@ export interface PollingState {
 
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
+  readonly terminalIssueReportingQueue: Set<number>;
   readonly runAbortControllers: Map<number, AbortController>;
   readonly retries: RetryRuntimeState;
   readonly hostDispatch: HostDispatchRuntimeState;
@@ -56,6 +57,7 @@ export interface OrchestratorState {
   readonly runningEntries: Map<number, RunningEntry>;
   readonly codexTotals: CodexTotals;
   rateLimits: RateLimits | null;
+  terminalIssueReportingBacklogScanned: boolean;
   readonly polling: PollingState;
 }
 
@@ -65,6 +67,7 @@ export function createOrchestratorState(
 ): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
+    terminalIssueReportingQueue: new Set<number>(),
     runAbortControllers: new Map<number, AbortController>(),
     retries: createRetryRuntimeState(),
     hostDispatch: createHostDispatchState(hostDispatchWorkerHosts),
@@ -81,6 +84,7 @@ export function createOrchestratorState(
       totalTokens: 0,
     },
     rateLimits: null,
+    terminalIssueReportingBacklogScanned: false,
     polling: {
       checkingNow: false,
       nextPollAtMs: Date.now(),

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -29,6 +29,10 @@ import {
   createWatchdogRuntimeState,
   type WatchdogRuntimeState,
 } from "./watchdog-state.js";
+import {
+  createTerminalIssueReportingRuntimeState,
+  type TerminalIssueReportingRuntimeState,
+} from "./terminal-reporting-state.js";
 
 export interface CodexTotals {
   inputTokens: number;
@@ -44,7 +48,7 @@ export interface PollingState {
 
 export interface OrchestratorState {
   readonly runningIssueNumbers: Set<number>;
-  readonly terminalIssueReportingQueue: Set<number>;
+  readonly terminalIssueReporting: TerminalIssueReportingRuntimeState;
   readonly runAbortControllers: Map<number, AbortController>;
   readonly retries: RetryRuntimeState;
   readonly hostDispatch: HostDispatchRuntimeState;
@@ -57,7 +61,6 @@ export interface OrchestratorState {
   readonly runningEntries: Map<number, RunningEntry>;
   readonly codexTotals: CodexTotals;
   rateLimits: RateLimits | null;
-  terminalIssueReportingBacklogScanned: boolean;
   readonly polling: PollingState;
 }
 
@@ -67,7 +70,7 @@ export function createOrchestratorState(
 ): OrchestratorState {
   return {
     runningIssueNumbers: new Set<number>(),
-    terminalIssueReportingQueue: new Set<number>(),
+    terminalIssueReporting: createTerminalIssueReportingRuntimeState(),
     runAbortControllers: new Map<number, AbortController>(),
     retries: createRetryRuntimeState(),
     hostDispatch: createHostDispatchState(hostDispatchWorkerHosts),
@@ -84,7 +87,6 @@ export function createOrchestratorState(
       totalTokens: 0,
     },
     rateLimits: null,
-    terminalIssueReportingBacklogScanned: false,
     polling: {
       checkingNow: false,
       nextPollAtMs: Date.now(),

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -323,8 +323,7 @@ export function upsertTerminalIssue(
     summary: issue.summary,
     observedAt: issue.observedAt,
     workspaceRetention: {
-      reason:
-        issue.terminalOutcome === "success" ? "success" : "failure",
+      reason: issue.terminalOutcome === "success" ? "success" : "failure",
       state:
         issue.workspaceRetentionState === "unknown"
           ? "terminal-retained"
@@ -335,7 +334,7 @@ export function upsertTerminalIssue(
         issue.workspaceRetentionState === "unknown"
           ? "retain"
           : "cleanup",
-      },
+    },
     reportingState: issue.reportingState,
     reportingSummary: issue.reportingSummary,
     reportingReceiptFile: issue.reportingReceiptFile,

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -331,6 +331,7 @@ export function upsertTerminalIssue(
           : issue.workspaceRetentionState,
       action:
         issue.workspaceRetentionState === "terminal-retained" ||
+        issue.workspaceRetentionState === "retry-retained" ||
         issue.workspaceRetentionState === "unknown"
           ? "retain"
           : "cleanup",

--- a/src/orchestrator/status-state.ts
+++ b/src/orchestrator/status-state.ts
@@ -10,6 +10,7 @@ import type {
   FactoryState,
   FactoryStatusAction,
   FactoryStatusSnapshot,
+  FactoryTerminalIssueSnapshot,
 } from "../observability/status.js";
 import type { FactoryRuntimeIdentity } from "../observability/runtime-identity.js";
 import type { DispatchPressureStateSnapshot } from "../domain/transient-failure.js";
@@ -299,6 +300,48 @@ export function noteTerminalIssue(
     summary: options.summary,
     observedAt: options.observedAt,
     workspaceRetention: options.workspaceRetention,
+    reportingState: null,
+    reportingSummary: null,
+    reportingReceiptFile: null,
+    reportJsonFile: null,
+    reportMarkdownFile: null,
+    publicationRoot: null,
+    blockedStage: null,
+  });
+}
+
+export function upsertTerminalIssue(
+  state: RuntimeStatusState,
+  issue: FactoryTerminalIssueSnapshot,
+): void {
+  state.terminalIssues = noteTerminalCleanupPosture(state.terminalIssues, {
+    issueNumber: issue.issueNumber,
+    issueIdentifier: issue.issueIdentifier,
+    title: issue.title,
+    branchName: issue.branchName,
+    terminalOutcome: issue.terminalOutcome,
+    summary: issue.summary,
+    observedAt: issue.observedAt,
+    workspaceRetention: {
+      reason:
+        issue.terminalOutcome === "success" ? "success" : "failure",
+      state:
+        issue.workspaceRetentionState === "unknown"
+          ? "terminal-retained"
+          : issue.workspaceRetentionState,
+      action:
+        issue.workspaceRetentionState === "terminal-retained" ||
+        issue.workspaceRetentionState === "unknown"
+          ? "retain"
+          : "cleanup",
+      },
+    reportingState: issue.reportingState,
+    reportingSummary: issue.reportingSummary,
+    reportingReceiptFile: issue.reportingReceiptFile,
+    reportJsonFile: issue.reportJsonFile,
+    reportMarkdownFile: issue.reportMarkdownFile,
+    publicationRoot: issue.publicationRoot,
+    blockedStage: issue.blockedStage,
   });
 }
 
@@ -347,6 +390,24 @@ export function buildFactoryStatusSnapshot(input: {
           hosts: listHostDispatchSnapshots(input.hostDispatch),
         };
 
+  const terminalIssues = input.state.terminalIssues.map((issue) => ({
+    issueNumber: issue.issueNumber,
+    issueIdentifier: issue.issueIdentifier,
+    title: issue.title,
+    branchName: issue.branchName,
+    terminalOutcome: issue.terminalOutcome,
+    summary: issue.summary,
+    observedAt: issue.observedAt,
+    workspaceRetentionState: issue.workspaceRetention.state,
+    reportingState: issue.reportingState,
+    reportingSummary: issue.reportingSummary,
+    reportingReceiptFile: issue.reportingReceiptFile,
+    reportJsonFile: issue.reportJsonFile,
+    reportMarkdownFile: issue.reportMarkdownFile,
+    publicationRoot: issue.publicationRoot,
+    blockedStage: issue.blockedStage,
+  })) satisfies readonly FactoryTerminalIssueSnapshot[];
+
   return {
     version: 1,
     generatedAt: new Date().toISOString(),
@@ -390,6 +451,7 @@ export function buildFactoryStatusSnapshot(input: {
     },
     lastAction: input.state.lastAction,
     activeIssues,
+    terminalIssues,
     readyQueue: input.state.readyQueue,
     retries,
   };

--- a/src/orchestrator/terminal-reporting-state.ts
+++ b/src/orchestrator/terminal-reporting-state.ts
@@ -1,0 +1,86 @@
+export interface TerminalIssueReportingRuntimeState {
+  readonly queuedIssueNumbers: Set<number>;
+  readonly retryDueAtMsByIssueNumber: Map<number, number>;
+  readonly retryAttemptCountByIssueNumber: Map<number, number>;
+  backlogScanned: boolean;
+}
+
+export function createTerminalIssueReportingRuntimeState(): TerminalIssueReportingRuntimeState {
+  return {
+    queuedIssueNumbers: new Set<number>(),
+    retryDueAtMsByIssueNumber: new Map<number, number>(),
+    retryAttemptCountByIssueNumber: new Map<number, number>(),
+    backlogScanned: false,
+  };
+}
+
+export function clearTerminalIssueReportingState(
+  state: TerminalIssueReportingRuntimeState,
+  issueNumber: number,
+): void {
+  state.queuedIssueNumbers.delete(issueNumber);
+  state.retryDueAtMsByIssueNumber.delete(issueNumber);
+  state.retryAttemptCountByIssueNumber.delete(issueNumber);
+}
+
+export function enqueueTerminalIssueReporting(
+  state: TerminalIssueReportingRuntimeState,
+  issueNumber: number,
+): void {
+  state.queuedIssueNumbers.add(issueNumber);
+}
+
+export function isTerminalIssueReportingDue(
+  state: TerminalIssueReportingRuntimeState,
+  issueNumber: number,
+  now = Date.now(),
+): boolean {
+  const dueAt = state.retryDueAtMsByIssueNumber.get(issueNumber);
+  return dueAt === undefined || dueAt <= now;
+}
+
+export function seedTerminalIssueReportingBackoff(
+  state: TerminalIssueReportingRuntimeState,
+  options: {
+    readonly issueNumber: number;
+    readonly updatedAt: string;
+    readonly baseBackoffMs: number;
+    readonly now?: number;
+  },
+): void {
+  const now = options.now ?? Date.now();
+  const updatedAtMs = Date.parse(options.updatedAt);
+  const dueAt =
+    Number.isFinite(updatedAtMs) && options.baseBackoffMs > 0
+      ? updatedAtMs + options.baseBackoffMs
+      : now;
+  state.retryAttemptCountByIssueNumber.set(options.issueNumber, 1);
+  state.retryDueAtMsByIssueNumber.set(options.issueNumber, dueAt);
+  state.queuedIssueNumbers.add(options.issueNumber);
+}
+
+export function scheduleTerminalIssueReportingRetry(
+  state: TerminalIssueReportingRuntimeState,
+  options: {
+    readonly issueNumber: number;
+    readonly now?: number;
+    readonly baseBackoffMs: number;
+    readonly maxBackoffMs: number;
+  },
+): number {
+  const now = options.now ?? Date.now();
+  const nextAttempt =
+    (state.retryAttemptCountByIssueNumber.get(options.issueNumber) ?? 0) + 1;
+  const delayMs =
+    options.baseBackoffMs <= 0
+      ? 0
+      : Math.min(
+          options.baseBackoffMs * 2 ** Math.max(0, nextAttempt - 1),
+          options.maxBackoffMs,
+        );
+  const dueAt = now + delayMs;
+  state.retryAttemptCountByIssueNumber.set(options.issueNumber, nextAttempt);
+  state.retryDueAtMsByIssueNumber.set(options.issueNumber, dueAt);
+  state.queuedIssueNumbers.add(options.issueNumber);
+  return dueAt;
+}

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -1525,7 +1525,9 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     const publicationEntries = await fs.readdir(publicationIssueRoot, {
       withFileTypes: true,
     });
-    const publicationDir = publicationEntries.find((entry) => entry.isDirectory());
+    const publicationDir = publicationEntries.find((entry) =>
+      entry.isDirectory(),
+    );
     expect(publicationDir?.name).toBeDefined();
     await expect(
       fs.readFile(
@@ -1665,7 +1667,9 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     await orchestrator.runOnce();
 
     const issue = server.getIssue(13);
-    expect(issue.labels.map((label) => label.name)).toContain("symphony:failed");
+    expect(issue.labels.map((label) => label.name)).toContain(
+      "symphony:failed",
+    );
     await expect(
       fs.readFile(
         path.join(tempDir, ".var", "reports", "issues", "13", "report.json"),

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -29,6 +29,7 @@ import {
   countRemoteBranchCommits,
   createSeedRemote,
   createTempDir,
+  initializeGitRepo,
   readRemoteBranchFile,
 } from "../support/git.js";
 import { MockGitHubServer } from "../support/mock-github-server.js";
@@ -85,6 +86,7 @@ async function writeWorkflow(options: {
         readonly required: boolean;
       }[]
     | undefined;
+  archiveRoot?: string | undefined;
 }): Promise<string> {
   const workflowPath = path.join(options.rootDir, "WORKFLOW.md");
   const workerHostsBlock =
@@ -203,7 +205,14 @@ ${remoteExecutionBlock}${
   timeout_ms: 30000
   max_turns: ${options.maxTurns ?? 3}
   env:
-${agentEnvBlock}---
+${agentEnvBlock}${
+      options.archiveRoot === undefined
+        ? ""
+        : `observability:
+  issue_reports:
+    archive_root: ${options.archiveRoot}
+`
+    }---
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 Issue summary: {{ issue.summary }}
 {% if pull_request %}
@@ -1403,16 +1412,6 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       costUsd: 0.25,
     });
 
-    await runReportCli([
-      "node",
-      "symphony-report",
-      "issue",
-      "--issue",
-      "12",
-      "--workflow",
-      workflowPath,
-    ]);
-
     const reportJson = await fs.readFile(
       path.join(tempDir, ".var", "reports", "issues", "12", "report.json"),
       "utf8",
@@ -1480,6 +1479,60 @@ describe("Phase 1.2 PR lifecycle factory", () => {
       status: "awaiting-landing-command",
       branchName: "symphony/47",
     });
+  });
+
+  it("publishes the terminal issue report automatically when an archive root is configured", async () => {
+    const archiveRoot = await createTempDir("symphony-factory-runs-e2e-");
+
+    server.seedIssue({
+      number: 49,
+      title: "Archive report automatically",
+      body: "Publish terminal reports without manual CLI follow-up",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-success.sh"),
+      archiveRoot,
+    });
+    await initializeGitRepo(archiveRoot);
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    server.setPullRequestCheckRuns("symphony/49", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    await orchestrator.runOnce();
+    server.mergePullRequest("symphony/49");
+    await orchestrator.runOnce();
+
+    await expect(
+      fs.readFile(
+        path.join(tempDir, ".var", "reports", "issues", "49", "report.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"issueNumber": 49');
+
+    const publicationIssueRoot = path.join(
+      archiveRoot,
+      "symphony-ts",
+      "issues",
+      "49",
+    );
+    const publicationEntries = await fs.readdir(publicationIssueRoot, {
+      withFileTypes: true,
+    });
+    const publicationDir = publicationEntries.find((entry) => entry.isDirectory());
+    expect(publicationDir?.name).toBeDefined();
+    await expect(
+      fs.readFile(
+        path.join(publicationIssueRoot, publicationDir!.name, "metadata.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"issueNumber": 49');
   });
 
   it("does not immediately re-close a reopened issue because of a previously merged PR", async () => {
@@ -1590,6 +1643,35 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     expect(reportMd).toContain("## Token Usage");
     expect(summaryAfter).toBe(summaryBefore);
     expect(eventsAfter).toBe(eventsBefore);
+  });
+
+  it("generates a terminal issue report automatically after a failed run", async () => {
+    server.seedIssue({
+      number: 13,
+      title: "Persist failed run report",
+      body: "Generate a report even when the run fails terminally",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve("tests/fixtures/fake-agent-fail.sh"),
+      maxAttempts: 1,
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(13);
+    expect(issue.labels.map((label) => label.name)).toContain("symphony:failed");
+    await expect(
+      fs.readFile(
+        path.join(tempDir, ".var", "reports", "issues", "13", "report.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"outcome": "failed"');
   });
 
   it("reruns the same PR branch after CI failure and closes only after the rerun goes green", async () => {
@@ -1974,7 +2056,14 @@ describe("TUI dashboard integration", () => {
     const frames: string[] = [];
     const dashboard = new StatusDashboard(
       () => orchestrator.snapshot(),
-      () => ({ dashboardEnabled: true, refreshMs: 50, renderIntervalMs: 10 }),
+      () => ({
+        dashboardEnabled: true,
+        refreshMs: 50,
+        renderIntervalMs: 10,
+        issueReports: {
+          archiveRoot: null,
+        },
+      }),
       {
         enabled: true,
         refreshMs: 50,

--- a/tests/integration/terminal-reporting.test.ts
+++ b/tests/integration/terminal-reporting.test.ts
@@ -51,9 +51,9 @@ describe("terminal issue reporting", () => {
     expect(result.receipt.reportJsonFile).toBe(
       path.join(rootDir, ".var", "reports", "issues", "44", "report.json"),
     );
-    await expect(fs.readFile(result.receipt.reportJsonFile!, "utf8")).resolves.toContain(
-      '"issueNumber": 44',
-    );
+    await expect(
+      fs.readFile(result.receipt.reportJsonFile!, "utf8"),
+    ).resolves.toContain('"issueNumber": 44');
     await expect(
       fs.readFile(result.receipt.reportMarkdownFile!, "utf8"),
     ).resolves.toContain("## Summary");

--- a/tests/integration/terminal-reporting.test.ts
+++ b/tests/integration/terminal-reporting.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listTerminalIssues,
+  readTerminalIssueReportingReceipt,
+  reconcileTerminalIssueReporting,
+} from "../../src/observability/terminal-reporting.js";
+import {
+  commitAllFiles,
+  createTempDir,
+  initializeGitRepo,
+} from "../support/git.js";
+import {
+  deriveReportInstance,
+  deriveWorkspaceRoot,
+  seedSuccessfulIssueArtifacts,
+  writeReportWorkflow,
+} from "../support/issue-report-fixtures.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+  );
+});
+
+describe("terminal issue reporting", () => {
+  it("generates the current terminal issue report when archive publication is not configured", async () => {
+    const rootDir = await createTempDir("symphony-terminal-reporting-");
+    tempRoots.push(rootDir);
+
+    await writeReportWorkflow(rootDir);
+    const workspaceRoot = deriveWorkspaceRoot(rootDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 44);
+
+    const instance = deriveReportInstance(rootDir);
+    const [issue] = await listTerminalIssues(instance);
+    expect(issue?.issueNumber).toBe(44);
+
+    const result = await reconcileTerminalIssueReporting({
+      instance,
+      issue: issue!,
+      archiveRoot: null,
+    });
+
+    expect(result.receipt.state).toBe("report-generated");
+    expect(result.receipt.reportJsonFile).toBe(
+      path.join(rootDir, ".var", "reports", "issues", "44", "report.json"),
+    );
+    await expect(fs.readFile(result.receipt.reportJsonFile!, "utf8")).resolves.toContain(
+      '"issueNumber": 44',
+    );
+    await expect(
+      fs.readFile(result.receipt.reportMarkdownFile!, "utf8"),
+    ).resolves.toContain("## Summary");
+  });
+
+  it("records blocked publication and then converges once the archive root is repaired", async () => {
+    const rootDir = await createTempDir("symphony-terminal-reporting-publish-");
+    const archiveRoot = await createTempDir(
+      "symphony-terminal-reporting-archive-",
+    );
+    const missingArchiveRoot = path.join(rootDir, "..", "missing-factory-runs");
+    tempRoots.push(rootDir, archiveRoot);
+
+    await writeReportWorkflow(rootDir);
+    const workspaceRoot = deriveWorkspaceRoot(rootDir);
+    await seedSuccessfulIssueArtifacts(workspaceRoot, 45);
+    const readableLogPath = path.join(workspaceRoot, "logs", "runner.log");
+    await fs.mkdir(path.dirname(readableLogPath), { recursive: true });
+    await fs.writeFile(readableLogPath, "runner log contents\n", "utf8");
+
+    await initializeGitRepo(rootDir);
+    await commitAllFiles(rootDir, "seed terminal reporting inputs");
+
+    const instance = deriveReportInstance(rootDir);
+    const [issue] = await listTerminalIssues(instance);
+    if (issue === undefined) {
+      throw new Error("Expected one terminal issue");
+    }
+
+    const blocked = await reconcileTerminalIssueReporting({
+      instance,
+      issue,
+      archiveRoot: missingArchiveRoot,
+    });
+    expect(blocked.receipt.state).toBe("blocked");
+    expect(blocked.receipt.blockedStage).toBe("publication");
+    expect(blocked.receipt.note).toContain("Archive root does not exist");
+
+    await initializeGitRepo(archiveRoot);
+    const recovered = await reconcileTerminalIssueReporting({
+      instance,
+      issue,
+      archiveRoot,
+    });
+    expect(recovered.receipt.state).toBe("published");
+    expect(recovered.receipt.publicationRoot).toContain(
+      path.join(archiveRoot, "symphony-ts", "issues", "45"),
+    );
+    await expect(
+      fs.readFile(
+        path.join(recovered.receipt.publicationRoot!, "report.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"issueNumber": 45');
+
+    const stored = await readTerminalIssueReportingReceipt(instance, 45);
+    expect(stored?.state).toBe("published");
+    expect(stored?.blockedStage).toBeNull();
+  });
+});

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -13,7 +13,12 @@ import {
 import type { RunnerAccountingSnapshot } from "../../src/runner/accounting.js";
 import { createRunnerTransportMetadata } from "../../src/runner/service.js";
 
-export async function writeReportWorkflow(rootDir: string): Promise<string> {
+export async function writeReportWorkflow(
+  rootDir: string,
+  options?: {
+    readonly archiveRoot?: string | undefined;
+  },
+): Promise<string> {
   const workflowPath = path.join(rootDir, "WORKFLOW.md");
   await fs.writeFile(
     workflowPath,
@@ -47,6 +52,14 @@ agent:
   prompt_transport: stdin
   timeout_ms: 1000
   env: {}
+observability:
+${
+  options?.archiveRoot === undefined
+    ? "  dashboard_enabled: true"
+    : `  dashboard_enabled: true
+  issue_reports:
+    archive_root: ${options.archiveRoot}`
+}
 ---
 Prompt body
 `,

--- a/tests/unit/orchestrator-terminal-reporting.test.ts
+++ b/tests/unit/orchestrator-terminal-reporting.test.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PromptBuilder, ResolvedConfig } from "../../src/domain/workflow.js";
+import { deriveRuntimeInstancePaths } from "../../src/domain/workflow.js";
+import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
+import type { Logger } from "../../src/observability/logger.js";
+import { createRunnerTransportMetadata, type Runner } from "../../src/runner/service.js";
+import type { Tracker } from "../../src/tracker/service.js";
+import type { WorkspaceManager } from "../../src/workspace/service.js";
+
+const terminalReportingMocks = vi.hoisted(() => {
+  return {
+    listTerminalIssues: vi.fn(),
+    readTerminalIssue: vi.fn(),
+    reconcileTerminalIssueReporting: vi.fn(),
+  };
+});
+
+vi.mock("../../src/observability/terminal-reporting.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/observability/terminal-reporting.js")
+  >("../../src/observability/terminal-reporting.js");
+  return {
+    ...actual,
+    listTerminalIssues: terminalReportingMocks.listTerminalIssues,
+    readTerminalIssue: terminalReportingMocks.readTerminalIssue,
+    reconcileTerminalIssueReporting:
+      terminalReportingMocks.reconcileTerminalIssueReporting,
+  };
+});
+
+const promptBuilder: PromptBuilder = {
+  async build(): Promise<string> {
+    return "prompt";
+  },
+  async buildContinuation(): Promise<string> {
+    return "prompt";
+  },
+};
+
+class NullLogger implements Logger {
+  info(): void {}
+  warn(): void {}
+  error(): void {}
+}
+
+class IdleTracker implements Tracker {
+  subject(): string {
+    return "test/tracker";
+  }
+
+  isHumanReviewFeedback(): boolean {
+    return true;
+  }
+
+  async ensureLabels(): Promise<void> {}
+
+  async fetchReadyIssues() {
+    return [];
+  }
+
+  async fetchRunningIssues() {
+    return [];
+  }
+
+  async fetchFailedIssues() {
+    return [];
+  }
+
+  async getIssue(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async claimIssue(): Promise<null> {
+    return null;
+  }
+
+  async inspectIssueHandoff(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async reconcileSuccessfulRun(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async executeLanding(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async recordRetry(): Promise<void> {}
+
+  async completeIssue(): Promise<void> {}
+
+  async markIssueFailed(): Promise<void> {}
+}
+
+class IdleWorkspaceManager implements WorkspaceManager {
+  async prepareWorkspace(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async cleanupWorkspace(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async cleanupWorkspaceForIssue(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+class IdleRunner implements Runner {
+  describeSession() {
+    return {
+      provider: "test-runner",
+      model: null,
+      transport: createRunnerTransportMetadata("local-process", {
+        canTerminateLocalProcess: true,
+      }),
+      backendSessionId: null,
+      backendThreadId: null,
+      latestTurnId: null,
+      latestTurnNumber: null,
+      logPointers: [],
+    } as const;
+  }
+
+  async run(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+function createConfig(root: string): ResolvedConfig {
+  return {
+    workflowPath: path.join(root, "WORKFLOW.md"),
+    instance: deriveRuntimeInstancePaths({
+      workflowPath: path.join(root, "WORKFLOW.md"),
+      workspaceRoot: root,
+    }),
+    tracker: {
+      kind: "github-bootstrap",
+      repo: "sociotechnica-org/symphony-ts",
+      apiUrl: "https://example.test",
+      readyLabel: "symphony:ready",
+      runningLabel: "symphony:running",
+      failedLabel: "symphony:failed",
+      successComment: "done",
+      reviewBotLogins: ["greptile[bot]"],
+    },
+    polling: {
+      intervalMs: 10,
+      maxConcurrentRuns: 1,
+      retry: {
+        maxAttempts: 1,
+        backoffMs: 0,
+      },
+    },
+    workspace: {
+      root,
+      repoUrl: "/tmp/remote.git",
+      branchPrefix: "symphony/",
+      retention: {
+        onSuccess: "retain",
+        onFailure: "retain",
+      },
+    },
+    hooks: {
+      afterCreate: [],
+    },
+    agent: {
+      runner: {
+        kind: "generic-command",
+      },
+      command: "test-agent",
+      promptTransport: "stdin",
+      timeoutMs: 1_000,
+      maxTurns: 3,
+      env: {},
+    },
+    observability: {
+      dashboardEnabled: false,
+      refreshMs: 1000,
+      renderIntervalMs: 16,
+      issueReports: {
+        archiveRoot: null,
+      },
+    },
+  };
+}
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      fs.rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("BootstrapOrchestrator terminal issue reporting reconciliation", () => {
+  it("scans the terminal issue backlog only once across poll cycles", async () => {
+    const root = await fs.mkdtemp(
+      path.join("/tmp", "symphony-terminal-reporting-runonce-"),
+    );
+    tempRoots.push(root);
+    terminalReportingMocks.listTerminalIssues.mockResolvedValue([]);
+
+    const orchestrator = new BootstrapOrchestrator(
+      createConfig(root),
+      promptBuilder,
+      new IdleTracker(),
+      new IdleWorkspaceManager(),
+      new IdleRunner(),
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    expect(terminalReportingMocks.listTerminalIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries queued terminal reporting work without rescanning the full backlog", async () => {
+    const root = await fs.mkdtemp(
+      path.join("/tmp", "symphony-terminal-reporting-queue-"),
+    );
+    tempRoots.push(root);
+    const issue = {
+      issueNumber: 44,
+      issueIdentifier: "sociotechnica-org/symphony-ts#44",
+      title: "Retry blocked terminal report publication",
+      currentOutcome: "failed" as const,
+      lastUpdatedAt: "2026-03-30T00:00:00.000Z",
+    };
+    terminalReportingMocks.listTerminalIssues.mockResolvedValue([issue]);
+    terminalReportingMocks.readTerminalIssue.mockResolvedValue(issue);
+    terminalReportingMocks.reconcileTerminalIssueReporting.mockResolvedValue({
+      changed: true,
+      receipt: {
+        version: 1,
+        issueNumber: 44,
+        issueIdentifier: issue.issueIdentifier,
+        issueTitle: issue.title,
+        terminalOutcome: "failed",
+        issueUpdatedAt: issue.lastUpdatedAt,
+        state: "blocked",
+        summary: "Terminal issue report publication is blocked.",
+        note: "Archive root does not exist.",
+        blockedStage: "publication",
+        archiveRoot: null,
+        reportGeneratedAt: null,
+        reportJsonFile: null,
+        reportMarkdownFile: null,
+        publicationId: null,
+        publicationRoot: null,
+        publicationMetadataFile: null,
+        publishedAt: null,
+        updatedAt: "2026-03-30T00:00:00.000Z",
+      },
+    });
+
+    const orchestrator = new BootstrapOrchestrator(
+      createConfig(root),
+      promptBuilder,
+      new IdleTracker(),
+      new IdleWorkspaceManager(),
+      new IdleRunner(),
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    expect(terminalReportingMocks.listTerminalIssues).toHaveBeenCalledTimes(1);
+    expect(terminalReportingMocks.readTerminalIssue).toHaveBeenCalledTimes(2);
+    expect(
+      terminalReportingMocks.reconcileTerminalIssueReporting,
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/orchestrator-terminal-reporting.test.ts
+++ b/tests/unit/orchestrator-terminal-reporting.test.ts
@@ -130,7 +130,13 @@ class IdleRunner implements Runner {
   }
 }
 
-function createConfig(root: string): ResolvedConfig {
+function createConfig(
+  root: string,
+  options: {
+    readonly intervalMs?: number;
+    readonly retryBackoffMs?: number;
+  } = {},
+): ResolvedConfig {
   return {
     workflowPath: path.join(root, "WORKFLOW.md"),
     instance: deriveRuntimeInstancePaths({
@@ -148,11 +154,11 @@ function createConfig(root: string): ResolvedConfig {
       reviewBotLogins: ["greptile[bot]"],
     },
     polling: {
-      intervalMs: 10,
+      intervalMs: options.intervalMs ?? 10,
       maxConcurrentRuns: 1,
       retry: {
         maxAttempts: 1,
-        backoffMs: 0,
+        backoffMs: options.retryBackoffMs ?? 0,
       },
     },
     workspace: {
@@ -271,10 +277,74 @@ describe("BootstrapOrchestrator terminal issue reporting reconciliation", () => 
     );
 
     await orchestrator.runOnce();
+    await new Promise((resolve) => setTimeout(resolve, 25));
     await orchestrator.runOnce();
 
     expect(terminalReportingMocks.listTerminalIssues).toHaveBeenCalledTimes(1);
     expect(terminalReportingMocks.readTerminalIssue).toHaveBeenCalledTimes(2);
+    expect(
+      terminalReportingMocks.reconcileTerminalIssueReporting,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("backs off blocked terminal reporting retries between poll cycles", async () => {
+    const root = await fs.mkdtemp(
+      path.join("/tmp", "symphony-terminal-reporting-backoff-"),
+    );
+    tempRoots.push(root);
+    const issue = {
+      issueNumber: 45,
+      issueIdentifier: "sociotechnica-org/symphony-ts#45",
+      title: "Throttle blocked terminal report publication retries",
+      currentOutcome: "failed" as const,
+      lastUpdatedAt: "2026-03-30T00:00:00.000Z",
+    };
+    terminalReportingMocks.listTerminalIssues.mockResolvedValue([issue]);
+    terminalReportingMocks.readTerminalIssue.mockResolvedValue(issue);
+    terminalReportingMocks.reconcileTerminalIssueReporting.mockResolvedValue({
+      changed: true,
+      receipt: {
+        version: 1,
+        issueNumber: 45,
+        issueIdentifier: issue.issueIdentifier,
+        issueTitle: issue.title,
+        terminalOutcome: "failed",
+        issueUpdatedAt: issue.lastUpdatedAt,
+        state: "blocked",
+        summary: "Terminal issue report publication is blocked.",
+        note: "Archive root does not exist.",
+        blockedStage: "publication",
+        archiveRoot: null,
+        reportGeneratedAt: null,
+        reportJsonFile: null,
+        reportMarkdownFile: null,
+        publicationId: null,
+        publicationRoot: null,
+        publicationMetadataFile: null,
+        publishedAt: null,
+        updatedAt: "2026-03-30T00:00:00.000Z",
+      },
+    });
+
+    const orchestrator = new BootstrapOrchestrator(
+      createConfig(root),
+      promptBuilder,
+      new IdleTracker(),
+      new IdleWorkspaceManager(),
+      new IdleRunner(),
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+    await orchestrator.runOnce();
+
+    expect(
+      terminalReportingMocks.reconcileTerminalIssueReporting,
+    ).toHaveBeenCalledTimes(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await orchestrator.runOnce();
+
     expect(
       terminalReportingMocks.reconcileTerminalIssueReporting,
     ).toHaveBeenCalledTimes(2);

--- a/tests/unit/orchestrator-terminal-reporting.test.ts
+++ b/tests/unit/orchestrator-terminal-reporting.test.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PromptBuilder, ResolvedConfig } from "../../src/domain/workflow.js";
+import type {
+  PromptBuilder,
+  ResolvedConfig,
+} from "../../src/domain/workflow.js";
 import { deriveRuntimeInstancePaths } from "../../src/domain/workflow.js";
 import { BootstrapOrchestrator } from "../../src/orchestrator/service.js";
 import type { Logger } from "../../src/observability/logger.js";
-import { createRunnerTransportMetadata, type Runner } from "../../src/runner/service.js";
+import {
+  createRunnerTransportMetadata,
+  type Runner,
+} from "../../src/runner/service.js";
 import type { Tracker } from "../../src/tracker/service.js";
 import type { WorkspaceManager } from "../../src/workspace/service.js";
 
@@ -199,9 +205,9 @@ const tempRoots: string[] = [];
 afterEach(async () => {
   vi.clearAllMocks();
   await Promise.all(
-    tempRoots.splice(0).map((root) =>
-      fs.rm(root, { recursive: true, force: true }),
-    ),
+    tempRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
   );
 });
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -214,6 +214,9 @@ const baseConfig: ResolvedConfig = {
     dashboardEnabled: false,
     refreshMs: 1000,
     renderIntervalMs: 16,
+    issueReports: {
+      archiveRoot: null,
+    },
   },
 };
 

--- a/tests/unit/recovery-posture.test.ts
+++ b/tests/unit/recovery-posture.test.ts
@@ -144,6 +144,13 @@ describe("projectRecoveryPosture", () => {
             action: "cleanup",
             cleanupError: "rm failed",
           },
+          reportingState: null,
+          reportingSummary: null,
+          reportingReceiptFile: null,
+          reportJsonFile: null,
+          reportMarkdownFile: null,
+          publicationRoot: null,
+          blockedStage: null,
         },
       ],
     });

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -87,6 +87,9 @@ function createConfig(
       dashboardEnabled: false,
       refreshMs: 1_000,
       renderIntervalMs: 1_000,
+      issueReports: {
+        archiveRoot: null,
+      },
     },
   };
 }

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -78,6 +78,9 @@ function makeConfig(
     dashboardEnabled: true,
     refreshMs: 1000,
     renderIntervalMs: 16,
+    issueReports: {
+      archiveRoot: null,
+    },
     ...overrides,
   };
 }

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -223,6 +223,9 @@ ${buildSharedWorkflowSections()}`,
           dashboardEnabled: true,
           refreshMs: 1000,
           renderIntervalMs: 16,
+          issueReports: {
+            archiveRoot: null,
+          },
         },
       }),
     ).toEqual(authoritative);
@@ -257,6 +260,33 @@ ${buildSharedWorkflowSections()}`,
     expect(workflow.config.workspace.repoUrl).toBe("git@example.com:repo.git");
     expect(workflow.config.agent.env["GITHUB_REPO"]).toBe(
       "sociotechnica-org/symphony-ts",
+    );
+  });
+
+  it("resolves issue report archive roots from the instance root", async () => {
+    const dir = await createTempDir("workflow-issue-reports-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+${buildSharedWorkflowSections()}
+observability:
+  issue_reports:
+    archive_root: ../factory-runs`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.observability.issueReports.archiveRoot).toBe(
+      path.resolve(dir, "..", "factory-runs"),
     );
   });
 


### PR DESCRIPTION
## Summary
- generate terminal issue reports automatically after successful merges and terminal failures
- optionally publish those reports to a configured `factory-runs` archive via `observability.issue_reports.archive_root`
- surface terminal report receipt/publication state in factory status, recovery posture, docs, and tests

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- Plan approved on issue #250 before implementation.
- No separate automated self-review tool was available beyond local diff review and the repo test/lint/typecheck gates.

Closes #250
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
