### PR TITLE
Make watchdog behavior robust for long-running Claude tasks

### DIFF
--- a/docs/guides/workflow-frontmatter-reference.md
+++ b/docs/guides/workflow-frontmatter-reference.md
@@ -366,6 +366,27 @@ When `enabled: true`, the watchdog section requires the remaining fields.
   - no when `enabled: false`
 - Disabled fallback default: `300000`
 
+Acts as the compatibility baseline. If the phase-specific fields below are
+omitted, Symphony uses this value for both active execution and PR
+follow-through.
+
+##### `polling.watchdog.execution_stall_threshold_ms`
+
+- Type: integer
+- Required: no
+- Default: `polling.watchdog.stall_threshold_ms`
+
+Applies while an active run has not yet reached PR follow-through.
+
+##### `polling.watchdog.pr_follow_through_stall_threshold_ms`
+
+- Type: integer
+- Required: no
+- Default: `polling.watchdog.stall_threshold_ms`
+
+Applies while an active run already has an open PR and is following through on
+review/check context.
+
 ##### `polling.watchdog.max_recovery_attempts`
 
 - Type: integer
@@ -788,6 +809,8 @@ agent:
 - `polling.retry.max_attempts` must be `>= 1`
 - `polling.watchdog.check_interval_ms` must be an integer `> 0`
 - `polling.watchdog.stall_threshold_ms` must be an integer `> 0`
+- `polling.watchdog.execution_stall_threshold_ms` must be an integer `> 0`
+- `polling.watchdog.pr_follow_through_stall_threshold_ms` must be an integer `> 0`
 - `polling.watchdog.max_recovery_attempts` must be an integer `>= 0`
 - `agent.runner.kind: codex` requires `agent.command` to invoke `codex`
 - `agent.runner.kind: claude-code` requires `agent.command` to invoke `claude`

