### PR TITLE
Persist merge and close lifecycle facts in issue artifacts

### DIFF
--- a/docs/plans/255-persist-merge-close-lifecycle-facts/plan.md
+++ b/docs/plans/255-persist-merge-close-lifecycle-facts/plan.md
@@ -259,13 +259,13 @@ The required terminal-success fact flow is:
 
 Because this slice depends on tracker-observed terminal facts, the plan should make degraded cases explicit.
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| PR merged and issue closed successfully | terminal success path, branch name, issue number | `mergedAt` and `closedAt` available | persist both facts; reports render concrete merge/close timing |
-| PR merged successfully but closed issue fetch does not yield exact `closedAt` | terminal success path, branch name, issue number | `mergedAt` available, `closedAt` missing | persist `mergedAt`, leave `closedAt` null, keep close note partial |
-| Issue closed successfully but no merged PR is found for the branch | terminal success path, branch name, issue number | `closedAt` available, `mergedAt` missing | persist `closedAt`, leave `mergedAt` null, keep merge note partial |
-| Tracker completion succeeds but follow-up lifecycle fact fetch fails | terminal success path only | no terminal lifecycle facts | preserve terminal success artifact/report flow, store null facts, and surface the persistence gap in logs/tests rather than failing report generation |
-| Older artifact directory predates this schema | summary/events/attempts only | none | load compatibly and keep existing unavailable notes |
+| Observed condition                                                            | Local facts available                            | Normalized tracker facts available       | Expected decision                                                                                                                                     |
+| ----------------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR merged and issue closed successfully                                       | terminal success path, branch name, issue number | `mergedAt` and `closedAt` available      | persist both facts; reports render concrete merge/close timing                                                                                        |
+| PR merged successfully but closed issue fetch does not yield exact `closedAt` | terminal success path, branch name, issue number | `mergedAt` available, `closedAt` missing | persist `mergedAt`, leave `closedAt` null, keep close note partial                                                                                    |
+| Issue closed successfully but no merged PR is found for the branch            | terminal success path, branch name, issue number | `closedAt` available, `mergedAt` missing | persist `closedAt`, leave `mergedAt` null, keep merge note partial                                                                                    |
+| Tracker completion succeeds but follow-up lifecycle fact fetch fails          | terminal success path only                       | no terminal lifecycle facts              | preserve terminal success artifact/report flow, store null facts, and surface the persistence gap in logs/tests rather than failing report generation |
+| Older artifact directory predates this schema                                 | summary/events/attempts only                     | none                                     | load compatibly and keep existing unavailable notes                                                                                                   |
 
 ## Observability Requirements
 

