### PR TITLE
Fix retry bootstrap for retained dirty workspaces

### DIFF
--- a/docs/plans/291-retained-dirty-workspace-retry-bootstrap/plan.md
+++ b/docs/plans/291-retained-dirty-workspace-retry-bootstrap/plan.md
@@ -1,0 +1,123 @@
+# Issue 291 Plan: Retained Dirty Workspace Retry Bootstrap
+
+## Summary
+
+Fix retry/bootstrap for retained local workspaces so a reclaimed issue does not
+fail immediately when prior failed-attempt changes would block `git checkout -B
+<default-branch> origin/<default-branch>`.
+
+This issue is being implemented under an explicit plan-review waiver based on
+direct human instruction to begin the fix immediately.
+
+## Scope
+
+In scope:
+
+- local workspace reuse for retained workspaces in `src/workspace/local.ts`
+- deterministic handling of dirty retained workspaces before branch reset
+- preservation of retained evidence in a recoverable form
+- unit coverage for the concrete retry-bootstrap failure mode
+
+Out of scope:
+
+- remote SSH workspace behavior
+- changing the retained-workspace policy itself
+- broader retry/orchestrator redesign
+
+## Symphony Layer Mapping
+
+- Policy:
+  - preserve retained workspace evidence while still allowing retry bootstrap
+- Configuration:
+  - no workflow schema changes
+- Coordination:
+  - none beyond keeping retry bootstrap deterministic
+- Execution:
+  - local workspace preparation and branch reset behavior
+- Integration:
+  - git working tree / stash interaction for reused workspaces
+- Observability:
+  - logger warning when dirty retained workspaces are sanitized before reuse
+
+## Current Gap
+
+`context-library#111` proved that a retained workspace can contain local file
+changes from a failed run, and the next reclaim path currently attempts branch
+checkout/reset without first sanitizing the working tree. That causes retry
+bootstrap to fail before any new coding work starts.
+
+## Architecture Boundary
+
+Keep the fix inside the local workspace preparation seam:
+
+- `src/workspace/local.ts` owns the git hygiene required to make an existing
+  local workspace reusable.
+- The orchestrator should continue to ask for a prepared workspace without
+  knowing how dirty retained state is repaired.
+- Evidence preservation should remain local to workspace preparation rather than
+  requiring orchestration-side special cases.
+
+What does not belong here:
+
+- tracker issue mutation
+- retry budget / stall policy changes
+- operator-specific recovery logic
+
+## Implementation Steps
+
+1. Add a focused helper in `src/workspace/local.ts` that detects a dirty reused
+   workspace before fetch/checkout, preserves that dirty state with a
+   deterministic stash entry, and leaves the working tree clean enough for the
+   existing checkout/reset flow.
+2. Keep the existing branch-selection logic intact after the new sanitization
+   step.
+3. Emit a warning log when a dirty retained workspace is sanitized so the event
+   is inspectable later.
+4. Add a regression test in `tests/unit/workspace-local.test.ts` that:
+   - prepares a workspace
+   - leaves tracked modifications in it
+   - reruns `prepareWorkspace`
+   - verifies preparation succeeds
+   - verifies the modified file resets to upstream state
+   - verifies a stash entry was created to preserve the dirty retained state
+
+## Tests
+
+- `pnpm exec vitest run tests/unit/workspace-local.test.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. Given an existing retained workspace with tracked modifications, when
+   `prepareWorkspace()` runs again, then the workspace is sanitized and the
+   branch reset succeeds instead of failing checkout.
+2. Given that same dirty retained workspace, when preparation sanitizes it,
+   then the prior dirty state remains preserved in a deterministic stash entry.
+
+## Exit Criteria
+
+- reused dirty workspaces no longer fail retry bootstrap on branch checkout
+- retained evidence is preserved rather than silently discarded
+- regression coverage reproduces and prevents the `context-library#111` failure
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR by staying on one narrow workspace
+preparation seam: all runtime changes stay inside `src/workspace/local.ts` and
+the corresponding regression coverage stays in
+`tests/unit/workspace-local.test.ts`.
+
+What does not belong in this PR:
+
+- orchestrator retry-budget or stall-policy changes
+- tracker/operator queue recovery behavior
+- workflow schema or prompt changes
+- remote SSH retained-workspace recovery
+
+## Deferred
+
+- richer archival/export of retained dirty workspace evidence
+- automatic handling for conflicting untracked files in retained workspaces
+- equivalent remote SSH retry-bootstrap handling if it proves necessary later

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -66,6 +66,57 @@ async function branchAheadCount(
   return Number(result.stdout.trim() || "0");
 }
 
