### PR TITLE
Add dependency-aware ready promotion for release DAG execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Operator wake-ups now inspect that ledger before ordinary queue advancement so
 completed-run report findings are turned into tracked follow-up work promptly.
 The current entry point requires a Unix-like shell environment such as macOS,
 Linux, or WSL/Git Bash on Windows.
+The same wake-up path now also runs a dependency-aware ready promoter for
+GitHub-backed release DAGs. It reads the canonical operator-local
+`release-state.json` dependency graph, computes which downstream issues are
+currently eligible, and records the resulting eligible set plus any added or
+removed `symphony:ready` labels back into that same typed artifact.
 
 Generate a per-issue report from local artifacts:
 

--- a/bin/check-operator-release-state.ts
+++ b/bin/check-operator-release-state.ts
@@ -66,6 +66,28 @@ function renderText(
             .map((issue) => `#${issue.issueNumber.toString()}`)
             .join(", ")
     }`,
+    `Ready promotion: ${state.promotion.state}`,
+    `Ready promotion eligible issues: ${
+      state.promotion.eligibleIssues.length === 0
+        ? "none"
+        : state.promotion.eligibleIssues
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Ready promotion added: ${
+      state.promotion.readyLabelsAdded.length === 0
+        ? "none"
+        : state.promotion.readyLabelsAdded
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Ready promotion removed: ${
+      state.promotion.readyLabelsRemoved.length === 0
+        ? "none"
+        : state.promotion.readyLabelsRemoved
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
     `Updated at: ${state.updatedAt}`,
     `Summary: ${state.evaluation.summary}`,
   ].join("\n");

--- a/bin/promote-operator-ready-issues.ts
+++ b/bin/promote-operator-ready-issues.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+} from "../src/domain/instance-identity.js";
+import { promoteOperatorReadyIssues } from "../src/observability/operator-ready-promotion.js";
+
+interface Args {
+  readonly workflowPath: string;
+  readonly operatorRepoRoot: string;
+  readonly json: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  return {
+    workflowPath: path.resolve(
+      readOptionalOptionValue(argv, "--workflow") ?? "WORKFLOW.md",
+    ),
+    operatorRepoRoot: path.resolve(
+      readOptionalOptionValue(argv, "--operator-repo-root") ?? process.cwd(),
+    ),
+    json: argv.includes("--json"),
+  };
+}
+
+function readOptionalOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function renderText(args: {
+  readonly releaseStateFile: string;
+  readonly state: Awaited<ReturnType<typeof promoteOperatorReadyIssues>>["state"];
+}): string {
+  const promotion = args.state.promotion;
+  return [
+    `Ready promotion: ${promotion.state}`,
+    `Release state file: ${args.releaseStateFile}`,
+    `Release id: ${args.state.configuration.releaseId ?? "unconfigured"}`,
+    `Eligible issues: ${
+      promotion.eligibleIssues.length === 0
+        ? "none"
+        : promotion.eligibleIssues
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Ready labels added: ${
+      promotion.readyLabelsAdded.length === 0
+        ? "none"
+        : promotion.readyLabelsAdded
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Ready labels removed: ${
+      promotion.readyLabelsRemoved.length === 0
+        ? "none"
+        : promotion.readyLabelsRemoved
+            .map((issue) => `#${issue.issueNumber.toString()}`)
+            .join(", ")
+    }`,
+    `Promoted at: ${promotion.promotedAt}`,
+    `Summary: ${promotion.summary}`,
+  ].join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const identity = deriveSymphonyInstanceIdentity(args.workflowPath);
+  const paths = deriveOperatorInstanceStatePaths({
+    operatorRepoRoot: args.operatorRepoRoot,
+    instanceKey: identity.instanceKey,
+  });
+  const result = await promoteOperatorReadyIssues({
+    workflowPath: args.workflowPath,
+    releaseStateFile: paths.releaseStatePath,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  process.stdout.write(
+    `${renderText({
+      releaseStateFile: paths.releaseStatePath,
+      state: result.state,
+    })}\n`,
+  );
+}
+
+main().catch((error: Error) => {
+  process.stderr.write(
+    error.stack ? `${error.stack}\n` : `${error.name}: ${error.message}\n`,
+  );
+  process.exit(1);
+});

--- a/bin/promote-operator-ready-issues.ts
+++ b/bin/promote-operator-ready-issues.ts
@@ -41,7 +41,9 @@ function readOptionalOptionValue(
 
 function renderText(args: {
   readonly releaseStateFile: string;
-  readonly state: Awaited<ReturnType<typeof promoteOperatorReadyIssues>>["state"];
+  readonly state: Awaited<
+    ReturnType<typeof promoteOperatorReadyIssues>
+  >["state"];
 }): string {
   const promotion = args.state.promotion;
   return [

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -85,14 +85,16 @@ pnpm tsx bin/check-operator-release-state.ts --workflow ../target-repo/WORKFLOW.
 ```
 
 5. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
-6. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
-7. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
-8. Check for operator-gated work the factory cannot clear by itself:
+6. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Read the stored `promotion` section in `release-state.json` when you need the latest eligible downstream issues or the exact `symphony:ready` labels that were added or removed.
+7. If ready promotion reports `sync-failed`, treat that as a release-advancement blocker alongside `blocked-by-prerequisite-failure` and `blocked-review-needed` until the label-sync failure is repaired.
+8. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
+9. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
+10. Check for operator-gated work the factory cannot clear by itself:
    - active issues in `awaiting-human-handoff`
    - active issues or PRs in `awaiting-landing-command`
-9. If the detached runtime is stopped or degraded, repair that first.
-10. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite or unresolved dependency metadata. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
-11. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
+11. If the detached runtime is stopped or degraded, repair that first.
+12. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite, unresolved dependency metadata, or a ready-promotion sync failure. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
+13. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
 
@@ -230,7 +232,9 @@ generated reports are pending review, reviewed, or blocked, and which follow-up
 issues were filed from report findings.
 Release dependency state lives there in `release-state.json`; this is the
 machine-readable record of configured prerequisite/downstream relationships plus
-the current blocked or clear release advancement posture.
+the current blocked or clear release advancement posture. The same artifact now
+also carries the latest ready-promotion result, including the eligible
+downstream issue set plus any `symphony:ready` labels added or removed.
 
 Workspace retention is config-driven. By default, failures stay inspectable and successes are cleaned up. If you need to inspect a successful workspace, temporarily set `workspace.retention.on_success: retain` before the run.
 

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -90,8 +90,10 @@ pnpm tsx bin/check-operator-release-state.ts --workflow ../target-repo/WORKFLOW.
 8. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
 9. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
 10. Check for operator-gated work the factory cannot clear by itself:
-   - active issues in `awaiting-human-handoff`
-   - active issues or PRs in `awaiting-landing-command`
+
+- active issues in `awaiting-human-handoff`
+- active issues or PRs in `awaiting-landing-command`
+
 11. If the detached runtime is stopped or degraded, repair that first.
 12. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite, unresolved dependency metadata, or a ready-promotion sync failure. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
 13. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.

--- a/docs/plans/283-dependency-aware-ready-promotion/plan.md
+++ b/docs/plans/283-dependency-aware-ready-promotion/plan.md
@@ -1,0 +1,349 @@
+# Issue 283 Plan: Dependency-Aware Ready Promotion For Release DAG Execution
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Add a minimal, dependency-aware ready promoter so GitHub label-driven execution cannot advance a planned release DAG out of order. The first slice should compute ready eligibility from canonical release dependency metadata plus normalized issue outcomes, then synchronize the GitHub `symphony:ready` label only for tickets that are currently eligible to run.
+
+The intended outcome of this slice is:
+
+1. release dependency metadata has one canonical machine-readable source for this workflow
+2. ready eligibility is computed from normalized prerequisite outcome facts instead of ad hoc label state
+3. GitHub ready labels are added only to eligible downstream leaves and removed from ineligible tickets
+4. prerequisite failure prevents downstream ready promotion
+5. the promoter is inspectable through tests and operator-facing status, not only prompt text
+
+## Scope
+
+This slice covers:
+
+1. extending the existing operator-owned release dependency seam from `#281` into a concrete ready-promotion mechanism
+2. a normalized dependency eligibility policy that reads canonical prerequisite/downstream mappings and current issue outcome facts
+3. GitHub tracker operations needed to read the current open issue label surface and synchronize `symphony:ready` for a bounded set of release-managed tickets
+4. a one-shot promoter entry point that the operator workflow can run before ordinary queue advancement
+5. focused unit, integration, and end-to-end coverage for prerequisite success/failure and label synchronization
+
+## Non-Goals
+
+This slice does not include:
+
+1. replacing the orchestrator ready queue with a DAG-aware scheduler
+2. new `WORKFLOW.md` syntax for release graphs
+3. broad GitHub issue-body parsing as the canonical dependency source
+4. Linear or Beads write-path implementation beyond defining a tracker-neutral eligibility seam
+5. release planning UX for authoring dependency metadata
+6. automatic recovery or rerun of failed prerequisite work
+
+## Current Gaps
+
+Today the repo has only the first half of the release-dependency protection:
+
+1. `src/observability/operator-release-state.ts` stores canonical prerequisite/downstream metadata and can block downstream advancement after a prerequisite failure, but it does not compute which open tickets should actually carry `symphony:ready`
+2. the factory still dispatches purely from tracker labels, so a downstream issue that already has `symphony:ready` can run even when the release DAG says it should be blocked
+3. `RuntimeIssue` does not yet carry a normalized dependency contract, so GitHub and future trackers do not share a clear eligibility-policy input
+4. the operator workflow warns “do not promote downstream tickets,” but there is no repo-owned promoter that performs the add/remove label synchronization
+
+## Decision Notes
+
+1. Keep the first usable slice operator-owned. The regression is about label-driven GitHub execution violating release sequencing; a promoter that keeps labels correct is the smallest fix that protects the existing orchestrator without reopening core dispatch logic.
+2. Reuse `.ralph/instances/<instance-key>/release-state.json` as the canonical dependency source for this slice. That state already exists, is typed, and is inspectable; the promoter should consume it instead of inventing a second release graph source.
+3. Introduce a tracker-neutral eligibility policy module even though GitHub is the only write target in this PR. The eligibility contract should accept normalized dependency relationships and issue outcomes so Beads can reuse the policy later.
+4. Keep GitHub transport, dependency normalization, and promotion policy separated. The GitHub client should do label reads/writes only; a dedicated policy module should decide eligibility and desired label mutations.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that a ticket is ready only when every configured prerequisite has terminal-success outcome
+2. the rule that prerequisite failure removes downstream ready eligibility
+3. the rule that only eligible leaves in the configured release graph should carry `symphony:ready`
+
+Does not belong here:
+
+1. GitHub REST request details
+2. shell-only promotion heuristics
+3. hidden notebook conventions that tests cannot inspect
+
+### Configuration Layer
+
+Belongs here:
+
+1. typed loading of the selected instance paths so the promoter can find canonical `release-state.json`
+2. any narrow workflow/operator wiring needed to invoke the promoter for the selected instance
+
+Does not belong here:
+
+1. new workflow-frontmatter release-DAG authoring semantics in this slice
+2. storing dependency truth only in prompt text or local shell variables
+
+### Coordination Layer
+
+Belongs here:
+
+1. no orchestrator dispatch/retry/reconciliation changes in this slice
+2. a narrow operator-owned promotion state model that is explicit about when label sync may run or must fail closed
+
+Does not belong here:
+
+1. pushing release dependency policy into orchestrator retry or lease state
+2. silently teaching the ready queue to infer missing dependency state
+
+### Execution Layer
+
+Belongs here:
+
+1. a one-shot promoter command or helper invoked by the operator workflow
+2. bounded label synchronization execution against the selected GitHub tracker
+
+Does not belong here:
+
+1. runner changes
+2. workspace changes
+3. long-running promotion daemons or background schedulers
+
+### Integration Layer
+
+Belongs here:
+
+1. normalized dependency/eligibility inputs derived from canonical release-state metadata and normalized issue outcome facts
+2. GitHub tracker operations that read current open issue labels and apply ready-label mutations
+3. tracker-neutral policy boundaries so future adapters can reuse the same eligibility logic
+
+Does not belong here:
+
+1. mixing GitHub transport logic into operator shell scripts
+2. coupling future tracker support to GitHub-specific label semantics
+3. parsing raw tracker payloads directly inside promotion policy
+
+### Observability Layer
+
+Belongs here:
+
+1. inspectable promotion results and summaries tied to the canonical release-state seam
+2. status output that shows whether promotion ran, was blocked, or changed ready labels
+3. tests that make the ready-promotion decision surface explicit
+
+Does not belong here:
+
+1. mutating tracker state while rendering status
+2. a second release graph source separate from `release-state.json`
+
+## Architecture Boundaries
+
+### `src/observability/operator-release-state.ts`
+
+Owns:
+
+1. the canonical release dependency configuration and evaluated blocked/clear posture
+2. any small extension needed to expose promotion-related facts in typed state
+
+Does not own:
+
+1. GitHub label API calls
+2. raw tracker reads
+3. orchestration scheduling logic
+
+### new release readiness policy module
+
+Owns:
+
+1. normalized dependency graph evaluation for ready eligibility
+2. determination of eligible issue numbers and desired add/remove ready-label mutations
+3. fail-closed behavior when dependency metadata or prerequisite facts are incomplete
+
+Does not own:
+
+1. tracker transport
+2. operator prompt wording
+3. shell command orchestration
+
+### GitHub tracker client/service seam
+
+Owns:
+
+1. reading current issue label state for relevant open issues
+2. applying label mutations determined by the policy layer
+3. preserving the existing ready/running/failed transport contract
+
+Does not own:
+
+1. dependency graph evaluation
+2. release-state persistence
+3. operator sequencing rules
+
+### operator command / workflow wiring
+
+Owns:
+
+1. invoking promotion at the correct checkpoint before ordinary queue advancement
+2. surfacing whether the promoter ran successfully or failed closed
+
+Does not own:
+
+1. the only definition of eligibility policy
+2. ad hoc JSON parsing or label diff logic in shell
+3. GitHub-specific business rules beyond calling the typed promoter entry point
+
+## Slice Strategy And PR Seam
+
+This issue should fit in one reviewable PR by staying on one narrow seam:
+
+1. promote GitHub ready labels from the existing operator-owned release graph instead of rewriting orchestrator dispatch
+2. add a tracker-neutral dependency eligibility policy module plus the minimum GitHub read/write support it needs
+3. wire that promoter into the operator checkpoint that already inspects release-state before queue advancement
+4. add focused tests for prerequisite failure, prerequisite success, and label removal/addition
+
+Deferred from this PR:
+
+1. orchestrator-native DAG dispatch or claim gating
+2. new repository authoring UX for release dependencies
+3. generalized non-GitHub write support
+4. broader release-portfolio management beyond one selected instance/release graph
+
+Why this seam is reviewable:
+
+1. it closes the real regression without broad scheduler churn
+2. it reuses the already-landed release-state source of truth
+3. it keeps transport, policy, and operator workflow changes separated and inspectable
+
+## Ready Promotion State Model
+
+This slice does not alter the orchestrator runtime state machine, but it does add stateful operator-side promotion behavior. The promoter therefore needs an explicit state model.
+
+### State Subject
+
+One promoter evaluation is keyed by selected instance and current release-state configuration. It combines:
+
+1. canonical dependency metadata from `release-state.json`
+2. normalized issue outcome facts from stored issue artifacts
+3. current GitHub open-issue label state for release-managed tickets
+4. the computed ready-label mutation set
+
+### States
+
+1. `unconfigured`
+   - no release dependency metadata exists; no label sync is attempted
+2. `blocked-review-needed`
+   - dependency metadata or required issue facts are incomplete; promotion fails closed and applies no mutations
+3. `eligible-set-computed`
+   - dependency metadata is complete and the promoter has computed the exact eligible/ineligible issue sets
+4. `labels-synchronized`
+   - computed label mutations were applied successfully and the ready surface now matches eligibility
+5. `sync-failed`
+   - eligibility was computed, but at least one tracker mutation failed; the promoter reports failure and does not claim success silently
+
+### Allowed Transitions
+
+1. `unconfigured -> blocked-review-needed`
+2. `unconfigured -> eligible-set-computed`
+3. `blocked-review-needed -> eligible-set-computed`
+4. `eligible-set-computed -> labels-synchronized`
+5. `eligible-set-computed -> sync-failed`
+6. `sync-failed -> eligible-set-computed`
+7. `labels-synchronized -> eligible-set-computed`
+
+### Contract Rules
+
+1. label mutation is allowed only after a complete eligibility computation
+2. prerequisite failure must exclude all downstream descendants from the eligible set
+3. a ticket with any unsatisfied prerequisite must not retain `symphony:ready`
+4. incomplete dependency metadata must fail closed with no speculative ready promotion
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| No dependency metadata configured | release-state absent or `dependencies: []` | open issue labels may exist | remain `unconfigured`; make no ready-label changes |
+| Prerequisite issue has terminal failed outcome | configured dependency graph | prerequisite outcome is `failed` | compute downstream as ineligible; remove `symphony:ready` from any affected downstream open issue |
+| Prerequisite issue is still non-terminal | configured dependency graph | prerequisite outcome is running / review / checks / unknown | downstream remains ineligible; do not add `symphony:ready` yet |
+| All prerequisites for a downstream leaf have terminal success outcome | configured dependency graph | prerequisite outcomes are `succeeded` and downstream issue is open | mark the leaf eligible; add `symphony:ready` if absent |
+| Metadata references an issue with no stored outcome fact | configured dependency graph | missing normalized issue fact | move to `blocked-review-needed`; apply no mutations |
+| Downstream issue is already closed or terminal succeeded | configured dependency graph | issue is closed or succeeded | do not add `symphony:ready`; remove it if still present |
+| GitHub label update fails after eligibility is computed | computed add/remove mutation set | current labels known, mutation request failed | report `sync-failed`; keep failure inspectable and do not claim successful promotion |
+
+## Storage And Persistence Contract
+
+The canonical release dependency source remains:
+
+1. `.ralph/instances/<instance-key>/release-state.json`
+
+This slice should extend inspectability by recording the latest promotion result in a typed form adjacent to or inside that operator-owned state, including:
+
+1. evaluation timestamp
+2. promotion state
+3. eligible issue numbers
+4. ready labels added
+5. ready labels removed
+6. any fail-closed or transport error summary
+
+The promoter must not invent a second writable dependency source.
+
+## Observability Requirements
+
+1. operator-visible status output should show whether ready promotion was skipped, blocked, synchronized, or failed
+2. the canonical release-state seam should expose the latest eligible set and applied add/remove mutations
+3. integration and e2e tests should assert both mutation behavior and inspectable summaries, not just silent side effects
+
+## Implementation Steps
+
+1. Add a tracker-neutral dependency readiness policy module that accepts canonical dependency metadata plus normalized issue facts and returns:
+   - eligible issue numbers
+   - ineligible issue numbers
+   - desired ready-label add/remove mutations
+   - fail-closed status when metadata is incomplete
+2. Extend the operator release-state contract with the latest promotion result so the promotion surface is inspectable after each run.
+3. Add focused GitHub tracker/client support to:
+   - read relevant open issue label state
+   - update labels for ready promotion/removal
+   - keep transport separate from eligibility policy
+4. Add a one-shot promoter command/helper that:
+   - loads the selected instance
+   - reads canonical release-state metadata
+   - reads normalized issue outcome facts
+   - computes eligibility
+   - applies the GitHub label diff
+   - persists the promotion result
+5. Update operator workflow wiring, prompt, and runbook so this promoter runs at the release-state checkpoint before ordinary queue advancement.
+6. Add tests for pure eligibility policy, GitHub label sync integration, and the release-regression scenario.
+
+## Tests And Acceptance Scenarios
+
+### Unit Tests
+
+1. eligibility policy returns only leaf downstream issues whose prerequisites all succeeded
+2. failed prerequisite removes all downstream descendants from the eligible set
+3. incomplete dependency metadata fails closed with no promotion mutations
+4. already-closed or terminal-succeeded issues are excluded from ready promotion
+
+### Integration Tests
+
+1. operator-ready promoter updates a mock GitHub issue by adding `symphony:ready` when prerequisites succeed
+2. operator-ready promoter removes `symphony:ready` from a downstream issue when a prerequisite fails
+3. promotion status is written back to the canonical operator release-state seam
+
+### End-To-End Scenario
+
+1. Given a release graph where issue `#111` blocks issue `#112`, when `#111` fails after `#112` was previously ready, the promotion step removes `symphony:ready` from `#112` before the factory can dispatch it again.
+2. Given the same graph after `#111` later reaches terminal success, the promotion step adds `symphony:ready` back only to currently eligible downstream leaves.
+
+## Exit Criteria
+
+1. the repository has one canonical, typed dependency source for this promoter
+2. ready eligibility is computed from prerequisite terminal-success facts, not stale labels
+3. GitHub ready labels are synchronized to the computed eligible set
+4. prerequisite failure demonstrably prevents downstream ready promotion
+5. unit, integration, and relevant end-to-end tests cover the regression and pass
+
+## Deferred To Later Issues Or PRs
+
+1. orchestrator-native dependency-aware dispatch
+2. generalized dependency normalization for all tracker adapters
+3. richer tools or UX for editing release dependency metadata
+4. broader observability views for multi-release promotion planning

--- a/docs/plans/283-dependency-aware-ready-promotion/plan.md
+++ b/docs/plans/283-dependency-aware-ready-promotion/plan.md
@@ -258,15 +258,15 @@ One promoter evaluation is keyed by selected instance and current release-state 
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| No dependency metadata configured | release-state absent or `dependencies: []` | open issue labels may exist | remain `unconfigured`; make no ready-label changes |
-| Prerequisite issue has terminal failed outcome | configured dependency graph | prerequisite outcome is `failed` | compute downstream as ineligible; remove `symphony:ready` from any affected downstream open issue |
-| Prerequisite issue is still non-terminal | configured dependency graph | prerequisite outcome is running / review / checks / unknown | downstream remains ineligible; do not add `symphony:ready` yet |
-| All prerequisites for a downstream leaf have terminal success outcome | configured dependency graph | prerequisite outcomes are `succeeded` and downstream issue is open | mark the leaf eligible; add `symphony:ready` if absent |
-| Metadata references an issue with no stored outcome fact | configured dependency graph | missing normalized issue fact | move to `blocked-review-needed`; apply no mutations |
-| Downstream issue is already closed or terminal succeeded | configured dependency graph | issue is closed or succeeded | do not add `symphony:ready`; remove it if still present |
-| GitHub label update fails after eligibility is computed | computed add/remove mutation set | current labels known, mutation request failed | report `sync-failed`; keep failure inspectable and do not claim successful promotion |
+| Observed condition                                                    | Local facts available                      | Normalized tracker facts available                                 | Expected decision                                                                                 |
+| --------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| No dependency metadata configured                                     | release-state absent or `dependencies: []` | open issue labels may exist                                        | remain `unconfigured`; make no ready-label changes                                                |
+| Prerequisite issue has terminal failed outcome                        | configured dependency graph                | prerequisite outcome is `failed`                                   | compute downstream as ineligible; remove `symphony:ready` from any affected downstream open issue |
+| Prerequisite issue is still non-terminal                              | configured dependency graph                | prerequisite outcome is running / review / checks / unknown        | downstream remains ineligible; do not add `symphony:ready` yet                                    |
+| All prerequisites for a downstream leaf have terminal success outcome | configured dependency graph                | prerequisite outcomes are `succeeded` and downstream issue is open | mark the leaf eligible; add `symphony:ready` if absent                                            |
+| Metadata references an issue with no stored outcome fact              | configured dependency graph                | missing normalized issue fact                                      | move to `blocked-review-needed`; apply no mutations                                               |
+| Downstream issue is already closed or terminal succeeded              | configured dependency graph                | issue is closed or succeeded                                       | do not add `symphony:ready`; remove it if still present                                           |
+| GitHub label update fails after eligibility is computed               | computed add/remove mutation set           | current labels known, mutation request failed                      | report `sync-failed`; keep failure inspectable and do not claim successful promotion              |
 
 ## Storage And Persistence Contract
 

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -50,25 +50,26 @@ metadata and the current release advancement posture also live there in
    - persist the decision through `symphony-report review-record` or `symphony-report review-follow-up`
    - and record what the report taught the factory in standing context or in the append-only wake-up log as appropriate
 8. Before any downstream release advancement work after completed-run report review is clear, run `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root <operator-repo-root> --json` for the selected instance.
-9. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
-10. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
-11. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
-12. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
+9. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` after that checkpoint so the stored `promotion` section records the latest eligible downstream set plus any `symphony:ready` labels added or removed.
+10. If the release-state artifact reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync failure is resolved.
+11. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
+12. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
+13. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
     - any active issue waiting in `plan-ready` / `awaiting-human-handoff`
     - any PR or active issue waiting in `awaiting-landing-command`
-13. If the factory is unhealthy, fix the concrete problem and restart it.
-14. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-15. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
-16. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
+14. If the factory is unhealthy, fix the concrete problem and restart it.
+15. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
+16. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
+17. If an active issue is waiting in `plan-ready`, review the plan and post an explicit review decision comment:
 
 - `Plan review: approved`
 - `Plan review: changes-requested`
 - `Plan review: waived` (record why in the comment)
 
-17. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
-18. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
-19. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
-20. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+18. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
+19. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
+20. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
+21. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
 

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -8,6 +8,7 @@ PROMPT_FILE="$SCRIPT_DIR/operator-prompt.md"
 RALPH_DIR="$REPO_ROOT/.ralph"
 INSTANCE_STATE_RESOLVER="$REPO_ROOT/bin/resolve-operator-instance.ts"
 RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
+READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
 INSTANCE_KEY=""
 DETACHED_SESSION_NAME=""
 INSTANCE_STATE_ROOT=""
@@ -43,6 +44,12 @@ RELEASE_ID=""
 RELEASE_BLOCKING_PREREQUISITE_NUMBER=""
 RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER=""
 RELEASE_STATE_REFRESH_ERROR=""
+READY_PROMOTION_STATE="unavailable"
+READY_PROMOTION_SUMMARY="Ready promotion is unavailable."
+READY_PROMOTION_UPDATED_AT=""
+READY_PROMOTION_ELIGIBLE_ISSUES=""
+READY_PROMOTION_ADDED=""
+READY_PROMOTION_REMOVED=""
 
 usage() {
   cat <<'EOF'
@@ -151,20 +158,47 @@ refresh_release_state_nonfatal() {
   return 1
 }
 
+run_ready_promotion_nonfatal() {
+  local promoter_output
+  if [ ! -f "$READY_PROMOTER" ]; then
+    echo "operator-loop: ready promoter not found: $READY_PROMOTER" >&2
+    return 1
+  fi
+
+  if promoter_output="$(
+    pnpm tsx "$READY_PROMOTER" \
+      --workflow "$WORKFLOW_PATH" \
+      --operator-repo-root "$REPO_ROOT" \
+      --json 2>&1 >/dev/null
+  )"; then
+    return 0
+  fi
+
+  promoter_output="$(printf '%s' "$promoter_output" | tr '\r\n' ' ' | tr -s ' ')"
+  echo "operator-loop: ready promotion failed unexpectedly: ${promoter_output:-unknown error}" >&2
+  return 1
+}
+
 load_release_state_snapshot() {
   local release_state_exports
   release_state_exports="$(
     RELEASE_STATE="$RELEASE_STATE" node -e '
 const fs = require("node:fs");
 const filePath = process.env.RELEASE_STATE;
-const defaults = {
-  advancementState: "unavailable",
-  summary: "Release state is unavailable.",
-  updatedAt: "",
-  releaseId: "",
-  blockingPrerequisiteNumber: "",
-  blockingPrerequisiteIdentifier: "",
-};
+  const defaults = {
+    advancementState: "unavailable",
+    summary: "Release state is unavailable.",
+    updatedAt: "",
+    releaseId: "",
+    blockingPrerequisiteNumber: "",
+    blockingPrerequisiteIdentifier: "",
+    promotionState: "unavailable",
+    promotionSummary: "Ready promotion is unavailable.",
+    promotionUpdatedAt: "",
+    promotionEligibleIssues: "",
+    promotionAdded: "",
+    promotionRemoved: "",
+  };
 
 try {
   const raw = fs.readFileSync(filePath, "utf8");
@@ -202,6 +236,52 @@ try {
     typeof blocking.issueIdentifier === "string"
       ? blocking.issueIdentifier
       : defaults.blockingPrerequisiteIdentifier;
+  const promotion =
+    parsed && typeof parsed === "object" && parsed.promotion && typeof parsed.promotion === "object"
+      ? parsed.promotion
+      : {};
+  const eligibleIssues = Array.isArray(promotion.eligibleIssues)
+    ? promotion.eligibleIssues
+        .map((issue) =>
+          issue && typeof issue === "object" && typeof issue.issueNumber === "number"
+            ? String(issue.issueNumber)
+            : null,
+        )
+        .filter((value) => value !== null)
+    : [];
+  const readyLabelsAdded = Array.isArray(promotion.readyLabelsAdded)
+    ? promotion.readyLabelsAdded
+        .map((issue) =>
+          issue && typeof issue === "object" && typeof issue.issueNumber === "number"
+            ? String(issue.issueNumber)
+            : null,
+        )
+        .filter((value) => value !== null)
+    : [];
+  const readyLabelsRemoved = Array.isArray(promotion.readyLabelsRemoved)
+    ? promotion.readyLabelsRemoved
+        .map((issue) =>
+          issue && typeof issue === "object" && typeof issue.issueNumber === "number"
+            ? String(issue.issueNumber)
+            : null,
+        )
+        .filter((value) => value !== null)
+    : [];
+  defaults.promotionState =
+    typeof promotion.state === "string"
+      ? promotion.state
+      : defaults.promotionState;
+  defaults.promotionSummary =
+    typeof promotion.summary === "string"
+      ? promotion.summary
+      : defaults.promotionSummary;
+  defaults.promotionUpdatedAt =
+    typeof promotion.promotedAt === "string"
+      ? promotion.promotedAt
+      : defaults.promotionUpdatedAt;
+  defaults.promotionEligibleIssues = eligibleIssues.join(",");
+  defaults.promotionAdded = readyLabelsAdded.join(",");
+  defaults.promotionRemoved = readyLabelsRemoved.join(",");
 } catch (error) {
   if (!error || error.code !== "ENOENT") {
     defaults.summary = `Release state could not be read: ${error instanceof Error ? error.message : String(error)}`;
@@ -229,6 +309,12 @@ for (const line of lines) {
     releaseId: "RELEASE_ID",
     blockingPrerequisiteNumber: "RELEASE_BLOCKING_PREREQUISITE_NUMBER",
     blockingPrerequisiteIdentifier: "RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER",
+    promotionState: "READY_PROMOTION_STATE",
+    promotionSummary: "READY_PROMOTION_SUMMARY",
+    promotionUpdatedAt: "READY_PROMOTION_UPDATED_AT",
+    promotionEligibleIssues: "READY_PROMOTION_ELIGIBLE_ISSUES",
+    promotionAdded: "READY_PROMOTION_ADDED",
+    promotionRemoved: "READY_PROMOTION_REMOVED",
   };
   console.log(`${mapping[key]}=${JSON.stringify(value)}`);
 }
@@ -281,7 +367,15 @@ write_status() {
     "summary": "$(json_escape "$RELEASE_STATE_SUMMARY")",
     "updatedAt": $(if [ -n "$RELEASE_STATE_UPDATED_AT" ]; then printf '"%s"' "$(json_escape "$RELEASE_STATE_UPDATED_AT")"; else printf 'null'; fi),
     "blockingPrerequisiteNumber": $(if [ -n "$RELEASE_BLOCKING_PREREQUISITE_NUMBER" ]; then printf '%s' "$RELEASE_BLOCKING_PREREQUISITE_NUMBER"; else printf 'null'; fi),
-    "blockingPrerequisiteIdentifier": $(if [ -n "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER" ]; then printf '"%s"' "$(json_escape "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER")"; else printf 'null'; fi)
+    "blockingPrerequisiteIdentifier": $(if [ -n "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER" ]; then printf '"%s"' "$(json_escape "$RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER")"; else printf 'null'; fi),
+    "promotion": {
+      "state": "$(json_escape "$READY_PROMOTION_STATE")",
+      "summary": "$(json_escape "$READY_PROMOTION_SUMMARY")",
+      "updatedAt": $(if [ -n "$READY_PROMOTION_UPDATED_AT" ]; then printf '"%s"' "$(json_escape "$READY_PROMOTION_UPDATED_AT")"; else printf 'null'; fi),
+      "eligibleIssueNumbers": $(printf '%s' "$READY_PROMOTION_ELIGIBLE_ISSUES" | node -e 'const fs = require("node:fs"); const raw = fs.readFileSync(0, "utf8").trim(); const values = raw === "" ? [] : raw.split(",").map((value) => Number(value)); process.stdout.write(JSON.stringify(values));'),
+      "readyLabelsAdded": $(printf '%s' "$READY_PROMOTION_ADDED" | node -e 'const fs = require("node:fs"); const raw = fs.readFileSync(0, "utf8").trim(); const values = raw === "" ? [] : raw.split(",").map((value) => Number(value)); process.stdout.write(JSON.stringify(values));'),
+      "readyLabelsRemoved": $(printf '%s' "$READY_PROMOTION_REMOVED" | node -e 'const fs = require("node:fs"); const raw = fs.readFileSync(0, "utf8").trim(); const values = raw === "" ? [] : raw.split(",").map((value) => Number(value)); process.stdout.write(JSON.stringify(values));')
+    }
   },
   "reportReviewState": "$(json_escape "$REPORT_REVIEW_STATE")",
   "selectedWorkflowPath": $(if [ -n "$WORKFLOW_PATH" ]; then printf '"%s"' "$(json_escape "$WORKFLOW_PATH")"; else printf 'null'; fi),
@@ -314,6 +408,11 @@ EOF
 - Release advancement state: $RELEASE_ADVANCEMENT_STATE
 - Release summary: $RELEASE_STATE_SUMMARY
 - Release blocked by prerequisite: ${RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER:-${RELEASE_BLOCKING_PREREQUISITE_NUMBER:-n/a}}
+- Ready promotion state: $READY_PROMOTION_STATE
+- Ready promotion summary: $READY_PROMOTION_SUMMARY
+- Ready promotion eligible issues: ${READY_PROMOTION_ELIGIBLE_ISSUES:-none}
+- Ready promotion added: ${READY_PROMOTION_ADDED:-none}
+- Ready promotion removed: ${READY_PROMOTION_REMOVED:-none}
 - Report review state: $REPORT_REVIEW_STATE
 - Prompt: $PROMPT_FILE
 - Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
@@ -455,6 +554,9 @@ run_cycle() {
   if ! refresh_release_state_nonfatal; then
     :
   fi
+  if ! run_ready_promotion_nonfatal; then
+    :
+  fi
   write_status "acting" "Running operator wake-up cycle"
 
   {
@@ -497,6 +599,9 @@ run_cycle() {
   LAST_CYCLE_FINISHED_AT="$(now_utc)"
   LAST_CYCLE_EXIT_CODE="$exit_code"
   if ! refresh_release_state_nonfatal; then
+    :
+  fi
+  if ! run_ready_promotion_nonfatal; then
     :
   fi
 

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -17,19 +17,20 @@ Required workflow:
    - or create a tracked follow-up issue with `pnpm tsx bin/symphony-report.ts review-follow-up --issue <number> --title <...> --body-file <...> --summary <...>`,
    - and record what was learned and queued in the standing context or wake-up log as appropriate before moving on.
 9. Before any downstream release advancement work after the completed-run report-review checkpoint is clear, inspect release advancement state by running `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-10. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact. If that release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
-11. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-12. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-13. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
-14. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-15. As mandatory operator checkpoints for this wake-up, explicitly:
+10. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact, including its stored `promotion` result with eligible downstream issues plus any `symphony:ready` labels added or removed.
+11. If the release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync error is resolved.
+12. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
+13. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+14. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
+15. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+16. As mandatory operator checkpoints for this wake-up, explicitly:
 
 - review any active `plan-ready` / `awaiting-human-handoff` issue and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
 - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 
-16. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-17. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
+17. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+18. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
 
 Constraints:
 

--- a/src/observability/operator-ready-promotion.ts
+++ b/src/observability/operator-ready-promotion.ts
@@ -102,7 +102,8 @@ async function createPromotionResult(args: {
     ),
   );
   const availableTrackerIssues = trackerIssues.filter(
-    (issue): issue is NonNullable<(typeof trackerIssues)[number]> => issue !== null,
+    (issue): issue is NonNullable<(typeof trackerIssues)[number]> =>
+      issue !== null,
   );
   const decision = evaluateReadyPromotion({
     configuration: args.releaseState.configuration,
@@ -157,7 +158,9 @@ async function createPromotionResult(args: {
         continue;
       }
       await client.updateIssue(issue.issueNumber, {
-        labels: trackerIssue.labels.filter((label) => label !== tracker.readyLabel),
+        labels: trackerIssue.labels.filter(
+          (label) => label !== tracker.readyLabel,
+        ),
       });
       readyLabelsRemoved.push(issue);
     }

--- a/src/observability/operator-ready-promotion.ts
+++ b/src/observability/operator-ready-promotion.ts
@@ -1,0 +1,253 @@
+import { loadWorkflow } from "../config/workflow.js";
+import type { RuntimeIssue } from "../domain/issue.js";
+import { TrackerError } from "../domain/errors.js";
+import {
+  listStoredIssueSummaries,
+  syncOperatorReleaseState,
+  writeOperatorReleaseState,
+  type OperatorReadyPromotionResult,
+  type OperatorReleaseIssueReference,
+  type OperatorReleaseStateDocument,
+} from "./operator-release-state.js";
+import { GitHubClient } from "../tracker/github-client.js";
+import { evaluateReadyPromotion } from "../tracker/ready-promotion-policy.js";
+
+export interface OperatorReadyPromotionExecution {
+  readonly releaseStateFile: string;
+  readonly state: OperatorReleaseStateDocument;
+}
+
+export async function promoteOperatorReadyIssues(args: {
+  readonly workflowPath: string;
+  readonly releaseStateFile: string;
+  readonly promotedAt?: string | undefined;
+}): Promise<OperatorReadyPromotionExecution> {
+  const promotedAt = args.promotedAt ?? new Date().toISOString();
+  const workflow = await loadWorkflow(args.workflowPath);
+  const current = await syncOperatorReleaseState({
+    instance: workflow.config.instance,
+    releaseStateFile: args.releaseStateFile,
+    updatedAt: promotedAt,
+  });
+  const issueFacts = await listStoredIssueSummaries(workflow.config.instance);
+
+  const promotion = await createPromotionResult({
+    workflow,
+    releaseState: current,
+    issueFacts,
+    promotedAt,
+  });
+  const nextState: OperatorReleaseStateDocument = {
+    version: current.version,
+    updatedAt: promotedAt,
+    configuration: current.configuration,
+    evaluation: current.evaluation,
+    promotion,
+  };
+  await writeOperatorReleaseState(args.releaseStateFile, nextState);
+
+  return {
+    releaseStateFile: args.releaseStateFile,
+    state: nextState,
+  };
+}
+
+async function createPromotionResult(args: {
+  readonly workflow: Awaited<ReturnType<typeof loadWorkflow>>;
+  readonly releaseState: OperatorReleaseStateDocument;
+  readonly issueFacts: Awaited<ReturnType<typeof listStoredIssueSummaries>>;
+  readonly promotedAt: string;
+}): Promise<OperatorReadyPromotionResult> {
+  const tracker = args.workflow.config.tracker;
+  if (tracker.kind !== "github" && tracker.kind !== "github-bootstrap") {
+    return {
+      state: "unconfigured",
+      summary:
+        "Ready promotion is only implemented for GitHub-backed workflows in this slice.",
+      promotedAt: args.promotedAt,
+      eligibleIssues: [],
+      readyLabelsAdded: [],
+      readyLabelsRemoved: [],
+      error: null,
+    };
+  }
+
+  if (args.releaseState.configuration.dependencies.length === 0) {
+    return {
+      state: "unconfigured",
+      summary:
+        "No release dependency metadata is configured for this operator instance.",
+      promotedAt: args.promotedAt,
+      eligibleIssues: [],
+      readyLabelsAdded: [],
+      readyLabelsRemoved: [],
+      error: null,
+    };
+  }
+
+  const client = new GitHubClient(tracker);
+  const downstreamIssueNumbers = [
+    ...new Set(
+      args.releaseState.configuration.dependencies.flatMap((dependency) =>
+        dependency.downstream.map((issue) => issue.issueNumber),
+      ),
+    ),
+  ];
+  const trackerIssues = await Promise.all(
+    downstreamIssueNumbers.map(async (issueNumber) =>
+      toTrackerIssueSnapshot(
+        await getIssueOrNull(client, issueNumber),
+        tracker.readyLabel,
+      ),
+    ),
+  );
+  const availableTrackerIssues = trackerIssues.filter(
+    (issue): issue is NonNullable<(typeof trackerIssues)[number]> => issue !== null,
+  );
+  const decision = evaluateReadyPromotion({
+    configuration: args.releaseState.configuration,
+    issueFacts: args.issueFacts,
+    trackerIssues: availableTrackerIssues,
+  });
+
+  if (decision.state === "unconfigured") {
+    return {
+      state: "unconfigured",
+      summary: decision.summary,
+      promotedAt: args.promotedAt,
+      eligibleIssues: [],
+      readyLabelsAdded: [],
+      readyLabelsRemoved: [],
+      error: null,
+    };
+  }
+
+  if (decision.state === "blocked-review-needed") {
+    return {
+      state: "blocked-review-needed",
+      summary: decision.summary,
+      promotedAt: args.promotedAt,
+      eligibleIssues: [],
+      readyLabelsAdded: [],
+      readyLabelsRemoved: [],
+      error: null,
+    };
+  }
+
+  const trackerIssuesByNumber = new Map(
+    availableTrackerIssues.map((issue) => [issue.issueNumber, issue]),
+  );
+  const readyLabelsAdded: OperatorReleaseIssueReference[] = [];
+  const readyLabelsRemoved: OperatorReleaseIssueReference[] = [];
+
+  try {
+    for (const issue of decision.addReadyLabelTo) {
+      const trackerIssue = trackerIssuesByNumber.get(issue.issueNumber);
+      if (trackerIssue === undefined) {
+        continue;
+      }
+      await client.updateIssue(issue.issueNumber, {
+        labels: [...trackerIssue.labels, tracker.readyLabel],
+      });
+      readyLabelsAdded.push(issue);
+    }
+    for (const issue of decision.removeReadyLabelFrom) {
+      const trackerIssue = trackerIssuesByNumber.get(issue.issueNumber);
+      if (trackerIssue === undefined) {
+        continue;
+      }
+      await client.updateIssue(issue.issueNumber, {
+        labels: trackerIssue.labels.filter((label) => label !== tracker.readyLabel),
+      });
+      readyLabelsRemoved.push(issue);
+    }
+  } catch (error) {
+    const message = normalizePromotionError(error);
+    return {
+      state: "sync-failed",
+      summary: `Ready promotion failed while synchronizing GitHub labels: ${message}`,
+      promotedAt: args.promotedAt,
+      eligibleIssues: decision.eligibleIssues,
+      readyLabelsAdded,
+      readyLabelsRemoved,
+      error: message,
+    };
+  }
+
+  return {
+    state: "labels-synchronized",
+    summary: formatSynchronizedSummary({
+      eligibleCount: decision.eligibleIssues.length,
+      addCount: readyLabelsAdded.length,
+      removeCount: readyLabelsRemoved.length,
+    }),
+    promotedAt: args.promotedAt,
+    eligibleIssues: decision.eligibleIssues,
+    readyLabelsAdded,
+    readyLabelsRemoved,
+    error: null,
+  };
+}
+
+function toTrackerIssueSnapshot(
+  issue: RuntimeIssue | null,
+  readyLabel: string,
+): {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string | null;
+  readonly title: string | null;
+  readonly state: string;
+  readonly hasReadyLabel: boolean;
+  readonly labels: readonly string[];
+} | null {
+  if (issue === null) {
+    return null;
+  }
+  return {
+    issueNumber: issue.number,
+    issueIdentifier: issue.identifier,
+    title: issue.title,
+    state: issue.state,
+    hasReadyLabel: issue.labels.includes(readyLabel),
+    labels: issue.labels,
+  };
+}
+
+async function getIssueOrNull(
+  client: GitHubClient,
+  issueNumber: number,
+): Promise<RuntimeIssue | null> {
+  try {
+    return await client.getIssue(issueNumber);
+  } catch (error) {
+    if (
+      error instanceof TrackerError &&
+      error.message.includes(" failed with 404:")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function formatSynchronizedSummary(args: {
+  readonly eligibleCount: number;
+  readonly addCount: number;
+  readonly removeCount: number;
+}): string {
+  return [
+    `Ready promotion synchronized ${args.eligibleCount.toString()} eligible downstream issue(s).`,
+    `Added ready to ${args.addCount.toString()} issue(s).`,
+    `Removed ready from ${args.removeCount.toString()} issue(s).`,
+  ].join(" ");
+}
+
+function normalizePromotionError(error: unknown): string {
+  if (error instanceof TrackerError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/observability/operator-release-state.ts
+++ b/src/observability/operator-release-state.ts
@@ -39,14 +39,31 @@ export interface OperatorReleaseEvaluation {
   readonly unresolvedReferences: readonly OperatorReleaseIssueReference[];
 }
 
+export type OperatorReadyPromotionState =
+  | "unconfigured"
+  | "blocked-review-needed"
+  | "labels-synchronized"
+  | "sync-failed";
+
+export interface OperatorReadyPromotionResult {
+  readonly state: OperatorReadyPromotionState;
+  readonly summary: string;
+  readonly promotedAt: string;
+  readonly eligibleIssues: readonly OperatorReleaseIssueReference[];
+  readonly readyLabelsAdded: readonly OperatorReleaseIssueReference[];
+  readonly readyLabelsRemoved: readonly OperatorReleaseIssueReference[];
+  readonly error: string | null;
+}
+
 export interface OperatorReleaseStateDocument {
   readonly version: typeof OPERATOR_RELEASE_STATE_SCHEMA_VERSION;
   readonly updatedAt: string;
   readonly configuration: OperatorReleaseConfiguration;
   readonly evaluation: OperatorReleaseEvaluation;
+  readonly promotion: OperatorReadyPromotionResult;
 }
 
-interface StoredIssueSummary {
+export interface StoredIssueSummary {
   readonly issueNumber: number;
   readonly issueIdentifier: string;
   readonly title: string;
@@ -72,6 +89,21 @@ export function createEmptyOperatorReleaseState(
       blockedDownstream: [],
       unresolvedReferences: [],
     },
+    promotion: createEmptyOperatorReadyPromotionResult(updatedAt),
+  };
+}
+
+export function createEmptyOperatorReadyPromotionResult(
+  promotedAt = new Date().toISOString(),
+): OperatorReadyPromotionResult {
+  return {
+    state: "unconfigured",
+    summary: "Ready promotion has not run for this operator instance.",
+    promotedAt,
+    eligibleIssues: [],
+    readyLabelsAdded: [],
+    readyLabelsRemoved: [],
+    error: null,
   };
 }
 
@@ -118,6 +150,7 @@ export async function syncOperatorReleaseState(args: {
     updatedAt,
     configuration: current.configuration,
     evaluation,
+    promotion: current.promotion,
   };
   await writeOperatorReleaseState(args.releaseStateFile, nextState);
   return nextState;
@@ -235,6 +268,7 @@ function parseOperatorReleaseStateDocument(
       filePath,
     ),
     evaluation: parseOperatorReleaseEvaluation(value.evaluation, filePath),
+    promotion: parseOperatorReadyPromotionResult(value.promotion, filePath),
   };
 }
 
@@ -340,6 +374,69 @@ function parseOperatorReleaseEvaluation(
   };
 }
 
+function parseOperatorReadyPromotionResult(
+  value: unknown,
+  filePath: string,
+): OperatorReadyPromotionResult {
+  if (value === undefined) {
+    return createEmptyOperatorReadyPromotionResult();
+  }
+  if (!isRecord(value)) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected promotion.`,
+    );
+  }
+  if (
+    value.state !== "unconfigured" &&
+    value.state !== "blocked-review-needed" &&
+    value.state !== "labels-synchronized" &&
+    value.state !== "sync-failed"
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected a supported promotion.state.`,
+    );
+  }
+  if (
+    typeof value.summary !== "string" ||
+    typeof value.promotedAt !== "string" ||
+    !Array.isArray(value.eligibleIssues) ||
+    !Array.isArray(value.readyLabelsAdded) ||
+    !Array.isArray(value.readyLabelsRemoved)
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator release state in ${filePath}; expected promotion fields.`,
+    );
+  }
+
+  return {
+    state: value.state,
+    summary: value.summary,
+    promotedAt: value.promotedAt,
+    eligibleIssues: value.eligibleIssues.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${filePath} promotion.eligibleIssues[${index.toString()}]`,
+      ),
+    ),
+    readyLabelsAdded: value.readyLabelsAdded.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${filePath} promotion.readyLabelsAdded[${index.toString()}]`,
+      ),
+    ),
+    readyLabelsRemoved: value.readyLabelsRemoved.map((reference, index) =>
+      parseOperatorReleaseIssueReference(
+        reference,
+        `${filePath} promotion.readyLabelsRemoved[${index.toString()}]`,
+      ),
+    ),
+    error:
+      value.error === null || value.error === undefined
+        ? null
+        : requireString(value.error, `${filePath} promotion.error`),
+  };
+}
+
 function parseOperatorReleaseIssueReference(
   value: unknown,
   field: string,
@@ -368,7 +465,7 @@ function parseOperatorReleaseIssueReference(
   };
 }
 
-async function listStoredIssueSummaries(
+export async function listStoredIssueSummaries(
   instance: ReturnType<typeof coerceRuntimeInstancePaths>,
 ): Promise<readonly StoredIssueSummary[]> {
   const entries = await fs

--- a/src/tracker/ready-promotion-policy.ts
+++ b/src/tracker/ready-promotion-policy.ts
@@ -56,7 +56,10 @@ export function evaluateReadyPromotion(args: {
   const trackerIssuesByNumber = new Map(
     args.trackerIssues.map((issue) => [issue.issueNumber, issue]),
   );
-  const prerequisitesByDownstream = new Map<number, OperatorReleaseIssueReference[]>();
+  const prerequisitesByDownstream = new Map<
+    number,
+    OperatorReleaseIssueReference[]
+  >();
   const downstreamReferences = new Map<number, OperatorReleaseIssueReference>();
   const unresolved: OperatorReleaseIssueReference[] = [];
 

--- a/src/tracker/ready-promotion-policy.ts
+++ b/src/tracker/ready-promotion-policy.ts
@@ -1,0 +1,156 @@
+import type { IssueArtifactOutcome } from "../observability/issue-artifacts.js";
+import type {
+  OperatorReleaseConfiguration,
+  OperatorReleaseIssueReference,
+} from "../observability/operator-release-state.js";
+
+export interface ReadyPromotionIssueFact {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly currentOutcome: IssueArtifactOutcome;
+}
+
+export interface ReadyPromotionTrackerIssue {
+  readonly issueNumber: number;
+  readonly issueIdentifier: string | null;
+  readonly title: string | null;
+  readonly state: string;
+  readonly hasReadyLabel: boolean;
+}
+
+export interface ReadyPromotionDecision {
+  readonly state:
+    | "unconfigured"
+    | "blocked-review-needed"
+    | "eligible-set-computed";
+  readonly summary: string;
+  readonly unresolvedReferences: readonly OperatorReleaseIssueReference[];
+  readonly eligibleIssues: readonly OperatorReleaseIssueReference[];
+  readonly addReadyLabelTo: readonly OperatorReleaseIssueReference[];
+  readonly removeReadyLabelFrom: readonly OperatorReleaseIssueReference[];
+}
+
+export function evaluateReadyPromotion(args: {
+  readonly configuration: OperatorReleaseConfiguration;
+  readonly issueFacts: readonly ReadyPromotionIssueFact[];
+  readonly trackerIssues: readonly ReadyPromotionTrackerIssue[];
+}): ReadyPromotionDecision {
+  const releaseLabel = formatReleaseLabel(args.configuration.releaseId);
+  const dependencies = args.configuration.dependencies;
+  if (dependencies.length === 0) {
+    return {
+      state: "unconfigured",
+      summary:
+        "No release dependency metadata is configured for this operator instance.",
+      unresolvedReferences: [],
+      eligibleIssues: [],
+      addReadyLabelTo: [],
+      removeReadyLabelFrom: [],
+    };
+  }
+
+  const issueFactsByNumber = new Map(
+    args.issueFacts.map((issue) => [issue.issueNumber, issue]),
+  );
+  const trackerIssuesByNumber = new Map(
+    args.trackerIssues.map((issue) => [issue.issueNumber, issue]),
+  );
+  const prerequisitesByDownstream = new Map<number, OperatorReleaseIssueReference[]>();
+  const downstreamReferences = new Map<number, OperatorReleaseIssueReference>();
+  const unresolved: OperatorReleaseIssueReference[] = [];
+
+  for (const dependency of dependencies) {
+    if (dependency.downstream.length === 0) {
+      unresolved.push(dependency.prerequisite);
+      continue;
+    }
+    if (!issueFactsByNumber.has(dependency.prerequisite.issueNumber)) {
+      unresolved.push(dependency.prerequisite);
+    }
+    for (const downstream of dependency.downstream) {
+      downstreamReferences.set(downstream.issueNumber, downstream);
+      const prerequisites =
+        prerequisitesByDownstream.get(downstream.issueNumber) ?? [];
+      prerequisites.push(dependency.prerequisite);
+      prerequisitesByDownstream.set(downstream.issueNumber, prerequisites);
+      if (!trackerIssuesByNumber.has(downstream.issueNumber)) {
+        unresolved.push(downstream);
+      }
+    }
+  }
+
+  const unresolvedReferences = dedupeIssueReferences(unresolved);
+  if (unresolvedReferences.length > 0) {
+    return {
+      state: "blocked-review-needed",
+      summary: `${releaseLabel} ready promotion needs review before label synchronization: dependency metadata is incomplete or required issue facts are unavailable.`,
+      unresolvedReferences,
+      eligibleIssues: [],
+      addReadyLabelTo: [],
+      removeReadyLabelFrom: [],
+    };
+  }
+
+  const eligibleIssues: OperatorReleaseIssueReference[] = [];
+  const addReadyLabelTo: OperatorReleaseIssueReference[] = [];
+  const removeReadyLabelFrom: OperatorReleaseIssueReference[] = [];
+
+  for (const [issueNumber, reference] of downstreamReferences) {
+    const trackerIssue = trackerIssuesByNumber.get(issueNumber);
+    if (trackerIssue === undefined) {
+      continue;
+    }
+    const issueFact = issueFactsByNumber.get(issueNumber) ?? null;
+    const prerequisites = prerequisitesByDownstream.get(issueNumber) ?? [];
+    const allPrerequisitesSucceeded = prerequisites.every(
+      (prerequisite) =>
+        issueFactsByNumber.get(prerequisite.issueNumber)?.currentOutcome ===
+        "succeeded",
+    );
+    const eligible =
+      trackerIssue.state === "open" &&
+      issueFact === null &&
+      allPrerequisitesSucceeded;
+
+    if (eligible) {
+      eligibleIssues.push(reference);
+      if (!trackerIssue.hasReadyLabel) {
+        addReadyLabelTo.push(reference);
+      }
+      continue;
+    }
+
+    if (trackerIssue.hasReadyLabel) {
+      removeReadyLabelFrom.push(reference);
+    }
+  }
+
+  return {
+    state: "eligible-set-computed",
+    summary: `${releaseLabel} ready promotion computed ${eligibleIssues.length.toString()} eligible downstream issue(s).`,
+    unresolvedReferences: [],
+    eligibleIssues,
+    addReadyLabelTo,
+    removeReadyLabelFrom,
+  };
+}
+
+function dedupeIssueReferences(
+  references: readonly OperatorReleaseIssueReference[],
+): readonly OperatorReleaseIssueReference[] {
+  const seen = new Set<number>();
+  const deduped: OperatorReleaseIssueReference[] = [];
+  for (const reference of references) {
+    if (seen.has(reference.issueNumber)) {
+      continue;
+    }
+    seen.add(reference.issueNumber);
+    deduped.push(reference);
+  }
+  return deduped;
+}
+
+function formatReleaseLabel(releaseId: string | null): string {
+  return releaseId === null ? "Configured release" : `Release ${releaseId}`;
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -7,7 +7,10 @@ import {
   deriveOperatorInstanceStatePaths,
   deriveSymphonyInstanceKey,
 } from "../../src/domain/instance-identity.js";
-import { writeOperatorReleaseState } from "../../src/observability/operator-release-state.js";
+import {
+  createEmptyOperatorReadyPromotionResult,
+  writeOperatorReleaseState,
+} from "../../src/observability/operator-release-state.js";
 import { createTempDir } from "../support/git.js";
 
 const execFileAsync = promisify(execFile);
@@ -22,11 +25,24 @@ async function writeWorkflow(rootDir: string): Promise<string> {
 tracker:
   kind: github-bootstrap
   repo: sociotechnica-org/symphony-ts
+  api_url: http://127.0.0.1:9
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
 polling:
   interval_ms: 1000
   max_concurrent_runs: 1
+  retry:
+    max_attempts: 1
+    backoff_ms: 1000
 workspace:
   root: ./.tmp/workspaces
+  repo_url: https://github.com/sociotechnica-org/symphony-ts.git
+  branch_prefix: symphony/
+  retention:
+    on_success: delete
+    on_failure: retain
 hooks:
   after_create: []
 agent:
@@ -35,6 +51,7 @@ agent:
   command: codex
   prompt_transport: stdin
   timeout_ms: 1000
+  max_turns: 3
   env: {}
 ---
 Prompt body
@@ -67,6 +84,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
       env: {
         ...process.env,
         SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+        GH_TOKEN: "test-token",
       },
     },
   );
@@ -113,6 +131,7 @@ async function runOperatorLoopWithCommand(
       env: {
         ...process.env,
         SYMPHONY_OPERATOR_COMMAND: command,
+        GH_TOKEN: "test-token",
       },
     },
   );
@@ -197,6 +216,9 @@ describe("operator loop workflow selection", () => {
         readonly releaseState: {
           readonly path: string;
           readonly advancementState: string;
+          readonly promotion: {
+            readonly state: string;
+          };
         };
       };
       const statusMd = await fs.readFile(run.statusMdPath, "utf8");
@@ -209,6 +231,7 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.wakeUpLog).toBe(run.wakeUpLogPath);
       expect(statusJson.releaseState.path).toBe(run.releaseStatePath);
       expect(statusJson.releaseState.advancementState).toBe("unconfigured");
+      expect(statusJson.releaseState.promotion.state).toBe("unconfigured");
       expect(statusMd).toContain(`- Selected workflow: ${workflowPath}`);
       expect(statusMd).toContain(`- Operator state root: ${run.stateRoot}`);
       expect(statusMd).toContain(
@@ -216,6 +239,7 @@ describe("operator loop workflow selection", () => {
       );
       expect(statusMd).toContain(`- Wake-up log: ${run.wakeUpLogPath}`);
       expect(statusMd).toContain(`- Release state: ${run.releaseStatePath}`);
+      expect(statusMd).toContain(`- Ready promotion state: unconfigured`);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -520,6 +544,9 @@ describe("operator loop workflow selection", () => {
           blockedDownstream: [],
           unresolvedReferences: [],
         },
+        promotion: createEmptyOperatorReadyPromotionResult(
+          "2026-03-30T00:00:00Z",
+        ),
       });
       await writeIssueSummary({
         workflowPath,

--- a/tests/integration/operator-ready-promotion.test.ts
+++ b/tests/integration/operator-ready-promotion.test.ts
@@ -123,15 +123,17 @@ describe("operator ready promotion", () => {
     }
     await server.stop();
     await Promise.all(
-      tempRoots.splice(0).map((root) =>
-        fs.rm(root, { recursive: true, force: true }),
-      ),
+      tempRoots
+        .splice(0)
+        .map((root) => fs.rm(root, { recursive: true, force: true })),
     );
   });
 
   it("adds ready to an eligible downstream issue and records the promotion result", async () => {
     const instanceRoot = await createTempDir("symphony-ready-promotion-");
-    const operatorRoot = await createTempDir("symphony-ready-promotion-operator-");
+    const operatorRoot = await createTempDir(
+      "symphony-ready-promotion-operator-",
+    );
     tempRoots.push(instanceRoot, operatorRoot);
     const workflowPath = await writeWorkflow({
       rootDir: instanceRoot,
@@ -185,7 +187,9 @@ describe("operator ready promotion", () => {
         blockedDownstream: [],
         unresolvedReferences: [],
       },
-      promotion: createEmptyOperatorReadyPromotionResult("2026-03-30T00:00:00Z"),
+      promotion: createEmptyOperatorReadyPromotionResult(
+        "2026-03-30T00:00:00Z",
+      ),
     });
     await writeIssueSummary({
       instanceRoot,
@@ -215,9 +219,9 @@ describe("operator ready promotion", () => {
 
     const state = await readOperatorReleaseState(releaseStatePath);
     expect(state.promotion.state).toBe("labels-synchronized");
-    expect(state.promotion.eligibleIssues.map((issue) => issue.issueNumber)).toEqual([
-      112,
-    ]);
+    expect(
+      state.promotion.eligibleIssues.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
     expect(
       state.promotion.readyLabelsAdded.map((issue) => issue.issueNumber),
     ).toEqual([112]);
@@ -225,7 +229,9 @@ describe("operator ready promotion", () => {
 
   it("removes ready when a prerequisite has failed", async () => {
     const instanceRoot = await createTempDir("symphony-ready-promotion-");
-    const operatorRoot = await createTempDir("symphony-ready-promotion-operator-");
+    const operatorRoot = await createTempDir(
+      "symphony-ready-promotion-operator-",
+    );
     tempRoots.push(instanceRoot, operatorRoot);
     const workflowPath = await writeWorkflow({
       rootDir: instanceRoot,
@@ -279,7 +285,9 @@ describe("operator ready promotion", () => {
         blockedDownstream: [],
         unresolvedReferences: [],
       },
-      promotion: createEmptyOperatorReadyPromotionResult("2026-03-30T00:00:00Z"),
+      promotion: createEmptyOperatorReadyPromotionResult(
+        "2026-03-30T00:00:00Z",
+      ),
     });
     await writeIssueSummary({
       instanceRoot,
@@ -303,9 +311,9 @@ describe("operator ready promotion", () => {
       },
     );
 
-    expect(server.getIssue(112).labels.map((label) => label.name)).not.toContain(
-      "symphony:ready",
-    );
+    expect(
+      server.getIssue(112).labels.map((label) => label.name),
+    ).not.toContain("symphony:ready");
 
     const state = await readOperatorReleaseState(releaseStatePath);
     expect(state.evaluation.advancementState).toBe(

--- a/tests/integration/operator-ready-promotion.test.ts
+++ b/tests/integration/operator-ready-promotion.test.ts
@@ -1,0 +1,319 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+} from "../../src/domain/instance-identity.js";
+import {
+  createEmptyOperatorReadyPromotionResult,
+  readOperatorReleaseState,
+  writeOperatorReleaseState,
+} from "../../src/observability/operator-release-state.js";
+import { MockGitHubServer } from "../support/mock-github-server.js";
+import { createTempDir } from "../support/git.js";
+
+const execFileAsync = promisify(execFile);
+
+async function writeWorkflow(args: {
+  readonly rootDir: string;
+  readonly apiUrl: string;
+}): Promise<string> {
+  const workflowPath = path.join(args.rootDir, "WORKFLOW.md");
+  await fs.writeFile(
+    workflowPath,
+    `---
+tracker:
+  kind: github-bootstrap
+  repo: sociotechnica-org/symphony-ts
+  api_url: ${args.apiUrl}
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+polling:
+  interval_ms: 1000
+  max_concurrent_runs: 1
+  retry:
+    max_attempts: 1
+    backoff_ms: 1000
+workspace:
+  root: ./.tmp/workspaces
+  repo_url: https://github.com/sociotechnica-org/symphony-ts.git
+  branch_prefix: symphony/
+  retention:
+    on_success: delete
+    on_failure: retain
+hooks:
+  after_create: []
+agent:
+  runner:
+    kind: codex
+  command: codex
+  prompt_transport: stdin
+  timeout_ms: 1000
+  max_turns: 3
+  env: {}
+---
+Prompt body
+`,
+    "utf8",
+  );
+  return workflowPath;
+}
+
+async function writeIssueSummary(args: {
+  readonly instanceRoot: string;
+  readonly issueNumber: number;
+  readonly currentOutcome: string;
+}): Promise<void> {
+  const issueRoot = path.join(
+    args.instanceRoot,
+    ".var",
+    "factory",
+    "issues",
+    args.issueNumber.toString(),
+  );
+  await fs.mkdir(issueRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(issueRoot, "issue.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        issueNumber: args.issueNumber,
+        issueIdentifier: `sociotechnica-org/symphony-ts#${args.issueNumber.toString()}`,
+        repo: "sociotechnica-org/symphony-ts",
+        title: `Issue ${args.issueNumber.toString()}`,
+        issueUrl: `https://github.com/sociotechnica-org/symphony-ts/issues/${args.issueNumber.toString()}`,
+        branch: null,
+        currentOutcome: args.currentOutcome,
+        currentSummary: `Outcome ${args.currentOutcome}`,
+        firstObservedAt: "2026-03-30T00:00:00Z",
+        lastUpdatedAt: "2026-03-30T00:00:00Z",
+        mergedAt: null,
+        closedAt: null,
+        latestAttemptNumber: null,
+        latestSessionId: null,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+describe("operator ready promotion", () => {
+  let server: MockGitHubServer;
+  const previousToken = process.env.GH_TOKEN;
+  const tempRoots: string[] = [];
+
+  beforeEach(async () => {
+    server = new MockGitHubServer();
+    await server.start();
+    process.env.GH_TOKEN = "test-token";
+  });
+
+  afterEach(async () => {
+    if (previousToken === undefined) {
+      delete process.env.GH_TOKEN;
+    } else {
+      process.env.GH_TOKEN = previousToken;
+    }
+    await server.stop();
+    await Promise.all(
+      tempRoots.splice(0).map((root) =>
+        fs.rm(root, { recursive: true, force: true }),
+      ),
+    );
+  });
+
+  it("adds ready to an eligible downstream issue and records the promotion result", async () => {
+    const instanceRoot = await createTempDir("symphony-ready-promotion-");
+    const operatorRoot = await createTempDir("symphony-ready-promotion-operator-");
+    tempRoots.push(instanceRoot, operatorRoot);
+    const workflowPath = await writeWorkflow({
+      rootDir: instanceRoot,
+      apiUrl: server.baseUrl,
+    });
+    const releaseStatePath = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: operatorRoot,
+      instanceKey: deriveSymphonyInstanceIdentity(workflowPath).instanceKey,
+    }).releaseStatePath;
+
+    server.seedIssue({
+      number: 111,
+      title: "Prerequisite",
+      body: "",
+      labels: [],
+    });
+    server.seedIssue({
+      number: 112,
+      title: "Downstream",
+      body: "",
+      labels: [],
+    });
+
+    await writeOperatorReleaseState(releaseStatePath, {
+      version: 1,
+      updatedAt: "2026-03-30T00:00:00Z",
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      evaluation: {
+        advancementState: "configured-clear",
+        summary: "Initial value",
+        evaluatedAt: "2026-03-30T00:00:00Z",
+        blockingPrerequisite: null,
+        blockedDownstream: [],
+        unresolvedReferences: [],
+      },
+      promotion: createEmptyOperatorReadyPromotionResult("2026-03-30T00:00:00Z"),
+    });
+    await writeIssueSummary({
+      instanceRoot,
+      issueNumber: 111,
+      currentOutcome: "succeeded",
+    });
+
+    await execFileAsync(
+      "pnpm",
+      [
+        "tsx",
+        "bin/promote-operator-ready-issues.ts",
+        "--workflow",
+        workflowPath,
+        "--operator-repo-root",
+        operatorRoot,
+      ],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+      },
+    );
+
+    expect(server.getIssue(112).labels.map((label) => label.name)).toContain(
+      "symphony:ready",
+    );
+
+    const state = await readOperatorReleaseState(releaseStatePath);
+    expect(state.promotion.state).toBe("labels-synchronized");
+    expect(state.promotion.eligibleIssues.map((issue) => issue.issueNumber)).toEqual([
+      112,
+    ]);
+    expect(
+      state.promotion.readyLabelsAdded.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
+  });
+
+  it("removes ready when a prerequisite has failed", async () => {
+    const instanceRoot = await createTempDir("symphony-ready-promotion-");
+    const operatorRoot = await createTempDir("symphony-ready-promotion-operator-");
+    tempRoots.push(instanceRoot, operatorRoot);
+    const workflowPath = await writeWorkflow({
+      rootDir: instanceRoot,
+      apiUrl: server.baseUrl,
+    });
+    const releaseStatePath = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: operatorRoot,
+      instanceKey: deriveSymphonyInstanceIdentity(workflowPath).instanceKey,
+    }).releaseStatePath;
+
+    server.seedIssue({
+      number: 111,
+      title: "Prerequisite",
+      body: "",
+      labels: [],
+    });
+    server.seedIssue({
+      number: 112,
+      title: "Downstream",
+      body: "",
+      labels: ["symphony:ready"],
+    });
+
+    await writeOperatorReleaseState(releaseStatePath, {
+      version: 1,
+      updatedAt: "2026-03-30T00:00:00Z",
+      configuration: {
+        releaseId: "context-library-bun-migration",
+        dependencies: [
+          {
+            prerequisite: {
+              issueNumber: 111,
+              issueIdentifier: "sociotechnica-org/symphony-ts#111",
+              title: "Prerequisite",
+            },
+            downstream: [
+              {
+                issueNumber: 112,
+                issueIdentifier: "sociotechnica-org/symphony-ts#112",
+                title: "Downstream",
+              },
+            ],
+          },
+        ],
+      },
+      evaluation: {
+        advancementState: "configured-clear",
+        summary: "Initial value",
+        evaluatedAt: "2026-03-30T00:00:00Z",
+        blockingPrerequisite: null,
+        blockedDownstream: [],
+        unresolvedReferences: [],
+      },
+      promotion: createEmptyOperatorReadyPromotionResult("2026-03-30T00:00:00Z"),
+    });
+    await writeIssueSummary({
+      instanceRoot,
+      issueNumber: 111,
+      currentOutcome: "failed",
+    });
+
+    await execFileAsync(
+      "pnpm",
+      [
+        "tsx",
+        "bin/promote-operator-ready-issues.ts",
+        "--workflow",
+        workflowPath,
+        "--operator-repo-root",
+        operatorRoot,
+      ],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+      },
+    );
+
+    expect(server.getIssue(112).labels.map((label) => label.name)).not.toContain(
+      "symphony:ready",
+    );
+
+    const state = await readOperatorReleaseState(releaseStatePath);
+    expect(state.evaluation.advancementState).toBe(
+      "blocked-by-prerequisite-failure",
+    );
+    expect(state.promotion.state).toBe("labels-synchronized");
+    expect(
+      state.promotion.readyLabelsRemoved.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
+  });
+});

--- a/tests/unit/operator-release-state.test.ts
+++ b/tests/unit/operator-release-state.test.ts
@@ -7,6 +7,7 @@ import {
   deriveSymphonyInstanceKey,
 } from "../../src/domain/instance-identity.js";
 import {
+  createEmptyOperatorReadyPromotionResult,
   evaluateOperatorReleaseState,
   readOperatorReleaseState,
   syncOperatorReleaseState,
@@ -280,6 +281,9 @@ describe("operator release state", () => {
         ],
         unresolvedReferences: [],
       },
+      promotion: createEmptyOperatorReadyPromotionResult(
+        "2026-03-30T00:00:00Z",
+      ),
     });
 
     await writeIssueSummary({

--- a/tests/unit/ready-promotion-policy.test.ts
+++ b/tests/unit/ready-promotion-policy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { evaluateReadyPromotion } from "../../src/tracker/ready-promotion-policy.js";
+
+describe("ready promotion policy", () => {
+  const configuration = {
+    releaseId: "context-library-bun-migration",
+    dependencies: [
+      {
+        prerequisite: {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+        },
+        downstream: [
+          {
+            issueNumber: 112,
+            issueIdentifier: "sociotechnica-org/symphony-ts#112",
+            title: "Downstream",
+          },
+        ],
+      },
+    ],
+  } as const;
+
+  it("adds ready only for downstream issues whose prerequisites succeeded", () => {
+    const decision = evaluateReadyPromotion({
+      configuration,
+      issueFacts: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "succeeded",
+        },
+      ],
+      trackerIssues: [
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          state: "open",
+          hasReadyLabel: false,
+        },
+      ],
+    });
+
+    expect(decision.state).toBe("eligible-set-computed");
+    expect(decision.eligibleIssues.map((issue) => issue.issueNumber)).toEqual([
+      112,
+    ]);
+    expect(decision.addReadyLabelTo.map((issue) => issue.issueNumber)).toEqual([
+      112,
+    ]);
+    expect(decision.removeReadyLabelFrom).toEqual([]);
+  });
+
+  it("removes ready when a prerequisite has failed", () => {
+    const decision = evaluateReadyPromotion({
+      configuration,
+      issueFacts: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "failed",
+        },
+      ],
+      trackerIssues: [
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          state: "open",
+          hasReadyLabel: true,
+        },
+      ],
+    });
+
+    expect(decision.state).toBe("eligible-set-computed");
+    expect(decision.eligibleIssues).toEqual([]);
+    expect(decision.addReadyLabelTo).toEqual([]);
+    expect(
+      decision.removeReadyLabelFrom.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
+  });
+
+  it("fails closed when a prerequisite issue fact is missing", () => {
+    const decision = evaluateReadyPromotion({
+      configuration,
+      issueFacts: [],
+      trackerIssues: [
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          state: "open",
+          hasReadyLabel: false,
+        },
+      ],
+    });
+
+    expect(decision.state).toBe("blocked-review-needed");
+    expect(
+      decision.unresolvedReferences.map((issue) => issue.issueNumber),
+    ).toEqual([111]);
+  });
+
+  it("excludes already-observed downstream issues from new ready promotion", () => {
+    const decision = evaluateReadyPromotion({
+      configuration,
+      issueFacts: [
+        {
+          issueNumber: 111,
+          issueIdentifier: "sociotechnica-org/symphony-ts#111",
+          title: "Prerequisite",
+          currentOutcome: "succeeded",
+        },
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          currentOutcome: "awaiting-human-review",
+        },
+      ],
+      trackerIssues: [
+        {
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          title: "Downstream",
+          state: "open",
+          hasReadyLabel: true,
+        },
+      ],
+    });
+
+    expect(decision.state).toBe("eligible-set-computed");
+    expect(decision.eligibleIssues).toEqual([]);
+    expect(
+      decision.removeReadyLabelFrom.map((issue) => issue.issueNumber),
+    ).toEqual([112]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dependency-aware ready promotion policy for release DAG execution
- run non-fatal ready promotion from the operator loop and persist promotion state in `release-state.json`
- cover promotion behavior in unit/integration tests and document the operator-facing workflow

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #283
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