--- a/docs/plans/255-persist-merge-close-lifecycle-facts/plan.md
+++ b/docs/plans/255-persist-merge-close-lifecycle-facts/plan.md
@@ -1,0 +1,330 @@
+# Issue 255 Plan: Persist Merge And Close Lifecycle Facts Into Canonical Issue Artifacts And Reports
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Persist merge timing and exact issue-close timing into the canonical local issue-artifact contract so per-issue reports and campaign digests can describe the full delivery loop from local facts instead of fallback notes.
+
+The intended outcome of this slice is:
+
+1. successful GitHub-backed runs record when the PR merged and when the issue closed in canonical issue artifacts
+2. issue reports render concrete `mergedAt` and `closedAt` values when those facts were observed
+3. campaign digests stop flagging those fields as unavailable for reports backed by the new artifact facts
+4. the implementation stays on one reviewable seam: additive lifecycle-fact persistence plus report consumption
+
+## Scope
+
+This slice covers:
+
+1. additive canonical issue-artifact schema changes for merge and issue-close lifecycle facts
+2. GitHub tracker/client normalization needed to surface exact issue close timing and merged PR timing to the runtime boundary
+3. orchestrator persistence wiring so terminal success stores those normalized lifecycle facts locally
+4. issue-report and campaign-report updates to read the canonical lifecycle facts instead of hardcoded unavailable notes
+5. unit and integration coverage for the new artifact contract and report rendering behavior
+
+## Non-Goals
+
+This slice does not include:
+
+1. reconstructing full issue state-transition history or label-transition history
+2. changing plan-review, review-loop, guarded-landing, retry, or reconciliation policy
+3. re-fetching GitHub during report generation
+4. changing tracker semantics for non-GitHub backends beyond preserving compatibility with the additive artifact shape
+5. broader report redesign unrelated to merge/close lifecycle facts
+
+## Current Gaps
+
+Today the needed facts are not preserved end-to-end:
+
+1. `src/observability/issue-report.ts` hardcodes merge and close timing as unavailable even though it already models those fields in the report shape
+2. `src/observability/campaign-report.ts` can only aggregate `mergedAt` and `closedAt` when issue reports already contain them, so the digest currently reports availability gaps rather than real timing
+3. `src/observability/issue-artifacts.ts` does not provide a typed canonical home for merged-at and closed-at facts
+4. `src/tracker/github-client.ts` normalizes merged PR timing for handoff detection, but `RuntimeIssue` and the terminal artifact path do not currently preserve exact issue close timing
+5. terminal success persistence in `src/orchestrator/service.ts` records a `succeeded` event and attempt snapshot, but not the terminal merge/close lifecycle facts reports need later
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that canonical local artifacts should preserve delivery facts needed for later reporting when the runtime already observed them
+2. the rule that reports consume canonical persisted facts rather than making post-hoc remote GitHub guesses
+3. the rule that this slice is additive and should not widen into full tracker-history reconstruction
+
+Does not belong here:
+
+1. raw GitHub REST field names
+2. artifact file-write mechanics
+3. markdown-only fallback wording without a durable storage contract
+
+### Configuration Layer
+
+Belongs here:
+
+1. no workflow or frontmatter changes are required for this slice
+2. existing instance/report path resolution remains unchanged
+
+Does not belong here:
+
+1. config switches for whether merge or close facts are persisted
+2. report-format knobs for lifecycle fact rendering
+
+### Coordination Layer
+
+Belongs here:
+
+1. terminal-success persistence wiring that attaches normalized lifecycle facts to canonical observations at the point the runtime closes the issue
+2. keeping the terminal observation path explicit instead of hiding GitHub fact lookups inside report generation
+
+Does not belong here:
+
+1. tracker transport parsing
+2. report aggregation logic
+3. retry or handoff-state changes unrelated to terminal fact persistence
+
+### Execution Layer
+
+Belongs here:
+
+1. untouched for this issue
+
+Does not belong here:
+
+1. runner or workspace changes to satisfy reporting
+
+### Integration Layer
+
+Belongs here:
+
+1. GitHub client normalization for exact issue-close timing and merged PR timing
+2. tracker-facing normalized lifecycle-fact shape passed into the coordinator without leaking raw transport payloads
+
+Does not belong here:
+
+1. issue-report rendering
+2. orchestrator terminal policy
+3. canonical artifact file layout decisions
+
+### Observability Layer
+
+Belongs here:
+
+1. additive canonical artifact schema for merge/close lifecycle facts
+2. report derivation that reads those facts from stored issue artifacts
+3. tests that lock in the canonical persistence and reporting contract
+
+Does not belong here:
+
+1. live GitHub API calls during report generation
+2. tracker mutation logic
+3. hidden inference beyond the stored local facts
+
+## Architecture Boundaries
+
+### `src/tracker/github-client.ts`
+
+Owns:
+
+1. parsing GitHub issue close timestamps from transport responses
+2. continuing to normalize merged PR timing for closed pull requests
+3. exposing a narrow normalized shape for the tracker layer to use
+
+Does not own:
+
+1. canonical artifact persistence
+2. report rendering
+3. orchestrator success/failure policy
+
+### `src/tracker/github.ts`
+
+Owns:
+
+1. keeping GitHub-specific lifecycle fact collection at the tracker edge
+2. supplying the terminal-success path with the merged PR / issue-close facts it can observe after completion
+
+Does not own:
+
+1. artifact writes
+2. report markdown wording
+3. cross-backend report fallback policy
+
+### `src/orchestrator/service.ts`
+
+Owns:
+
+1. requesting the terminal lifecycle facts after tracker completion succeeds
+2. attaching those normalized facts to the terminal issue-artifact observation in one explicit seam
+3. keeping the success path order inspectable: complete issue, observe final tracker facts, persist canonical artifact, run terminal reporting
+
+Does not own:
+
+1. raw GitHub REST parsing
+2. report aggregation internals
+3. tracker-specific heuristics beyond calling the tracker boundary
+
+### `src/observability/issue-artifacts.ts`
+
+Owns:
+
+1. the additive canonical schema for terminal merge and close facts
+2. durable read/write helpers and backward-compatible loading for older artifacts without those fields
+
+Does not own:
+
+1. live tracker fetches
+2. report markdown
+3. terminal policy decisions about when facts are available
+
+### `src/observability/issue-report.ts` and `src/observability/campaign-report.ts`
+
+Own:
+
+1. consuming the canonical lifecycle facts from stored artifacts
+2. rendering concrete merge/close values and accurate availability notes
+
+Do not own:
+
+1. backfilling facts from GitHub
+2. tracker transport knowledge
+3. artifact persistence
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR by staying on one end-to-end lifecycle-fact seam:
+
+1. add a narrow canonical storage contract for `mergedAt` and `closedAt`
+2. normalize those facts at the GitHub tracker boundary
+3. persist them during terminal success observation
+4. update report readers and tests to consume the stored facts
+
+This PR deliberately defers:
+
+1. full issue state-transition history in canonical artifacts
+2. label-transition artifacts
+3. richer merge identity such as merge commit metadata unless a tiny additive field is required by the final implementation
+4. report backfills for older artifact directories that never observed the facts
+
+Why this seam is reviewable:
+
+1. it is additive to the existing artifact contract
+2. it keeps transport parsing, persistence, and report reading in separate layers
+3. it avoids mixing landing-policy changes, report redesign, and broader tracker-history work
+
+## Storage And Persistence Contract
+
+This issue changes durable state, so the storage contract must be explicit.
+
+### Canonical issue summary
+
+Add additive terminal lifecycle fields to the canonical issue summary document:
+
+1. `mergedAt: string | null`
+2. `closedAt: string | null`
+
+These fields should mean:
+
+1. `mergedAt`
+   - the exact PR merge timestamp observed from the tracker for the issue branch's landed pull request
+2. `closedAt`
+   - the exact issue-close timestamp observed from the tracker after terminal success closes the issue
+
+### Canonical event details
+
+Keep the event stream additive and inspectable by including the same lifecycle facts on the terminal success event details when available so the raw event ledger explains why the summary fields changed.
+
+### Backward compatibility
+
+1. older artifact summaries without these fields must still load as `null`
+2. reports must continue to render partial/unavailable notes for old artifacts that predate the schema addition
+3. schema evolution remains additive rather than replacing existing attempt or event structures
+
+## Runtime Fact Flow
+
+This issue does not change retries, continuations, or reconciliation, so a new orchestration state machine is not required.
+
+The required terminal-success fact flow is:
+
+1. the orchestrator completes the issue through the tracker
+2. the GitHub tracker reads the freshly closed issue and latest merged pull-request facts for the branch
+3. the orchestrator persists those normalized facts into the canonical issue summary and terminal success event
+4. terminal reporting consumes the stored local facts without making additional network calls
+
+## Failure-Class Matrix
+
+Because this slice depends on tracker-observed terminal facts, the plan should make degraded cases explicit.
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| PR merged and issue closed successfully | terminal success path, branch name, issue number | `mergedAt` and `closedAt` available | persist both facts; reports render concrete merge/close timing |
+| PR merged successfully but closed issue fetch does not yield exact `closedAt` | terminal success path, branch name, issue number | `mergedAt` available, `closedAt` missing | persist `mergedAt`, leave `closedAt` null, keep close note partial |
+| Issue closed successfully but no merged PR is found for the branch | terminal success path, branch name, issue number | `closedAt` available, `mergedAt` missing | persist `closedAt`, leave `mergedAt` null, keep merge note partial |
+| Tracker completion succeeds but follow-up lifecycle fact fetch fails | terminal success path only | no terminal lifecycle facts | preserve terminal success artifact/report flow, store null facts, and surface the persistence gap in logs/tests rather than failing report generation |
+| Older artifact directory predates this schema | summary/events/attempts only | none | load compatibly and keep existing unavailable notes |
+
+## Observability Requirements
+
+1. canonical raw issue artifacts remain the sole source for issue-report merge/close timing
+2. issue reports explicitly distinguish complete versus partial lifecycle fact availability
+3. campaign digests summarize availability based on stored issue-report facts without new tracker dependencies
+4. the raw success event and canonical issue summary remain sufficient to audit why a report claims a given merge/close timestamp
+
+## Implementation Steps
+
+1. extend the canonical issue-artifact summary and read/write helpers with additive `mergedAt` and `closedAt` fields plus compatibility defaults
+2. extend the GitHub client/runtime normalization to capture `closed_at` for issues and keep merged PR timing available through a narrow tracker-owned helper
+3. add a focused tracker/coordinator seam that obtains final terminal lifecycle facts after `completeIssue()` and before artifact persistence/report generation
+4. include those lifecycle facts in the success observation summary/event details without mixing raw transport payloads into observability code
+5. update issue-report derivation to read stored `mergedAt` and `closedAt`, replacing the current hardcoded unavailable notes with fact-aware notes/status
+6. update campaign digest aggregation and notes so availability reflects the new stored values
+7. add or extend fixture helpers and tests for artifact persistence, issue-report rendering, and campaign digest availability
+8. run the relevant local checks and inspect representative generated report output
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. issue-artifact summary read/write preserves additive `mergedAt` and `closedAt` values
+2. issue-artifact readers default missing `mergedAt` and `closedAt` to `null` for older summaries
+3. issue-report generation renders concrete merge/close timestamps when the canonical summary contains them
+4. issue-report generation keeps partial notes when only one of the two facts is available
+5. campaign digest availability notes report full coverage once all selected reports contain merge/close timing
+
+### Integration
+
+1. terminal reporting over seeded successful artifacts containing canonical merge/close facts writes reports that include the concrete timestamps
+2. GitHub-backed integration coverage proves the terminal success path persists exact issue close timing and merged PR timing into canonical artifacts after completion
+
+### Acceptance Scenarios
+
+1. a successful GitHub issue with a merged PR produces canonical issue artifacts where both `mergedAt` and `closedAt` are non-null and the issue report markdown prints both values
+2. a campaign digest built from representative successful reports no longer says merge/close timing is unavailable when those reports observed the facts
+3. an older artifact directory generated before this slice still loads and produces a partial report rather than failing
+
+## Exit Criteria
+
+This issue is complete when:
+
+1. canonical issue artifacts persist additive merge/close lifecycle facts for successful GitHub runs
+2. issue reports consume those facts and stop rendering unconditional unavailable placeholders
+3. campaign digests reflect the new availability accurately
+4. local unit, integration, and repo-required checks pass
+5. the implementation remains within one PR that preserves tracker transport, normalization, persistence, and report-reading boundaries
+
+## Deferred To Later Issues Or PRs
+
+1. exact issue state-transition history and label-transition ledgers
+2. merge-commit identity or richer release metadata if campaign analysis needs it later
+3. backfill tooling to enrich already-generated historical artifact directories
+4. parity work for non-GitHub tracker backends if they later expose equivalent terminal lifecycle facts
+
+## Decision Notes
+
+1. Persist lifecycle facts on the canonical issue summary instead of only on derived reports so later report generators and campaign digests can share one source of truth.
+2. Keep GitHub-specific fact discovery at the tracker boundary; report generation should remain offline and artifact-driven.
+3. Treat the slice as additive storage plus read-side consumption, not as a broader tracker-history project, to keep the PR reviewable.