--- a/docs/plans/282-third-party-watchdog-long-running-claude/plan.md
+++ b/docs/plans/282-third-party-watchdog-long-running-claude/plan.md
@@ -184,13 +184,13 @@ The changed policy in this slice is only which idle threshold applies when those
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| Long Claude execution wrote files early, then went quiet with no PR yet | workspace diff hash present, no new log/heartbeat activity | none required | use execution idle budget; do not stall until that budget expires |
-| Long Claude follow-up run has an open PR and is quiet while processing review/check context | PR head SHA present, no new log/heartbeat activity | normalized PR snapshot | use PR follow-through idle budget; do not stall until that budget expires |
-| No observable activity within the applicable budget and no PR exists | stale local liveness signals | none required | classify using existing reason precedence and recover/abort normally |
-| No observable activity within the applicable budget and PR facts remain unchanged | stale local liveness signals | PR head/actionable feedback unchanged | classify `pr-stall` or `workspace-stall` with existing precedence and recover/abort normally |
-| Observable activity resumes before the applicable budget expires | advancing heartbeat/log/diff/PR facts | whatever tracker facts already exist | treat as live and reset idle baseline |
+| Observed condition                                                                          | Local facts available                                      | Normalized tracker facts available    | Expected decision                                                                            |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Long Claude execution wrote files early, then went quiet with no PR yet                     | workspace diff hash present, no new log/heartbeat activity | none required                         | use execution idle budget; do not stall until that budget expires                            |
+| Long Claude follow-up run has an open PR and is quiet while processing review/check context | PR head SHA present, no new log/heartbeat activity         | normalized PR snapshot                | use PR follow-through idle budget; do not stall until that budget expires                    |
+| No observable activity within the applicable budget and no PR exists                        | stale local liveness signals                               | none required                         | classify using existing reason precedence and recover/abort normally                         |
+| No observable activity within the applicable budget and PR facts remain unchanged           | stale local liveness signals                               | PR head/actionable feedback unchanged | classify `pr-stall` or `workspace-stall` with existing precedence and recover/abort normally |
+| Observable activity resumes before the applicable budget expires                            | advancing heartbeat/log/diff/PR facts                      | whatever tracker facts already exist  | treat as live and reset idle baseline                                                        |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/282-third-party-watchdog-long-running-claude/plan.md
+++ b/docs/plans/282-third-party-watchdog-long-running-claude/plan.md
@@ -1,0 +1,255 @@
+# Issue 282 Plan: Third-Party Watchdog Robustness For Long-Running Claude Tasks
+
+## Status
+
+- approved
+- Review handoff recorded on issue `#282` with `Plan review: approved`
+
+## Goal
+
+Make third-party factory watchdog behavior robust for long-running Claude tasks by replacing the single watchdog idle budget with explicit reviewed budgets for active execution and PR follow-through, without weakening genuine-stall detection or mixing tracker-specific policy into the fix.
+
+## Scope
+
+- recreate the missing checked-in plan document for the already approved issue seam
+- keep the runtime change narrow around watchdog policy and workflow config
+- let active execution use a distinct idle budget from PR follow-through
+- preserve existing watchdog reason precedence (`pr-stall` > `workspace-stall` > `log-stall`)
+- add parser, detector, orchestrator, and end-to-end coverage for representative long-running Claude quiet periods
+- document the new watchdog frontmatter contract
+
+## Non-goals
+
+- redesigning the overall watchdog architecture
+- changing tracker transport, normalization, or lifecycle policy
+- adding Claude-specific output parsing
+- introducing cross-restart watchdog persistence
+- changing retry budgets or retry classes
+- broad TUI or status-surface redesign
+
+## Current Gaps
+
+- the current watchdog uses one global `stall_threshold_ms` for every active-run posture
+- long third-party Claude turns can make legitimate progress, then remain quiet for longer than that single threshold while still being healthy
+- the earlier `#251` slice covered raw stdio activity, but it does not cover the remaining quiet-period case where a run has already written or opened a PR and then goes silent while still working
+- the current config cannot express a reviewed distinction between execution-idle tolerance and PR follow-through tolerance
+
+## Decision Notes
+
+- treat this as a coordination/config policy issue first, not a tracker issue
+- keep the change provider-neutral even though Claude is the motivating failure mode
+- preserve the existing stall reasons and recovery model; only the idle-budget selection changes
+- keep backward compatibility by retaining `stall_threshold_ms` as the base/default contract
+
+## Spec Alignment By Abstraction Level
+
+### Policy Layer
+
+- belongs here:
+  - the repo-owned rule that one watchdog threshold is too brittle for long-running third-party tasks
+  - the policy that idle budgets should differ between active execution and PR follow-through
+- does not belong here:
+  - subprocess plumbing
+  - GitHub-specific handoff parsing
+
+### Configuration Layer
+
+- belongs here:
+  - extending `polling.watchdog` with explicit reviewed idle-budget fields
+  - retaining `stall_threshold_ms` as the compatibility baseline/default
+- does not belong here:
+  - watchdog classification branches hidden outside typed config resolution
+
+### Coordination Layer
+
+- belongs here:
+  - selecting the applicable watchdog idle budget from normalized liveness facts
+  - preserving explicit stall-reason precedence and recovery decisions
+- does not belong here:
+  - tracker API behavior
+  - provider-specific Claude parsing
+
+### Execution Layer
+
+- touched only enough to support regression coverage
+- does not own watchdog budget policy
+
+### Integration Layer
+
+- intentionally untouched
+- tracker transport, normalization, and policy remain unchanged
+
+### Observability Layer
+
+- belongs here:
+  - reflecting the new config contract in docs and preserving explicit watchdog outcomes in tests/status
+- does not belong here:
+  - becoming the source of threshold-selection policy truth
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+- `src/domain/workflow.ts`
+  - extend typed watchdog config with explicit idle-budget fields
+- `src/config/workflow.ts`
+  - parse and validate the new fields while preserving backward compatibility
+- `src/orchestrator/stall-detector.ts`
+  - select the applicable threshold from normalized liveness facts
+- tests
+  - parser coverage
+  - detector coverage
+  - orchestrator/e2e regressions for quiet long-running Claude postures
+- docs
+  - frontmatter reference updates for the new watchdog contract
+
+### Does not belong in this issue
+
+- tracker lifecycle changes
+- runner protocol redesign
+- remote execution changes
+- broad observability refactors
+
+## Layering Notes
+
+- config/workflow
+  - defines the reviewed contract
+  - must not embed tracker-specific policy
+- runner
+  - may help reproduce the regression in tests
+  - must not choose watchdog thresholds
+- orchestrator
+  - chooses the applicable budget and enforces recovery
+  - must not reach into tracker transport details
+- tracker
+  - remains the source of normalized PR/review facts
+  - must not compensate for watchdog policy gaps
+
+## Slice Strategy And PR Seam
+
+This issue stays reviewable in one PR by limiting the change to one seam:
+
+1. restore the missing approved plan file
+2. add explicit watchdog idle-budget config fields
+3. teach the detector how to choose between execution and PR-follow-through budgets
+4. add focused regressions for quiet long-running Claude behavior
+5. document the contract
+
+Deferred from this PR:
+
+- multi-phase budgets beyond execution vs PR follow-through
+- semantic parsing of Claude output
+- durable watchdog forensics across restarts
+
+## Runtime State Machine
+
+States for one active issue:
+
+1. `watching-execution`
+   - no PR-follow-through posture is active
+   - watchdog uses the execution idle budget
+2. `watching-pr-follow-through`
+   - a PR exists for the active run
+   - watchdog uses the PR-follow-through idle budget
+3. `stalled-recoverable`
+   - no observable activity advanced within the applicable budget and recovery remains
+4. `stalled-terminal`
+   - no observable activity advanced within the applicable budget and recovery is exhausted
+5. `runner-finished`
+   - the run exits normally and watchdog state is cleared
+
+Allowed transitions:
+
+- `watching-execution -> watching-execution`
+- `watching-execution -> watching-pr-follow-through`
+- `watching-pr-follow-through -> watching-pr-follow-through`
+- `watching-execution -> stalled-recoverable`
+- `watching-execution -> stalled-terminal`
+- `watching-pr-follow-through -> stalled-recoverable`
+- `watching-pr-follow-through -> stalled-terminal`
+- `stalled-recoverable -> runner-finished`
+- `stalled-terminal -> runner-finished`
+- `watching-execution -> runner-finished`
+- `watching-pr-follow-through -> runner-finished`
+
+Authoritative activity sources remain unchanged in this slice:
+
+- run start
+- runner heartbeat/action
+- watchdog log growth
+- workspace diff movement
+- PR head movement
+
+The changed policy in this slice is only which idle threshold applies when those sources stop moving.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| Long Claude execution wrote files early, then went quiet with no PR yet | workspace diff hash present, no new log/heartbeat activity | none required | use execution idle budget; do not stall until that budget expires |
+| Long Claude follow-up run has an open PR and is quiet while processing review/check context | PR head SHA present, no new log/heartbeat activity | normalized PR snapshot | use PR follow-through idle budget; do not stall until that budget expires |
+| No observable activity within the applicable budget and no PR exists | stale local liveness signals | none required | classify using existing reason precedence and recover/abort normally |
+| No observable activity within the applicable budget and PR facts remain unchanged | stale local liveness signals | PR head/actionable feedback unchanged | classify `pr-stall` or `workspace-stall` with existing precedence and recover/abort normally |
+| Observable activity resumes before the applicable budget expires | advancing heartbeat/log/diff/PR facts | whatever tracker facts already exist | treat as live and reset idle baseline |
+
+## Storage / Persistence Contract
+
+- no new durable tracker or workspace state is introduced
+- workflow config becomes the only new durable contract in this slice
+- status and issue artifacts continue to reflect the existing watchdog outcomes and summaries
+
+## Observability Requirements
+
+- watchdog summaries must remain explicit about the classified reason
+- docs must make the new idle-budget contract inspectable to operators
+- tests should prove which threshold is being applied without requiring operator guesswork
+
+## Implementation Steps
+
+1. Restore the missing checked-in plan document on the issue branch.
+2. Extend `WatchdogConfig` with explicit execution and PR-follow-through threshold fields that default from `stall_threshold_ms`.
+3. Parse and validate the new frontmatter fields in workflow config resolution.
+4. Update stall detection to select the applicable threshold from normalized liveness facts while preserving existing reason precedence.
+5. Add detector tests covering threshold selection for execution and PR-follow-through postures.
+6. Add a regression that simulates a quiet long-running Claude execution posture not already covered by raw-stdio tests.
+7. Update frontmatter docs for the new watchdog fields.
+
+## Tests
+
+Unit:
+
+- `tests/unit/workflow.test.ts`
+  - loads the new watchdog threshold fields
+  - preserves backward-compatible defaults from `stall_threshold_ms`
+- `tests/unit/stall-detector.test.ts`
+  - execution posture uses execution threshold
+  - PR posture uses PR-follow-through threshold
+  - reason precedence remains unchanged
+
+Orchestrator / end-to-end:
+
+- add a regression where a Claude fixture writes early, then stays quiet longer than the execution baseline but shorter than the execution-specific threshold
+- add a regression where a PR-follow-through posture remains quiet longer than the baseline but shorter than the PR threshold
+
+## Acceptance Scenarios
+
+1. A long-running Claude task that writes early but then remains quiet does not fail at the old single global threshold when the execution threshold is higher.
+2. A long-running Claude follow-up with an open PR does not fail at the old single global threshold when the PR threshold is higher.
+3. A genuinely silent stalled run still fails once the applicable threshold is exceeded.
+4. Existing `pr-stall` / `workspace-stall` classification precedence remains unchanged.
+
+## Exit Criteria
+
+- plan file exists in the repository and matches the approved issue seam
+- watchdog config supports explicit execution and PR-follow-through idle budgets
+- detector applies the correct threshold without changing stall-reason precedence
+- quiet long-running Claude regressions are covered by tests
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Deferred To Later Issues Or PRs
+
+- more than two watchdog idle phases
+- provider-specific progress semantics
+- restart-persistent watchdog state or forensics

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -63,6 +63,8 @@ const DEFAULT_LINEAR_TERMINAL_STATES = [
 const DEFAULT_DISABLED_WATCHDOG_CONFIG: Omit<WatchdogConfig, "enabled"> = {
   checkIntervalMs: 60_000,
   stallThresholdMs: 300_000,
+  executionStallThresholdMs: 300_000,
+  prFollowThroughStallThresholdMs: 300_000,
   maxRecoveryAttempts: 2,
 };
 const SUPPORTED_TRACKER_KINDS = [
@@ -1238,6 +1240,16 @@ function resolveWatchdogConfig(value: unknown): WatchdogConfig | undefined {
     "polling.watchdog.stall_threshold_ms",
     enabled ? undefined : DEFAULT_DISABLED_WATCHDOG_CONFIG.stallThresholdMs,
   );
+  const executionStallThresholdMs = requireOptionalPositiveInteger(
+    watchdog["execution_stall_threshold_ms"],
+    "polling.watchdog.execution_stall_threshold_ms",
+    stallThresholdMs,
+  );
+  const prFollowThroughStallThresholdMs = requireOptionalPositiveInteger(
+    watchdog["pr_follow_through_stall_threshold_ms"],
+    "polling.watchdog.pr_follow_through_stall_threshold_ms",
+    stallThresholdMs,
+  );
   const maxRecoveryAttempts = requireOptionalRecoveryAttempts(
     watchdog["max_recovery_attempts"],
     "polling.watchdog.max_recovery_attempts",
@@ -1248,6 +1260,8 @@ function resolveWatchdogConfig(value: unknown): WatchdogConfig | undefined {
     enabled,
     checkIntervalMs,
     stallThresholdMs,
+    executionStallThresholdMs,
+    prFollowThroughStallThresholdMs,
     maxRecoveryAttempts,
   };
 }

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -23,6 +23,8 @@ export interface WatchdogConfig {
   readonly enabled: boolean;
   readonly checkIntervalMs: number;
   readonly stallThresholdMs: number;
+  readonly executionStallThresholdMs: number;
+  readonly prFollowThroughStallThresholdMs: number;
   readonly maxRecoveryAttempts: number;
 }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1833,6 +1833,34 @@ export class BootstrapOrchestrator implements Orchestrator {
               this.#config.agent.maxTurns,
             )
           ) {
+            upsertActiveIssue(this.#state.status, issue, {
+              source,
+              runSequence: attempt,
+              branchName: workspace.branchName,
+              status: "running",
+              summary: `Running ${issue.identifier}`,
+              pullRequest:
+                nextLifecycle.pullRequest === null
+                  ? null
+                  : {
+                      number: nextLifecycle.pullRequest.number,
+                      url: nextLifecycle.pullRequest.url,
+                      headSha: nextLifecycle.pullRequest.headSha,
+                      latestCommitAt: nextLifecycle.pullRequest.latestCommitAt,
+                    },
+              checks: {
+                pendingNames: nextLifecycle.pendingCheckNames,
+                failingNames: nextLifecycle.failingCheckNames,
+              },
+              review: {
+                actionableCount:
+                  nextLifecycle.actionableReviewFeedback.length,
+                unresolvedThreadCount:
+                  nextLifecycle.unresolvedThreadIds.length,
+              },
+              blockedReason: null,
+            });
+            await this.#persistStatusSnapshot();
             this.#logger.info("Continuing agent turn on live session", {
               issueNumber: issue.number,
               branchName: workspace.branchName,

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1853,10 +1853,8 @@ export class BootstrapOrchestrator implements Orchestrator {
                 failingNames: nextLifecycle.failingCheckNames,
               },
               review: {
-                actionableCount:
-                  nextLifecycle.actionableReviewFeedback.length,
-                unresolvedThreadCount:
-                  nextLifecycle.unresolvedThreadIds.length,
+                actionableCount: nextLifecycle.actionableReviewFeedback.length,
+                unresolvedThreadCount: nextLifecycle.unresolvedThreadIds.length,
               },
               blockedReason: null,
             });

