### PR TITLE
Handle conflicting untracked files in retained workspace retry bootstrap

### DIFF
--- a/docs/plans/294-untracked-file-conflict-retry-bootstrap/plan.md
+++ b/docs/plans/294-untracked-file-conflict-retry-bootstrap/plan.md
@@ -1,0 +1,153 @@
+# Issue 294 Plan: Untracked File Conflict Recovery in Retained Workspace Retry Bootstrap
+
+## Goal
+
+Extend retained-workspace retry bootstrap so conflicting untracked files are
+removed before branch reset, preventing checkout failures while preserving
+retained evidence in an inspectable form.
+
+## Scope
+
+In scope:
+
+- detect and handle untracked files in retained workspaces before branch reset
+- preserve untracked file evidence in git stash alongside tracked modifications
+- allow retry bootstrap to proceed instead of failing on untracked path conflicts
+- regression test for retained workspaces with conflicting untracked files
+
+Out of scope:
+
+- remote SSH workspace behavior
+- changing the retained-workspace policy itself
+- broader retry/orchestrator redesign
+- richer archival/export of retained workspace evidence
+
+## Non-Goals
+
+- introducing new configuration knobs for untracked file handling
+- changing workspace retention policy
+- modifying orchestrator retry logic
+
+## Symphony Layer Mapping
+
+- **Policy:** preserve retained workspace evidence while allowing retry bootstrap
+  (unchanged from #291)
+- **Configuration:** no workflow schema changes
+- **Coordination:** none beyond keeping retry bootstrap deterministic
+- **Execution:** local workspace preparation and branch reset behavior in
+  `src/workspace/local.ts`
+- **Integration:** git working tree / stash interaction for reused workspaces
+- **Observability:** logger warning when untracked files are cleaned before reuse
+
+What does not belong here:
+
+- tracker issue mutation
+- retry budget / stall policy changes
+- operator-specific recovery logic
+- orchestrator state changes
+
+## Current Gap
+
+PR #292 fixed retry bootstrap for retained workspaces with **tracked**
+modifications by stashing them before branch reset. However,
+`stashDirtyWorkspaceForReuse` explicitly passes `--untracked-files=no` and uses
+plain `git stash push` without `--include-untracked`.
+
+If a failed coding-agent run creates new files (e.g., new source files,
+generated artifacts, context library outputs), and a later retry needs to check
+out a branch where those same paths are tracked, `git checkout -B` fails with:
+
+```
+error: The following untracked working tree files would be overwritten by checkout:
+  <path>
+```
+
+This is the exact failure mode described in issue #294.
+
+## Architecture Boundary
+
+Keep the fix inside the local workspace preparation seam:
+
+- `src/workspace/local.ts` owns git hygiene for making an existing local
+  workspace reusable
+- the orchestrator should not know how dirty retained state is repaired
+- evidence preservation stays local to workspace preparation
+
+What does not belong in this layer:
+
+- tracker issue mutation
+- retry budget / stall policy changes
+- operator queue recovery behavior
+- workflow schema or prompt changes
+
+## Implementation Steps
+
+1. **Modify `stashDirtyWorkspaceForReuse`** to include untracked files:
+   - Change `readWorktreeStatus` call to use `includeUntracked: true` for the
+     dirty-check (so the function detects untracked files as dirty state)
+   - Add `--include-untracked` to the `git stash push` command so untracked
+     files are captured in the stash entry alongside tracked modifications
+   - This is the minimal change: the existing stash-based evidence preservation
+     strategy already works; we just need to widen what it captures
+
+2. **No new helper needed.** The existing `stashDirtyWorkspaceForReuse` already
+   has the right shape. The fix is two small edits:
+   - `includeUntracked: false` -> `includeUntracked: true`
+   - `["stash", "push", "--message", entryName]` ->
+     `["stash", "push", "--include-untracked", "--message", entryName]`
+
+3. **Update the logger warning** metadata to distinguish tracked vs untracked
+   changed paths for inspectability. The `changedPaths` field already captures
+   status lines; with `includeUntracked: true`, untracked files will appear
+   with `??` status markers, which is sufficient for distinguishing them in logs.
+
+## Tests
+
+Add a regression test in `tests/unit/workspace-local.test.ts`:
+
+1. Prepare a workspace
+2. Create an untracked file in it (e.g., `GENERATED.txt`)
+3. Rerun `prepareWorkspace`
+4. Verify preparation succeeds (no checkout failure)
+5. Verify the untracked file is gone from the working tree
+6. Verify a stash entry was created preserving the untracked file
+
+Named acceptance scenarios:
+
+- **Scenario: untracked-file-conflict-recovery** — Given an existing retained
+  workspace with untracked files that would conflict with checkout, when
+  `prepareWorkspace()` runs again, then the workspace is sanitized and the
+  branch reset succeeds.
+- **Scenario: untracked-file-evidence-preservation** — Given that same dirty
+  retained workspace, when preparation sanitizes it, then the untracked files
+  are preserved in the stash entry.
+- **Scenario: mixed-tracked-and-untracked** — Given a retained workspace with
+  both tracked modifications and untracked files, when `prepareWorkspace()`
+  runs again, then both are stashed together and bootstrap succeeds.
+
+## Exit Criteria
+
+- reused retained workspaces with conflicting untracked files no longer fail
+  retry bootstrap on branch checkout
+- untracked file evidence is preserved in the stash entry, not silently
+  discarded
+- regression coverage reproduces and prevents the failure mode
+
+## Slice Strategy and PR Seam
+
+This issue fits in one reviewable PR. All runtime changes stay inside
+`src/workspace/local.ts` (two line edits to `stashDirtyWorkspaceForReuse`) and
+all test changes stay in `tests/unit/workspace-local.test.ts`.
+
+What does not belong in this PR:
+
+- orchestrator retry-budget or stall-policy changes
+- tracker/operator queue recovery behavior
+- workflow schema or prompt changes
+- remote SSH retained-workspace recovery
+
+## Deferred
+
+- richer archival/export of retained dirty workspace evidence
+- equivalent remote SSH retry-bootstrap handling
+- automatic cleanup of old stash entries in long-lived workspaces

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -96,7 +96,7 @@ async function stashDirtyWorkspaceForReuse(cwd: string): Promise<{
   readonly changedPaths: readonly string[];
 }> {
   const statusLines = await readWorktreeStatus(cwd, {
-    includeUntracked: false,
+    includeUntracked: true,
   });
   if (statusLines.length === 0) {
     return {
@@ -107,9 +107,11 @@ async function stashDirtyWorkspaceForReuse(cwd: string): Promise<{
   }
 
   const entryName = `symphony-retained-workspace-${new Date().toISOString()}`;
-  await execFileAsync("git", ["stash", "push", "--message", entryName], {
-    cwd,
-  });
+  await execFileAsync(
+    "git",
+    ["stash", "push", "--include-untracked", "--message", entryName],
+    { cwd },
+  );
   return {
     stashed: true,
     entryName,

--- a/tests/fixtures/fake-agent-concurrent-mixed.sh
+++ b/tests/fixtures/fake-agent-concurrent-mixed.sh
@@ -8,7 +8,7 @@ git config user.name "Symphony Test Agent"
 git config user.email "symphony-test@example.com"
 
 if [[ "${SYMPHONY_ISSUE_NUMBER}" == "90" ]]; then
-  MARKER=".rate-limit-once"
+  MARKER="$(dirname "$PWD")/.rate-limit-once-${SYMPHONY_ISSUE_NUMBER}"
   if [[ ! -f "$MARKER" ]]; then
     touch "$MARKER"
     cat <<'JSON'
@@ -25,9 +25,6 @@ fi
 
 echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER}" > IMPLEMENTED.txt
 git add .agent-prompt.txt IMPLEMENTED.txt
-if [[ -f .rate-limit-once ]]; then
-  git add .rate-limit-once
-fi
 git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER}"
 git push origin HEAD:${SYMPHONY_BRANCH_NAME}
 curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \

--- a/tests/fixtures/fake-agent-rate-limit-then-success.sh
+++ b/tests/fixtures/fake-agent-rate-limit-then-success.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PROMPT="$(cat)"
 printf '%s' "$PROMPT" > .agent-prompt.txt
 
-MARKER=".rate-limit-once"
+MARKER="$(dirname "$PWD")/.rate-limit-once-${SYMPHONY_ISSUE_NUMBER}"
 
 if [[ ! -f "$MARKER" ]]; then
   touch "$MARKER"
@@ -19,7 +19,7 @@ git config user.name "Symphony Test Agent"
 git config user.email "symphony-test@example.com"
 
 echo "Implemented ${SYMPHONY_ISSUE_IDENTIFIER}" > IMPLEMENTED.txt
-git add .agent-prompt.txt IMPLEMENTED.txt "$MARKER"
+git add .agent-prompt.txt IMPLEMENTED.txt
 git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER}"
 git push --force origin "HEAD:${SYMPHONY_BRANCH_NAME}"
 

--- a/tests/unit/workspace-local.test.ts
+++ b/tests/unit/workspace-local.test.ts
@@ -322,6 +322,128 @@ describe("LocalWorkspaceManager", () => {
     }
   });
 
+  it("recovers from conflicting untracked files in retained workspaces", async () => {
+    const tempDir = await createTempDir("workspace-retained-untracked-");
+    const remote = await createSeedRemote();
+    const logger = new JsonLogger();
+    const manager = new LocalWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remote.remotePath,
+        branchPrefix: "symphony/",
+        retention: {
+          onSuccess: "retain",
+          onFailure: "retain",
+        },
+      },
+      [],
+      logger,
+    );
+
+    try {
+      const prepared = await manager.prepareWorkspace({
+        issue: createIssue(12),
+      });
+      const workspacePath = getPreparedWorkspacePath(prepared);
+      if (workspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      await fs.writeFile(
+        path.join(workspacePath, "GENERATED.txt"),
+        "untracked artifact from failed run\n",
+        "utf8",
+      );
+
+      const reused = await manager.prepareWorkspace({
+        issue: createIssue(12),
+      });
+      const reusedWorkspacePath = getPreparedWorkspacePath(reused);
+      if (reusedWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      expect(reused.createdNow).toBe(false);
+      const untrackedExists = await fs
+        .stat(path.join(reusedWorkspacePath, "GENERATED.txt"))
+        .then(() => true)
+        .catch(() => false);
+      expect(untrackedExists).toBe(false);
+
+      const stashEntries = await listStashEntries(reusedWorkspacePath);
+      expect(stashEntries).toHaveLength(1);
+      expect(stashEntries[0]).toContain("symphony-retained-workspace-");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stashes both tracked modifications and untracked files together", async () => {
+    const tempDir = await createTempDir("workspace-retained-mixed-");
+    const remote = await createSeedRemote();
+    const logger = new JsonLogger();
+    const manager = new LocalWorkspaceManager(
+      {
+        root: path.join(tempDir, ".tmp", "workspaces"),
+        repoUrl: remote.remotePath,
+        branchPrefix: "symphony/",
+        retention: {
+          onSuccess: "retain",
+          onFailure: "retain",
+        },
+      },
+      [],
+      logger,
+    );
+
+    try {
+      const prepared = await manager.prepareWorkspace({
+        issue: createIssue(13),
+      });
+      const workspacePath = getPreparedWorkspacePath(prepared);
+      if (workspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      await fs.writeFile(
+        path.join(workspacePath, "README.md"),
+        "# tracked modification\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(workspacePath, "NEW_FILE.txt"),
+        "untracked new file\n",
+        "utf8",
+      );
+
+      const reused = await manager.prepareWorkspace({
+        issue: createIssue(13),
+      });
+      const reusedWorkspacePath = getPreparedWorkspacePath(reused);
+      if (reusedWorkspacePath === null) {
+        throw new Error("expected local workspace path");
+      }
+
+      expect(reused.createdNow).toBe(false);
+      await expect(
+        fs.readFile(path.join(reusedWorkspacePath, "README.md"), "utf8"),
+      ).resolves.toContain("# mock repo");
+      const newFileExists = await fs
+        .stat(path.join(reusedWorkspacePath, "NEW_FILE.txt"))
+        .then(() => true)
+        .catch(() => false);
+      expect(newFileExists).toBe(false);
+
+      const stashEntries = await listStashEntries(reusedWorkspacePath);
+      expect(stashEntries).toHaveLength(1);
+      expect(stashEntries[0]).toContain("symphony-retained-workspace-");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.rm(remote.rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an idempotent cleanup result when the workspace is already absent", async () => {
     const tempDir = await createTempDir("workspace-cleanup-");
     const remote = await createSeedRemote();


### PR DESCRIPTION
## Summary

- Extend `stashDirtyWorkspaceForReuse` to include untracked files in the stash, preventing checkout failures when retained workspaces contain leftover artifacts from failed runs
- Fix fake agent test scripts to store rate-limit marker files outside the workspace so they survive workspace sanitization

Closes #294

## Changes

Two line edits in `src/workspace/local.ts`:
- `includeUntracked: false` → `true` so untracked files are detected as dirty state
- Add `--include-untracked` to `git stash push` so untracked files are preserved in the stash entry

Test fixture fixes in `tests/fixtures/`:
- Move `.rate-limit-once` marker files to the workspace parent directory so they survive the new untracked file cleanup

New regression tests in `tests/unit/workspace-local.test.ts`:
- Untracked file conflict recovery
- Mixed tracked + untracked stashing

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all 961 tests pass
- [x] Rate-limit retry test passes in isolation (was consistently failing before fixture fix)
- [x] Concurrent mixed status test passes in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