--- a/src/domain/handoff.ts
+++ b/src/domain/handoff.ts
@@ -26,6 +26,7 @@ export interface PullRequestHandle {
   readonly branchName: string;
   readonly headSha: string | null;
   readonly latestCommitAt: string | null;
+  readonly mergedAt?: string | null;
 }
 
 export interface PullRequestCheck {

--- a/src/domain/issue.ts
+++ b/src/domain/issue.ts
@@ -18,5 +18,6 @@ export interface RuntimeIssue {
   readonly url: string;
   readonly createdAt: string;
   readonly updatedAt: string;
+  readonly closedAt?: string | null;
   readonly queuePriority: QueuePriority | null;
 }

--- a/src/observability/campaign-report-markdown.ts
+++ b/src/observability/campaign-report-markdown.ts
@@ -130,7 +130,19 @@ export function renderCampaignGitHubActivityMarkdown(
     `- Failing checks: ${renderPatternList(digest.githubActivity.failingChecks)}`,
   );
   lines.push(`- Merge timing: ${digest.githubActivity.mergeAvailabilityNote}`);
+  lines.push(
+    `- First merge observed: ${renderValue(digest.githubActivity.earliestMergedAt)}`,
+  );
+  lines.push(
+    `- Latest merge observed: ${renderValue(digest.githubActivity.latestMergedAt)}`,
+  );
   lines.push(`- Close timing: ${digest.githubActivity.closeAvailabilityNote}`);
+  lines.push(
+    `- First close observed: ${renderValue(digest.githubActivity.earliestClosedAt)}`,
+  );
+  lines.push(
+    `- Latest close observed: ${renderValue(digest.githubActivity.latestClosedAt)}`,
+  );
   for (const note of digest.githubActivity.notes) {
     lines.push(`- Note: ${note}`);
   }

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -128,7 +128,13 @@ export interface CampaignGitHubActivity {
   readonly blockingReviewerVerdictCount: number | null;
   readonly pendingChecks: readonly CampaignCheckPattern[];
   readonly failingChecks: readonly CampaignCheckPattern[];
+  readonly mergeObservedCount: number;
+  readonly earliestMergedAt: string | null;
+  readonly latestMergedAt: string | null;
   readonly mergeAvailabilityNote: string;
+  readonly closeObservedCount: number;
+  readonly earliestClosedAt: string | null;
+  readonly latestClosedAt: string | null;
   readonly closeAvailabilityNote: string;
   readonly notes: readonly string[];
 }
@@ -537,12 +543,12 @@ function buildCampaignGitHubActivity(
       ? ""
       : `Failing checks were observed for ${pullRequests.filter((pullRequest) => pullRequest.failingChecks.length > 0).length.toString()} pull requests.`,
   ]);
