### PR TITLE
Fix self-hosted startup when observability section is comment-only

### DIFF
--- a/docs/plans/275-workflow-observability-startup-regression/plan.md
+++ b/docs/plans/275-workflow-observability-startup-regression/plan.md
@@ -1,0 +1,61 @@
+# Plan for #275: Repair merged WORKFLOW.md observability parse regression blocking factory startup
+
+## Scope
+
+Restore self-hosted factory startup on `main` by making workflow parsing tolerate a comment-only top-level `observability:` block, then cover the regression with a focused parser test.
+
+## Plan Review Status
+
+Plan review is explicitly waived by direct human instruction in the active terminal session to fix and land this outage immediately.
+
+## Layer Mapping
+
+- Policy: preserve existing workflow semantics where omitted optional sections resolve through defaults.
+- Configuration: adjust workflow parsing so top-level `observability: null` is treated like an omitted optional section.
+- Coordination: none beyond restoring factory start/restart behavior.
+- Execution: validate with direct startup smoke for the self-hosted workflow.
+- Integration: none; this is local config parsing.
+- Observability: add a unit regression so the startup failure mode stays covered.
+
+## Non-Goals
+
+- no broader redesign of `WORKFLOW.md`
+- no changes to tracker semantics or runtime identity handling
+- no changes to user local workflow content beyond preserving current behavior
+
+## Current Gap
+
+Merged `main` rejects the checked-in `WORKFLOW.md` because a bare `observability:` stanza parses as YAML `null`, while `coerceOptionalObject` currently throws on explicit `null` for all top-level optional sections.
+
+## Architecture Boundary
+
+- Touch only config parsing and tests.
+- Do not alter operator logic, tracker policy, or factory control paths.
+
+## Implementation Steps
+
+1. Update config resolution so `raw.observability === null` resolves to `{}` before optional observability parsing.
+2. Add a focused unit test covering a comment-only top-level `observability:` block.
+3. Validate with workflow unit tests and a real self-hosted startup smoke.
+4. Open a PR, watch CI, address review, and merge.
+
+## Tests
+
+- `pnpm exec vitest run tests/unit/workflow.test.ts`
+- `SYMPHONY_REPO=sociotechnica-org/symphony-ts pnpm tsx bin/symphony.ts run --workflow WORKFLOW.md --once --i-understand-that-this-will-be-running-without-the-usual-guardrails`
+- repo pre-push gate via push / CI (`typecheck`, `lint`, `format:check`, `test`)
+
+## Acceptance Scenarios
+
+- Self-hosted `WORKFLOW.md` with a comment-only top-level `observability:` block loads successfully.
+- Detached `factory start` can succeed again on repaired code.
+- No regression to explicit observability config parsing.
+
+## Exit Criteria
+
+- parser fix and regression test merged to `main`
+- self-hosted factory restarted successfully from merged `main`
+
+## Deferred
+
+- any broader cleanup of optional-null parsing consistency across other top-level sections

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -39,7 +39,7 @@ interface RawWorkflow {
   readonly workspace?: Record<string, unknown>;
   readonly hooks?: Record<string, unknown>;
   readonly agent?: Record<string, unknown>;
-  readonly observability?: Record<string, unknown>;
+  readonly observability?: Record<string, unknown> | null;
 }
 
 const liquid = new Liquid({
@@ -573,10 +573,10 @@ function resolveConfig(raw: RawWorkflow, workflowPath: string): ResolvedConfig {
   const workspace = coerceOptionalObject(raw.workspace, "workspace");
   const hooks = coerceOptionalObject(raw.hooks, "hooks");
   const agent = coerceOptionalObject(raw.agent, "agent");
-  const observabilityRaw = coerceOptionalObject(
-    raw.observability,
-    "observability",
-  );
+  const observabilityRaw =
+    raw.observability === null
+      ? {}
+      : coerceOptionalObject(raw.observability, "observability");
 
   // Apply SYMPHONY_REPO env override (GitHub-backed trackers only; ignored by other tracker kinds)
   const rawRepoEnv = process.env["SYMPHONY_REPO"];

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -290,6 +290,39 @@ observability:
     );
   });
 
+  it("treats a comment-only top-level observability block as omitted", async () => {
+    const dir = await createTempDir("workflow-observability-comments-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+${buildSharedWorkflowSections()}
+observability:
+  # Optional automatic archive publication for terminal issue reports.
+  # issue_reports:
+  #   archive_root: ../factory-runs`,
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    expect(workflow.config.observability).toEqual({
+      dashboardEnabled: true,
+      refreshMs: 1000,
+      renderIntervalMs: 16,
+      issueReports: {
+        archiveRoot: null,
+      },
+    });
+  });
+
   it("loads optional tracker queue-priority config for github", async () => {
     const dir = await createTempDir("workflow-github-queue-priority-");
     const workflowPath = path.join(dir, "WORKFLOW.md");


### PR DESCRIPTION
## Summary
- treat a comment-only top-level `observability:` block as omitted during workflow parsing
- add a regression test covering the checked-in self-hosted WORKFLOW shape
- restore self-hosted factory startup on current main

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `SYMPHONY_REPO=sociotechnica-org/symphony-ts pnpm tsx bin/symphony.ts run --workflow WORKFLOW.md --once --i-understand-that-this-will-be-running-without-the-usual-guardrails`

Closes #275.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