+async function readWorktreeStatus(
+  cwd: string,
+  options?: {
+    readonly includeUntracked?: boolean;
+  },
+): Promise<readonly string[]> {
+  const includeUntracked = options?.includeUntracked ?? true;
+  const result = await execFileAsync(
+    "git",
+    [
+      "status",
+      "--porcelain",
+      includeUntracked ? "--untracked-files=all" : "--untracked-files=no",
+    ],
+    {
+      cwd,
+    },
+  );
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+}
+
+async function stashDirtyWorkspaceForReuse(cwd: string): Promise<{
+  readonly stashed: boolean;
+  readonly entryName: string | null;
+  readonly changedPaths: readonly string[];
+}> {
+  const statusLines = await readWorktreeStatus(cwd, {
+    includeUntracked: false,
+  });
+  if (statusLines.length === 0) {
+    return {
+      stashed: false,
+      entryName: null,
+      changedPaths: [],
+    };
+  }
+
+  const entryName = `symphony-retained-workspace-${new Date().toISOString()}`;
+  await execFileAsync("git", ["stash", "push", "--message", entryName], {
+    cwd,
+  });
+  return {
+    stashed: true,
+    entryName,
+    changedPaths: statusLines.map((line) => line.slice(3)),
+  };
+}
+
 async function syncOriginHead(cwd: string): Promise<void> {
   try {
     await execFileAsync("git", ["remote", "set-head", "origin", "--auto"], {
@@ -180,6 +231,16 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       }
     } else {
       await configureOriginRemote(workspacePath, source, this.#config.repoUrl);
+      const sanitized = await stashDirtyWorkspaceForReuse(workspacePath);
+      if (sanitized.stashed) {
+        this.#logger.warn("Sanitized dirty retained workspace before reuse", {
+          workspacePath,
+          issueIdentifier: issue.identifier,
+          branchName,
+          stashEntryName: sanitized.entryName,
+          changedPaths: sanitized.changedPaths,
+        });
+      }
     }
 
     await execFileAsync("git", ["fetch", "origin"], { cwd: workspacePath });

--- a/tests/unit/workspace-local.test.ts
+++ b/tests/unit/workspace-local.test.ts
@@ -46,6 +46,14 @@ async function withScrubbedGitIdentity<T>(
   }
 }
 
+async function listStashEntries(cwd: string): Promise<readonly string[]> {
+  const result = await execFile("git", ["stash", "list"], { cwd });
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
 function createIssue(number: number) {
   return {
     id: String(number),
@@ -253,6 +261,61 @@ describe("LocalWorkspaceManager", () => {
           "IMPLEMENTED.txt",
         ),
       ).resolves.toContain("bootstrap push path");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stashes dirty retained workspaces before resetting them for reuse", async () => {
+    const tempDir = await createTempDir("workspace-retained-dirty-");
+    const remote = await createSeedRemote();
+    const logger = new JsonLogger();
+    const manager = new LocalWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remote.remotePath,
+        branchPrefix: "symphony/",
+        retention: {
+          onSuccess: "retain",
+          onFailure: "retain",
+        },
+      },
+      [],
+      logger,
+    );
+
+    try {
+      const prepared = await manager.prepareWorkspace({
+        issue: createIssue(11),
+      });
+      const workspacePath = getPreparedWorkspacePath(prepared);
+      if (workspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      await fs.writeFile(
+        path.join(workspacePath, "README.md"),
+        "# locally modified for retry\n",
+        "utf8",
+      );
+
+      const reused = await manager.prepareWorkspace({
+        issue: createIssue(11),
+      });
+      const reusedWorkspacePath = getPreparedWorkspacePath(reused);
+      if (reusedWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      expect(reused.createdNow).toBe(false);
+      await expect(
+        fs.readFile(path.join(reusedWorkspacePath, "README.md"), "utf8"),
+      ).resolves.toContain("# mock repo");
+
+      const stashEntries = await listStashEntries(reusedWorkspacePath);
+      expect(stashEntries).toHaveLength(1);
+      expect(stashEntries[0]).toContain("symphony-retained-workspace-");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       await fs.rm(remote.rootDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- sanitize tracked changes in retained workspaces before retry bootstrap resets them
- preserve the dirty snapshot in git stash so retry evidence is not lost
- add a regression test for retained dirty workspace reuse

Closes #291

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