--- a/src/orchestrator/stall-detector.ts
+++ b/src/orchestrator/stall-detector.ts
@@ -47,6 +47,7 @@ export interface StallCheckResult {
   // activity. On the non-stalled activity-detected path it is only the lag
   // between the current probe wall clock and the credited activity timestamp.
   readonly stalledForMs: number;
+  readonly appliedThresholdMs: number;
   readonly lastObservableActivityAt: number;
   readonly lastObservableActivitySource: LivenessSource | null;
 }
@@ -82,6 +83,7 @@ export function checkStall(
   config: WatchdogConfig,
 ): StallCheckResult {
   const previous = entry.lastLiveness;
+  const appliedThresholdMs = resolveStallThresholdMs(current, config);
 
   const activity = detectObservableActivity(previous, current);
   // Only credit activity that is at-or-after the last known baseline.
@@ -103,6 +105,7 @@ export function checkStall(
       stalled: false,
       reason: null,
       stalledForMs: current.capturedAt - creditedAt,
+      appliedThresholdMs,
       lastObservableActivityAt: entry.lastObservableActivityAt,
       lastObservableActivitySource: entry.lastObservableActivitySource,
     };
@@ -112,12 +115,13 @@ export function checkStall(
   entry.lastLiveness = current;
 
   const stalledForMs = current.capturedAt - entry.lastObservableActivityAt;
-  if (stalledForMs < config.stallThresholdMs) {
+  if (stalledForMs < appliedThresholdMs) {
     return {
       issueNumber: entry.issueNumber,
       stalled: false,
       reason: null,
       stalledForMs,
+      appliedThresholdMs,
       lastObservableActivityAt: entry.lastObservableActivityAt,
       lastObservableActivitySource: entry.lastObservableActivitySource,
     };
@@ -130,6 +134,7 @@ export function checkStall(
     stalled: true,
     reason,
     stalledForMs,
+    appliedThresholdMs,
     lastObservableActivityAt: entry.lastObservableActivityAt,
     lastObservableActivitySource: entry.lastObservableActivitySource,
   };
@@ -166,8 +171,20 @@ export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
   enabled: false,
   checkIntervalMs: 60_000,
   stallThresholdMs: 300_000,
+  executionStallThresholdMs: 300_000,
+  prFollowThroughStallThresholdMs: 300_000,
   maxRecoveryAttempts: 2,
 };
+
+export function resolveStallThresholdMs(
+  snapshot: LivenessSnapshot,
+  config: WatchdogConfig,
+): number {
+  if (snapshot.prHeadSha !== null) {
+    return config.prFollowThroughStallThresholdMs;
+  }
+  return config.executionStallThresholdMs;
+}
 
 interface ObservableActivity {
   readonly at: number;

--- a/src/templates/third-party-workflow.ts
+++ b/src/templates/third-party-workflow.ts
@@ -42,6 +42,8 @@ export function renderThirdPartyWorkflowTemplate(
     "    enabled: true",
     "    check_interval_ms: 60000",
     "    stall_threshold_ms: 300000",
+    "    execution_stall_threshold_ms: 900000",
+    "    pr_follow_through_stall_threshold_ms: 1800000",
     "    max_recovery_attempts: 2",
     "workspace:",
     "  root: ./.tmp/workspaces",

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -76,6 +76,8 @@ async function writeWorkflow(options: {
         readonly enabled: boolean;
         readonly checkIntervalMs: number;
         readonly stallThresholdMs: number;
+        readonly executionStallThresholdMs?: number;
+        readonly prFollowThroughStallThresholdMs?: number;
         readonly maxRecoveryAttempts: number;
       }
     | undefined;
@@ -177,7 +179,9 @@ ${
     enabled: ${options.watchdog.enabled ? "true" : "false"}
     check_interval_ms: ${options.watchdog.checkIntervalMs}
     stall_threshold_ms: ${options.watchdog.stallThresholdMs}
-    max_recovery_attempts: ${options.watchdog.maxRecoveryAttempts}
+${options.watchdog.executionStallThresholdMs === undefined ? "" : `    execution_stall_threshold_ms: ${options.watchdog.executionStallThresholdMs}
+`}${options.watchdog.prFollowThroughStallThresholdMs === undefined ? "" : `    pr_follow_through_stall_threshold_ms: ${options.watchdog.prFollowThroughStallThresholdMs}
+`}    max_recovery_attempts: ${options.watchdog.maxRecoveryAttempts}
 `
 }
 workspace:
@@ -1095,6 +1099,66 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     const artifactSummary = await readIssueArtifactSummary(
       path.join(tempDir, ".tmp", "workspaces"),
       84,
+    );
+    expect(artifactSummary.currentOutcome).toBe("succeeded");
+    expect(artifactSummary.currentSummary).not.toContain(
+      "Stall detected (workspace-stall)",
+    );
+  });
+
+  it("keeps a third-party Claude run alive through a quiet post-write execution window when the execution threshold is higher", async () => {
+    server.seedIssue({
+      number: 85,
+      title: "Claude quiet post-write watchdog window",
+      body: "Keep the run alive while Claude stays quiet after an early write.",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      runnerKind: "claude-code",
+      agentCommand:
+        "claude --add-dir . --file=WORKFLOW.md -p --output-format json --permission-mode bypassPermissions --model sonnet",
+      maxAttempts: 1,
+      maxTurns: 2,
+      watchdog: {
+        enabled: true,
+        checkIntervalMs: 5,
+        stallThresholdMs: 100,
+        executionStallThresholdMs: 500,
+        maxRecoveryAttempts: 0,
+      },
+      agentEnv: {
+        FAKE_CLAUDE_QUIET_AFTER_WRITE_MS: "250",
+      },
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+    await waitForPullRequestHead(server, "symphony/85");
+    server.setPullRequestCheckRuns("symphony/85", [
+      { name: "CI", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestComment({
+      head: "symphony/85",
+      authorLogin: "jessmartin",
+      body: "/land",
+    });
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(85);
+    expect(issue.state).toBe("closed");
+    expect(
+      issue.comments.some((comment) =>
+        comment.includes("Stall detected (workspace-stall)"),
+      ),
+    ).toBe(false);
+
+    const artifactSummary = await readIssueArtifactSummary(
+      path.join(tempDir, ".tmp", "workspaces"),
+      85,
     );
     expect(artifactSummary.currentOutcome).toBe("succeeded");
     expect(artifactSummary.currentSummary).not.toContain(

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -179,9 +179,17 @@ ${
     enabled: ${options.watchdog.enabled ? "true" : "false"}
     check_interval_ms: ${options.watchdog.checkIntervalMs}
     stall_threshold_ms: ${options.watchdog.stallThresholdMs}
-${options.watchdog.executionStallThresholdMs === undefined ? "" : `    execution_stall_threshold_ms: ${options.watchdog.executionStallThresholdMs}
-`}${options.watchdog.prFollowThroughStallThresholdMs === undefined ? "" : `    pr_follow_through_stall_threshold_ms: ${options.watchdog.prFollowThroughStallThresholdMs}
-`}    max_recovery_attempts: ${options.watchdog.maxRecoveryAttempts}
+${
+  options.watchdog.executionStallThresholdMs === undefined
+    ? ""
+    : `    execution_stall_threshold_ms: ${options.watchdog.executionStallThresholdMs}
+`
+}${
+        options.watchdog.prFollowThroughStallThresholdMs === undefined
+          ? ""
+          : `    pr_follow_through_stall_threshold_ms: ${options.watchdog.prFollowThroughStallThresholdMs}
+`
+      }    max_recovery_attempts: ${options.watchdog.maxRecoveryAttempts}
 `
 }
 workspace:

--- a/tests/fixtures/claude
+++ b/tests/fixtures/claude
@@ -68,6 +68,7 @@ ACTIVITY_TICKS="${FAKE_CLAUDE_ACTIVITY_TICKS:-0}"
 ACTIVITY_INTERVAL_MS="${FAKE_CLAUDE_ACTIVITY_INTERVAL_MS:-0.05}"
 ACTIVITY_STREAM="${FAKE_CLAUDE_ACTIVITY_STREAM:-stderr}"
 COMMIT_EACH_ATTEMPT="${FAKE_CLAUDE_COMMIT_EACH_ATTEMPT:-false}"
+QUIET_AFTER_WRITE_MS="${FAKE_CLAUDE_QUIET_AFTER_WRITE_MS:-0}"
 ACTIVITY_PID=""
 
 start_activity_ticks() {
@@ -97,6 +98,18 @@ wait_for_activity_ticks() {
 
 trap 'wait_for_activity_ticks' EXIT
 
+sleep_quiet_after_write() {
+  if [[ "$QUIET_AFTER_WRITE_MS" == "0" ]]; then
+    return
+  fi
+  python3 - "$QUIET_AFTER_WRITE_MS" <<'PY'
+import sys
+import time
+
+time.sleep(float(sys.argv[1]) / 1000.0)
+PY
+}
+
 if [[ "${SYMPHONY_RUN_TURN}" == "1" ]]; then
   if [[ "$COMMIT_EACH_ATTEMPT" == "true" || "${SYMPHONY_RUN_ATTEMPT}" == "1" ]]; then
     if [[ "$COMMIT_EACH_ATTEMPT" == "true" ]]; then
@@ -109,6 +122,7 @@ if [[ "${SYMPHONY_RUN_TURN}" == "1" ]]; then
       git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} via Claude"
     fi
     start_activity_ticks
+    sleep_quiet_after_write
     git push origin HEAD:${SYMPHONY_BRANCH_NAME}
     curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
       -H 'content-type: application/json' \

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -14,6 +14,7 @@ import {
 import type {
   PromptBuilder,
   ResolvedConfig,
+  WatchdogConfig,
 } from "../../src/domain/workflow.js";
 import { deriveRuntimeInstancePaths } from "../../src/domain/workflow.js";
 import { LocalIssueLeaseManager } from "../../src/orchestrator/issue-lease.js";
@@ -116,6 +117,23 @@ function createRunnerVisibilityProbe(): LivenessProbe {
         capturedAt: Date.now(),
       };
     },
+  };
+}
+
+function createWatchdogConfig(
+  overrides: Partial<WatchdogConfig>,
+): WatchdogConfig {
+  const stallThresholdMs = overrides.stallThresholdMs ?? 0;
+  return {
+    enabled: true,
+    checkIntervalMs: 0,
+    stallThresholdMs,
+    executionStallThresholdMs:
+      overrides.executionStallThresholdMs ?? stallThresholdMs,
+    prFollowThroughStallThresholdMs:
+      overrides.prFollowThroughStallThresholdMs ?? stallThresholdMs,
+    maxRecoveryAttempts: 1,
+    ...overrides,
   };
 }
 
@@ -4263,12 +4281,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0, // immediate stall detection for testing
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4367,12 +4383,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 1,
           stallThresholdMs: 20,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4442,12 +4456,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 1,
           stallThresholdMs: 5,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4468,6 +4480,205 @@ describe("BootstrapOrchestrator watchdog", () => {
     expect(tracker.retried).toEqual([]);
     expect(tracker.failed).toEqual([]);
     expect(tracker.completed).toEqual([94]);
+  });
+
+  it("keeps a quiet execution run alive when the execution threshold exceeds the legacy baseline", async () => {
+    const issue = createIssue(95);
+    const tracker = new SequencedTracker({ ready: [issue] });
+    tracker.setLifecycleSequence(95, [
+      lifecycle("handoff-ready", "symphony/95"),
+    ]);
+
+    let runAborted = false;
+
+    const quietRunner: Runner = {
+      describeSession() {
+        return createRunnerSessionDescription();
+      },
+      async run(_session, options) {
+        const startedAt = new Date().toISOString();
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            options?.signal?.removeEventListener("abort", handleAbort);
+            resolve();
+          }, 35);
+          const handleAbort = (): void => {
+            clearTimeout(timer);
+            runAborted = true;
+            reject(new RunnerAbortedError("Aborted"));
+          };
+          if (options?.signal?.aborted) {
+            handleAbort();
+            return;
+          }
+          options?.signal?.addEventListener("abort", handleAbort, {
+            once: true,
+          });
+        });
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+      },
+    };
+
+    const quietWorkspaceProbe: LivenessProbe = {
+      async capture(options) {
+        return {
+          logSizeBytes: null,
+          workspaceDiffHash: "diff-95",
+          prHeadSha: options.prHeadSha,
+          runStartedAt: options.runStartedAt,
+          runnerPhase: options.runnerPhase,
+          runnerHeartbeatAt: options.runnerHeartbeatAt,
+          runnerActionAt: options.runnerActionAt,
+          hasActionableFeedback: options.hasActionableFeedback,
+          capturedAt: Date.now(),
+        };
+      },
+    };
+
+    const watchdogConfig = {
+      ...withLocalInstanceRoot(baseConfig, tmpDir),
+      polling: {
+        ...baseConfig.polling,
+        watchdog: {
+          enabled: true,
+          checkIntervalMs: 1,
+          stallThresholdMs: 5,
+          executionStallThresholdMs: 50,
+          prFollowThroughStallThresholdMs: 5,
+          maxRecoveryAttempts: 1,
+        },
+      },
+    };
+
+    const orchestrator = new BootstrapOrchestrator(
+      watchdogConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      quietRunner,
+      new NullLogger(),
+      undefined,
+      quietWorkspaceProbe,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(runAborted).toBe(false);
+    expect(tracker.retried).toEqual([]);
+    expect(tracker.failed).toEqual([]);
+    expect(tracker.completed).toEqual([95]);
+  });
+
+  it("keeps a quiet PR follow-through run alive when the PR threshold exceeds the legacy baseline", async () => {
+    const issue = createIssue(96);
+    const tracker = new SequencedTracker({ ready: [issue] });
+    tracker.setLifecycleSequence(96, [
+      lifecycle("rework-required", "symphony/96"),
+      lifecycle("handoff-ready", "symphony/96"),
+    ]);
+
+    let turnNumber = 0;
+    let runAborted = false;
+
+    const quietFollowThroughRunner: Runner = {
+      describeSession() {
+        return createRunnerSessionDescription();
+      },
+      async run(_session, options) {
+        turnNumber += 1;
+        const startedAt = new Date().toISOString();
+        if (turnNumber === 1) {
+          return {
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            startedAt,
+            finishedAt: new Date().toISOString(),
+          };
+        }
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            options?.signal?.removeEventListener("abort", handleAbort);
+            resolve();
+          }, 35);
+          const handleAbort = (): void => {
+            clearTimeout(timer);
+            runAborted = true;
+            reject(new RunnerAbortedError("Aborted"));
+          };
+          if (options?.signal?.aborted) {
+            handleAbort();
+            return;
+          }
+          options?.signal?.addEventListener("abort", handleAbort, {
+            once: true,
+          });
+        });
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+      },
+    };
+
+    const quietPrProbe: LivenessProbe = {
+      async capture(options) {
+        return {
+          logSizeBytes: null,
+          workspaceDiffHash: "diff-96",
+          prHeadSha: options.prHeadSha,
+          runStartedAt: options.runStartedAt,
+          runnerPhase: options.runnerPhase,
+          runnerHeartbeatAt: options.runnerHeartbeatAt,
+          runnerActionAt: options.runnerActionAt,
+          hasActionableFeedback: options.hasActionableFeedback,
+          capturedAt: Date.now(),
+        };
+      },
+    };
+
+    const watchdogConfig = {
+      ...withLocalInstanceRoot(baseConfig, tmpDir),
+      polling: {
+        ...baseConfig.polling,
+        watchdog: {
+          enabled: true,
+          checkIntervalMs: 1,
+          stallThresholdMs: 5,
+          executionStallThresholdMs: 5,
+          prFollowThroughStallThresholdMs: 200,
+          maxRecoveryAttempts: 1,
+        },
+      },
+    };
+
+    const orchestrator = new BootstrapOrchestrator(
+      watchdogConfig,
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      quietFollowThroughRunner,
+      new NullLogger(),
+      undefined,
+      quietPrProbe,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(turnNumber).toBe(2);
+    expect(runAborted).toBe(false);
+    expect(tracker.retried).toEqual([]);
+    expect(tracker.failed).toEqual([]);
+    expect(tracker.completed).toEqual([96]);
   });
 
   it("recovers a startup run that never advances beyond its start time", async () => {
@@ -4504,12 +4715,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4587,12 +4796,10 @@ describe("BootstrapOrchestrator watchdog", () => {
         ...withLocalInstanceRoot(baseConfig, tmpDir),
         polling: {
           ...baseConfig.polling,
-          watchdog: {
-            enabled: true,
+          watchdog: createWatchdogConfig({
             checkIntervalMs: 0,
             stallThresholdMs: 0,
-            maxRecoveryAttempts: 1,
-          },
+          }),
         },
       },
       staticPromptBuilder,
@@ -4655,12 +4862,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4759,12 +4964,11 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0,
           maxRecoveryAttempts: 0,
-        },
+        }),
       },
     };
 