-  const mergeAvailabilityCount = reports.filter(
-    (storedReport) => storedReport.report.githubActivity.mergedAt !== null,
-  ).length;
-  const closeAvailabilityCount = reports.filter(
-    (storedReport) => storedReport.report.githubActivity.closedAt !== null,
-  ).length;
+  const mergeCoverage = summarizeObservedLifecycleTimestamps(
+    reports.map((storedReport) => storedReport.report.githubActivity.mergedAt),
+  );
+  const closeCoverage = summarizeObservedLifecycleTimestamps(
+    reports.map((storedReport) => storedReport.report.githubActivity.closedAt),
+  );
 
   return {
     status:
@@ -564,15 +570,43 @@ function buildCampaignGitHubActivity(
     blockingReviewerVerdictCount,
     pendingChecks,
     failingChecks,
+    mergeObservedCount: mergeCoverage.observedCount,
+    earliestMergedAt: mergeCoverage.earliestAt,
+    latestMergedAt: mergeCoverage.latestAt,
     mergeAvailabilityNote:
-      mergeAvailabilityCount === reports.length
-        ? "Merge timing was available for all selected issue reports."
-        : `Merge timing was unavailable for ${(reports.length - mergeAvailabilityCount).toString()} of ${reports.length.toString()} selected issue reports.`,
+      mergeCoverage.observedCount === 0
+        ? "No selected issue reports recorded merge timing."
+        : mergeCoverage.observedCount === reports.length
+          ? `Merge timing was recorded for all ${reports.length.toString()} selected issue reports.`
+          : `Merge timing was recorded for ${mergeCoverage.observedCount.toString()} of ${reports.length.toString()} selected issue reports.`,
+    closeObservedCount: closeCoverage.observedCount,
+    earliestClosedAt: closeCoverage.earliestAt,
+    latestClosedAt: closeCoverage.latestAt,
     closeAvailabilityNote:
-      closeAvailabilityCount === reports.length
-        ? "Issue close timing was available for all selected issue reports."
-        : `Issue close timing was unavailable for ${(reports.length - closeAvailabilityCount).toString()} of ${reports.length.toString()} selected issue reports.`,
+      closeCoverage.observedCount === 0
+        ? "No selected issue reports recorded issue-close timing."
+        : closeCoverage.observedCount === reports.length
+          ? `Issue close timing was recorded for all ${reports.length.toString()} selected issue reports.`
+          : `Issue close timing was recorded for ${closeCoverage.observedCount.toString()} of ${reports.length.toString()} selected issue reports.`,
     notes,
+  };
+}
+
+function summarizeObservedLifecycleTimestamps(
+  timestamps: readonly (string | null)[],
+): {
+  readonly observedCount: number;
+  readonly earliestAt: string | null;
+  readonly latestAt: string | null;
+} {
+  const observed = timestamps
+    .filter((timestamp): timestamp is string => timestamp !== null)
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    observedCount: observed.length,
+    earliestAt: observed[0] ?? null,
+    latestAt: observed.at(-1) ?? null,
   };
 }
 

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -82,8 +82,18 @@ export interface IssueArtifactSummary {
   readonly currentSummary: string;
   readonly firstObservedAt: string;
   readonly lastUpdatedAt: string;
+  readonly mergedAt: string | null;
+  readonly closedAt: string | null;
   readonly latestAttemptNumber: number | null;
   readonly latestSessionId: string | null;
+}
+
+interface LegacyIssueArtifactSummary extends Omit<
+  IssueArtifactSummary,
+  "mergedAt" | "closedAt"
+> {
+  readonly mergedAt?: string | null | undefined;
+  readonly closedAt?: string | null | undefined;
 }
 
 export interface IssueArtifactEvent {
@@ -193,6 +203,8 @@ export interface IssueArtifactIssueUpdate {
   readonly currentOutcome: IssueArtifactOutcome;
   readonly currentSummary: string;
   readonly observedAt: string;
+  readonly mergedAt?: string | null | undefined;
+  readonly closedAt?: string | null | undefined;
   readonly latestAttemptNumber?: number | null | undefined;
   readonly latestSessionId?: string | null | undefined;
 }
@@ -270,7 +282,7 @@ export class LocalIssueArtifactStore implements IssueArtifactStore {
     issueFile: string,
     update: IssueArtifactIssueUpdate,
   ): Promise<IssueArtifactSummary> {
-    const existing = await readJsonFile<IssueArtifactSummary>(issueFile).catch(
+    const existing = await readIssueArtifactSummaryFile(issueFile).catch(
       (error) => {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           return null;
@@ -291,6 +303,14 @@ export class LocalIssueArtifactStore implements IssueArtifactStore {
       currentSummary: update.currentSummary,
       firstObservedAt: existing?.firstObservedAt ?? update.observedAt,
       lastUpdatedAt: update.observedAt,
+      mergedAt:
+        update.mergedAt === undefined
+          ? (existing?.mergedAt ?? null)
+          : update.mergedAt,
+      closedAt:
+        update.closedAt === undefined
+          ? (existing?.closedAt ?? null)
+          : update.closedAt,
       latestAttemptNumber:
         update.latestAttemptNumber === undefined
           ? (existing?.latestAttemptNumber ?? null)
@@ -442,7 +462,7 @@ export async function readIssueArtifactSummary(
   instance: RuntimeInstanceInput,
   issueNumber: number,
 ): Promise<IssueArtifactSummary> {
-  return await readJsonFile<IssueArtifactSummary>(
+  return await readIssueArtifactSummaryFile(
     deriveIssueArtifactPaths(instance, issueNumber).issueFile,
   );
 }
@@ -557,6 +577,17 @@ async function readIssueArtifactSessionFile(
         }),
         appServerPid ?? null,
       ),
+  };
+}
+
+async function readIssueArtifactSummaryFile(
+  filePath: string,
+): Promise<IssueArtifactSummary> {
+  const summary = await readJsonFile<LegacyIssueArtifactSummary>(filePath);
+  return {
+    ...summary,
+    mergedAt: summary.mergedAt ?? null,
+    closedAt: summary.closedAt ?? null,
   };
 }
 

--- a/src/observability/issue-report.ts
+++ b/src/observability/issue-report.ts
@@ -23,7 +23,10 @@ import type {
   IssueArtifactSessionSnapshot,
   IssueArtifactSummary,
 } from "./issue-artifacts.js";
-import { deriveIssueArtifactPaths } from "./issue-artifacts.js";
+import {
+  deriveIssueArtifactPaths,
+  readIssueArtifactSummary,
+} from "./issue-artifacts.js";
 import {
   createRunnerAccountingSnapshot,
   sumIfAnyPresent,
@@ -453,7 +456,7 @@ export async function loadIssueArtifacts(
 
   const [issue, eventLedger, attempts, sessions, logPointers] =
     await Promise.all([
-      readOptionalJson<IssueArtifactSummary>(paths.issueFile),
+      readOptionalIssueArtifactSummary(instance, issueNumber),
       readOptionalJsonLines(paths.eventsFile),
       readJsonArrayFromDir<IssueArtifactAttemptSnapshot>(
         paths.attemptsDir,
@@ -888,9 +891,23 @@ function buildGitHubActivity(
   const reviewFeedbackRounds = loaded.events.filter(
     (event) => event.kind === "review-feedback",
   ).length;
+  const mergedAt = loaded.issue?.mergedAt ?? null;
+  const closedAt = loaded.issue?.closedAt ?? null;
   const notes = [
     "Issue state and label transitions are not part of the canonical local artifact contract yet.",
-    "Merge timing and exact issue-close timing remain unavailable until richer raw GitHub lifecycle facts are stored locally.",
+    ...(mergedAt === null && closedAt === null
+      ? [
+          "Merge timing and exact issue-close timing remained unavailable in the canonical local artifacts for this issue.",
+        ]
+      : mergedAt === null
+        ? [
+            "Merge timing was not preserved in the canonical local artifacts for this issue.",
+          ]
+        : closedAt === null
+          ? [
+              "Exact issue-close timing was not preserved in the canonical local artifacts for this issue.",
+            ]
+          : []),
   ];
 
   return {
@@ -904,12 +921,16 @@ function buildGitHubActivity(
       pullRequests,
       reviewFeedbackRounds,
     ),
-    mergedAt: null,
+    mergedAt,
     mergeNote:
-      "Canonical local artifacts do not yet record merge timestamps or merge commits.",
-    closedAt: null,
+      mergedAt === null
+        ? "Canonical local artifacts did not preserve a merged pull request timestamp for this issue."
+        : "Canonical local artifacts preserved the merged pull request timestamp for this issue.",
+    closedAt,
     closeNote:
-      "Canonical local artifacts do not yet record exact issue close timing.",
+      closedAt === null
+        ? "Canonical local artifacts did not preserve exact issue close timing for this issue."
+        : "Canonical local artifacts preserved the exact issue close timestamp for this issue.",
     notes,
   };
 }
@@ -2213,6 +2234,20 @@ async function readJsonFile<T>(filePath: string): Promise<T> {
       },
     );
   }
+}
+
+async function readOptionalIssueArtifactSummary(
+  instance: RuntimeInstanceInput,
+  issueNumber: number,
+): Promise<IssueArtifactSummary | null> {
+  return await readIssueArtifactSummary(instance, issueNumber).catch(
+    (error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    },
+  );
 }
 
 function earliestTimestamp(

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1189,7 +1189,10 @@ export class BootstrapOrchestrator implements Orchestrator {
 
     if (lifecycle.kind === "handoff-ready") {
       clearLandingRuntimeState(this.#state.landing, issue.number);
-      await this.#completeIssue(issue);
+      await this.#completeIssue(issue, {
+        branchName,
+        lifecycle,
+      });
       return false;
     }
 
@@ -1350,6 +1353,7 @@ export class BootstrapOrchestrator implements Orchestrator {
         attemptNumber: attempt,
         branchName,
         finishedAt: new Date().toISOString(),
+        lifecycle: refreshedLifecycle,
       });
       return;
     }
@@ -1811,6 +1815,7 @@ export class BootstrapOrchestrator implements Orchestrator {
               workspace,
               session: sessionState,
               finishedAt: result.finishedAt,
+              lifecycle: nextLifecycle,
             });
             return false;
           }
@@ -2163,6 +2168,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly workspace?: PreparedWorkspace | undefined;
       readonly session?: RunSessionArtifactsState;
       readonly finishedAt?: string;
+      readonly lifecycle?: HandoffLifecycle | null;
     },
   ): Promise<void> {
     const runnerPid = this.#currentRunnerPid(issue.number);
@@ -2176,7 +2182,9 @@ export class BootstrapOrchestrator implements Orchestrator {
           hasRuntimeIssueIdentity(nextIssue) ? nextIssue : issue,
         )
         .catch(() => issue),
-      this.#tracker.inspectIssueHandoff(branchName).catch(() => null),
+      options?.lifecycle === undefined
+        ? this.#tracker.inspectIssueHandoff(branchName).catch(() => null)
+        : Promise.resolve(options.lifecycle),
     ]);
     clearRetryState(this.#state.retries, issue.number);
     clearPreferredHost(this.#state.hostDispatch, issue.number);
@@ -2783,6 +2791,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       attemptNumber: runSequence,
       branchName,
       workspace: options?.session?.runSession.workspace,
+      lifecycle: refreshedLifecycle,
       ...(options?.session === undefined ? {} : { session: options.session }),
       ...(options?.finishedAt === undefined
         ? {}

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -2170,7 +2170,12 @@ export class BootstrapOrchestrator implements Orchestrator {
     const branchName = options?.branchName ?? this.#branchName(issue.number);
     await this.#tracker.completeIssue(issue.number);
     const [completedIssue, completedLifecycle] = await Promise.all([
-      this.#tracker.getIssue(issue.number).catch(() => issue),
+      this.#tracker
+        .getIssue(issue.number)
+        .then((nextIssue) =>
+          hasRuntimeIssueIdentity(nextIssue) ? nextIssue : issue,
+        )
+        .catch(() => issue),
       this.#tracker.inspectIssueHandoff(branchName).catch(() => null),
     ]);
     clearRetryState(this.#state.retries, issue.number);
@@ -4845,4 +4850,15 @@ function resolvePublishedCodexTotals(
   }
 
   return visibleLiveTotals;
+}
+
+function hasRuntimeIssueIdentity(value: unknown): value is RuntimeIssue {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "number" in value &&
+    "identifier" in value &&
+    "title" in value &&
+    "url" in value
+  );
 }

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -2167,7 +2167,12 @@ export class BootstrapOrchestrator implements Orchestrator {
   ): Promise<void> {
     const runnerPid = this.#currentRunnerPid(issue.number);
     const observedAt = options?.finishedAt ?? new Date().toISOString();
+    const branchName = options?.branchName ?? this.#branchName(issue.number);
     await this.#tracker.completeIssue(issue.number);
+    const [completedIssue, completedLifecycle] = await Promise.all([
+      this.#tracker.getIssue(issue.number).catch(() => issue),
+      this.#tracker.inspectIssueHandoff(branchName).catch(() => null),
+    ]);
     clearRetryState(this.#state.retries, issue.number);
     clearPreferredHost(this.#state.hostDispatch, issue.number);
     clearWatchdogIssueState(this.#state.watchdog, issue.number);
@@ -2186,8 +2191,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       `Completed issue #${issue.number.toString()}`,
       workspaceRetention,
     );
-    noteTerminalIssue(this.#state.status, issue, {
-      branchName: options?.branchName ?? this.#branchName(issue.number),
+    noteTerminalIssue(this.#state.status, completedIssue, {
+      branchName,
       terminalOutcome: "success",
       summary,
       observedAt,
@@ -2202,15 +2207,17 @@ export class BootstrapOrchestrator implements Orchestrator {
     await this.#persistStatusSnapshot();
     await this.#recordIssueArtifact(
       this.#createTerminalObservation(issue, "succeeded", {
+        terminalIssue: completedIssue,
         observedAt,
         summary: this.#summarizeTerminalOutcome(
           `Completed ${issue.identifier}`,
           workspaceRetention,
         ),
         attemptNumber: options?.attemptNumber,
-        branchName: options?.branchName ?? this.#branchName(issue.number),
+        branchName,
         session: options?.session,
         runnerPid,
+        lifecycle: completedLifecycle,
         workspaceRetention,
       }),
     );
@@ -3137,6 +3144,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       readonly outcome: IssueArtifactOutcome;
       readonly summary: string;
       readonly branchName?: string | null | undefined;
+      readonly mergedAt?: string | null | undefined;
+      readonly closedAt?: string | null | undefined;
       readonly latestAttemptNumber?: number | null | undefined;
       readonly latestSessionId?: string | null | undefined;
     },
@@ -3151,6 +3160,8 @@ export class BootstrapOrchestrator implements Orchestrator {
       currentOutcome: options.outcome,
       currentSummary: options.summary,
       observedAt: options.observedAt,
+      mergedAt: options.mergedAt,
+      closedAt: options.closedAt,
       latestAttemptNumber: options.latestAttemptNumber,
       latestSessionId: options.latestSessionId,
     } as const;
@@ -3465,6 +3476,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     issue: RuntimeIssue,
     outcome: "succeeded" | "failed",
     options: {
+      readonly terminalIssue?: RuntimeIssue | undefined;
       readonly observedAt: string;
       readonly summary: string;
       readonly attemptNumber?: number | undefined;
@@ -3482,12 +3494,20 @@ export class BootstrapOrchestrator implements Orchestrator {
             options.session,
             options.observedAt,
           );
+    const terminalIssue = options.terminalIssue ?? issue;
+    const mergedAt =
+      options.lifecycle?.pullRequest?.mergedAt === undefined
+        ? null
+        : options.lifecycle.pullRequest.mergedAt;
+    const closedAt = terminalIssue.closedAt ?? null;
     return {
-      issue: this.#createIssueArtifactUpdate(issue, {
+      issue: this.#createIssueArtifactUpdate(terminalIssue, {
         observedAt: options.observedAt,
         outcome,
         summary: options.summary,
         branchName: options.branchName,
+        mergedAt,
+        closedAt,
         latestAttemptNumber: options.attemptNumber,
         latestSessionId: options.session?.runSession.id,
       }),
@@ -3502,6 +3522,8 @@ export class BootstrapOrchestrator implements Orchestrator {
             latestTurnNumber: options.session?.latestTurnNumber ?? null,
             backendSessionId:
               options.session?.description.backendSessionId ?? null,
+            ...(mergedAt === null ? {} : { mergedAt }),
+            ...(closedAt === null ? {} : { closedAt }),
             ...this.#createWorkspaceRetentionDetails(
               options.workspaceRetention,
             ),

--- a/src/tracker/github-client.ts
+++ b/src/tracker/github-client.ts
@@ -23,6 +23,7 @@ export interface GitHubIssueResponse {
   readonly html_url: string;
   readonly created_at: string;
   readonly updated_at: string;
+  readonly closed_at: string | null;
   readonly labels: ReadonlyArray<{ readonly name: string }>;
 }
 
@@ -550,6 +551,7 @@ export function toRuntimeIssue(
     url: issue.html_url,
     createdAt: issue.created_at,
     updatedAt: issue.updated_at,
+    closedAt: issue.closed_at ?? null,
     queuePriority,
   };
 }

--- a/src/tracker/github.ts
+++ b/src/tracker/github.ts
@@ -133,6 +133,7 @@ export class GitHubTracker implements Tracker {
           branchName: pullRequest.head.ref,
           headSha: pullRequest.head.sha,
           latestCommitAt: null,
+          mergedAt: pullRequest.mergedAt,
         },
         landingCommand: null,
         checks: [],

--- a/tests/integration/campaign-report-cli.test.ts
+++ b/tests/integration/campaign-report-cli.test.ts
@@ -112,7 +112,15 @@ describe("campaign report CLI", () => {
     ).resolves.toContain("#43 Generate per-issue reports from local artifacts");
     await expect(
       fs.readFile(path.join(campaignDir, "github-activity.md"), "utf8"),
-    ).resolves.toContain("Pull requests observed");
+    ).resolves.toContain(
+      "Merge timing: Merge timing was recorded for 1 of 3 selected issue reports.",
+    );
+    await expect(
+      fs.readFile(path.join(campaignDir, "github-activity.md"), "utf8"),
+    ).resolves.toContain("First merge observed: 2026-03-09T10:18:00.000Z");
+    await expect(
+      fs.readFile(path.join(campaignDir, "github-activity.md"), "utf8"),
+    ).resolves.toContain("Latest close observed: 2026-03-02T10:00:00.000Z");
     await expect(
       fs.readFile(path.join(campaignDir, "token-usage.md"), "utf8"),
     ).resolves.toContain("Aggregate status: partial");

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -125,9 +125,11 @@ describe("GitHubTracker", () => {
     );
 
     await tracker.completeIssue(7);
-    const issue = server.getIssue(7);
+    const issue = await tracker.getIssue(7);
+    const serverIssue = server.getIssue(7);
     expect(issue.state).toBe("closed");
-    expect(issue.comments).toContain("done");
+    expect(issue.closedAt).not.toBeNull();
+    expect(serverIssue.comments).toContain("done");
   });
 
   it("reports a missing lifecycle when no PR exists for the branch", async () => {

--- a/tests/support/issue-report-fixtures.ts
+++ b/tests/support/issue-report-fixtures.ts
@@ -104,6 +104,8 @@ export async function seedSuccessfulIssueArtifacts(
     readonly attemptStartedAt?: string | undefined;
     readonly prOpenedAt?: string | undefined;
     readonly latestCommitAt?: string | undefined;
+    readonly mergedAt?: string | undefined;
+    readonly closedAt?: string | undefined;
     readonly succeededAt?: string | undefined;
     readonly finalCommitAt?: string | undefined;
     readonly accounting?: RunnerAccountingSnapshot | undefined;
@@ -136,6 +138,8 @@ export async function seedSuccessfulIssueArtifacts(
   const prOpenedAt = options?.prOpenedAt ?? "2026-03-09T10:10:00.000Z";
   const latestCommitAt = options?.latestCommitAt ?? "2026-03-09T10:09:30.000Z";
   const succeededAt = options?.succeededAt ?? "2026-03-09T10:20:00.000Z";
+  const mergedAt = options?.mergedAt ?? "2026-03-09T10:18:00.000Z";
+  const closedAt = options?.closedAt ?? succeededAt;
   const finalCommitAt = options?.finalCommitAt ?? "2026-03-09T10:19:00.000Z";
   const review = {
     actionableCount: options?.review?.actionableCount ?? 0,
@@ -324,6 +328,8 @@ export async function seedSuccessfulIssueArtifacts(
       currentOutcome: "succeeded",
       currentSummary: "Issue completed successfully",
       observedAt: succeededAt,
+      mergedAt,
+      closedAt,
       latestAttemptNumber: 1,
       latestSessionId: sessionId,
     },
@@ -337,6 +343,8 @@ export async function seedSuccessfulIssueArtifacts(
         sessionId,
         details: {
           summary: "Issue completed successfully",
+          mergedAt,
+          closedAt,
           pullRequest: {
             number: 144,
             url: "https://github.com/sociotechnica-org/symphony-ts/pull/144",

--- a/tests/support/mock-github-server.ts
+++ b/tests/support/mock-github-server.ts
@@ -96,6 +96,7 @@ interface MockIssue {
   html_url: string;
   created_at: string;
   updated_at: string;
+  closed_at: string | null;
   labels: Array<{ name: string }>;
   comments: MockIssueComment[];
 }
@@ -219,6 +220,7 @@ export class MockGitHubServer {
       html_url: `${this.#baseUrl}/issues/${input.number}`,
       created_at: now,
       updated_at: now,
+      closed_at: input.state === "closed" ? now : null,
       labels: input.labels.map((name) => ({ name })),
       comments: [],
     });
@@ -741,6 +743,7 @@ export class MockGitHubServer {
         html_url: `${this.#baseUrl}/issues/${number.toString()}`,
         created_at: now,
         updated_at: now,
+        closed_at: null,
         labels: [],
         comments: [],
       };
@@ -917,6 +920,8 @@ export class MockGitHubServer {
         }
         if (body.state) {
           issue.state = body.state;
+          issue.closed_at =
+            body.state === "closed" ? new Date().toISOString() : null;
         }
         issue.updated_at = new Date().toISOString();
         json(response, 200, issue);

--- a/tests/unit/campaign-report.test.ts
+++ b/tests/unit/campaign-report.test.ts
@@ -110,6 +110,8 @@ describe("campaign report", () => {
               },
             ],
             reviewFeedbackRounds: 1,
+            mergedAt: "2026-03-03T11:30:00.000Z",
+            closedAt: "2026-03-03T12:00:00.000Z",
           },
           tokenUsage: {
             status: "complete",
@@ -192,6 +194,13 @@ describe("campaign report", () => {
       { name: "lint", count: 1 },
     ]);
     expect(digest.githubActivity.blockingReviewerVerdictCount).toBe(1);
+    expect(digest.githubActivity.mergeObservedCount).toBe(1);
+    expect(digest.githubActivity.earliestMergedAt).toBe(
+      "2026-03-03T11:30:00.000Z",
+    );
+    expect(digest.githubActivity.latestClosedAt).toBe(
+      "2026-03-03T12:00:00.000Z",
+    );
     expect(digest.tokenUsage.status).toBe("partial");
     expect(digest.tokenUsage.totalTokens).toBeNull();
     expect(digest.tokenUsage.observedTokenSubtotal).toBe(4400);
@@ -239,6 +248,12 @@ describe("campaign report", () => {
     );
     expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
       "- Blocking reviewer-app verdicts: Unavailable",
+    );
+    expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
+      "- Merge timing: No selected issue reports recorded merge timing.",
+    );
+    expect(renderCampaignGitHubActivityMarkdown(digest)).toContain(
+      "- First merge observed: Unavailable",
     );
   });
 
@@ -392,6 +407,8 @@ function buildStoredIssueReport(options: {
       | undefined;
     readonly reviewFeedbackRounds?: number | undefined;
     readonly blockingReviewerVerdictCount?: number | null | undefined;
+    readonly mergedAt?: string | null | undefined;
+    readonly closedAt?: string | null | undefined;
   };
   readonly tokenUsage?: {
     readonly status?:
@@ -459,10 +476,18 @@ function buildStoredIssueReport(options: {
       pullRequests: options.githubActivity?.pullRequests ?? [],
       reviewFeedbackRounds: options.githubActivity?.reviewFeedbackRounds ?? 0,
       reviewLoopSummary: "No review activity recorded.",
-      mergedAt: null,
-      mergeNote: "Merge timing unavailable.",
-      closedAt: null,
-      closeNote: "Close timing unavailable.",
+      mergedAt: options.githubActivity?.mergedAt ?? null,
+      mergeNote:
+        options.githubActivity?.mergedAt === undefined ||
+        options.githubActivity.mergedAt === null
+          ? "Merge timing unavailable."
+          : "Merge timing recorded in canonical issue artifacts.",
+      closedAt: options.githubActivity?.closedAt ?? null,
+      closeNote:
+        options.githubActivity?.closedAt === undefined ||
+        options.githubActivity.closedAt === null
+          ? "Close timing unavailable."
+          : "Close timing recorded in canonical issue artifacts.",
       notes: [],
     },
     tokenUsage: {

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -156,6 +156,8 @@ describe("issue artifacts", () => {
     expect(summary.lastUpdatedAt).toBe(secondObservedAt);
     expect(summary.latestAttemptNumber).toBe(1);
     expect(summary.branch).toBe("symphony/43");
+    expect(summary.mergedAt).toBeNull();
+    expect(summary.closedAt).toBeNull();
 
     const events = await readIssueArtifactEvents(instance, 43);
     expect(events).toHaveLength(1);
@@ -168,6 +170,46 @@ describe("issue artifacts", () => {
     await expect(fs.stat(paths.attemptsDir)).resolves.toBeDefined();
     await expect(fs.stat(paths.sessionsDir)).resolves.toBeDefined();
     await expect(fs.stat(paths.logsDir)).resolves.toBeDefined();
+  });
+
+  it("persists additive merge and close lifecycle facts in the canonical issue summary", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const instance = deriveInstanceFromWorkspaceRoot(workspaceRoot);
+    const store = new LocalIssueArtifactStore(instance);
+
+    await store.recordObservation({
+      issue: {
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        branch: "symphony/43",
+        currentOutcome: "succeeded",
+        currentSummary: "Issue completed successfully",
+        observedAt: "2026-03-09T10:20:00.000Z",
+        mergedAt: "2026-03-09T10:18:00.000Z",
+        closedAt: "2026-03-09T10:20:00.000Z",
+      },
+      events: [
+        {
+          version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+          kind: "succeeded",
+          issueNumber: 43,
+          observedAt: "2026-03-09T10:20:00.000Z",
+          attemptNumber: 1,
+          sessionId: null,
+          details: {
+            mergedAt: "2026-03-09T10:18:00.000Z",
+            closedAt: "2026-03-09T10:20:00.000Z",
+          },
+        },
+      ],
+    });
+
+    const summary = await readIssueArtifactSummary(instance, 43);
+    expect(summary.mergedAt).toBe("2026-03-09T10:18:00.000Z");
+    expect(summary.closedAt).toBe("2026-03-09T10:20:00.000Z");
   });
 
   it("deduplicates keyed operator intervention events across non-consecutive writes", async () => {

--- a/tests/unit/issue-report.test.ts
+++ b/tests/unit/issue-report.test.ts
@@ -49,6 +49,12 @@ describe("issue report generation", () => {
     expect(generated.report.summary.outcome).toBe("succeeded");
     expect(generated.report.summary.attemptCount).toBe(1);
     expect(generated.report.summary.pullRequestCount).toBe(1);
+    expect(generated.report.githubActivity.mergedAt).toBe(
+      "2026-03-09T10:18:00.000Z",
+    );
+    expect(generated.report.githubActivity.closedAt).toBe(
+      "2026-03-09T10:20:00.000Z",
+    );
     expect(generated.report.learnings.status).toBe("complete");
     expect(generated.report.timeline.map((entry) => entry.kind)).toEqual(
       expect.arrayContaining([
@@ -65,6 +71,8 @@ describe("issue report generation", () => {
     expect(generated.markdown).toContain("## GitHub Activity");
     expect(generated.markdown).toContain("## Token Usage");
     expect(generated.markdown).toContain("## Learnings");
+    expect(generated.markdown).toContain("Merged at: 2026-03-09T10:18:00.000Z");
+    expect(generated.markdown).toContain("Closed at: 2026-03-09T10:20:00.000Z");
     expect(generated.markdown).toContain("pending checks None");
     expect(generated.markdown).toContain("failing checks None");
   });

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -340,6 +340,7 @@ class SequencedTracker implements Tracker {
   readonly retried: Array<{ issueNumber: number; reason: string }> = [];
   readonly failed: Array<{ issueNumber: number; reason: string }> = [];
   readonly resolvedThreadBatches: string[][] = [];
+  inspectIssueHandoffCalls = 0;
   ensureLabelsCalls = 0;
 
   constructor(options: {
@@ -402,6 +403,7 @@ class SequencedTracker implements Tracker {
   }
 
   async inspectIssueHandoff(branchName: string): Promise<HandoffLifecycle> {
+    this.inspectIssueHandoffCalls += 1;
     const issueNumber = Number(branchName.split("/").at(-1));
     if (Number.isNaN(issueNumber)) {
       throw new Error(`Invalid branch name ${branchName}`);
@@ -461,6 +463,20 @@ class SequencedTracker implements Tracker {
       issueNumber,
       createIssue(issueNumber, "symphony:failed"),
     );
+  }
+}
+
+class ClosedIssueTracker extends SequencedTracker {
+  override async getIssue(issueNumber: number): Promise<RuntimeIssue> {
+    if (this.completed.includes(issueNumber)) {
+      return {
+        ...createIssue(issueNumber, "symphony:running"),
+        labels: [],
+        state: "closed",
+        closedAt: "2026-03-11T12:06:00.000Z",
+      };
+    }
+    return await super.getIssue(issueNumber);
   }
 }
 
@@ -3552,6 +3568,58 @@ describe("BootstrapOrchestrator", () => {
           observation.issue.currentOutcome === "failed",
       ),
     ).toBe(false);
+  });
+
+  it("persists mergedAt from the observed handoff lifecycle while reloading closedAt after completion", async () => {
+    const tracker = new ClosedIssueTracker({
+      ready: [createIssue(86)],
+    });
+    tracker.setLifecycleSequence(86, [
+      {
+        ...lifecycle("handoff-ready", "symphony/86"),
+        pullRequest: {
+          number: 1,
+          url: "https://example.test/pulls/symphony/86",
+          branchName: "symphony/86",
+          headSha: "test-head-sha",
+          latestCommitAt: "2026-03-11T12:05:00.000Z",
+          mergedAt: "2026-03-11T12:05:27.000Z",
+        },
+      },
+    ]);
+    const artifactStore = new RecordingIssueArtifactStore();
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunnerExecutionResult> {
+          throw new Error("runner should not be called");
+        },
+      },
+      new NullLogger(),
+      artifactStore,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(tracker.completed).toEqual([86]);
+    expect(tracker.inspectIssueHandoffCalls).toBe(1);
+    expect(
+      artifactStore.observations.find(
+        (observation) =>
+          observation.issue.issueNumber === 86 &&
+          observation.issue.currentOutcome === "succeeded" &&
+          observation.issue.mergedAt === "2026-03-11T12:05:27.000Z" &&
+          observation.issue.closedAt === "2026-03-11T12:06:00.000Z",
+      ),
+    ).toBeDefined();
   });
 
   it("cleans up the issue workspace when merged reconciliation wins after an unexpected failure without a session", async () => {


### PR DESCRIPTION
Closes #255

## Summary
- persist merge and close lifecycle timestamps in canonical issue summaries
- thread merged and closed facts through GitHub normalization and terminal artifact persistence
- surface the canonical timestamps in issue reports and cover the flow with unit and integration tests

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
