### PR TITLE
Make operator halt release advancement when a prerequisite ticket fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ local/generated-only for per-instance standing context, append-only wake-up
 history, loop status, logs, and lock files under
 `.ralph/instances/<instance-key>/`, including the
 machine-readable completed-run review ledger `report-review-state.json`.
+The same operator state root now also carries `release-state.json`, the typed
+record of configured release dependencies plus the current blocked or clear
+release-advancement posture for that instance.
 Operator wake-ups now inspect that ledger before ordinary queue advancement so
 completed-run report findings are turned into tracked follow-up work promptly.
 The current entry point requires a Unix-like shell environment such as macOS,

--- a/bin/check-operator-release-state.ts
+++ b/bin/check-operator-release-state.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { loadWorkflowInstancePaths } from "../src/config/workflow.js";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+} from "../src/domain/instance-identity.js";
+import {
+  syncOperatorReleaseState,
+  type OperatorReleaseStateDocument,
+} from "../src/observability/operator-release-state.js";
+
+interface Args {
+  readonly workflowPath: string;
+  readonly operatorRepoRoot: string;
+  readonly json: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  return {
+    workflowPath: path.resolve(
+      readOptionalOptionValue(argv, "--workflow") ?? "WORKFLOW.md",
+    ),
+    operatorRepoRoot: path.resolve(
+      readOptionalOptionValue(argv, "--operator-repo-root") ?? process.cwd(),
+    ),
+    json: argv.includes("--json"),
+  };
+}
+
+function readOptionalOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function renderText(state: OperatorReleaseStateDocument, filePath: string): string {
+  return [
+    `Release state: ${state.evaluation.advancementState}`,
+    `Release state file: ${filePath}`,
+    `Release id: ${state.configuration.releaseId ?? "unconfigured"}`,
+    `Blocking prerequisite: ${state.evaluation.blockingPrerequisite?.issueNumber.toString() ?? "none"}`,
+    `Blocked downstream: ${
+      state.evaluation.blockedDownstream.length === 0
+        ? "none"
+        : state.evaluation.blockedDownstream
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Unresolved references: ${
+      state.evaluation.unresolvedReferences.length === 0
+        ? "none"
+        : state.evaluation.unresolvedReferences
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Updated at: ${state.updatedAt}`,
+    `Summary: ${state.evaluation.summary}`,
+  ].join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const instance = await loadWorkflowInstancePaths(args.workflowPath);
+  const identity = deriveSymphonyInstanceIdentity(args.workflowPath);
+  const paths = deriveOperatorInstanceStatePaths({
+    operatorRepoRoot: args.operatorRepoRoot,
+    instanceKey: identity.instanceKey,
+  });
+  const state = await syncOperatorReleaseState({
+    instance,
+    releaseStateFile: paths.releaseStatePath,
+  });
+
+  if (args.json) {
+    process.stdout.write(
+      `${JSON.stringify({
+        releaseStateFile: paths.releaseStatePath,
+        state,
+      })}\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(`${renderText(state, paths.releaseStatePath)}\n`);
+}
+
+main().catch((error: Error) => {
+  process.stderr.write(
+    error.stack ? `${error.stack}\n` : `${error.name}: ${error.message}\n`,
+  );
+  process.exit(1);
+});

--- a/bin/check-operator-release-state.ts
+++ b/bin/check-operator-release-state.ts
@@ -43,7 +43,10 @@ function readOptionalOptionValue(
   return value;
 }
 
-function renderText(state: OperatorReleaseStateDocument, filePath: string): string {
+function renderText(
+  state: OperatorReleaseStateDocument,
+  filePath: string,
+): string {
   return [
     `Release state: ${state.evaluation.advancementState}`,
     `Release state file: ${filePath}`,

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -74,14 +74,22 @@ pnpm tsx bin/symphony-report.ts review-pending --workflow ../target-repo/WORKFLO
    - record a no-follow-up decision with `symphony-report.ts review-record`
    - or create a tracked follow-up issue with `symphony-report.ts review-follow-up`
    - and record durable guidance in standing context plus per-cycle findings in the wake-up log
-4. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
-5. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
-6. Check for operator-gated work the factory cannot clear by itself:
+4. Before downstream release advancement work, inspect release dependency state with:
+
+```bash
+pnpm tsx bin/check-operator-release-state.ts --operator-repo-root <operator-checkout> --json
+pnpm tsx bin/check-operator-release-state.ts --workflow ../target-repo/WORKFLOW.md --operator-repo-root <operator-checkout> --json
+```
+
+5. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
+6. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
+7. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
+8. Check for operator-gated work the factory cannot clear by itself:
    - active issues in `awaiting-human-handoff`
    - active issues or PRs in `awaiting-landing-command`
-7. If the detached runtime is stopped or degraded, repair that first.
-8. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
-9. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
+9. If the detached runtime is stopped or degraded, repair that first.
+10. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite or unresolved dependency metadata. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
+11. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
 
@@ -201,6 +209,9 @@ Completed-run report review state also lives there in
 `report-review-state.json`; this is the machine-readable ledger for which
 generated reports are pending review, reviewed, or blocked, and which follow-up
 issues were filed from report findings.
+Release dependency state lives there in `release-state.json`; this is the
+machine-readable record of configured prerequisite/downstream relationships plus
+the current blocked or clear release advancement posture.
 
 Workspace retention is config-driven. By default, failures stay inspectable and successes are cleaned up. If you need to inspect a successful workspace, temporarily set `workspace.retention.on_success: retain` before the run.
 

--- a/docs/plans/281-operator-prerequisite-failure-release-halt/plan.md
+++ b/docs/plans/281-operator-prerequisite-failure-release-halt/plan.md
@@ -255,14 +255,14 @@ One release state document is keyed by selected instance and stores:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| No release dependency metadata configured for this instance | release-state file absent or unconfigured | ordinary issue/PR state only | remain `unconfigured`; do not invent release blocking |
-| Release metadata exists and all prerequisites are non-failed | configured prerequisite/downstream mapping | prerequisite issues are open, merged, or otherwise non-failed | record `configured-clear`; ordinary advancement may continue |
-| A prerequisite issue is terminal failed | configured prerequisite/downstream mapping | prerequisite issue outcome is failed | record `blocked-by-prerequisite-failure`; do not promote downstream tickets or post `/land` for downstream PRs |
-| Multiple prerequisites exist and one fails while another is still running | configured dependency graph | one prerequisite failed, others non-terminal | record `blocked-by-prerequisite-failure`; the first failed prerequisite is sufficient to halt advancement |
-| Metadata references an issue that cannot be resolved from current facts | configured dependency graph with missing reference | current tracker snapshot missing or ambiguous for referenced issue | record `blocked-review-needed`; fail closed until corrected |
-| Previously failed prerequisite is later repaired and no prerequisite remains failed | existing blocked release-state entry | refreshed prerequisite outcomes no longer failed | transition back to `configured-clear`; advancement may resume on a later wake-up |
+| Observed condition                                                                  | Local facts available                              | Normalized tracker facts available                                 | Expected decision                                                                                              |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| No release dependency metadata configured for this instance                         | release-state file absent or unconfigured          | ordinary issue/PR state only                                       | remain `unconfigured`; do not invent release blocking                                                          |
+| Release metadata exists and all prerequisites are non-failed                        | configured prerequisite/downstream mapping         | prerequisite issues are open, merged, or otherwise non-failed      | record `configured-clear`; ordinary advancement may continue                                                   |
+| A prerequisite issue is terminal failed                                             | configured prerequisite/downstream mapping         | prerequisite issue outcome is failed                               | record `blocked-by-prerequisite-failure`; do not promote downstream tickets or post `/land` for downstream PRs |
+| Multiple prerequisites exist and one fails while another is still running           | configured dependency graph                        | one prerequisite failed, others non-terminal                       | record `blocked-by-prerequisite-failure`; the first failed prerequisite is sufficient to halt advancement      |
+| Metadata references an issue that cannot be resolved from current facts             | configured dependency graph with missing reference | current tracker snapshot missing or ambiguous for referenced issue | record `blocked-review-needed`; fail closed until corrected                                                    |
+| Previously failed prerequisite is later repaired and no prerequisite remains failed | existing blocked release-state entry               | refreshed prerequisite outcomes no longer failed                   | transition back to `configured-clear`; advancement may resume on a later wake-up                               |
 
 ## Storage Contract
 

--- a/docs/plans/281-operator-prerequisite-failure-release-halt/plan.md
+++ b/docs/plans/281-operator-prerequisite-failure-release-halt/plan.md
@@ -1,0 +1,329 @@
+# Issue 281 Plan: Operator Halts Release Advancement On Prerequisite Failure
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Give the operator a deterministic, repo-owned rule for dependency-driven releases: when a prerequisite ticket in the selected release fails, the operator must stop advancing downstream tickets and persist that blocked release posture in canonical operator state instead of relying on scratchpad prose or memory.
+
+The intended outcome of this slice is:
+
+1. the operator wake-up workflow checks release dependency state before ordinary release advancement work
+2. a failed prerequisite blocks downstream promotion/landing decisions for that release
+3. the blocked release posture is stored in typed operator-local state and surfaced in operator status/notebook artifacts
+4. tests cover the regression where a failed prerequisite previously allowed later tickets to keep moving
+
+## Scope
+
+This slice covers:
+
+1. a typed operator-owned release/dependency state contract under the selected instance state root
+2. wake-up policy updates in the operator skill, prompt, and runbook so prerequisite-failure inspection happens before downstream release advancement
+3. narrow helper logic that evaluates release dependency metadata plus current tracked issue outcomes into a deterministic blocked/clear decision
+4. operator-loop status surfacing for the current release block state and reason
+5. focused tests for state evaluation, operator-loop wiring, and the failed-prerequisite regression path
+
+## Non-Goals
+
+This slice does not include:
+
+1. orchestrator dispatch, retry, reconciliation, or tracker claim policy changes
+2. a full factory-wide stop-the-line system
+3. new tracker transport or broad GitHub normalization refactors
+4. generic release planning automation across every future rollout shape
+5. automatic repair or rerun of failed prerequisite tickets
+6. replacing standing context as the place for durable human release notes beyond the new typed release-state seam
+
+## Current Gaps
+
+Today the checked-in operator workflow preserves release sequencing only as free-form notebook guidance:
+
+1. standing context can mention release order, but there is no typed operator state for prerequisite relationships or blocked release posture
+2. the operator prompt/skill instructs the agent to handle plan review, report review, and landing checkpoints, but not a deterministic prerequisite-failure checkpoint
+3. operator-loop status surfaces point to notebooks and report-review state, but do not expose whether a release is currently blocked by a failed prerequisite
+4. tests cover notebook persistence and report-review prioritization, but not the release regression where a failed prerequisite still allowed later tickets to advance
+
+## Decision Notes
+
+1. Keep this seam operator-local. The issue asks for operator halt behavior before broader stop-the-line support exists, so the first slice should not reopen orchestrator scheduling or tracker lifecycle policy.
+2. Add a typed operator release-state file instead of encoding dependency truth only in markdown sections. The operator needs an auditable, machine-readable place to store both configured dependencies and the current blocked posture.
+3. Reuse standing context for durable narrative guidance, but keep the release dependency graph and blocked fact in dedicated state so status/tests can inspect it directly.
+4. Treat downstream "advancement" narrowly in this slice: operator-owned promotion and landing decisions, not speculative factory dispatch suppression.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that a failed prerequisite blocks downstream release advancement on operator wake-up
+2. the rule that operators must not promote or land downstream work while that prerequisite failure remains unresolved
+3. the conditions under which the blocked posture may optionally escalate to a broader stop-the-line follow-up, without making that broader system part of this issue
+
+Does not belong here:
+
+1. raw GitHub payload parsing
+2. orchestrator dispatch suppression
+3. hidden notebook-only conventions that tests cannot inspect
+
+### Configuration Layer
+
+Belongs here:
+
+1. typed derivation of the new operator release-state path for the selected instance
+2. any narrow environment/status wiring needed so the operator command can read and update that state
+
+Does not belong here:
+
+1. new `WORKFLOW.md` runtime semantics for core orchestrator scheduling
+2. embedding release dependency truth only in prompt text
+
+### Coordination Layer
+
+Belongs here:
+
+1. no orchestrator-runtime changes in this slice
+2. an explicit operator-owned release advancement state model kept outside orchestrator retry/dispatch state
+
+Does not belong here:
+
+1. mixing operator release blocking into orchestrator lease, retry, or recovery maps
+2. teaching the factory runtime to consume operator notebook state as scheduling truth
+
+### Execution Layer
+
+Belongs here:
+
+1. operator-loop initialization/wiring of the release-state artifact
+2. bounded helper execution that inspects dependency metadata and current issue outcomes during a wake-up cycle
+
+Does not belong here:
+
+1. runner changes
+2. workspace changes
+3. provider-specific assumptions about Codex, Claude, or generic-command
+
+### Integration Layer
+
+Belongs here:
+
+1. the narrow boundary that reads current issue outcomes needed to determine whether prerequisites failed
+2. normalization of those outcome facts into an operator release decision without leaking tracker-specific shapes into the prompt text
+
+Does not belong here:
+
+1. broader tracker transport refactors
+2. mixing dependency metadata storage with raw GitHub API payloads
+3. orchestrator-owned release sequencing policy
+
+### Observability Layer
+
+Belongs here:
+
+1. the operator-local release-state document
+2. status/notebook surfacing for the blocked release posture and blocking prerequisite
+3. tests and docs that make the blocked release fact inspectable
+
+Does not belong here:
+
+1. mutating tracker state while rendering status
+2. inventing a second source of truth for issue outcome beyond normalized tracker facts plus operator-local release metadata
+
+## Architecture Boundaries
+
+### `src/domain/instance-identity.ts`
+
+Owns:
+
+1. typed derivation of the release-state file path under `.ralph/instances/<instance-key>/`
+2. naming the canonical operator-local artifact
+
+Does not own:
+
+1. dependency evaluation logic
+2. notebook wording
+3. tracker reads
+
+### operator release-state helper module
+
+Owns:
+
+1. the typed document schema for release dependency metadata and blocked posture
+2. pure evaluation of prerequisite outcomes into `clear` vs `blocked`
+3. atomic read/write helpers for that state
+
+Does not own:
+
+1. shell prompt text
+2. tracker transport clients
+3. orchestrator dispatch decisions
+
+### `skills/symphony-operator/operator-loop.sh`
+
+Owns:
+
+1. creation and exposure of the release-state artifact for the selected instance
+2. surfacing the release-state path in loop status artifacts
+
+Does not own:
+
+1. the only definition of release-blocking policy
+2. ad hoc dependency parsing logic in shell
+3. tracker-specific release heuristics
+
+### `skills/symphony-operator/SKILL.md`, `skills/symphony-operator/operator-prompt.md`, `docs/guides/operator-runbook.md`
+
+Owns:
+
+1. wake-up ordering rules for prerequisite-failure checks
+2. the operator-facing rule that downstream release advancement halts while blocked
+3. guidance on when to update standing context versus typed release-state artifacts
+
+Does not own:
+
+1. machine-readable state persistence
+2. tracker transport details
+3. orchestrator runtime behavior
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR by staying on one narrow operator-policy seam:
+
+1. add a typed release-state artifact under the existing instance-scoped operator state root
+2. add pure helper logic for evaluating prerequisite outcomes from stored release metadata plus current issue facts
+3. update operator loop/prompt/skill/runbook to require the release-block checkpoint before downstream advancement work
+4. expose the release-state path and current posture in operator status artifacts
+5. add focused unit/integration tests
+
+Deferred from this PR:
+
+1. automatic factory-wide stop-the-line mode
+2. orchestrator dispatch gating based on dependency graphs
+3. broad tracker-side dependency normalization beyond what the selected operator seam minimally needs
+4. generalized multi-release portfolio management
+
+Why this seam is reviewable:
+
+1. it improves operator correctness without reopening core runtime scheduling
+2. it keeps durable release coordination in a typed, inspectable local contract
+3. it avoids mixing tracker transport, orchestrator state, and operator prompt changes into one broad refactor
+
+## Operator Release Advancement State Model
+
+This issue does not change the orchestrator runtime state machine, but it does add stateful operator behavior. The release advancement state therefore needs an explicit operator-owned state model.
+
+### State subject
+
+One release state document is keyed by selected instance and stores:
+
+1. release identifier / label
+2. dependency metadata for prerequisite and downstream issue relationships
+3. the current blocked or clear advancement posture
+4. the latest factual reason and timestamps for that posture
+
+### States
+
+1. `unconfigured`
+   - no dependency-driven release metadata is defined for the selected instance
+2. `configured-clear`
+   - release dependency metadata exists and all prerequisites needed for downstream advancement are currently non-failed
+3. `blocked-by-prerequisite-failure`
+   - at least one prerequisite has a normalized failed outcome, so downstream advancement is halted
+4. `blocked-review-needed`
+   - metadata is present but incomplete or inconsistent enough that the operator cannot safely determine whether advancement should continue
+
+### Allowed transitions
+
+1. `unconfigured -> configured-clear`
+2. `configured-clear -> blocked-by-prerequisite-failure`
+3. `configured-clear -> blocked-review-needed`
+4. `blocked-by-prerequisite-failure -> configured-clear`
+5. `blocked-by-prerequisite-failure -> blocked-review-needed`
+6. `blocked-review-needed -> configured-clear`
+7. `blocked-review-needed -> blocked-by-prerequisite-failure`
+
+### Contract Rules
+
+1. downstream advancement is allowed only in `configured-clear`
+2. `blocked-by-prerequisite-failure` must record the blocking prerequisite issue identifier and factual summary
+3. `blocked-review-needed` must fail closed for advancement until the metadata gap is corrected
+4. standing context may explain release sequencing, but the current blocked posture must live in typed release-state data
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| No release dependency metadata configured for this instance | release-state file absent or unconfigured | ordinary issue/PR state only | remain `unconfigured`; do not invent release blocking |
+| Release metadata exists and all prerequisites are non-failed | configured prerequisite/downstream mapping | prerequisite issues are open, merged, or otherwise non-failed | record `configured-clear`; ordinary advancement may continue |
+| A prerequisite issue is terminal failed | configured prerequisite/downstream mapping | prerequisite issue outcome is failed | record `blocked-by-prerequisite-failure`; do not promote downstream tickets or post `/land` for downstream PRs |
+| Multiple prerequisites exist and one fails while another is still running | configured dependency graph | one prerequisite failed, others non-terminal | record `blocked-by-prerequisite-failure`; the first failed prerequisite is sufficient to halt advancement |
+| Metadata references an issue that cannot be resolved from current facts | configured dependency graph with missing reference | current tracker snapshot missing or ambiguous for referenced issue | record `blocked-review-needed`; fail closed until corrected |
+| Previously failed prerequisite is later repaired and no prerequisite remains failed | existing blocked release-state entry | refreshed prerequisite outcomes no longer failed | transition back to `configured-clear`; advancement may resume on a later wake-up |
+
+## Storage Contract
+
+The new operator release-state document should:
+
+1. live under `.ralph/instances/<instance-key>/release-state.json`
+2. use an explicit schema version
+3. store both configured release dependency metadata and the current evaluated posture
+4. be written atomically like other operator-owned state artifacts
+5. remain operator-local and instance-scoped; it is not tracker truth and not orchestrator runtime state
+
+## Observability Requirements
+
+1. operator-loop `status.json` and `status.md` should surface the release-state path
+2. operator-facing docs/prompt should tell the operator to treat a blocked prerequisite as a mandatory checkpoint before downstream advancement
+3. the blocked posture should be inspectable without reading free-form notebook history
+4. standing context should remain available for durable release notes, but not as the sole place where blocked release truth lives
+
+## Implementation Steps
+
+1. Extend operator instance path derivation with a canonical `release-state.json` path.
+2. Add a focused operator release-state helper module that:
+   - defines the schema
+   - reads/writes the document
+   - evaluates prerequisite metadata plus current issue outcomes into a posture
+3. Update operator-loop wiring/status output so the release-state artifact is initialized and discoverable.
+4. Update the operator skill, prompt, and runbook to require the prerequisite-failure checkpoint before downstream advancement work.
+5. Add unit tests for release-state transitions and failure-class decisions.
+6. Add integration coverage proving the operator loop/status/prompt surface the new checkpoint and artifact.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. release-state evaluation returns `blocked-by-prerequisite-failure` when any configured prerequisite has failed
+2. release-state evaluation returns `blocked-review-needed` when dependency metadata is incomplete or references unresolved issues
+3. release-state evaluation returns `configured-clear` when prerequisites are configured and none have failed
+4. instance-path helpers expose `release-state.json`
+
+### Integration
+
+1. operator-loop status output includes the release-state path for the selected instance
+2. operator prompt places prerequisite-failure inspection before downstream release advancement work
+3. notebook/status wiring preserves standing context while making blocked release truth inspectable through the typed artifact
+
+### Acceptance Scenarios
+
+1. Given a dependency-driven release where issue `#111` is a prerequisite for downstream ticket `#112`, when `#111` is failed, then the operator wake-up contract marks the release blocked and does not allow downstream advancement.
+2. Given a previously blocked release whose failed prerequisite is later repaired, when the operator refreshes the state, then the release returns to clear posture and downstream advancement may resume.
+3. Given malformed or incomplete dependency metadata, when the operator evaluates release state, then the system fails closed with an explicit review-needed posture instead of advancing.
+
+## Exit Criteria
+
+1. repo-owned operator guidance explicitly says prerequisite failure halts downstream release advancement
+2. canonical operator-local state preserves the blocked release posture and blocking prerequisite
+3. operator-loop status artifacts expose the release-state seam clearly enough to inspect it directly
+4. tests cover the failed-prerequisite regression and the clear/review-needed alternatives
+
+## Deferred To Later Issues Or PRs
+
+1. factory-wide stop-the-line orchestration
+2. tracker-native dependency graph ingestion for GitHub issues
+3. automatic relabeling or queue mutation for blocked releases
+4. richer operator UX for editing release dependency metadata

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -20,7 +20,9 @@ Supported repo-owned entry point:
 The checked-in loop and prompt live next to this skill under
 `skills/symphony-operator/`. `.ralph/` is local/generated-only state for the
 instance-scoped standing context, wake-up log, status snapshots, logs, and
-loop lock files under `.ralph/instances/<instance-key>/`.
+loop lock files under `.ralph/instances/<instance-key>/`. Release dependency
+metadata and the current release advancement posture also live there in
+`release-state.json`.
 
 ## Scope
 
@@ -32,6 +34,7 @@ loop lock files under `.ralph/instances/<instance-key>/`.
 - Maintain the selected instance's persistent local operator notebook as:
   - `.ralph/instances/<instance-key>/standing-context.md` for durable guidance
   - `.ralph/instances/<instance-key>/wake-up-log.md` for append-only wake-up history
+  - `.ralph/instances/<instance-key>/release-state.json` for typed release dependency metadata and blocked/clear advancement posture
 
 ## Wake-Up Workflow
 
@@ -46,24 +49,26 @@ loop lock files under `.ralph/instances/<instance-key>/`.
    - decide whether the report yields no tracked follow-up, a concrete follow-up issue, or a blocked review state
    - persist the decision through `symphony-report review-record` or `symphony-report review-follow-up`
    - and record what the report taught the factory in standing context or in the append-only wake-up log as appropriate
-8. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
-9. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
-10. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
+8. Before any downstream release advancement work after completed-run report review is clear, run `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root <operator-repo-root> --json` for the selected instance.
+9. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
+10. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
+11. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
+12. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
     - any active issue waiting in `plan-ready` / `awaiting-human-handoff`
     - any PR or active issue waiting in `awaiting-landing-command`
-11. If the factory is unhealthy, fix the concrete problem and restart it.
-12. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-13. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
-14. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
+13. If the factory is unhealthy, fix the concrete problem and restart it.
+14. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
+15. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
+16. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
 
 - `Plan review: approved`
 - `Plan review: changes-requested`
 - `Plan review: waived` (record why in the comment)
 
-15. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
-16. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
-17. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
-18. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+17. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
+18. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
+19. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
+20. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
 
@@ -82,6 +87,7 @@ loop lock files under `.ralph/instances/<instance-key>/`.
 - Do not silently replace the worker on an active PR just because the next fix is obvious. Operator PR intervention is for stalled or broken factory behavior, not the normal path.
 - If a PR's required checks remain non-terminal for an unusually long time but the same behavior can be reproduced locally, do not stop at the first fixed assertion failure. Keep the PR in active operator treatment until the full locally reproducible hang is resolved or reduced to clearly external infrastructure.
 - Keep runner assumptions provider-neutral. The current runtime may use `codex`, `claude-code`, or `generic-command`; do not assume every healthy run appears as a direct `codex exec` child process.
+- Keep release dependency truth in the typed `release-state.json` artifact, not only in markdown notes. Standing context may explain release sequencing, but prerequisite failure gating must remain inspectable through the typed artifact.
 - Treat plan review as a required operator checkpoint:
   - if the plan is sound, post `Plan review: approved`,
   - if revisions are needed, post `Plan review: changes-requested` with concrete guidance,
@@ -108,6 +114,7 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
 - Low-severity cleanup comments can be answered instead of fixed only when the tradeoff is explicit and defensible.
 - Plan review and landing are default operator duties, not optional extras:
   - each wake-up should clear completed-run report review work before ordinary queue advancement
+  - each wake-up should clear the release-state prerequisite-failure checkpoint before downstream advancement or `/land` for dependent work
   - each wake-up should check for `plan-ready` issues and decide `approved`, `changes-requested`, or `waived`
   - each wake-up should check for review-clean PRs waiting on `/land` and post it when the guard conditions are satisfied
 - Landing is not complete at merge observation alone:

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PROMPT_FILE="$SCRIPT_DIR/operator-prompt.md"
 RALPH_DIR="$REPO_ROOT/.ralph"
 INSTANCE_STATE_RESOLVER="$REPO_ROOT/bin/resolve-operator-instance.ts"
+RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 INSTANCE_KEY=""
 DETACHED_SESSION_NAME=""
 INSTANCE_STATE_ROOT=""
@@ -18,6 +19,7 @@ STATUS_MD=""
 STANDING_CONTEXT=""
 WAKE_UP_LOG=""
 LEGACY_SCRATCHPAD=""
+RELEASE_STATE=""
 REPORT_REVIEW_STATE=""
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
@@ -34,6 +36,12 @@ LAST_CYCLE_STARTED_AT=""
 LAST_CYCLE_FINISHED_AT=""
 LAST_CYCLE_EXIT_CODE=""
 NEXT_WAKE_AT=""
+RELEASE_ADVANCEMENT_STATE="unavailable"
+RELEASE_STATE_SUMMARY="Release state is unavailable."
+RELEASE_STATE_UPDATED_AT=""
+RELEASE_ID=""
+RELEASE_BLOCKING_PREREQUISITE_NUMBER=""
+RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER=""
 
 usage() {
   cat <<'EOF'
@@ -102,6 +110,7 @@ const data = JSON.parse(fs.readFileSync(0, "utf8"));
   standingContextPath: "STANDING_CONTEXT",
   wakeUpLogPath: "WAKE_UP_LOG",
   legacyScratchpadPath: "LEGACY_SCRATCHPAD",
+  releaseStatePath: "RELEASE_STATE",
   reportReviewStatePath: "REPORT_REVIEW_STATE",
 };
 for (const [jsonKey, shellKey] of Object.entries(mappings)) {
@@ -116,6 +125,99 @@ for (const [jsonKey, shellKey] of Object.entries(mappings)) {
   eval "$metadata_exports"
 }
 
+refresh_release_state() {
+  pnpm tsx "$RELEASE_STATE_CHECKER" \
+    --workflow "$WORKFLOW_PATH" \
+    --operator-repo-root "$REPO_ROOT" \
+    --json >/dev/null
+}
+
+load_release_state_snapshot() {
+  local release_state_exports
+  release_state_exports="$(
+    RELEASE_STATE="$RELEASE_STATE" node -e '
+const fs = require("node:fs");
+const filePath = process.env.RELEASE_STATE;
+const defaults = {
+  advancementState: "unavailable",
+  summary: "Release state is unavailable.",
+  updatedAt: "",
+  releaseId: "",
+  blockingPrerequisiteNumber: "",
+  blockingPrerequisiteIdentifier: "",
+};
+
+try {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw);
+  const evaluation =
+    parsed && typeof parsed === "object" && parsed.evaluation && typeof parsed.evaluation === "object"
+      ? parsed.evaluation
+      : {};
+  const blocking =
+    evaluation && typeof evaluation === "object" && evaluation.blockingPrerequisite && typeof evaluation.blockingPrerequisite === "object"
+      ? evaluation.blockingPrerequisite
+      : {};
+
+  defaults.advancementState =
+    typeof evaluation.advancementState === "string"
+      ? evaluation.advancementState
+      : defaults.advancementState;
+  defaults.summary =
+    typeof evaluation.summary === "string" ? evaluation.summary : defaults.summary;
+  defaults.updatedAt =
+    typeof parsed.updatedAt === "string" ? parsed.updatedAt : defaults.updatedAt;
+  defaults.releaseId =
+    parsed &&
+    typeof parsed === "object" &&
+    parsed.configuration &&
+    typeof parsed.configuration === "object" &&
+    typeof parsed.configuration.releaseId === "string"
+      ? parsed.configuration.releaseId
+      : defaults.releaseId;
+  defaults.blockingPrerequisiteNumber =
+    typeof blocking.issueNumber === "number"
+      ? String(blocking.issueNumber)
+      : defaults.blockingPrerequisiteNumber;
+  defaults.blockingPrerequisiteIdentifier =
+    typeof blocking.issueIdentifier === "string"
+      ? blocking.issueIdentifier
+      : defaults.blockingPrerequisiteIdentifier;
+} catch (error) {
+  if (!error || error.code !== "ENOENT") {
+    defaults.summary = `Release state could not be read: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+for (const [key, value] of Object.entries(defaults)) {
+  console.log(`${key}=${JSON.stringify(value)}`);
+}
+' \
+      | node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync(0, "utf8").trim().split(/\n/u);
+for (const line of lines) {
+  if (!line) {
+    continue;
+  }
+  const index = line.indexOf("=");
+  const key = line.slice(0, index);
+  const value = JSON.parse(line.slice(index + 1));
+  const mapping = {
+    advancementState: "RELEASE_ADVANCEMENT_STATE",
+    summary: "RELEASE_STATE_SUMMARY",
+    updatedAt: "RELEASE_STATE_UPDATED_AT",
+    releaseId: "RELEASE_ID",
+    blockingPrerequisiteNumber: "RELEASE_BLOCKING_PREREQUISITE_NUMBER",
+    blockingPrerequisiteIdentifier: "RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER",
+  };
+  console.log(`${mapping[key]}=${JSON.stringify(value)}`);
+}
+'
+  )"
+  eval "$release_state_exports"
+}
+
 pid_is_live() {
   local pid="${1:-}"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
@@ -127,6 +229,7 @@ write_status() {
   local message="$2"
   local updated_at
   updated_at="$(now_utc)"
+  load_release_state_snapshot
 
   cat >"$STATUS_JSON" <<EOF
 {
@@ -145,6 +248,15 @@ write_status() {
   "promptFile": "$(json_escape "$PROMPT_FILE")",
   "standingContext": "$(json_escape "$STANDING_CONTEXT")",
   "wakeUpLog": "$(json_escape "$WAKE_UP_LOG")",
+  "releaseState": {
+    "path": "$(json_escape "$RELEASE_STATE")",
+    "releaseId": $(if [ -n "$RELEASE_ID" ]; then printf '"%s"' "$(json_escape "$RELEASE_ID")"; else printf 'null'; fi),
+    "advancementState": "$(json_escape "$RELEASE_ADVANCEMENT_STATE")",
+    "summary": "$(json_escape "$RELEASE_STATE_SUMMARY")",
+    "updatedAt": $(if [ -n "$RELEASE_STATE_UPDATED_AT" ]; then printf '"%s"' "$(json_escape "$RELEASE_STATE_UPDATED_AT")"; else printf 'null'; fi),
+    "blockingPrerequisiteNumber": $(if [ -n "$RELEASE_BLOCKING_PREREQUISITE_NUMBER" ]; then printf '%s' "$RELEASE_BLOCKING_PREREQUISITE_NUMBER"; else printf 'null'; fi),
+    "blockingPrerequisiteIdentifier": $(if [ -n "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER" ]; then printf '"%s"' "$(json_escape "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER")"; else printf 'null'; fi)
+  },
   "reportReviewState": "$(json_escape "$REPORT_REVIEW_STATE")",
   "selectedWorkflowPath": $(if [ -n "$WORKFLOW_PATH" ]; then printf '"%s"' "$(json_escape "$WORKFLOW_PATH")"; else printf 'null'; fi),
   "lastCycle": {
@@ -172,6 +284,10 @@ EOF
 - Selected workflow: ${WORKFLOW_PATH:-n/a}
 - Standing context: $STANDING_CONTEXT
 - Wake-up log: $WAKE_UP_LOG
+- Release state: $RELEASE_STATE
+- Release advancement state: $RELEASE_ADVANCEMENT_STATE
+- Release summary: $RELEASE_STATE_SUMMARY
+- Release blocked by prerequisite: ${RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER:-${RELEASE_BLOCKING_PREREQUISITE_NUMBER:-n/a}}
 - Report review state: $REPORT_REVIEW_STATE
 - Prompt: $PROMPT_FILE
 - Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
@@ -236,6 +352,8 @@ Append a new timestamped entry for each operator wake-up. Keep earlier entries
 intact unless you are running an explicit maintenance or compaction flow.
 EOF
   fi
+
+  refresh_release_state
 }
 
 acquire_lock() {
@@ -303,6 +421,7 @@ run_cycle() {
   LAST_CYCLE_FINISHED_AT=""
   LAST_CYCLE_EXIT_CODE=""
   NEXT_WAKE_AT=""
+  refresh_release_state
   write_status "acting" "Running operator wake-up cycle"
 
   {
@@ -328,6 +447,7 @@ run_cycle() {
     export SYMPHONY_OPERATOR_STANDING_CONTEXT="$STANDING_CONTEXT"
     export SYMPHONY_OPERATOR_WAKE_UP_LOG="$WAKE_UP_LOG"
     export SYMPHONY_OPERATOR_LEGACY_SCRATCHPAD="$LEGACY_SCRATCHPAD"
+    export SYMPHONY_OPERATOR_RELEASE_STATE="$RELEASE_STATE"
     export SYMPHONY_OPERATOR_STATUS_JSON="$STATUS_JSON"
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
     export SYMPHONY_OPERATOR_LOG_DIR="$LOG_DIR"
@@ -343,6 +463,7 @@ run_cycle() {
 
   LAST_CYCLE_FINISHED_AT="$(now_utc)"
   LAST_CYCLE_EXIT_CODE="$exit_code"
+  refresh_release_state
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"
@@ -407,6 +528,11 @@ fi
 
 if [ ! -f "$INSTANCE_STATE_RESOLVER" ]; then
   echo "operator-loop: instance-state resolver not found: $INSTANCE_STATE_RESOLVER" >&2
+  exit 1
+fi
+
+if [ ! -f "$RELEASE_STATE_CHECKER" ]; then
+  echo "operator-loop: release-state checker not found: $RELEASE_STATE_CHECKER" >&2
   exit 1
 fi
 

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -42,6 +42,7 @@ RELEASE_STATE_UPDATED_AT=""
 RELEASE_ID=""
 RELEASE_BLOCKING_PREREQUISITE_NUMBER=""
 RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER=""
+RELEASE_STATE_REFRESH_ERROR=""
 
 usage() {
   cat <<'EOF'
@@ -130,6 +131,24 @@ refresh_release_state() {
     --workflow "$WORKFLOW_PATH" \
     --operator-repo-root "$REPO_ROOT" \
     --json >/dev/null
+}
+
+refresh_release_state_nonfatal() {
+  local checker_output
+  if checker_output="$(
+    pnpm tsx "$RELEASE_STATE_CHECKER" \
+      --workflow "$WORKFLOW_PATH" \
+      --operator-repo-root "$REPO_ROOT" \
+      --json 2>&1 >/dev/null
+  )"; then
+    RELEASE_STATE_REFRESH_ERROR=""
+    return 0
+  fi
+
+  checker_output="$(printf '%s' "$checker_output" | tr '\r\n' ' ' | tr -s ' ')"
+  RELEASE_STATE_REFRESH_ERROR="Release state refresh failed: ${checker_output:-unknown error}"
+  echo "operator-loop: $RELEASE_STATE_REFRESH_ERROR" >&2
+  return 1
 }
 
 load_release_state_snapshot() {
@@ -230,6 +249,13 @@ write_status() {
   local updated_at
   updated_at="$(now_utc)"
   load_release_state_snapshot
+  if [ -n "$RELEASE_STATE_REFRESH_ERROR" ]; then
+    RELEASE_ADVANCEMENT_STATE="unavailable"
+    RELEASE_STATE_SUMMARY="$RELEASE_STATE_REFRESH_ERROR"
+    RELEASE_STATE_UPDATED_AT=""
+    RELEASE_BLOCKING_PREREQUISITE_NUMBER=""
+    RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER=""
+  fi
 
   cat >"$STATUS_JSON" <<EOF
 {
@@ -331,6 +357,9 @@ intact unless you are running an explicit maintenance or compaction flow.
 Legacy `operator-scratchpad.md` content was preserved in `standing-context.md`
 when this notebook was initialized.
 EOF
+    if ! refresh_release_state_nonfatal; then
+      :
+    fi
     return
   fi
 
@@ -353,7 +382,9 @@ intact unless you are running an explicit maintenance or compaction flow.
 EOF
   fi
 
-  refresh_release_state
+  if ! refresh_release_state_nonfatal; then
+    :
+  fi
 }
 
 acquire_lock() {
@@ -421,7 +452,9 @@ run_cycle() {
   LAST_CYCLE_FINISHED_AT=""
   LAST_CYCLE_EXIT_CODE=""
   NEXT_WAKE_AT=""
-  refresh_release_state
+  if ! refresh_release_state_nonfatal; then
+    :
+  fi
   write_status "acting" "Running operator wake-up cycle"
 
   {
@@ -463,7 +496,9 @@ run_cycle() {
 
   LAST_CYCLE_FINISHED_AT="$(now_utc)"
   LAST_CYCLE_EXIT_CODE="$exit_code"
-  refresh_release_state
+  if ! refresh_release_state_nonfatal; then
+    :
+  fi
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -16,18 +16,20 @@ Required workflow:
    - record a no-follow-up decision with `pnpm tsx bin/symphony-report.ts review-record --issue <number> --status reviewed-no-follow-up --summary <...>`,
    - or create a tracked follow-up issue with `pnpm tsx bin/symphony-report.ts review-follow-up --issue <number> --title <...> --body-file <...> --summary <...>`,
    - and record what was learned and queued in the standing context or wake-up log as appropriate before moving on.
-9. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-10. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-11. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint is clear.
-12. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-13. As mandatory operator checkpoints for this wake-up, explicitly:
+9. Before any downstream release advancement work after the completed-run report-review checkpoint is clear, inspect release advancement state by running `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+10. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact. If that release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
+11. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
+12. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+13. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
+14. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+15. As mandatory operator checkpoints for this wake-up, explicitly:
 
 - review any active `plan-ready` / `awaiting-human-handoff` issue and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
 - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 
-14. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-15. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
+16. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+17. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
 
 Constraints:
 

--- a/src/domain/instance-identity.ts
+++ b/src/domain/instance-identity.ts
@@ -22,6 +22,7 @@ export interface OperatorInstanceStatePaths {
   readonly standingContextPath: string;
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
+  readonly releaseStatePath: string;
   readonly reportReviewStatePath: string;
 }
 
@@ -71,6 +72,7 @@ export function deriveOperatorInstanceStatePaths(args: {
       operatorStateRoot,
       "operator-scratchpad.md",
     ),
+    releaseStatePath: path.join(operatorStateRoot, "release-state.json"),
     reportReviewStatePath: path.join(
       operatorStateRoot,
       "report-review-state.json",

--- a/src/observability/operator-release-state.ts
+++ b/src/observability/operator-release-state.ts
@@ -1,0 +1,471 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ObservabilityError } from "../domain/errors.js";
+import type { RuntimeInstanceInput } from "../domain/workflow.js";
+import { coerceRuntimeInstancePaths } from "../domain/workflow.js";
+import type { IssueArtifactOutcome } from "./issue-artifacts.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
+
+export const OPERATOR_RELEASE_STATE_SCHEMA_VERSION = 1 as const;
+
+export type OperatorReleaseAdvancementState =
+  | "unconfigured"
+  | "configured-clear"
+  | "blocked-by-prerequisite-failure"
+  | "blocked-review-needed";
+
+export interface OperatorReleaseIssueReference {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string | null;
+  readonly title: string | null;
+}
+
+export interface OperatorReleaseDependency {
+  readonly prerequisite: OperatorReleaseIssueReference;
+  readonly downstream: readonly OperatorReleaseIssueReference[];
+}
+
+export interface OperatorReleaseConfiguration {
+  readonly releaseId: string | null;
+  readonly dependencies: readonly OperatorReleaseDependency[];
+}
+
+export interface OperatorReleaseEvaluation {
+  readonly advancementState: OperatorReleaseAdvancementState;
+  readonly summary: string;
+  readonly evaluatedAt: string;
+  readonly blockingPrerequisite: OperatorReleaseIssueReference | null;
+  readonly blockedDownstream: readonly OperatorReleaseIssueReference[];
+  readonly unresolvedReferences: readonly OperatorReleaseIssueReference[];
+}
+
+export interface OperatorReleaseStateDocument {
+  readonly version: typeof OPERATOR_RELEASE_STATE_SCHEMA_VERSION;
+  readonly updatedAt: string;
+  readonly configuration: OperatorReleaseConfiguration;
+  readonly evaluation: OperatorReleaseEvaluation;
+}
+
+interface StoredIssueSummary {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly currentOutcome: IssueArtifactOutcome;
+}
+
+export function createEmptyOperatorReleaseState(
+  updatedAt = new Date().toISOString(),
+): OperatorReleaseStateDocument {
+  return {
+    version: OPERATOR_RELEASE_STATE_SCHEMA_VERSION,
+    updatedAt,
+    configuration: {
+      releaseId: null,
+      dependencies: [],
+    },
+    evaluation: {
+      advancementState: "unconfigured",
+      summary:
+        "No release dependency metadata is configured for this operator instance.",
+      evaluatedAt: updatedAt,
+      blockingPrerequisite: null,
+      blockedDownstream: [],
+      unresolvedReferences: [],
+    },
+  };
+}
+
+export async function readOperatorReleaseState(
+  filePath: string,
+): Promise<OperatorReleaseStateDocument> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    return parseOperatorReleaseStateDocument(parsed, filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return createEmptyOperatorReleaseState();
+    }
+    throw error;
+  }
+}
+
+export async function writeOperatorReleaseState(
+  filePath: string,
+  state: OperatorReleaseStateDocument,
+): Promise<void> {
+  await writeJsonFileAtomic(filePath, state, {
+    tempPrefix: ".operator-release-state",
+  });
+}
+
+export async function syncOperatorReleaseState(args: {
+  readonly instance: RuntimeInstanceInput;
+  readonly releaseStateFile: string;
+  readonly updatedAt?: string | undefined;
+}): Promise<OperatorReleaseStateDocument> {
+  const updatedAt = args.updatedAt ?? new Date().toISOString();
+  const instance = coerceRuntimeInstancePaths(args.instance);
+  const current = await readOperatorReleaseState(args.releaseStateFile);
+  const issueSummaries = await listStoredIssueSummaries(instance);
+  const evaluation = evaluateOperatorReleaseState({
+    configuration: current.configuration,
+    issueSummaries,
+    evaluatedAt: updatedAt,
+  });
+  const nextState: OperatorReleaseStateDocument = {
+    version: OPERATOR_RELEASE_STATE_SCHEMA_VERSION,
+    updatedAt,
+    configuration: current.configuration,
+    evaluation,
+  };
+  await writeOperatorReleaseState(args.releaseStateFile, nextState);
+  return nextState;
+}
+
+export function evaluateOperatorReleaseState(args: {
+  readonly configuration: OperatorReleaseConfiguration;
+  readonly issueSummaries: readonly {
+    readonly issueNumber: number;
+    readonly issueIdentifier: string;
+    readonly title: string;
+    readonly currentOutcome: string;
+  }[];
+  readonly evaluatedAt: string;
+}): OperatorReleaseEvaluation {
+  const releaseLabel = formatReleaseLabel(args.configuration.releaseId);
+  const dependencies = args.configuration.dependencies;
+  if (dependencies.length === 0) {
+    return {
+      advancementState: "unconfigured",
+      summary:
+        "No release dependency metadata is configured for this operator instance.",
+      evaluatedAt: args.evaluatedAt,
+      blockingPrerequisite: null,
+      blockedDownstream: [],
+      unresolvedReferences: [],
+    };
+  }
+
+  const issuesByNumber = new Map(
+    args.issueSummaries.map((issue) => [issue.issueNumber, issue]),
+  );
+
+  for (const dependency of dependencies) {
+    const prerequisite = issuesByNumber.get(dependency.prerequisite.issueNumber);
+    if (prerequisite?.currentOutcome === "failed") {
+      return {
+        advancementState: "blocked-by-prerequisite-failure",
+        summary: `${releaseLabel} is blocked: prerequisite issue #${dependency.prerequisite.issueNumber.toString()} failed. Do not advance downstream work until the prerequisite is repaired.`,
+        evaluatedAt: args.evaluatedAt,
+        blockingPrerequisite: dependency.prerequisite,
+        blockedDownstream: dependency.downstream,
+        unresolvedReferences: [],
+      };
+    }
+  }
+
+  const unresolvedReferences: OperatorReleaseIssueReference[] = [];
+  for (const dependency of dependencies) {
+    if (dependency.downstream.length === 0) {
+      unresolvedReferences.push(dependency.prerequisite);
+      continue;
+    }
+    if (!issuesByNumber.has(dependency.prerequisite.issueNumber)) {
+      unresolvedReferences.push(dependency.prerequisite);
+    }
+    for (const downstream of dependency.downstream) {
+      if (!issuesByNumber.has(downstream.issueNumber)) {
+        unresolvedReferences.push(downstream);
+      }
+    }
+  }
+
+  const dedupedUnresolved = dedupeIssueReferences(unresolvedReferences);
+  if (dedupedUnresolved.length > 0) {
+    return {
+      advancementState: "blocked-review-needed",
+      summary: `${releaseLabel} needs review before downstream advancement: dependency metadata is incomplete or references issue facts that are not currently available.`,
+      evaluatedAt: args.evaluatedAt,
+      blockingPrerequisite: null,
+      blockedDownstream: [],
+      unresolvedReferences: dedupedUnresolved,
+    };
+  }
+
+  return {
+    advancementState: "configured-clear",
+    summary: `${releaseLabel} is clear for downstream advancement: no configured prerequisite issue is currently failed.`,
+    evaluatedAt: args.evaluatedAt,
+    blockingPrerequisite: null,
+    blockedDownstream: [],
+    unresolvedReferences: [],
+  };
+}
+
+function parseOperatorReleaseStateDocument(
+  value: unknown,
+  filePath: string,
+): OperatorReleaseStateDocument {
+  if (!isRecord(value)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected an object.`,
+    );
+  }
+
+  if (value.version !== OPERATOR_RELEASE_STATE_SCHEMA_VERSION) {
+    throw new ObservabilityError(
+      `Unsupported operator release state schema in ${filePath}`,
+    );
+  }
+
+  if (typeof value.updatedAt !== "string") {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected updatedAt.`,
+    );
+  }
+
+  return {
+    version: OPERATOR_RELEASE_STATE_SCHEMA_VERSION,
+    updatedAt: value.updatedAt,
+    configuration: parseOperatorReleaseConfiguration(
+      value.configuration,
+      filePath,
+    ),
+    evaluation: parseOperatorReleaseEvaluation(value.evaluation, filePath),
+  };
+}
+
+function parseOperatorReleaseConfiguration(
+  value: unknown,
+  filePath: string,
+): OperatorReleaseConfiguration {
+  if (!isRecord(value) || !Array.isArray(value.dependencies)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected configuration.dependencies.`,
+    );
+  }
+  return {
+    releaseId:
+      value.releaseId === null || value.releaseId === undefined
+        ? null
+        : requireString(value.releaseId, `${filePath} configuration.releaseId`),
+    dependencies: value.dependencies.map((dependency, index) =>
+      parseOperatorReleaseDependency(
+        dependency,
+        `${filePath} configuration.dependencies[${index.toString()}]`,
+      ),
+    ),
+  };
+}
+
+function parseOperatorReleaseDependency(
+  value: unknown,
+  field: string,
+): OperatorReleaseDependency {
+  if (!isRecord(value) || !Array.isArray(value.downstream)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${field}; expected prerequisite and downstream references.`,
+    );
+  }
+  return {
+    prerequisite: parseOperatorReleaseIssueReference(
+      value.prerequisite,
+      `${field}.prerequisite`,
+    ),
+    downstream: value.downstream.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${field}.downstream[${index.toString()}]`,
+      ),
+    ),
+  };
+}
+
+function parseOperatorReleaseEvaluation(
+  value: unknown,
+  filePath: string,
+): OperatorReleaseEvaluation {
+  if (!isRecord(value)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected evaluation.`,
+    );
+  }
+  if (
+    value.advancementState !== "unconfigured" &&
+    value.advancementState !== "configured-clear" &&
+    value.advancementState !== "blocked-by-prerequisite-failure" &&
+    value.advancementState !== "blocked-review-needed"
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected a supported advancementState.`,
+    );
+  }
+  if (
+    typeof value.summary !== "string" ||
+    typeof value.evaluatedAt !== "string" ||
+    !Array.isArray(value.blockedDownstream) ||
+    !Array.isArray(value.unresolvedReferences)
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected evaluation fields.`,
+    );
+  }
+  return {
+    advancementState: value.advancementState,
+    summary: value.summary,
+    evaluatedAt: value.evaluatedAt,
+    blockingPrerequisite:
+      value.blockingPrerequisite === null ||
+      value.blockingPrerequisite === undefined
+        ? null
+        : parseOperatorReleaseIssueReference(
+            value.blockingPrerequisite,
+            `${filePath} evaluation.blockingPrerequisite`,
+          ),
+    blockedDownstream: value.blockedDownstream.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${filePath} evaluation.blockedDownstream[${index.toString()}]`,
+      ),
+    ),
+    unresolvedReferences: value.unresolvedReferences.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${filePath} evaluation.unresolvedReferences[${index.toString()}]`,
+      ),
+    ),
+  };
+}
+
+function parseOperatorReleaseIssueReference(
+  value: unknown,
+  field: string,
+): OperatorReleaseIssueReference {
+  if (!isRecord(value)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${field}; expected an issue reference.`,
+    );
+  }
+
+  const issueNumber = value.issueNumber;
+  if (
+    typeof issueNumber !== "number" ||
+    !Number.isSafeInteger(issueNumber) ||
+    issueNumber <= 0
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${field}; expected a positive integer issueNumber.`,
+    );
+  }
+
+  return {
+    issueNumber,
+    issueIdentifier: normalizeNullableString(value.issueIdentifier, field),
+    title: normalizeNullableString(value.title, field),
+  };
+}
+
+async function listStoredIssueSummaries(
+  instance: ReturnType<typeof coerceRuntimeInstancePaths>,
+): Promise<readonly StoredIssueSummary[]> {
+  const entries = await fs
+    .readdir(instance.issueArtifactsRoot, { withFileTypes: true })
+    .catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+
+  const issues = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/u.test(entry.name))
+      .map(async (entry) => {
+        const issueFile = path.join(
+          instance.issueArtifactsRoot,
+          entry.name,
+          "issue.json",
+        );
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(await fs.readFile(issueFile, "utf8")) as Record<
+            string,
+            unknown
+          >;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return null;
+          }
+          throw error;
+        }
+
+        const issueNumber = parsed["issueNumber"];
+        const issueIdentifier = parsed["issueIdentifier"];
+        const title = parsed["title"];
+        const currentOutcome = parsed["currentOutcome"];
+        if (
+          typeof issueNumber !== "number" ||
+          typeof issueIdentifier !== "string" ||
+          typeof title !== "string" ||
+          typeof currentOutcome !== "string"
+        ) {
+          throw new ObservabilityError(
+            `Malformed issue summary at ${issueFile}; expected issueNumber, issueIdentifier, title, and currentOutcome.`,
+          );
+        }
+        return {
+          issueNumber,
+          issueIdentifier,
+          title,
+          currentOutcome: currentOutcome as IssueArtifactOutcome,
+        } satisfies StoredIssueSummary;
+      }),
+  );
+
+  return issues.filter((issue): issue is StoredIssueSummary => issue !== null);
+}
+
+function dedupeIssueReferences(
+  references: readonly OperatorReleaseIssueReference[],
+): readonly OperatorReleaseIssueReference[] {
+  const seen = new Set<number>();
+  const deduped: OperatorReleaseIssueReference[] = [];
+  for (const reference of references) {
+    if (seen.has(reference.issueNumber)) {
+      continue;
+    }
+    seen.add(reference.issueNumber);
+    deduped.push(reference);
+  }
+  return deduped;
+}
+
+function formatReleaseLabel(releaseId: string | null): string {
+  return releaseId === null ? "Configured release" : `Release ${releaseId}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new ObservabilityError(`Malformed operator release state in ${field}`);
+  }
+  return value;
+}
+
+function normalizeNullableString(
+  value: unknown,
+  field: string,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new ObservabilityError(`Malformed operator release state in ${field}`);
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/src/observability/operator-release-state.ts
+++ b/src/observability/operator-release-state.ts
@@ -152,7 +152,9 @@ export function evaluateOperatorReleaseState(args: {
   );
 
   for (const dependency of dependencies) {
-    const prerequisite = issuesByNumber.get(dependency.prerequisite.issueNumber);
+    const prerequisite = issuesByNumber.get(
+      dependency.prerequisite.issueNumber,
+    );
     if (prerequisite?.currentOutcome === "failed") {
       return {
         advancementState: "blocked-by-prerequisite-failure",
@@ -451,20 +453,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function requireString(value: unknown, field: string): string {
   if (typeof value !== "string") {
-    throw new ObservabilityError(`Malformed operator release state in ${field}`);
+    throw new ObservabilityError(
+      `Malformed operator release state in ${field}`,
+    );
   }
   return value;
 }
 
-function normalizeNullableString(
-  value: unknown,
-  field: string,
-): string | null {
+function normalizeNullableString(value: unknown, field: string): string | null {
   if (value === null || value === undefined) {
     return null;
   }
   if (typeof value !== "string") {
-    throw new ObservabilityError(`Malformed operator release state in ${field}`);
+    throw new ObservabilityError(
+      `Malformed operator release state in ${field}`,
+    );
   }
   const trimmed = value.trim();
   return trimmed === "" ? null : trimmed;

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -7,6 +7,7 @@ import {
   deriveOperatorInstanceStatePaths,
   deriveSymphonyInstanceKey,
 } from "../../src/domain/instance-identity.js";
+import { writeOperatorReleaseState } from "../../src/observability/operator-release-state.js";
 import { createTempDir } from "../support/git.js";
 
 const execFileAsync = promisify(execFile);
@@ -50,6 +51,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
   readonly standingContextPath: string;
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
+  readonly releaseStatePath: string;
   readonly logFile: string | null;
 }> {
   await execFileAsync(
@@ -89,6 +91,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
     standingContextPath: paths.standingContextPath,
     wakeUpLogPath: paths.wakeUpLogPath,
     legacyScratchpadPath: paths.legacyScratchpadPath,
+    releaseStatePath: paths.releaseStatePath,
     logFile: statusJson.lastCycle.logFile,
   };
 }
@@ -121,6 +124,46 @@ function buildAppendWakeUpLogCommand(entryTitle: string): string {
   return `node -e ${JSON.stringify(program)}`;
 }
 
+async function writeIssueSummary(args: {
+  readonly workflowPath: string;
+  readonly issueNumber: number;
+  readonly currentOutcome: string;
+}): Promise<void> {
+  const issueRoot = path.join(
+    path.dirname(args.workflowPath),
+    ".var",
+    "factory",
+    "issues",
+    args.issueNumber.toString(),
+  );
+  await fs.mkdir(issueRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(issueRoot, "issue.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        issueNumber: args.issueNumber,
+        issueIdentifier: `sociotechnica-org/symphony-ts#${args.issueNumber.toString()}`,
+        repo: "sociotechnica-org/symphony-ts",
+        title: `Issue ${args.issueNumber.toString()}`,
+        issueUrl: `https://github.com/sociotechnica-org/symphony-ts/issues/${args.issueNumber.toString()}`,
+        branch: null,
+        currentOutcome: args.currentOutcome,
+        currentSummary: `Outcome ${args.currentOutcome}`,
+        firstObservedAt: "2026-03-30T00:00:00Z",
+        lastUpdatedAt: "2026-03-30T00:00:00Z",
+        mergedAt: null,
+        closedAt: null,
+        latestAttemptNumber: null,
+        latestSessionId: null,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
 describe("operator loop workflow selection", () => {
   const createdPaths = new Set<string>();
 
@@ -151,6 +194,10 @@ describe("operator loop workflow selection", () => {
         readonly operatorStateRoot: string;
         readonly standingContext: string;
         readonly wakeUpLog: string;
+        readonly releaseState: {
+          readonly path: string;
+          readonly advancementState: string;
+        };
       };
       const statusMd = await fs.readFile(run.statusMdPath, "utf8");
 
@@ -160,12 +207,15 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.operatorStateRoot).toBe(run.stateRoot);
       expect(statusJson.standingContext).toBe(run.standingContextPath);
       expect(statusJson.wakeUpLog).toBe(run.wakeUpLogPath);
+      expect(statusJson.releaseState.path).toBe(run.releaseStatePath);
+      expect(statusJson.releaseState.advancementState).toBe("unconfigured");
       expect(statusMd).toContain(`- Selected workflow: ${workflowPath}`);
       expect(statusMd).toContain(`- Operator state root: ${run.stateRoot}`);
       expect(statusMd).toContain(
         `- Standing context: ${run.standingContextPath}`,
       );
       expect(statusMd).toContain(`- Wake-up log: ${run.wakeUpLogPath}`);
+      expect(statusMd).toContain(`- Release state: ${run.releaseStatePath}`);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -242,6 +292,9 @@ describe("operator loop workflow selection", () => {
       const reportReviewIndex = prompt.indexOf(
         "bin/symphony-report.ts review-pending",
       );
+      const releaseStateIndex = prompt.indexOf(
+        "bin/check-operator-release-state.ts",
+      );
       const queueWorkIndex = prompt.indexOf("review any active `plan-ready`");
       const standingContextIndex = prompt.indexOf(
         "SYMPHONY_OPERATOR_STANDING_CONTEXT",
@@ -253,15 +306,18 @@ describe("operator loop workflow selection", () => {
 
       expect(freshnessIndex).toBeGreaterThanOrEqual(0);
       expect(reportReviewIndex).toBeGreaterThanOrEqual(0);
+      expect(releaseStateIndex).toBeGreaterThanOrEqual(0);
       expect(queueWorkIndex).toBeGreaterThanOrEqual(0);
       expect(standingContextIndex).toBeGreaterThanOrEqual(0);
       expect(wakeUpLogIndex).toBeGreaterThanOrEqual(0);
       expect(appendIndex).toBeGreaterThanOrEqual(0);
       expect(freshnessIndex).toBeLessThan(reportReviewIndex);
-      expect(reportReviewIndex).toBeLessThan(queueWorkIndex);
+      expect(reportReviewIndex).toBeLessThan(releaseStateIndex);
+      expect(releaseStateIndex).toBeLessThan(queueWorkIndex);
       expect(prompt).toContain("bin/check-factory-runtime-freshness.ts");
       expect(standingContextIndex).toBeLessThan(appendIndex);
       expect(prompt).toContain("bin/symphony-report.ts review-pending");
+      expect(prompt).toContain("bin/check-operator-release-state.ts");
       expect(prompt).toContain("Read the instance-scoped standing context");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -348,6 +404,96 @@ describe("operator loop workflow selection", () => {
       expect(standingContext).toContain("Preserve release sequencing notes.");
       expect(wakeUpLog).toContain("## Migration Note");
       expect(legacyScratchpad).toContain("# Operator Scratchpad");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces blocked prerequisite release state in operator status artifacts", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-release-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
+
+    try {
+      await fs.mkdir(paths.operatorStateRoot, { recursive: true });
+      await writeOperatorReleaseState(paths.releaseStatePath, {
+        version: 1,
+        updatedAt: "2026-03-30T00:00:00Z",
+        configuration: {
+          releaseId: "context-library-bun-migration",
+          dependencies: [
+            {
+              prerequisite: {
+                issueNumber: 111,
+                issueIdentifier: "sociotechnica-org/symphony-ts#111",
+                title: "Issue 111",
+              },
+              downstream: [
+                {
+                  issueNumber: 112,
+                  issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                  title: "Issue 112",
+                },
+              ],
+            },
+          ],
+        },
+        evaluation: {
+          advancementState: "configured-clear",
+          summary: "Initial value",
+          evaluatedAt: "2026-03-30T00:00:00Z",
+          blockingPrerequisite: null,
+          blockedDownstream: [],
+          unresolvedReferences: [],
+        },
+      });
+      await writeIssueSummary({
+        workflowPath,
+        issueNumber: 111,
+        currentOutcome: "failed",
+      });
+      await writeIssueSummary({
+        workflowPath,
+        issueNumber: 112,
+        currentOutcome: "awaiting-landing-command",
+      });
+
+      const run = await runOperatorLoop(workflowPath);
+      createdPaths.add(tempDir);
+      createdPaths.add(paths.operatorStateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      const statusJson = JSON.parse(
+        await fs.readFile(run.statusJsonPath, "utf8"),
+      ) as {
+        readonly releaseState: {
+          readonly path: string;
+          readonly releaseId: string | null;
+          readonly advancementState: string;
+          readonly summary: string;
+          readonly blockingPrerequisiteNumber: number | null;
+        };
+      };
+      const statusMd = await fs.readFile(run.statusMdPath, "utf8");
+
+      expect(statusJson.releaseState.path).toBe(paths.releaseStatePath);
+      expect(statusJson.releaseState.releaseId).toBe(
+        "context-library-bun-migration",
+      );
+      expect(statusJson.releaseState.advancementState).toBe(
+        "blocked-by-prerequisite-failure",
+      );
+      expect(statusJson.releaseState.blockingPrerequisiteNumber).toBe(111);
+      expect(statusJson.releaseState.summary).toContain("#111");
+      expect(statusMd).toContain(
+        "- Release advancement state: blocked-by-prerequisite-failure",
+      );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -399,11 +399,81 @@ describe("operator loop workflow selection", () => {
         paths.legacyScratchpadPath,
         "utf8",
       );
+      const releaseState = JSON.parse(
+        await fs.readFile(paths.releaseStatePath, "utf8"),
+      ) as {
+        readonly evaluation: {
+          readonly advancementState: string;
+        };
+      };
 
       expect(standingContext).toContain("## Migrated Legacy Scratchpad");
       expect(standingContext).toContain("Preserve release sequencing notes.");
       expect(wakeUpLog).toContain("## Migration Note");
       expect(legacyScratchpad).toContain("# Operator Scratchpad");
+      expect(releaseState.evaluation.advancementState).toBe("unconfigured");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the operator loop running when release-state refresh fails", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-release-fail-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const markerPath = path.join(tempDir, "operator-ran.txt");
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
+
+    try {
+      const malformedIssueRoot = path.join(
+        path.dirname(workflowPath),
+        ".var",
+        "factory",
+        "issues",
+        "111",
+      );
+      await fs.mkdir(malformedIssueRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(malformedIssueRoot, "issue.json"),
+        '{"issueNumber":"bad"}\n',
+        "utf8",
+      );
+
+      await runOperatorLoopWithCommand(
+        workflowPath,
+        `node -e ${JSON.stringify(`require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "ran\\n")`)}`,
+      );
+      createdPaths.add(tempDir);
+      createdPaths.add(paths.operatorStateRoot);
+
+      const statusJson = JSON.parse(
+        await fs.readFile(paths.statusJsonPath, "utf8"),
+      ) as {
+        readonly state: string;
+        readonly lastCycle: {
+          readonly exitCode: number | null;
+        };
+        readonly releaseState: {
+          readonly advancementState: string;
+          readonly summary: string;
+        };
+      };
+      const statusMd = await fs.readFile(paths.statusMdPath, "utf8");
+
+      expect(await fs.readFile(markerPath, "utf8")).toContain("ran");
+      expect(statusJson.state).toBe("idle");
+      expect(statusJson.lastCycle.exitCode).toBe(0);
+      expect(statusJson.releaseState.advancementState).toBe("unavailable");
+      expect(statusJson.releaseState.summary).toContain(
+        "Release state refresh failed:",
+      );
+      expect(statusJson.releaseState.summary).toContain(
+        "Malformed issue summary",
+      );
+      expect(statusMd).toContain("- Release advancement state: unavailable");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/instance-identity.test.ts
+++ b/tests/unit/instance-identity.test.ts
@@ -49,6 +49,9 @@ describe("instance identity helpers", () => {
     expect(paths.legacyScratchpadPath).toBe(
       path.join(paths.operatorStateRoot, "operator-scratchpad.md"),
     );
+    expect(paths.releaseStatePath).toBe(
+      path.join(paths.operatorStateRoot, "release-state.json"),
+    );
     expect(paths.reportReviewStatePath).toBe(
       path.join(paths.operatorStateRoot, "report-review-state.json"),
     );

--- a/tests/unit/operator-release-state.test.ts
+++ b/tests/unit/operator-release-state.test.ts
@@ -1,0 +1,304 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadWorkflowInstancePaths } from "../../src/config/workflow.js";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceKey,
+} from "../../src/domain/instance-identity.js";
+import {
+  evaluateOperatorReleaseState,
+  readOperatorReleaseState,
+  syncOperatorReleaseState,
+  writeOperatorReleaseState,
+} from "../../src/observability/operator-release-state.js";
+import { createTempDir } from "../support/git.js";
+
+async function writeWorkflow(rootDir: string): Promise<string> {
+  const workflowPath = path.join(rootDir, "WORKFLOW.md");
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+workspace:
+  root: ./.tmp/workspaces
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
+async function writeIssueSummary(args: {
+  readonly instanceRoot: string;
+  readonly issueNumber: number;
+  readonly currentOutcome: string;
+  readonly issueIdentifier?: string | undefined;
+  readonly title?: string | undefined;
+}): Promise<void> {
+  const issueRoot = path.join(
+    args.instanceRoot,
+    ".var",
+    "factory",
+    "issues",
+    args.issueNumber.toString(),
+  );
+  await fs.mkdir(issueRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(issueRoot, "issue.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        issueNumber: args.issueNumber,
+        issueIdentifier:
+          args.issueIdentifier ?? `sociotechnica-org/symphony-ts#${args.issueNumber.toString()}`,
+        repo: "sociotechnica-org/symphony-ts",
+        title: args.title ?? `Issue ${args.issueNumber.toString()}`,
+        issueUrl: `https://github.com/sociotechnica-org/symphony-ts/issues/${args.issueNumber.toString()}`,
+        branch: null,
+        currentOutcome: args.currentOutcome,
+        currentSummary: `Outcome ${args.currentOutcome}`,
+        firstObservedAt: "2026-03-30T00:00:00Z",
+        lastUpdatedAt: "2026-03-30T00:00:00Z",
+        mergedAt: null,
+        closedAt: null,
+        latestAttemptNumber: null,
+        latestSessionId: null,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+describe("operator release state", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    for (const root of tempRoots) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+    tempRoots.length = 0;
+  });
+
+  it("blocks release advancement when any configured prerequisite has failed", () => {
+    const evaluation = evaluateOperatorReleaseState({
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      issueSummaries: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "failed",
+        },
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          currentOutcome: "awaiting-landing-command",
+        },
+      ],
+      evaluatedAt: "2026-03-30T00:00:00Z",
+    });
+
+    expect(evaluation.advancementState).toBe(
+      "blocked-by-prerequisite-failure",
+    );
+    expect(evaluation.blockingPrerequisite?.issueNumber).toBe(111);
+    expect(evaluation.blockedDownstream.map((issue) => issue.issueNumber)).toEqual(
+      [112],
+    );
+    expect(evaluation.summary).toContain("#111");
+  });
+
+  it("fails closed when dependency metadata references unresolved issues", () => {
+    const evaluation = evaluateOperatorReleaseState({
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      issueSummaries: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "awaiting-system-checks",
+        },
+      ],
+      evaluatedAt: "2026-03-30T00:00:00Z",
+    });
+
+    expect(evaluation.advancementState).toBe("blocked-review-needed");
+    expect(evaluation.unresolvedReferences.map((issue) => issue.issueNumber)).toEqual(
+      [112],
+    );
+  });
+
+  it("returns configured-clear when no prerequisite has failed", () => {
+    const evaluation = evaluateOperatorReleaseState({
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      issueSummaries: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "succeeded",
+        },
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          currentOutcome: "awaiting-human-review",
+        },
+      ],
+      evaluatedAt: "2026-03-30T00:00:00Z",
+    });
+
+    expect(evaluation.advancementState).toBe("configured-clear");
+    expect(evaluation.summary).toContain("clear");
+  });
+
+  it("syncs a stored release-state document back to clear when the prerequisite is repaired", async () => {
+    const instanceRoot = await createTempDir("symphony-release-state-instance-");
+    const operatorRoot = await createTempDir("symphony-release-state-operator-");
+    tempRoots.push(instanceRoot, operatorRoot);
+    const workflowPath = await writeWorkflow(instanceRoot);
+    const instance = await loadWorkflowInstancePaths(workflowPath);
+    const instanceKey = deriveSymphonyInstanceKey(instanceRoot);
+    const releaseStateFile = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: operatorRoot,
+      instanceKey,
+    }).releaseStatePath;
+
+    await writeOperatorReleaseState(releaseStateFile, {
+      version: 1,
+      updatedAt: "2026-03-30T00:00:00Z",
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      evaluation: {
+        advancementState: "blocked-by-prerequisite-failure",
+        summary: "Previously blocked",
+        evaluatedAt: "2026-03-30T00:00:00Z",
+        blockingPrerequisite: {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+        },
+        blockedDownstream: [
+          {
+            issueNumber: 112,
+            issueIdentifier: "sociotechnica-org/symphony-ts#112",
+            title: "Downstream",
+          },
+        ],
+        unresolvedReferences: [],
+      },
+    });
+
+    await writeIssueSummary({
+      instanceRoot,
+      issueNumber: 111,
+      currentOutcome: "succeeded",
+    });
+    await writeIssueSummary({
+      instanceRoot,
+      issueNumber: 112,
+      currentOutcome: "awaiting-landing-command",
+    });
+
+    const synced = await syncOperatorReleaseState({
+      instance,
+      releaseStateFile,
+      updatedAt: "2026-03-30T01:00:00Z",
+    });
+    const stored = await readOperatorReleaseState(releaseStateFile);
+
+    expect(synced.evaluation.advancementState).toBe("configured-clear");
+    expect(stored.evaluation.advancementState).toBe("configured-clear");
+    expect(stored.updatedAt).toBe("2026-03-30T01:00:00Z");
+  });
+});

--- a/tests/unit/operator-release-state.test.ts
+++ b/tests/unit/operator-release-state.test.ts
@@ -66,7 +66,8 @@ async function writeIssueSummary(args: {
         version: 1,
         issueNumber: args.issueNumber,
         issueIdentifier:
-          args.issueIdentifier ?? `sociotechnica-org/symphony-ts#${args.issueNumber.toString()}`,
+          args.issueIdentifier ??
+          `sociotechnica-org/symphony-ts#${args.issueNumber.toString()}`,
         repo: "sociotechnica-org/symphony-ts",
         title: args.title ?? `Issue ${args.issueNumber.toString()}`,
         issueUrl: `https://github.com/sociotechnica-org/symphony-ts/issues/${args.issueNumber.toString()}`,
@@ -135,13 +136,11 @@ describe("operator release state", () => {
       evaluatedAt: "2026-03-30T00:00:00Z",
     });
 
-    expect(evaluation.advancementState).toBe(
-      "blocked-by-prerequisite-failure",
-    );
+    expect(evaluation.advancementState).toBe("blocked-by-prerequisite-failure");
     expect(evaluation.blockingPrerequisite?.issueNumber).toBe(111);
-    expect(evaluation.blockedDownstream.map((issue) => issue.issueNumber)).toEqual(
-      [112],
-    );
+    expect(
+      evaluation.blockedDownstream.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
     expect(evaluation.summary).toContain("#111");
   });
 
@@ -178,9 +177,9 @@ describe("operator release state", () => {
     });
 
     expect(evaluation.advancementState).toBe("blocked-review-needed");
-    expect(evaluation.unresolvedReferences.map((issue) => issue.issueNumber)).toEqual(
-      [112],
-    );
+    expect(
+      evaluation.unresolvedReferences.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
   });
 
   it("returns configured-clear when no prerequisite has failed", () => {
@@ -226,8 +225,12 @@ describe("operator release state", () => {
   });
 
   it("syncs a stored release-state document back to clear when the prerequisite is repaired", async () => {
-    const instanceRoot = await createTempDir("symphony-release-state-instance-");
-    const operatorRoot = await createTempDir("symphony-release-state-operator-");
+    const instanceRoot = await createTempDir(
+      "symphony-release-state-instance-",
+    );
+    const operatorRoot = await createTempDir(
+      "symphony-release-state-operator-",
+    );
     tempRoots.push(instanceRoot, operatorRoot);
     const workflowPath = await writeWorkflow(instanceRoot);
     const instance = await loadWorkflowInstancePaths(workflowPath);


### PR DESCRIPTION
## Summary
- add a typed operator `release-state.json` artifact plus a checker that evaluates configured prerequisite/downstream dependencies against stored issue outcomes
- surface release advancement posture in operator-loop status and require the release-state checkpoint before downstream advancement or `/land`
- document the new operator checkpoint and cover the failed-prerequisite regression with unit and integration tests

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- References #281.
- Local self-review was completed by manual diff review; no dedicated local review tool is configured in this workspace.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