@@ -4802,12 +5006,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 50,
           stallThresholdMs: 0,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4858,12 +5060,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 
@@ -4905,12 +5105,10 @@ describe("BootstrapOrchestrator watchdog", () => {
       ...withLocalInstanceRoot(baseConfig, tmpDir),
       polling: {
         ...baseConfig.polling,
-        watchdog: {
-          enabled: true,
+        watchdog: createWatchdogConfig({
           checkIntervalMs: 0,
           stallThresholdMs: 0,
-          maxRecoveryAttempts: 1,
-        },
+        }),
       },
     };
 

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -6,6 +6,7 @@ import {
   canRecover,
   createWatchdogEntry,
   DEFAULT_WATCHDOG_CONFIG,
+  resolveStallThresholdMs,
 } from "../../src/orchestrator/stall-detector.js";
 import type { WatchdogConfig } from "../../src/domain/workflow.js";
 
@@ -13,6 +14,8 @@ const config: WatchdogConfig = {
   enabled: true,
   checkIntervalMs: 1_000,
   stallThresholdMs: 5_000,
+  executionStallThresholdMs: 5_000,
+  prFollowThroughStallThresholdMs: 5_000,
   maxRecoveryAttempts: 2,
 };
 
@@ -267,6 +270,7 @@ describe("checkStall", () => {
     expect(result.stalled).toBe(true);
     expect(result.reason).toBe("log-stall");
     expect(result.stalledForMs).toBe(6000);
+    expect(result.appliedThresholdMs).toBe(5000);
     expect(result.lastObservableActivitySource).toBe("run-start");
   });
 
@@ -341,6 +345,7 @@ describe("checkStall", () => {
     expect(result.stalled).toBe(true);
     expect(result.reason).toBe("log-stall");
     expect(result.stalledForMs).toBe(6000);
+    expect(result.appliedThresholdMs).toBe(5000);
   });
 
   it("stalls runner-progress-only runs after timestamps stop changing", () => {
@@ -426,6 +431,34 @@ describe("checkStall", () => {
   });
 });
 
+describe("resolveStallThresholdMs", () => {
+  it("uses the execution threshold before a PR exists", () => {
+    expect(
+      resolveStallThresholdMs(
+        snapshot(),
+        {
+          ...config,
+          executionStallThresholdMs: 9_000,
+          prFollowThroughStallThresholdMs: 18_000,
+        },
+      ),
+    ).toBe(9_000);
+  });
+
+  it("uses the PR follow-through threshold when a PR exists", () => {
+    expect(
+      resolveStallThresholdMs(
+        snapshot({ prHeadSha: "sha1" }),
+        {
+          ...config,
+          executionStallThresholdMs: 9_000,
+          prFollowThroughStallThresholdMs: 18_000,
+        },
+      ),
+    ).toBe(18_000);
+  });
+});
+
 describe("classifyStallReason", () => {
   it("returns pr-stall for actionable feedback with PR head", () => {
     expect(
@@ -466,6 +499,10 @@ describe("DEFAULT_WATCHDOG_CONFIG", () => {
 
   it("has sensible defaults", () => {
     expect(DEFAULT_WATCHDOG_CONFIG.stallThresholdMs).toBe(300_000);
+    expect(DEFAULT_WATCHDOG_CONFIG.executionStallThresholdMs).toBe(300_000);
+    expect(DEFAULT_WATCHDOG_CONFIG.prFollowThroughStallThresholdMs).toBe(
+      300_000,
+    );
     expect(DEFAULT_WATCHDOG_CONFIG.maxRecoveryAttempts).toBe(2);
   });
 });

--- a/tests/unit/stall-detector.test.ts
+++ b/tests/unit/stall-detector.test.ts
@@ -434,27 +434,21 @@ describe("checkStall", () => {
 describe("resolveStallThresholdMs", () => {
   it("uses the execution threshold before a PR exists", () => {
     expect(
-      resolveStallThresholdMs(
-        snapshot(),
-        {
-          ...config,
-          executionStallThresholdMs: 9_000,
-          prFollowThroughStallThresholdMs: 18_000,
-        },
-      ),
+      resolveStallThresholdMs(snapshot(), {
+        ...config,
+        executionStallThresholdMs: 9_000,
+        prFollowThroughStallThresholdMs: 18_000,
+      }),
     ).toBe(9_000);
   });
 
   it("uses the PR follow-through threshold when a PR exists", () => {
     expect(
-      resolveStallThresholdMs(
-        snapshot({ prHeadSha: "sha1" }),
-        {
-          ...config,
-          executionStallThresholdMs: 9_000,
-          prFollowThroughStallThresholdMs: 18_000,
-        },
-      ),
+      resolveStallThresholdMs(snapshot({ prHeadSha: "sha1" }), {
+        ...config,
+        executionStallThresholdMs: 9_000,
+        prFollowThroughStallThresholdMs: 18_000,
+      }),
     ).toBe(18_000);
   });
 });

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -897,6 +897,64 @@ agent:
       enabled: true,
       checkIntervalMs: 60000,
       stallThresholdMs: 300000,
+      executionStallThresholdMs: 300000,
+      prFollowThroughStallThresholdMs: 300000,
+      maxRecoveryAttempts: 2,
+    });
+  });
+
+  it("loads explicit phase-specific polling.watchdog thresholds", async () => {
+    const dir = await createTempDir("workflow-watchdog-phase-thresholds-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 2
+    backoff_ms: 10
+  watchdog:
+    enabled: true
+    check_interval_ms: 60000
+    stall_threshold_ms: 300000
+    execution_stall_threshold_ms: 900000
+    pr_follow_through_stall_threshold_ms: 1800000
+    max_recovery_attempts: 2
+workspace:
+  root: ./.tmp/ws
+  repo_url: git@example.com:repo.git
+  branch_prefix: symphony/
+  cleanup_on_success: true
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex exec -
+  prompt_transport: stdin
+  timeout_ms: 1000
+  env: {}`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+
+    expect(workflow.config.polling.watchdog).toEqual({
+      enabled: true,
+      checkIntervalMs: 60000,
+      stallThresholdMs: 300000,
+      executionStallThresholdMs: 900000,
+      prFollowThroughStallThresholdMs: 1800000,
       maxRecoveryAttempts: 2,
     });
   });
@@ -1040,6 +1098,8 @@ agent:
       enabled: false,
       checkIntervalMs: 60000,
       stallThresholdMs: 300000,
+      executionStallThresholdMs: 300000,
+      prFollowThroughStallThresholdMs: 300000,
       maxRecoveryAttempts: 2,
     });
   });


### PR DESCRIPTION
## Summary
- add phase-specific watchdog thresholds for active execution vs PR follow-through, defaulting both from the legacy `stall_threshold_ms`
- update the orchestrator to persist newly observed PR/check/review state before continuing live follow-through turns so watchdog posture stays aligned with the active run
- add workflow docs, unit coverage, and Claude quiet-window regression tests for execution and long-running follow-through behavior

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #282
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
