### PR TITLE
Add operator CLI flags for model/harness selection and resumable infinite-session mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ entry point instead of any local `.ralph/` script:
 pnpm operator        # continuous wake-up loop
 pnpm operator:once   # single operator wake-up cycle
 pnpm operator -- --workflow ../target-repo/WORKFLOW.md
+pnpm operator -- --provider codex --model gpt-5.4-mini
+pnpm operator -- --provider claude
+pnpm operator -- --provider codex --model gpt-5.4-mini --resume-session
 ```
 
 The checked-in loop lives under `skills/symphony-operator/`. `.ralph/` remains
@@ -180,6 +183,10 @@ machine-readable completed-run review ledger `report-review-state.json`.
 The same operator state root now also carries `release-state.json`, the typed
 record of configured release dependencies plus the current blocked or clear
 release-advancement posture for that instance.
+When resumable operator sessions are enabled, the same state root also carries
+`operator-session.json`, the typed instance-local record of the reusable
+backend session id plus the provider/model/command fingerprint it is compatible
+with.
 Operator wake-ups now inspect that ledger before ordinary queue advancement so
 completed-run report findings are turned into tracked follow-up work promptly.
 The current entry point requires a Unix-like shell environment such as macOS,
@@ -189,6 +196,12 @@ GitHub-backed release DAGs. It reads the canonical operator-local
 `release-state.json` dependency graph, computes which downstream issues are
 currently eligible, and records the resulting eligible set plus any added or
 removed `symphony:ready` labels back into that same typed artifact.
+Use `--provider` and `--model` for the normal harness-selection path,
+`--resume-session` or `--infinite-session` to reuse a compatible provider
+session across wake-ups, and `--operator-command` or
+`SYMPHONY_OPERATOR_COMMAND` only as the raw-command escape hatch. Operator
+status artifacts now expose the resolved provider, model, command source,
+effective command, and session mode/reset reason.
 
 Generate a per-issue report from local artifacts:
 

--- a/bin/prepare-operator-loop-cycle.ts
+++ b/bin/prepare-operator-loop-cycle.ts
@@ -1,0 +1,61 @@
+import { type OperatorProvider } from "../src/config/operator-loop.js";
+import { prepareOperatorCycle } from "../src/runner/operator-session.js";
+
+interface Args {
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+  readonly resumeSession: boolean;
+  readonly sessionStatePath: string;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const provider = readOptionValue(argv, "--provider");
+  const baseCommand = readOptionValue(argv, "--base-command");
+  const sessionStatePath = readOptionValue(argv, "--session-state-path");
+  if (provider !== "codex" && provider !== "claude" && provider !== "custom") {
+    throw new Error("Missing or invalid --provider");
+  }
+  if (baseCommand === null) {
+    throw new Error("Missing value for --base-command");
+  }
+  if (sessionStatePath === null) {
+    throw new Error("Missing value for --session-state-path");
+  }
+  const model = readOptionValue(argv, "--model");
+  const resumeRaw = readOptionValue(argv, "--resume-session");
+  return {
+    provider,
+    model,
+    baseCommand,
+    resumeSession: resumeRaw === "true",
+    sessionStatePath,
+  };
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const prepared = await prepareOperatorCycle(args);
+  process.stdout.write(`${JSON.stringify(prepared)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/bin/record-operator-loop-cycle.ts
+++ b/bin/record-operator-loop-cycle.ts
@@ -1,0 +1,87 @@
+import type { OperatorProvider } from "../src/config/operator-loop.js";
+import { recordOperatorCycle } from "../src/runner/operator-session.js";
+
+interface Args {
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+  readonly resumeSession: boolean;
+  readonly sessionMode: "disabled" | "fresh" | "resuming";
+  readonly sessionStatePath: string;
+  readonly repoRoot: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly exitCode: number;
+  readonly logFile: string;
+  readonly resetReason: string | null;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const provider = readRequiredOption(argv, "--provider");
+  if (provider !== "codex" && provider !== "claude" && provider !== "custom") {
+    throw new Error("Missing or invalid --provider");
+  }
+  const sessionMode = readRequiredOption(argv, "--session-mode");
+  if (
+    sessionMode !== "disabled" &&
+    sessionMode !== "fresh" &&
+    sessionMode !== "resuming"
+  ) {
+    throw new Error("Missing or invalid --session-mode");
+  }
+  return {
+    provider,
+    model: readOptionValue(argv, "--model"),
+    baseCommand: readRequiredOption(argv, "--base-command"),
+    resumeSession: readRequiredOption(argv, "--resume-session") === "true",
+    sessionMode,
+    sessionStatePath: readRequiredOption(argv, "--session-state-path"),
+    repoRoot: readRequiredOption(argv, "--repo-root"),
+    startedAt: readRequiredOption(argv, "--started-at"),
+    finishedAt: readRequiredOption(argv, "--finished-at"),
+    exitCode: Number.parseInt(readRequiredOption(argv, "--exit-code"), 10),
+    logFile: readRequiredOption(argv, "--log-file"),
+    resetReason: normalizeNullableOption(
+      readOptionValue(argv, "--reset-reason"),
+    ),
+  };
+}
+
+function readRequiredOption(argv: readonly string[], option: string): string {
+  const value = readOptionValue(argv, option);
+  if (value === null) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function normalizeNullableOption(value: string | null): string | null {
+  return value === null || value === "" ? null : value;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const recorded = await recordOperatorCycle(args);
+  process.stdout.write(`${JSON.stringify(recorded)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/bin/resolve-operator-loop-config.ts
+++ b/bin/resolve-operator-loop-config.ts
@@ -1,0 +1,13 @@
+import { resolveOperatorLoopConfig } from "../src/config/operator-loop.js";
+
+try {
+  const resolved = resolveOperatorLoopConfig({
+    argv: process.argv.slice(2),
+    env: process.env,
+  });
+  process.stdout.write(`${JSON.stringify(resolved)}\n`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -34,7 +34,19 @@ Use the repo-owned operator loop when you want repeated wake-up cycles:
 pnpm operator
 pnpm operator:once
 pnpm operator -- --workflow ../target-repo/WORKFLOW.md
+pnpm operator -- --provider codex --model gpt-5.4-mini
+pnpm operator -- --provider claude
+pnpm operator -- --provider codex --model gpt-5.4-mini --resume-session
 ```
+
+Use `--provider` and `--model` for the normal checked-in harness-selection
+path. `--resume-session` and `--infinite-session` are aliases for the same
+instance-scoped resumable-session mode. `--operator-command` and
+`SYMPHONY_OPERATOR_COMMAND` remain available as the raw-command escape hatch.
+When resumable mode is enabled, the operator state root also carries
+`operator-session.json`, and `status.json` / `status.md` expose the resolved
+provider, model, command source, effective command, session mode, and any
+automatic reset reason.
 
 ## Third-Party Onboarding
 

--- a/docs/guides/self-hosting-loop.md
+++ b/docs/guides/self-hosting-loop.md
@@ -103,13 +103,22 @@ package scripts:
 ```bash
 pnpm operator
 pnpm operator:once
+pnpm operator -- --provider codex --model gpt-5.4-mini
+pnpm operator -- --provider claude
+pnpm operator -- --provider codex --model gpt-5.4-mini --resume-session
 ```
 
 `pnpm operator` runs the continuous wake-up loop. `pnpm operator:once` runs one
 operator cycle and exits. The loop writes only local/generated artifacts under
 `.ralph/instances/<instance-key>/` such as `standing-context.md`,
-`wake-up-log.md`, `status.json`, `status.md`, `logs/`, and lock files; the
-durable tooling and prompt live in `skills/symphony-operator/`.
+`wake-up-log.md`, `status.json`, `status.md`, `logs/`, lock files, and the
+optional resumable-session artifact `operator-session.json`; the durable
+tooling and prompt live in `skills/symphony-operator/`.
+Use `--provider` and `--model` for the normal harness-selection path.
+`--resume-session` and `--infinite-session` reuse a compatible provider session
+across wake-ups when the selected command supports safe resume reconstruction.
+`SYMPHONY_OPERATOR_COMMAND` and `--operator-command` remain the raw-command
+escape hatch.
 This entry point currently expects a Unix-like shell environment such as macOS,
 Linux, or WSL/Git Bash on Windows.
 

--- a/docs/plans/296-operator-cli-harness-and-session-flags/plan.md
+++ b/docs/plans/296-operator-cli-harness-and-session-flags/plan.md
@@ -276,17 +276,17 @@ The persisted artifact should record only the facts needed to decide reuse safel
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected decision |
-| --- | --- | --- |
-| Operator runs with no new flags and no `SYMPHONY_OPERATOR_COMMAND` override | loop argv, default settings | keep today’s fresh default command behavior |
-| Operator selects `--provider codex --model gpt-5.4-mini` | parsed loop flags | build the documented Codex operator command with the requested model and publish provider/model in status |
-| Operator selects `--provider claude` without a model | parsed loop flags | build the documented Claude headless command, letting model remain omitted/default unless explicitly set |
-| Operator passes `--operator-command <raw>` | parsed loop flags | use the raw command as the effective command and preserve it as the escape hatch path |
-| Resumable mode is enabled but no stored session file exists | instance-scoped session state path | run fresh, then attempt to capture/store a resumable backend session id if the provider exposes one |
-| Stored session exists but provider/model/base command fingerprint changed | stored record plus current resolved command facts | clear or ignore the stale record and run fresh; do not attempt resume |
-| Stored session exists but selected provider does not support safe resume reconstruction for the effective command | stored record plus provider kind | treat as `reset-required` or `fresh`; do not guess a resume command |
-| Resume attempt fails or returns no reusable session id | process exit/output plus stored record | clear the stored record, surface the reset in status/logs, and fall back to fresh mode on a later cycle |
-| Stored session artifact is unreadable or malformed | persisted session file | clear/replace it and continue with a fresh run instead of wedging the loop |
+| Observed condition                                                                                                | Local facts available                             | Expected decision                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Operator runs with no new flags and no `SYMPHONY_OPERATOR_COMMAND` override                                       | loop argv, default settings                       | keep today’s fresh default command behavior                                                               |
+| Operator selects `--provider codex --model gpt-5.4-mini`                                                          | parsed loop flags                                 | build the documented Codex operator command with the requested model and publish provider/model in status |
+| Operator selects `--provider claude` without a model                                                              | parsed loop flags                                 | build the documented Claude headless command, letting model remain omitted/default unless explicitly set  |
+| Operator passes `--operator-command <raw>`                                                                        | parsed loop flags                                 | use the raw command as the effective command and preserve it as the escape hatch path                     |
+| Resumable mode is enabled but no stored session file exists                                                       | instance-scoped session state path                | run fresh, then attempt to capture/store a resumable backend session id if the provider exposes one       |
+| Stored session exists but provider/model/base command fingerprint changed                                         | stored record plus current resolved command facts | clear or ignore the stale record and run fresh; do not attempt resume                                     |
+| Stored session exists but selected provider does not support safe resume reconstruction for the effective command | stored record plus provider kind                  | treat as `reset-required` or `fresh`; do not guess a resume command                                       |
+| Resume attempt fails or returns no reusable session id                                                            | process exit/output plus stored record            | clear the stored record, surface the reset in status/logs, and fall back to fresh mode on a later cycle   |
+| Stored session artifact is unreadable or malformed                                                                | persisted session file                            | clear/replace it and continue with a fresh run instead of wedging the loop                                |
 
 ## Storage And Persistence Contract
 

--- a/docs/plans/296-operator-cli-harness-and-session-flags/plan.md
+++ b/docs/plans/296-operator-cli-harness-and-session-flags/plan.md
@@ -1,0 +1,382 @@
+# Issue 296 Plan: Operator CLI Harness Flags And Resumable Session Mode
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make the repo-owned operator loop easier to run and cheaper to iterate on by replacing most routine `SYMPHONY_OPERATOR_COMMAND` hand-authoring with first-class CLI flags for harness/model selection, while adding an instance-scoped resumable operator-session mode that can reuse a compatible backend session across wake-up cycles.
+
+The intended outcome of this slice is:
+
+1. operators can choose Codex or Claude plus an explicit model from `pnpm operator` / `operator-loop.sh` flags
+2. `SYMPHONY_OPERATOR_COMMAND` remains available as an escape hatch, but the normal path is explicit and inspectable
+3. an optional infinite-session mode can reuse one compatible provider session across wake-ups instead of cold-starting every cycle
+4. operator status artifacts make the selected harness, effective command, and session mode/state obvious
+5. the change stays on the operator-local tooling seam and does not reopen factory runtime, tracker, or worker-runner contracts
+
+## Scope
+
+This slice covers:
+
+1. operator-loop flag parsing for harness/provider selection, model selection, raw command override, and resumable-session mode
+2. a typed command-resolution helper that turns those flags plus existing environment fallbacks into one effective operator command
+3. an instance-scoped persisted operator-session record under `.ralph/instances/<instance-key>/` for resumable mode
+4. provider-specific resume-command reconstruction for the supported operator harnesses
+5. operator-loop status JSON/Markdown updates so the chosen provider/model, command source, and session posture are visible
+6. focused tests for flag precedence, command building, persisted-session compatibility/reset behavior, and loop integration
+7. README / runbook / self-hosting / skill updates for the new operator UX and the reset semantics of resumed sessions
+
+## Non-Goals
+
+This slice does not include:
+
+1. changing `WORKFLOW.md` worker runner selection or any factory worker model selection behavior
+2. changing tracker transport, normalization, handoff policy, CI/review policy, or landing policy
+3. moving the operator loop into the product `symphony` CLI
+4. removing `SYMPHONY_OPERATOR_COMMAND` or forbidding fully custom commands
+5. building a general multi-provider session protocol beyond the providers the repo can reconstruct safely today
+6. introducing background multi-session pooling, multiple resumable sessions per instance, or cross-instance session sharing
+7. broad orchestration/runtime changes outside the operator-local wake-up loop
+
+## Current Gaps
+
+Today the checked-in operator loop is too opaque for routine selection and too stateless for cheap repeated wake-ups:
+
+1. `skills/symphony-operator/operator-loop.sh` exposes only `--once`, `--interval-seconds`, and `--workflow`; harness and model changes require rewriting a raw command string
+2. the default command is Codex-specific, but the repo documentation also supports Claude, so the normal operator UX is less provider-neutral than the surrounding runtime model
+3. status artifacts record only the final raw `command` string, which hides whether it came from defaults, CLI flags, or an explicit escape hatch
+4. the loop does not keep any provider session identity between wake-ups, so each cycle cold-starts a fresh operator conversation
+5. there is no typed instance-local storage contract for operator session reuse analogous to existing instance-local notebook and release-state artifacts
+6. command-building and session-resume rules currently live only in adjacent runner helpers for factory workers, not in operator-loop-specific tooling
+
+## Decision Notes
+
+1. Keep the shell script thin. Complex flag validation, provider-specific command construction, and persisted-session compatibility logic should move into focused checked-in TypeScript helpers instead of expanding shell-only branching.
+2. Keep the seam operator-local. This issue should not thread operator harness selection into `WORKFLOW.md`, runner factory wiring, or orchestrator state.
+3. Reuse existing command-shape knowledge where possible. Codex and Claude already have checked-in command parsing / resume helpers; the operator loop should build on those conventions rather than inventing unrelated flag semantics.
+4. Treat persisted operator session state as local operator tooling state, not runtime source of truth. Standing context, wake-up log, release state, and tracker artifacts remain the system of record for work state.
+5. Keep backward compatibility explicit. Existing `SYMPHONY_OPERATOR_COMMAND` workflows must keep working, and default behavior without new flags must remain a fresh-command loop.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the repo-owned rule that routine operator harness/model selection should be explicit and inspectable instead of hidden in one opaque environment string
+2. the rule that resumable operator sessions are optional, instance-scoped, and compatibility-checked before reuse
+3. the rule that a stored operator session is a convenience artifact only; it does not replace standing context, wake-up history, release state, or tracker facts
+
+Does not belong here:
+
+1. provider-specific shell tokenization or resume-command reconstruction
+2. tracker lifecycle changes
+3. worker-runner policy in `WORKFLOW.md`
+
+### Configuration Layer
+
+Belongs here:
+
+1. typed parsing of operator-loop flags and environment fallbacks
+2. precedence rules between `--provider` / `--model` / `--operator-command` and `SYMPHONY_OPERATOR_COMMAND`
+3. typed derivation of the persisted operator-session state path and command fingerprint inputs
+
+Does not belong here:
+
+1. tracker reads
+2. shell log scraping embedded inline in the bash loop
+3. factory worker config changes
+
+### Coordination Layer
+
+Belongs here:
+
+1. the operator-loop-local session reuse policy for one selected instance
+2. explicit transitions between fresh run, resumable run, incompatible-stored-session reset, and cleared session state after failure
+3. keeping the operator loop’s outer cycle state and inner session state distinguishable
+
+Does not belong here:
+
+1. factory dispatch, retry, reconciliation, or lease logic
+2. reusing orchestrator counters or issue lifecycle state as operator-session state
+3. tracker-specific handoff decisions
+
+### Execution Layer
+
+Belongs here:
+
+1. the concrete effective command executed for each wake-up cycle
+2. provider-specific resume-command reconstruction for supported harnesses
+3. capture and persistence of resumable backend session ids when available
+
+Does not belong here:
+
+1. worker runner changes
+2. workspace lifecycle changes
+3. tracker mutation logic
+
+### Integration Layer
+
+Belongs here:
+
+1. thin provider-specific command-compatibility rules at the operator boundary
+2. safe use of existing Codex and Claude command conventions for resume behavior
+
+Does not belong here:
+
+1. tracker transport or normalization work
+2. GitHub-specific operator policy mixed into command resolution
+3. assuming every custom raw command supports reusable sessions
+
+### Observability Layer
+
+Belongs here:
+
+1. operator status JSON/Markdown fields that expose provider, model, command source, session mode, and persisted session state path/summary
+2. the instance-scoped persisted operator-session artifact under `.ralph/instances/<instance-key>/`
+3. docs and tests that make reset and compatibility behavior inspectable
+
+Does not belong here:
+
+1. treating status artifacts as the only source of session truth
+2. hiding resume/reset decisions only inside logs
+3. factory runtime status redesign outside the operator loop
+
+## Architecture Boundaries
+
+### `skills/symphony-operator/operator-loop.sh`
+
+Owns:
+
+1. user-facing shell entry-point parsing and forwarding of operator-loop arguments
+2. invocation of focused TypeScript helpers for command/session resolution where needed
+3. publishing the final resolved operator status plus running the effective command
+
+Does not own:
+
+1. large provider-specific command-building branches
+2. the only definition of persisted operator-session compatibility
+3. worker-runner semantics
+
+### `src/domain/instance-identity.ts`
+
+Owns:
+
+1. derivation of the new operator-session state path under the selected instance root
+2. naming the operator-local persistence artifact alongside existing notebook/release artifacts
+
+Does not own:
+
+1. session content or reset policy
+2. provider-specific resume logic
+3. shell execution
+
+### New focused operator helper module(s)
+
+Owns:
+
+1. typed operator-loop option parsing / normalization
+2. effective-command construction for supported providers and the raw-command escape hatch
+3. command fingerprinting, persisted-session compatibility checks, and provider-specific resume-command reconstruction
+4. extraction / persistence of resumable backend session ids where the supported provider exposes them
+
+Does not own:
+
+1. tracker reads or writes
+2. notebook content rules
+3. factory worker runner selection
+
+### `skills/symphony-operator/SKILL.md`, `operator-prompt.md`, `docs/guides/operator-runbook.md`, `docs/guides/self-hosting-loop.md`, and `README.md`
+
+Owns:
+
+1. the operator-facing contract for the new flags
+2. the distinction between fresh-command mode and resumable-session mode
+3. documentation of when stored sessions are reused versus reset
+
+Does not own:
+
+1. hidden precedence rules that are not backed by code/tests
+2. the only persistence definition
+3. tracker/runtime semantics unrelated to the operator loop
+
+## Slice Strategy And PR Seam
+
+This should fit in one reviewable PR by staying on one narrow operator-tooling seam:
+
+1. add typed harness/model/raw-command flag support for the checked-in operator loop
+2. add one instance-scoped persisted operator-session artifact plus compatibility/reset logic
+3. expose the resolved mode through operator status/docs/tests
+
+Deferred from this PR:
+
+1. user-tunable session reset budgets or compaction policies beyond the minimum documented reset behavior in this slice
+2. more provider integrations beyond the supported operator harnesses and raw-command passthrough
+3. product-CLI promotion of the operator loop
+4. any worker-runner or orchestrator runtime changes
+
+Why this seam is reviewable:
+
+1. it stays in operator-local tooling, docs, and tests
+2. it avoids mixing tracker, worker-runner, and orchestrator code into the same review surface
+3. it yields a concrete operator-facing improvement without reopening the factory core
+
+## Operator Session State Model
+
+This issue does not change the factory runtime state machine, but resumable operator sessions add explicit operator-local state that must be named separately from the outer wake-up loop.
+
+### Session modes
+
+1. `disabled`
+   - default behavior; no persisted operator session is consulted or written
+2. `fresh`
+   - resumable mode is enabled, but no compatible persisted backend session is available for this cycle
+3. `resuming`
+   - resumable mode is enabled and a compatible stored session id is used to build the effective resume command
+4. `reset-required`
+   - resumable mode is enabled, but the stored session must be cleared before the next run because it is incompatible, unreadable, unsupported for the selected command, or was invalidated by a failed resume path
+
+### Stored session record
+
+The persisted artifact should record only the facts needed to decide reuse safely:
+
+1. selected provider
+2. resolved base command fingerprint
+3. selected model, when applicable
+4. stored backend session id
+5. timestamps for creation and most recent use
+6. last known mode/decision summary
+
+### Allowed transitions
+
+1. `disabled -> fresh`
+   - operator enables resumable mode
+2. `fresh -> resuming`
+   - a successful fresh run captures a backend session id that can be reused later
+3. `resuming -> resuming`
+   - a resume run succeeds and keeps the stored session compatible
+4. `resuming -> reset-required`
+   - resume fails, stored session cannot be parsed, or the selected command/provider/model changed incompatibly
+5. `reset-required -> fresh`
+   - the loop clears the incompatible record and starts a new session on the next wake-up
+6. `fresh -> disabled`
+   - resumable mode is turned off
+7. `resuming -> disabled`
+   - resumable mode is turned off and the stored record is ignored or cleared per the documented behavior
+
+### Notes
+
+1. The outer operator-loop status states such as `sleeping`, `acting`, and `retrying` remain unchanged; session mode is additional operator-local state, not a replacement for those coarse loop states.
+2. Compatibility must be strict enough that changing provider, model, or explicit raw command does not silently resume the wrong conversation.
+3. This slice’s reset policy is minimum and explicit: incompatible or failed stored sessions are cleared and replaced by a fresh session on a later wake-up. Smarter periodic resets can be deferred if they would broaden the seam.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected decision |
+| --- | --- | --- |
+| Operator runs with no new flags and no `SYMPHONY_OPERATOR_COMMAND` override | loop argv, default settings | keep today’s fresh default command behavior |
+| Operator selects `--provider codex --model gpt-5.4-mini` | parsed loop flags | build the documented Codex operator command with the requested model and publish provider/model in status |
+| Operator selects `--provider claude` without a model | parsed loop flags | build the documented Claude headless command, letting model remain omitted/default unless explicitly set |
+| Operator passes `--operator-command <raw>` | parsed loop flags | use the raw command as the effective command and preserve it as the escape hatch path |
+| Resumable mode is enabled but no stored session file exists | instance-scoped session state path | run fresh, then attempt to capture/store a resumable backend session id if the provider exposes one |
+| Stored session exists but provider/model/base command fingerprint changed | stored record plus current resolved command facts | clear or ignore the stale record and run fresh; do not attempt resume |
+| Stored session exists but selected provider does not support safe resume reconstruction for the effective command | stored record plus provider kind | treat as `reset-required` or `fresh`; do not guess a resume command |
+| Resume attempt fails or returns no reusable session id | process exit/output plus stored record | clear the stored record, surface the reset in status/logs, and fall back to fresh mode on a later cycle |
+| Stored session artifact is unreadable or malformed | persisted session file | clear/replace it and continue with a fresh run instead of wedging the loop |
+
+## Storage And Persistence Contract
+
+Versioned:
+
+1. operator-loop code, docs, and tests
+2. typed helpers for operator command/session resolution
+
+Local/generated under `.ralph/instances/<instance-key>/`:
+
+1. `standing-context.md`
+2. `wake-up-log.md`
+3. `release-state.json`
+4. `report-review-state.json`
+5. new operator-session state artifact for resumable mode
+6. existing status/log/lock artifacts
+
+Rules:
+
+1. the persisted session artifact is instance-scoped and must never be shared across instance keys
+2. the artifact is convenience state only; if it is missing, stale, or unreadable, the loop must remain operable in fresh mode
+3. status output should point to the session-state artifact when resumable mode is selected
+
+## Observability Requirements
+
+1. operator status JSON/Markdown should expose the selected provider, selected model, resolved command source, and effective command
+2. status should show whether the current cycle used fresh or resumable session mode
+3. status should surface a concise session summary or reset reason when resumable mode is enabled
+4. logs should make fresh-versus-resume decisions inspectable without requiring raw shell archaeology
+5. docs should explain how operators intentionally switch providers/models and what causes an automatic session reset
+
+## Implementation Steps
+
+1. Add `docs/plans/296-operator-cli-harness-and-session-flags/plan.md`.
+2. Extend the operator instance-state path contract with a dedicated persisted session-state path.
+3. Add a focused TypeScript helper for operator-loop option normalization and effective command resolution, including precedence rules for new flags versus `SYMPHONY_OPERATOR_COMMAND`.
+4. Add focused persisted-session helpers for command fingerprinting, compatibility checks, stored-session loading/saving, and provider-specific resume-command reconstruction.
+5. Update `skills/symphony-operator/operator-loop.sh` to:
+   - parse and validate the new flags
+   - resolve the effective command through the helper
+   - load or clear persisted session state as needed
+   - record the richer status fields
+   - persist any resumable backend session id after successful cycles
+6. Reuse or adapt existing Codex and Claude command conventions so supported operator harnesses have explicit default command templates and safe resume behavior.
+7. Add or update tests for command resolution, persisted-session state transitions, and operator-loop integration.
+8. Update README, operator skill, runbook, and self-hosting docs with the new commands and reset semantics.
+9. Run local QA, self-review the diff, and open/update the PR for `#296`.
+
+## Tests And Acceptance Scenarios
+
+### Unit tests
+
+1. operator command resolution builds the expected Codex default, Codex-with-model, and Claude default commands
+2. `--operator-command` and `SYMPHONY_OPERATOR_COMMAND` precedence remains explicit and backward compatible
+3. persisted-session compatibility rejects provider/model/base-command mismatches
+4. persisted-session loading tolerates missing or malformed files by falling back to fresh mode
+5. provider-specific resume-command reconstruction forwards only supported flags
+
+### Integration tests
+
+1. invoking `operator-loop.sh --once --provider codex --model ...` publishes the resolved provider/model/command fields in status artifacts
+2. invoking `operator-loop.sh --once --provider claude` publishes the Claude provider selection cleanly
+3. enabling resumable mode across two operator cycles for a supported provider reuses the stored backend session id on the second cycle
+4. changing provider/model/raw command between cycles invalidates the stored session and forces a fresh cycle
+5. a bad stored session artifact or failed resume path does not wedge the loop; the next cycle can proceed fresh
+
+### End-to-end seam statement
+
+This issue stays entirely on the checked-in operator loop. The end-to-end slice for this seam is the integration path that invokes the real shell entry point with fake provider commands and inspects the generated instance-scoped operator artifacts.
+
+### Acceptance scenarios
+
+1. `pnpm operator -- --provider codex --model gpt-5.4-mini` runs without requiring a hand-authored raw operator command.
+2. `pnpm operator -- --provider claude` switches the operator harness without editing the script or exporting a custom command.
+3. `pnpm operator -- --provider codex --model gpt-5.4-mini --infinite-session` reuses a compatible stored session on later wake-ups when the provider supports resume.
+4. operator status artifacts make it obvious whether the cycle used a fresh or resumed session and what effective command was selected.
+5. existing raw-command usage remains available for unsupported/custom operator commands.
+
+## Exit Criteria
+
+1. the checked-in operator loop supports explicit provider/model/raw-command selection with documented precedence rules
+2. the loop exposes an opt-in resumable session mode with instance-scoped persisted session state
+3. status artifacts clearly surface the selected harness/model/command and fresh-versus-resume posture
+4. docs explain the supported operator UX and reset semantics
+5. local QA passes and the PR stays limited to operator-local tooling/doc/test changes
+
+## Deferred
+
+1. product-CLI promotion of the operator loop
+2. user-configurable session rotation budgets or richer compaction policies
+3. multi-session pooling or concurrent operator conversations per instance
+4. support for arbitrary custom raw commands to participate in resumable mode without provider-specific helpers
+5. any factory worker or orchestrator behavior changes

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -16,13 +16,18 @@ Supported repo-owned entry point:
 
 - `pnpm operator` for the continuous wake-up loop
 - `pnpm operator:once` for one cycle
+- `pnpm operator -- --provider codex --model gpt-5.4-mini` for explicit Codex model selection
+- `pnpm operator -- --provider claude` for the checked-in Claude harness path
+- `pnpm operator -- --provider codex --model gpt-5.4-mini --resume-session` for instance-scoped resumable wake-ups
 
 The checked-in loop and prompt live next to this skill under
 `skills/symphony-operator/`. `.ralph/` is local/generated-only state for the
 instance-scoped standing context, wake-up log, status snapshots, logs, and
 loop lock files under `.ralph/instances/<instance-key>/`. Release dependency
 metadata and the current release advancement posture also live there in
-`release-state.json`.
+`release-state.json`. When resumable mode is enabled, that same root also
+carries `operator-session.json`, the typed record of the compatible reusable
+provider session for that instance.
 
 ## Scope
 

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -7,6 +7,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PROMPT_FILE="$SCRIPT_DIR/operator-prompt.md"
 RALPH_DIR="$REPO_ROOT/.ralph"
 INSTANCE_STATE_RESOLVER="$REPO_ROOT/bin/resolve-operator-instance.ts"
+OPERATOR_CONFIG_RESOLVER="$REPO_ROOT/bin/resolve-operator-loop-config.ts"
+PREPARE_OPERATOR_CYCLE="$REPO_ROOT/bin/prepare-operator-loop-cycle.ts"
+RECORD_OPERATOR_CYCLE="$REPO_ROOT/bin/record-operator-loop-cycle.ts"
 RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
 INSTANCE_KEY=""
@@ -22,11 +25,21 @@ WAKE_UP_LOG=""
 LEGACY_SCRATCHPAD=""
 RELEASE_STATE=""
 REPORT_REVIEW_STATE=""
+SESSION_STATE=""
 
 INTERVAL_SECONDS="${SYMPHONY_OPERATOR_INTERVAL_SECONDS:-300}"
 WORKFLOW_PATH="${SYMPHONY_OPERATOR_WORKFLOW_PATH:-}"
 DEFAULT_OPERATOR_COMMAND="codex exec --dangerously-bypass-approvals-and-sandbox -C . -"
-OPERATOR_COMMAND="${SYMPHONY_OPERATOR_COMMAND:-$DEFAULT_OPERATOR_COMMAND}"
+BASE_OPERATOR_COMMAND="$DEFAULT_OPERATOR_COMMAND"
+EFFECTIVE_OPERATOR_COMMAND="$DEFAULT_OPERATOR_COMMAND"
+OPERATOR_COMMAND_SOURCE="default"
+OPERATOR_PROVIDER="codex"
+OPERATOR_MODEL=""
+RESUME_SESSION=0
+OPERATOR_SESSION_MODE="disabled"
+OPERATOR_SESSION_SUMMARY="Resumable operator sessions are disabled."
+OPERATOR_SESSION_ID=""
+OPERATOR_SESSION_RESET_REASON=""
 RECORDING_SETTLE_SECONDS=1
 
 RUN_ONCE=0
@@ -53,7 +66,7 @@ READY_PROMOTION_REMOVED=""
 
 usage() {
   cat <<'EOF'
-Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--workflow <path>] [--help]
+Usage: operator-loop.sh [--once] [--interval-seconds <seconds>] [--workflow <path>] [--provider <codex|claude|custom>] [--model <name>] [--operator-command <raw command>] [--resume-session|--infinite-session] [--help]
 
 Environment:
   SYMPHONY_OPERATOR_COMMAND           Command that reads the operator prompt from stdin.
@@ -65,6 +78,9 @@ Environment:
 Examples:
   pnpm operator
   pnpm operator:once
+  pnpm operator -- --provider codex --model gpt-5.4-mini
+  pnpm operator -- --provider claude
+  pnpm operator -- --provider codex --model gpt-5.4-mini --infinite-session
   pnpm operator -- --workflow ../target-repo/WORKFLOW.md
   SYMPHONY_OPERATOR_INTERVAL_SECONDS=60 pnpm operator
 EOF
@@ -120,6 +136,7 @@ const data = JSON.parse(fs.readFileSync(0, "utf8"));
   legacyScratchpadPath: "LEGACY_SCRATCHPAD",
   releaseStatePath: "RELEASE_STATE",
   reportReviewStatePath: "REPORT_REVIEW_STATE",
+  sessionStatePath: "SESSION_STATE",
 };
 for (const [jsonKey, shellKey] of Object.entries(mappings)) {
   const value = data[jsonKey];
@@ -131,6 +148,124 @@ for (const [jsonKey, shellKey] of Object.entries(mappings)) {
 '
   )"
   eval "$metadata_exports"
+}
+
+resolve_operator_config() {
+  local config_json config_exports
+  config_json="$(pnpm tsx "$OPERATOR_CONFIG_RESOLVER" "$@")"
+  config_exports="$(
+    printf '%s' "$config_json" | node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const mappings = {
+  runOnce: "RUN_ONCE",
+  intervalSeconds: "INTERVAL_SECONDS",
+  workflowPath: "WORKFLOW_PATH",
+  provider: "OPERATOR_PROVIDER",
+  model: "OPERATOR_MODEL",
+  baseCommand: "BASE_OPERATOR_COMMAND",
+  commandSource: "OPERATOR_COMMAND_SOURCE",
+  resumeSession: "RESUME_SESSION",
+};
+for (const [jsonKey, shellKey] of Object.entries(mappings)) {
+  const value = data[jsonKey];
+  if (jsonKey === "runOnce" || jsonKey === "resumeSession") {
+    if (typeof value !== "boolean") {
+      throw new Error(`Expected boolean for ${jsonKey}`);
+    }
+    console.log(`${shellKey}=${value ? "1" : "0"}`);
+    continue;
+  }
+  if (jsonKey === "intervalSeconds") {
+    if (typeof value !== "number") {
+      throw new Error(`Expected number for ${jsonKey}`);
+    }
+    console.log(`${shellKey}=${JSON.stringify(String(value))}`);
+    continue;
+  }
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`Expected string|null for ${jsonKey}`);
+  }
+  console.log(`${shellKey}=${JSON.stringify(value ?? "")}`);
+}
+'
+  )"
+  eval "$config_exports"
+  EFFECTIVE_OPERATOR_COMMAND="$BASE_OPERATOR_COMMAND"
+}
+
+prepare_operator_cycle() {
+  local prepared_json prepared_exports
+  local args=(
+    --provider "$OPERATOR_PROVIDER"
+    --base-command "$BASE_OPERATOR_COMMAND"
+    --resume-session "$(if [ "$RESUME_SESSION" -eq 1 ]; then printf 'true'; else printf 'false'; fi)"
+    --session-state-path "$SESSION_STATE"
+  )
+  if [ -n "$OPERATOR_MODEL" ]; then
+    args+=(--model "$OPERATOR_MODEL")
+  fi
+  prepared_json="$(pnpm tsx "$PREPARE_OPERATOR_CYCLE" "${args[@]}")"
+  prepared_exports="$(
+    printf '%s' "$prepared_json" | node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const mappings = {
+  effectiveCommand: "EFFECTIVE_OPERATOR_COMMAND",
+  sessionMode: "OPERATOR_SESSION_MODE",
+  sessionSummary: "OPERATOR_SESSION_SUMMARY",
+  backendSessionId: "OPERATOR_SESSION_ID",
+  resetReason: "OPERATOR_SESSION_RESET_REASON",
+};
+for (const [jsonKey, shellKey] of Object.entries(mappings)) {
+  const value = data[jsonKey];
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`Expected string|null for ${jsonKey}`);
+  }
+  console.log(`${shellKey}=${JSON.stringify(value ?? "")}`);
+}
+'
+  )"
+  eval "$prepared_exports"
+}
+
+record_operator_cycle() {
+  local recorded_json recorded_exports
+  local args=(
+    --provider "$OPERATOR_PROVIDER"
+    --base-command "$BASE_OPERATOR_COMMAND"
+    --resume-session "$(if [ "$RESUME_SESSION" -eq 1 ]; then printf 'true'; else printf 'false'; fi)"
+    --session-mode "$OPERATOR_SESSION_MODE"
+    --session-state-path "$SESSION_STATE"
+    --repo-root "$REPO_ROOT"
+    --started-at "$LAST_CYCLE_STARTED_AT"
+    --finished-at "$LAST_CYCLE_FINISHED_AT"
+    --exit-code "$LAST_CYCLE_EXIT_CODE"
+    --log-file "$LAST_LOG_FILE"
+    --reset-reason "$OPERATOR_SESSION_RESET_REASON"
+  )
+  if [ -n "$OPERATOR_MODEL" ]; then
+    args+=(--model "$OPERATOR_MODEL")
+  fi
+  recorded_json="$(pnpm tsx "$RECORD_OPERATOR_CYCLE" "${args[@]}")"
+  recorded_exports="$(
+    printf '%s' "$recorded_json" | node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const mappings = {
+  sessionSummary: "OPERATOR_SESSION_SUMMARY",
+  backendSessionId: "OPERATOR_SESSION_ID",
+};
+for (const [jsonKey, shellKey] of Object.entries(mappings)) {
+  const value = data[jsonKey];
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`Expected string|null for ${jsonKey}`);
+  }
+  console.log(`${shellKey}=${JSON.stringify(value ?? "")}`);
+}
+'
+  )"
+  eval "$recorded_exports"
 }
 
 refresh_release_state() {
@@ -356,10 +491,22 @@ write_status() {
   "pid": $$,
   "runOnce": $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'true'; else printf 'false'; fi),
   "intervalSeconds": $INTERVAL_SECONDS,
-  "command": "$(json_escape "$OPERATOR_COMMAND")",
+  "provider": "$(json_escape "$OPERATOR_PROVIDER")",
+  "model": $(if [ -n "$OPERATOR_MODEL" ]; then printf '"%s"' "$(json_escape "$OPERATOR_MODEL")"; else printf 'null'; fi),
+  "commandSource": "$(json_escape "$OPERATOR_COMMAND_SOURCE")",
+  "command": "$(json_escape "$BASE_OPERATOR_COMMAND")",
+  "effectiveCommand": "$(json_escape "$EFFECTIVE_OPERATOR_COMMAND")",
   "promptFile": "$(json_escape "$PROMPT_FILE")",
   "standingContext": "$(json_escape "$STANDING_CONTEXT")",
   "wakeUpLog": "$(json_escape "$WAKE_UP_LOG")",
+  "operatorSession": {
+    "enabled": $(if [ "$RESUME_SESSION" -eq 1 ]; then printf 'true'; else printf 'false'; fi),
+    "path": "$(json_escape "$SESSION_STATE")",
+    "mode": "$(json_escape "$OPERATOR_SESSION_MODE")",
+    "summary": "$(json_escape "$OPERATOR_SESSION_SUMMARY")",
+    "backendSessionId": $(if [ -n "$OPERATOR_SESSION_ID" ]; then printf '"%s"' "$(json_escape "$OPERATOR_SESSION_ID")"; else printf 'null'; fi),
+    "resetReason": $(if [ -n "$OPERATOR_SESSION_RESET_REASON" ]; then printf '"%s"' "$(json_escape "$OPERATOR_SESSION_RESET_REASON")"; else printf 'null'; fi)
+  },
   "releaseState": {
     "path": "$(json_escape "$RELEASE_STATE")",
     "releaseId": $(if [ -n "$RELEASE_ID" ]; then printf '"%s"' "$(json_escape "$RELEASE_ID")"; else printf 'null'; fi),
@@ -402,6 +549,17 @@ EOF
 - Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
 - Interval seconds: $INTERVAL_SECONDS
 - Selected workflow: ${WORKFLOW_PATH:-n/a}
+- Provider: $OPERATOR_PROVIDER
+- Model: ${OPERATOR_MODEL:-default}
+- Command source: $OPERATOR_COMMAND_SOURCE
+- Base command: $BASE_OPERATOR_COMMAND
+- Effective command: $EFFECTIVE_OPERATOR_COMMAND
+- Resumable session enabled: $(if [ "$RESUME_SESSION" -eq 1 ]; then printf 'true'; else printf 'false'; fi)
+- Session state: $SESSION_STATE
+- Session mode: $OPERATOR_SESSION_MODE
+- Session summary: $OPERATOR_SESSION_SUMMARY
+- Session backend id: ${OPERATOR_SESSION_ID:-n/a}
+- Session reset reason: ${OPERATOR_SESSION_RESET_REASON:-n/a}
 - Standing context: $STANDING_CONTEXT
 - Wake-up log: $WAKE_UP_LOG
 - Release state: $RELEASE_STATE
@@ -536,7 +694,7 @@ sleep_until_next_cycle() {
 }
 
 warn_default_command() {
-  if [ "$OPERATOR_COMMAND" = "$DEFAULT_OPERATOR_COMMAND" ]; then
+  if [ "$OPERATOR_COMMAND_SOURCE" = "default" ]; then
     echo "operator-loop: using the default Codex command with approvals and sandbox bypass enabled" >&2
   fi
 }
@@ -557,6 +715,7 @@ run_cycle() {
   if ! run_ready_promotion_nonfatal; then
     :
   fi
+  prepare_operator_cycle
   write_status "acting" "Running operator wake-up cycle"
 
   {
@@ -567,7 +726,15 @@ run_cycle() {
     printf 'detached_session=%s\n' "$DETACHED_SESSION_NAME"
     printf 'operator_state_root=%s\n' "$INSTANCE_STATE_ROOT"
     printf 'selected_workflow=%s\n' "${WORKFLOW_PATH:-}"
-    printf 'command=%s\n' "$OPERATOR_COMMAND"
+    printf 'provider=%s\n' "$OPERATOR_PROVIDER"
+    printf 'model=%s\n' "${OPERATOR_MODEL:-}"
+    printf 'command_source=%s\n' "$OPERATOR_COMMAND_SOURCE"
+    printf 'base_command=%s\n' "$BASE_OPERATOR_COMMAND"
+    printf 'effective_command=%s\n' "$EFFECTIVE_OPERATOR_COMMAND"
+    printf 'session_state=%s\n' "$SESSION_STATE"
+    printf 'session_mode=%s\n' "$OPERATOR_SESSION_MODE"
+    printf 'session_summary=%s\n' "$OPERATOR_SESSION_SUMMARY"
+    printf 'session_backend_id=%s\n' "${OPERATOR_SESSION_ID:-}"
     printf 'prompt=%s\n' "$PROMPT_FILE"
     printf '\n'
   } >>"$log_file"
@@ -589,15 +756,23 @@ run_cycle() {
     export SYMPHONY_OPERATOR_PROMPT_FILE="$PROMPT_FILE"
     export SYMPHONY_OPERATOR_WORKFLOW_PATH="$WORKFLOW_PATH"
     export SYMPHONY_OPERATOR_REPORT_REVIEW_STATE="$REPORT_REVIEW_STATE"
+    export SYMPHONY_OPERATOR_SESSION_STATE="$SESSION_STATE"
+    export SYMPHONY_OPERATOR_PROVIDER="$OPERATOR_PROVIDER"
+    export SYMPHONY_OPERATOR_MODEL="$OPERATOR_MODEL"
+    export SYMPHONY_OPERATOR_COMMAND_SOURCE="$OPERATOR_COMMAND_SOURCE"
+    export SYMPHONY_OPERATOR_BASE_COMMAND="$BASE_OPERATOR_COMMAND"
+    export SYMPHONY_OPERATOR_EFFECTIVE_COMMAND="$EFFECTIVE_OPERATOR_COMMAND"
+    export SYMPHONY_OPERATOR_SESSION_MODE="$OPERATOR_SESSION_MODE"
     # Intentionally use a login shell so PATH-managed runner installs such as
     # codex or claude remain discoverable during unattended operator cycles.
-    bash -l -c "$OPERATOR_COMMAND" <"$PROMPT_FILE"
+    bash -l -c "$EFFECTIVE_OPERATOR_COMMAND" <"$PROMPT_FILE"
   ) >>"$log_file" 2>&1
   exit_code=$?
   set -e
 
   LAST_CYCLE_FINISHED_AT="$(now_utc)"
   LAST_CYCLE_EXIT_CODE="$exit_code"
+  record_operator_cycle
   if ! refresh_release_state_nonfatal; then
     :
   fi
@@ -619,47 +794,12 @@ run_cycle() {
   return "$exit_code"
 }
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --)
-      shift
-      ;;
-    --once)
-      RUN_ONCE=1
-      shift
-      ;;
-    --interval-seconds)
-      if [ $# -lt 2 ]; then
-        echo "operator-loop: --interval-seconds requires a value" >&2
-        exit 1
-      fi
-      INTERVAL_SECONDS="$2"
-      shift 2
-      ;;
-    --workflow)
-      if [ $# -lt 2 ]; then
-        echo "operator-loop: --workflow requires a value" >&2
-        exit 1
-      fi
-      WORKFLOW_PATH="$2"
-      shift 2
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "operator-loop: unknown argument: $1" >&2
-      usage >&2
-      exit 1
-      ;;
-  esac
+for arg in "$@"; do
+  if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then
+    usage
+    exit 0
+  fi
 done
-
-if ! [[ "$INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || [ "$INTERVAL_SECONDS" -le 0 ]; then
-  echo "operator-loop: interval must be a positive integer" >&2
-  exit 1
-fi
 
 if [ ! -f "$PROMPT_FILE" ]; then
   echo "operator-loop: prompt file not found: $PROMPT_FILE" >&2
@@ -668,6 +808,21 @@ fi
 
 if [ ! -f "$INSTANCE_STATE_RESOLVER" ]; then
   echo "operator-loop: instance-state resolver not found: $INSTANCE_STATE_RESOLVER" >&2
+  exit 1
+fi
+
+if [ ! -f "$OPERATOR_CONFIG_RESOLVER" ]; then
+  echo "operator-loop: operator config resolver not found: $OPERATOR_CONFIG_RESOLVER" >&2
+  exit 1
+fi
+
+if [ ! -f "$PREPARE_OPERATOR_CYCLE" ]; then
+  echo "operator-loop: operator cycle preparer not found: $PREPARE_OPERATOR_CYCLE" >&2
+  exit 1
+fi
+
+if [ ! -f "$RECORD_OPERATOR_CYCLE" ]; then
+  echo "operator-loop: operator cycle recorder not found: $RECORD_OPERATOR_CYCLE" >&2
   exit 1
 fi
 
@@ -680,6 +835,8 @@ if ! command -v node >/dev/null 2>&1; then
   echo "operator-loop: node not found in PATH; required for timestamp calculation" >&2
   exit 1
 fi
+
+resolve_operator_config "$@"
 
 if [ -n "$WORKFLOW_PATH" ]; then
   WORKFLOW_PATH="$(resolve_path "$WORKFLOW_PATH")"

--- a/src/config/operator-loop.ts
+++ b/src/config/operator-loop.ts
@@ -1,0 +1,294 @@
+import path from "node:path";
+import { describeClaudeCodeSession } from "../runner/claude-code-command.js";
+import {
+  describeLocalRunnerBackend,
+  parseLocalRunnerCommand,
+  quoteShellToken,
+} from "../runner/local-command.js";
+
+export type OperatorProvider = "codex" | "claude" | "custom";
+
+export type OperatorCommandSource =
+  | "default"
+  | "environment"
+  | "cli-command"
+  | "provider-template";
+
+export interface ResolvedOperatorLoopConfig {
+  readonly runOnce: boolean;
+  readonly intervalSeconds: number;
+  readonly workflowPath: string | null;
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+  readonly commandSource: OperatorCommandSource;
+  readonly resumeSession: boolean;
+}
+
+interface ParsedOperatorLoopArgs {
+  readonly runOnce: boolean;
+  readonly intervalSeconds: string | null;
+  readonly workflowPath: string | null;
+  readonly provider: OperatorProvider | null;
+  readonly model: string | null;
+  readonly operatorCommand: string | null;
+  readonly resumeSession: boolean;
+}
+
+export function resolveOperatorLoopConfig(args: {
+  readonly argv: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+}): ResolvedOperatorLoopConfig {
+  const parsed = parseOperatorLoopArgs(args.argv);
+  const intervalRaw =
+    parsed.intervalSeconds ??
+    args.env.SYMPHONY_OPERATOR_INTERVAL_SECONDS ??
+    "300";
+  const intervalSeconds = Number.parseInt(intervalRaw, 10);
+  if (!Number.isInteger(intervalSeconds) || intervalSeconds <= 0) {
+    throw new Error("operator-loop: interval must be a positive integer");
+  }
+
+  const workflowPath =
+    parsed.workflowPath ?? args.env.SYMPHONY_OPERATOR_WORKFLOW_PATH ?? null;
+  const environmentOperatorCommand =
+    args.env.SYMPHONY_OPERATOR_COMMAND?.trim() || null;
+
+  if (parsed.operatorCommand !== null && parsed.model !== null) {
+    throw new Error(
+      "operator-loop: --operator-command cannot be combined with --model",
+    );
+  }
+  if (parsed.operatorCommand !== null && parsed.provider !== null) {
+    throw new Error(
+      "operator-loop: --operator-command cannot be combined with --provider",
+    );
+  }
+  if (parsed.provider === "custom" && parsed.model !== null) {
+    throw new Error(
+      "operator-loop: --provider custom cannot be combined with --model",
+    );
+  }
+
+  if (parsed.operatorCommand !== null) {
+    const described = describeOperatorCommand(parsed.operatorCommand);
+    return {
+      runOnce: parsed.runOnce,
+      intervalSeconds,
+      workflowPath,
+      provider: described.provider,
+      model: described.model,
+      baseCommand: parsed.operatorCommand,
+      commandSource: "cli-command",
+      resumeSession: parsed.resumeSession,
+    };
+  }
+
+  if (parsed.provider !== null || parsed.model !== null) {
+    if (parsed.provider === "custom") {
+      if (environmentOperatorCommand === null) {
+        throw new Error(
+          "operator-loop: --provider custom requires SYMPHONY_OPERATOR_COMMAND to be set",
+        );
+      }
+      const described = describeOperatorCommand(environmentOperatorCommand);
+      return {
+        runOnce: parsed.runOnce,
+        intervalSeconds,
+        workflowPath,
+        provider: described.provider,
+        model: described.model,
+        baseCommand: environmentOperatorCommand,
+        commandSource: "environment",
+        resumeSession: parsed.resumeSession,
+      };
+    }
+
+    const provider = parsed.provider ?? "codex";
+    return {
+      runOnce: parsed.runOnce,
+      intervalSeconds,
+      workflowPath,
+      provider,
+      model: parsed.model,
+      baseCommand: buildDefaultOperatorCommand(provider, parsed.model),
+      commandSource: "provider-template",
+      resumeSession: parsed.resumeSession,
+    };
+  }
+
+  if (environmentOperatorCommand !== null) {
+    const described = describeOperatorCommand(environmentOperatorCommand);
+    return {
+      runOnce: parsed.runOnce,
+      intervalSeconds,
+      workflowPath,
+      provider: described.provider,
+      model: described.model,
+      baseCommand: environmentOperatorCommand,
+      commandSource: "environment",
+      resumeSession: parsed.resumeSession,
+    };
+  }
+
+  return {
+    runOnce: parsed.runOnce,
+    intervalSeconds,
+    workflowPath,
+    provider: "codex",
+    model: null,
+    baseCommand: buildDefaultOperatorCommand("codex", null),
+    commandSource: "default",
+    resumeSession: parsed.resumeSession,
+  };
+}
+
+export function buildDefaultOperatorCommand(
+  provider: Exclude<OperatorProvider, "custom">,
+  model: string | null,
+): string {
+  if (provider === "codex") {
+    const tokens = [
+      "codex",
+      "exec",
+      "--dangerously-bypass-approvals-and-sandbox",
+      ...(model === null ? [] : ["--model", model]),
+      "-C",
+      ".",
+      "-",
+    ];
+    return tokens.map((token) => quoteShellToken(token)).join(" ");
+  }
+
+  const tokens = [
+    "claude",
+    "-p",
+    "--output-format",
+    "json",
+    "--permission-mode",
+    "bypassPermissions",
+    ...(model === null ? [] : ["--model", model]),
+  ];
+  return tokens.map((token) => quoteShellToken(token)).join(" ");
+}
+
+export function describeOperatorCommand(command: string): {
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+} {
+  const parsed = parseLocalRunnerCommand(command);
+  if (parsed.executable === null) {
+    return {
+      provider: "custom",
+      model: null,
+    };
+  }
+
+  const executable = path.basename(parsed.executable);
+  if (executable === "codex") {
+    const described = describeLocalRunnerBackend(command);
+    return {
+      provider: "codex",
+      model: described.model,
+    };
+  }
+
+  if (executable === "claude") {
+    const described = describeClaudeCodeSession(command);
+    return {
+      provider: "claude",
+      model: described.model,
+    };
+  }
+
+  return {
+    provider: "custom",
+    model: null,
+  };
+}
+
+function parseOperatorLoopArgs(
+  argv: readonly string[],
+): ParsedOperatorLoopArgs {
+  let runOnce = false;
+  let intervalSeconds: string | null = null;
+  let workflowPath: string | null = null;
+  let provider: OperatorProvider | null = null;
+  let model: string | null = null;
+  let operatorCommand: string | null = null;
+  let resumeSession = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === undefined || token === "--") {
+      continue;
+    }
+
+    switch (token) {
+      case "--once":
+        runOnce = true;
+        continue;
+      case "--interval-seconds":
+        intervalSeconds = requireOptionValue(argv, index, token);
+        index += 1;
+        continue;
+      case "--workflow":
+        workflowPath = requireOptionValue(argv, index, token);
+        index += 1;
+        continue;
+      case "--provider":
+        provider = parseProvider(requireOptionValue(argv, index, token));
+        index += 1;
+        continue;
+      case "--model":
+        model = requireOptionValue(argv, index, token);
+        index += 1;
+        continue;
+      case "--operator-command":
+        operatorCommand = requireOptionValue(argv, index, token);
+        index += 1;
+        continue;
+      case "--resume-session":
+      case "--infinite-session":
+        resumeSession = true;
+        continue;
+      default:
+        throw new Error(`operator-loop: unknown argument: ${token}`);
+    }
+  }
+
+  return {
+    runOnce,
+    intervalSeconds,
+    workflowPath,
+    provider,
+    model,
+    operatorCommand,
+    resumeSession,
+  };
+}
+
+function parseProvider(value: string): OperatorProvider {
+  switch (value) {
+    case "codex":
+    case "claude":
+    case "custom":
+      return value;
+    default:
+      throw new Error(
+        `operator-loop: --provider must be one of codex, claude, custom; received ${JSON.stringify(value)}`,
+      );
+  }
+}
+
+function requireOptionValue(
+  argv: readonly string[],
+  index: number,
+  option: string,
+): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`operator-loop: ${option} requires a value`);
+  }
+  return value;
+}

--- a/src/domain/instance-identity.ts
+++ b/src/domain/instance-identity.ts
@@ -24,6 +24,7 @@ export interface OperatorInstanceStatePaths {
   readonly legacyScratchpadPath: string;
   readonly releaseStatePath: string;
   readonly reportReviewStatePath: string;
+  readonly sessionStatePath: string;
 }
 
 export function deriveSymphonyInstanceIdentity(
@@ -77,6 +78,7 @@ export function deriveOperatorInstanceStatePaths(args: {
       operatorStateRoot,
       "report-review-state.json",
     ),
+    sessionStatePath: path.join(operatorStateRoot, "operator-session.json"),
   };
 }
 

--- a/src/observability/operator-session-state.ts
+++ b/src/observability/operator-session-state.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { ObservabilityError } from "../domain/errors.js";
+import type { OperatorProvider } from "../config/operator-loop.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
+
+export const OPERATOR_SESSION_STATE_SCHEMA_VERSION = 1 as const;
+
+export interface OperatorSessionStateDocument {
+  readonly version: typeof OPERATOR_SESSION_STATE_SCHEMA_VERSION;
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommandFingerprint: string;
+  readonly backendSessionId: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string;
+  readonly lastMode: "fresh" | "resuming";
+  readonly lastSummary: string;
+}
+
+export async function readOperatorSessionState(
+  filePath: string,
+): Promise<OperatorSessionStateDocument | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return parseOperatorSessionStateDocument(JSON.parse(raw), filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function writeOperatorSessionState(
+  filePath: string,
+  state: OperatorSessionStateDocument,
+): Promise<void> {
+  await writeJsonFileAtomic(filePath, state, {
+    tempPrefix: ".operator-session-state",
+  });
+}
+
+export async function clearOperatorSessionState(
+  filePath: string,
+): Promise<void> {
+  await fs.rm(filePath, { force: true });
+}
+
+export function fingerprintOperatorCommand(args: {
+  readonly provider: OperatorProvider;
+  readonly baseCommand: string;
+}): string {
+  return createHash("sha256")
+    .update(args.provider)
+    .update("\u0000")
+    .update(args.baseCommand)
+    .digest("hex");
+}
+
+export function describeOperatorSessionCompatibility(args: {
+  readonly stored: OperatorSessionStateDocument;
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+}): {
+  readonly compatible: boolean;
+  readonly reason: string | null;
+} {
+  if (args.stored.provider !== args.provider) {
+    return {
+      compatible: false,
+      reason: `stored provider ${args.stored.provider} does not match selected provider ${args.provider}`,
+    };
+  }
+  if (args.stored.model !== args.model) {
+    return {
+      compatible: false,
+      reason: `stored model ${renderNullable(args.stored.model)} does not match selected model ${renderNullable(args.model)}`,
+    };
+  }
+
+  const nextFingerprint = fingerprintOperatorCommand({
+    provider: args.provider,
+    baseCommand: args.baseCommand,
+  });
+  if (args.stored.baseCommandFingerprint !== nextFingerprint) {
+    return {
+      compatible: false,
+      reason:
+        "stored command fingerprint does not match the selected operator command",
+    };
+  }
+
+  return {
+    compatible: true,
+    reason: null,
+  };
+}
+
+function parseOperatorSessionStateDocument(
+  value: unknown,
+  filePath: string,
+): OperatorSessionStateDocument {
+  if (!isRecord(value)) {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected an object.`,
+    );
+  }
+  if (value.version !== OPERATOR_SESSION_STATE_SCHEMA_VERSION) {
+    throw new ObservabilityError(
+      `Unsupported operator session state schema in ${filePath}`,
+    );
+  }
+  if (
+    value.provider !== "codex" &&
+    value.provider !== "claude" &&
+    value.provider !== "custom"
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected provider.`,
+    );
+  }
+  if (typeof value.baseCommandFingerprint !== "string") {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected baseCommandFingerprint.`,
+    );
+  }
+  if (
+    typeof value.backendSessionId !== "string" ||
+    value.backendSessionId === ""
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected backendSessionId.`,
+    );
+  }
+  if (
+    typeof value.createdAt !== "string" ||
+    typeof value.lastUsedAt !== "string"
+  ) {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected timestamps.`,
+    );
+  }
+  if (value.lastMode !== "fresh" && value.lastMode !== "resuming") {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected lastMode.`,
+    );
+  }
+  if (typeof value.lastSummary !== "string") {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected lastSummary.`,
+    );
+  }
+  if (value.model !== null && typeof value.model !== "string") {
+    throw new ObservabilityError(
+      `Malformed operator session state in ${filePath}; expected model.`,
+    );
+  }
+
+  return {
+    version: OPERATOR_SESSION_STATE_SCHEMA_VERSION,
+    provider: value.provider,
+    model: value.model,
+    baseCommandFingerprint: value.baseCommandFingerprint,
+    backendSessionId: value.backendSessionId,
+    createdAt: value.createdAt,
+    lastUsedAt: value.lastUsedAt,
+    lastMode: value.lastMode,
+    lastSummary: value.lastSummary,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function renderNullable(value: string | null): string {
+  return value ?? "(default)";
+}

--- a/src/runner/operator-session.ts
+++ b/src/runner/operator-session.ts
@@ -1,0 +1,335 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import { promisify } from "node:util";
+import type { OperatorProvider } from "../config/operator-loop.js";
+import {
+  buildClaudeResumeCommand,
+  parseClaudeCodeResult,
+} from "./claude-code-command.js";
+import { findCodexSession } from "./codex-session-discovery.js";
+import { buildCodexResumeCommand } from "./codex-resume-command.js";
+import {
+  clearOperatorSessionState,
+  describeOperatorSessionCompatibility,
+  fingerprintOperatorCommand,
+  type OperatorSessionStateDocument,
+  readOperatorSessionState,
+  writeOperatorSessionState,
+} from "../observability/operator-session-state.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface PreparedOperatorCycle {
+  readonly effectiveCommand: string;
+  readonly sessionMode: "disabled" | "fresh" | "resuming";
+  readonly sessionSummary: string;
+  readonly backendSessionId: string | null;
+  readonly resetReason: string | null;
+}
+
+export interface RecordedOperatorCycle {
+  readonly sessionSummary: string;
+  readonly backendSessionId: string | null;
+}
+
+export async function prepareOperatorCycle(args: {
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+  readonly resumeSession: boolean;
+  readonly sessionStatePath: string;
+}): Promise<PreparedOperatorCycle> {
+  if (!args.resumeSession) {
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "disabled",
+      sessionSummary: "Resumable operator sessions are disabled.",
+      backendSessionId: null,
+      resetReason: null,
+    };
+  }
+
+  const stored = await readStoredSessionLenient(args.sessionStatePath);
+  const resumeSupport = buildResumeCommand({
+    provider: args.provider,
+    baseCommand: args.baseCommand,
+    sessionId: stored.document?.backendSessionId ?? "probe-session",
+  });
+
+  if (!resumeSupport.supported) {
+    if (stored.document !== null || stored.error !== null) {
+      await clearOperatorSessionState(args.sessionStatePath);
+    }
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "fresh",
+      sessionSummary:
+        stored.error !== null
+          ? `Stored operator session was cleared after a read error (${stored.error}); running fresh because the selected command cannot be resumed safely.`
+          : "Selected operator command does not support safe resumable sessions; running fresh.",
+      backendSessionId: null,
+      resetReason: resumeSupport.reason,
+    };
+  }
+
+  if (stored.error !== null) {
+    await clearOperatorSessionState(args.sessionStatePath);
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "fresh",
+      sessionSummary: `Stored operator session was unreadable and was cleared (${stored.error}); running fresh.`,
+      backendSessionId: null,
+      resetReason: stored.error,
+    };
+  }
+
+  if (stored.document === null) {
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "fresh",
+      sessionSummary:
+        "No stored operator session matched this instance; running fresh.",
+      backendSessionId: null,
+      resetReason: null,
+    };
+  }
+
+  const compatibility = describeOperatorSessionCompatibility({
+    stored: stored.document,
+    provider: args.provider,
+    model: args.model,
+    baseCommand: args.baseCommand,
+  });
+  if (!compatibility.compatible) {
+    await clearOperatorSessionState(args.sessionStatePath);
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "fresh",
+      sessionSummary: `Stored operator session was cleared because ${compatibility.reason}; running fresh.`,
+      backendSessionId: null,
+      resetReason: compatibility.reason,
+    };
+  }
+
+  const resume = buildResumeCommand({
+    provider: args.provider,
+    baseCommand: args.baseCommand,
+    sessionId: stored.document.backendSessionId,
+  });
+  if (!resume.supported) {
+    await clearOperatorSessionState(args.sessionStatePath);
+    return {
+      effectiveCommand: args.baseCommand,
+      sessionMode: "fresh",
+      sessionSummary: `Stored operator session was cleared because the resume command could not be reconstructed (${resume.reason}); running fresh.`,
+      backendSessionId: null,
+      resetReason: resume.reason,
+    };
+  }
+
+  const droppedArgsSummary =
+    resume.droppedArgs.length === 0
+      ? ""
+      : ` Dropped unsupported resume args: ${resume.droppedArgs.join(" ")}.`;
+
+  return {
+    effectiveCommand: resume.command,
+    sessionMode: "resuming",
+    sessionSummary:
+      `Resuming stored ${args.provider} operator session ${stored.document.backendSessionId}.${droppedArgsSummary}`.trim(),
+    backendSessionId: stored.document.backendSessionId,
+    resetReason: null,
+  };
+}
+
+export async function recordOperatorCycle(args: {
+  readonly provider: OperatorProvider;
+  readonly model: string | null;
+  readonly baseCommand: string;
+  readonly resumeSession: boolean;
+  readonly sessionMode: PreparedOperatorCycle["sessionMode"];
+  readonly sessionStatePath: string;
+  readonly repoRoot: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly exitCode: number;
+  readonly logFile: string;
+  readonly resetReason: string | null;
+}): Promise<RecordedOperatorCycle> {
+  if (!args.resumeSession) {
+    return {
+      sessionSummary: "Resumable operator sessions are disabled.",
+      backendSessionId: null,
+    };
+  }
+
+  if (args.exitCode !== 0) {
+    if (args.sessionMode === "resuming") {
+      await clearOperatorSessionState(args.sessionStatePath);
+      return {
+        sessionSummary:
+          "Resume attempt failed; cleared the stored operator session so the next cycle starts fresh.",
+        backendSessionId: null,
+      };
+    }
+    return {
+      sessionSummary:
+        "Operator cycle failed before a reusable backend session was recorded.",
+      backendSessionId: null,
+    };
+  }
+
+  const sessionId = await detectBackendSessionId(args);
+  if (sessionId === null) {
+    await clearOperatorSessionState(args.sessionStatePath);
+    return {
+      sessionSummary:
+        args.resetReason === null
+          ? "Operator cycle succeeded but no reusable backend session id was discovered; the next cycle will start fresh."
+          : `Stored operator session was cleared because ${args.resetReason}. Operator cycle succeeded but no reusable backend session id was discovered; the next cycle will start fresh.`,
+      backendSessionId: null,
+    };
+  }
+
+  const now = args.finishedAt;
+  const current = await readOperatorSessionState(args.sessionStatePath);
+  const summary =
+    args.sessionMode === "resuming"
+      ? `Resumed operator session ${sessionId} and refreshed the stored record.`
+      : args.resetReason === null
+        ? `Captured reusable operator session ${sessionId} for later wake-up cycles.`
+        : `Stored operator session was cleared because ${args.resetReason}. Captured reusable operator session ${sessionId} for later wake-up cycles.`;
+
+  const nextState: OperatorSessionStateDocument = {
+    version: 1,
+    provider: args.provider,
+    model: args.model,
+    baseCommandFingerprint: fingerprintOperatorCommand({
+      provider: args.provider,
+      baseCommand: args.baseCommand,
+    }),
+    backendSessionId: sessionId,
+    createdAt: current?.createdAt ?? now,
+    lastUsedAt: now,
+    lastMode: args.sessionMode === "resuming" ? "resuming" : "fresh",
+    lastSummary: summary,
+  };
+  await writeOperatorSessionState(args.sessionStatePath, nextState);
+  return {
+    sessionSummary: summary,
+    backendSessionId: sessionId,
+  };
+}
+
+async function detectBackendSessionId(args: {
+  readonly provider: OperatorProvider;
+  readonly repoRoot: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly logFile: string;
+}): Promise<string | null> {
+  if (args.provider === "claude") {
+    const output = await fs.readFile(args.logFile, "utf8").catch(() => null);
+    if (output === null) {
+      return null;
+    }
+    try {
+      return parseClaudeCodeResult(output).sessionId;
+    } catch {
+      return null;
+    }
+  }
+
+  if (args.provider === "codex") {
+    const branchName = await readCurrentGitBranch(args.repoRoot);
+    if (branchName === null) {
+      return null;
+    }
+    const session = await findCodexSession({
+      workspacePath: args.repoRoot,
+      branchName,
+      startedAt: args.startedAt,
+      finishedAt: args.finishedAt,
+    });
+    return session?.id ?? null;
+  }
+
+  return null;
+}
+
+async function readStoredSessionLenient(filePath: string): Promise<{
+  readonly document: OperatorSessionStateDocument | null;
+  readonly error: string | null;
+}> {
+  try {
+    return {
+      document: await readOperatorSessionState(filePath),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      document: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readCurrentGitBranch(repoRoot: string): Promise<string | null> {
+  try {
+    const result = await execFileAsync(
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      { cwd: repoRoot },
+    );
+    const branchName = result.stdout.trim();
+    return branchName.length === 0 ? null : branchName;
+  } catch {
+    return null;
+  }
+}
+
+function buildResumeCommand(args: {
+  readonly provider: OperatorProvider;
+  readonly baseCommand: string;
+  readonly sessionId: string;
+}):
+  | {
+      readonly supported: true;
+      readonly command: string;
+      readonly droppedArgs: readonly string[];
+    }
+  | {
+      readonly supported: false;
+      readonly reason: string;
+      readonly droppedArgs: readonly string[];
+    } {
+  try {
+    if (args.provider === "codex") {
+      const resume = buildCodexResumeCommand(args.baseCommand, args.sessionId);
+      return {
+        supported: true,
+        command: resume.command,
+        droppedArgs: resume.droppedArgs,
+      };
+    }
+    if (args.provider === "claude") {
+      return {
+        supported: true,
+        command: buildClaudeResumeCommand(args.baseCommand, args.sessionId),
+        droppedArgs: [],
+      };
+    }
+    return {
+      supported: false,
+      reason:
+        "custom operator commands do not have a checked-in resume adapter",
+      droppedArgs: [],
+    };
+  } catch (error) {
+    return {
+      supported: false,
+      reason: error instanceof Error ? error.message : String(error),
+      droppedArgs: [],
+    };
+  }
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -69,6 +69,27 @@ async function runOperatorLoop(workflowPath: string): Promise<{
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
   readonly releaseStatePath: string;
+  readonly sessionStatePath: string;
+  readonly logFile: string | null;
+}> {
+  return await runOperatorLoopWithOptions(workflowPath);
+}
+
+async function runOperatorLoopWithOptions(
+  workflowPath: string,
+  options?: {
+    readonly args?: readonly string[] | undefined;
+    readonly env?: NodeJS.ProcessEnv | undefined;
+  },
+): Promise<{
+  readonly stateRoot: string;
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+  readonly standingContextPath: string;
+  readonly wakeUpLogPath: string;
+  readonly legacyScratchpadPath: string;
+  readonly releaseStatePath: string;
+  readonly sessionStatePath: string;
   readonly logFile: string | null;
 }> {
   await execFileAsync(
@@ -78,6 +99,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
       "--once",
       "--workflow",
       workflowPath,
+      ...(options?.args ?? []),
     ],
     {
       cwd: repoRoot,
@@ -85,6 +107,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
         ...process.env,
         SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
         GH_TOKEN: "test-token",
+        ...options?.env,
       },
     },
   );
@@ -110,6 +133,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
     wakeUpLogPath: paths.wakeUpLogPath,
     legacyScratchpadPath: paths.legacyScratchpadPath,
     releaseStatePath: paths.releaseStatePath,
+    sessionStatePath: paths.sessionStatePath,
     logFile: statusJson.lastCycle.logFile,
   };
 }
@@ -118,6 +142,18 @@ async function runOperatorLoopWithCommand(
   workflowPath: string,
   command: string,
 ): Promise<void> {
+  await runOperatorLoopWithOptions(workflowPath, {
+    env: {
+      SYMPHONY_OPERATOR_COMMAND: command,
+    },
+  });
+}
+
+async function runOperatorLoopWithArgs(
+  workflowPath: string,
+  args: readonly string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<void> {
   await execFileAsync(
     "bash",
     [
@@ -125,13 +161,14 @@ async function runOperatorLoopWithCommand(
       "--once",
       "--workflow",
       workflowPath,
+      ...args,
     ],
     {
       cwd: repoRoot,
       env: {
         ...process.env,
-        SYMPHONY_OPERATOR_COMMAND: command,
         GH_TOKEN: "test-token",
+        ...env,
       },
     },
   );
@@ -141,6 +178,62 @@ function buildAppendWakeUpLogCommand(entryTitle: string): string {
   const entry = `\n## ${entryTitle}\n- Appended by integration test.\n`;
   const program = `const fs = require("node:fs"); fs.appendFileSync(process.env.SYMPHONY_OPERATOR_WAKE_UP_LOG, ${JSON.stringify(entry)});`;
   return `node -e ${JSON.stringify(program)}`;
+}
+
+async function createFakeOperatorExecutable(args: {
+  readonly directory: string;
+  readonly name: "codex" | "claude";
+  readonly logPath: string;
+}): Promise<string> {
+  const executablePath = path.join(args.directory, args.name);
+  const script =
+    args.name === "codex"
+      ? `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> ${JSON.stringify(args.logPath)}
+cat >/dev/null
+`
+      : `#!/usr/bin/env bash
+set -euo pipefail
+ORIGINAL_ARGS="$*"
+MODEL=""
+RESUME_SESSION=""
+while (($# > 0)); do
+  case "$1" in
+    --model)
+      MODEL="\${2:-}"
+      shift 2
+      ;;
+    --model=*)
+      MODEL="\${1#--model=}"
+      shift
+      ;;
+    --resume|-r)
+      RESUME_SESSION="\${2:-}"
+      shift 2
+      ;;
+    --output-format|--permission-mode)
+      shift 2
+      ;;
+    -p|--print|--dangerously-skip-permissions)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$ORIGINAL_ARGS" >> ${JSON.stringify(args.logPath)}
+cat >/dev/null
+if [[ -n "$RESUME_SESSION" ]]; then
+  SESSION_ID="$RESUME_SESSION"
+else
+  SESSION_ID="claude-session-\${MODEL:-default}"
+fi
+printf '{"type":"result","session_id":"%s","modelUsage":{"%s":{"inputTokens":1,"outputTokens":1}}}\\n' "$SESSION_ID" "\${MODEL:-claude-default}"
+`;
+  await fs.writeFile(executablePath, script, { encoding: "utf8", mode: 0o755 });
+  return executablePath;
 }
 
 async function writeIssueSummary(args: {
@@ -590,6 +683,266 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.releaseState.summary).toContain("#111");
       expect(statusMd).toContain(
         "- Release advancement state: blocked-by-prerequisite-failure",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes codex provider and model selection in operator status artifacts", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-codex-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const fakeBinDir = path.join(tempDir, "bin");
+    const commandLog = path.join(tempDir, "codex-invocations.log");
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await createFakeOperatorExecutable({
+      directory: fakeBinDir,
+      name: "codex",
+      logPath: commandLog,
+    });
+
+    try {
+      const run = await runOperatorLoopWithOptions(workflowPath, {
+        args: ["--provider", "codex", "--model", "gpt-5.4-mini"],
+        env: {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+      createdPaths.add(tempDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      const statusJson = JSON.parse(
+        await fs.readFile(run.statusJsonPath, "utf8"),
+      ) as {
+        readonly provider: string;
+        readonly model: string | null;
+        readonly commandSource: string;
+        readonly command: string;
+        readonly effectiveCommand: string;
+        readonly operatorSession: {
+          readonly enabled: boolean;
+          readonly path: string;
+        };
+      };
+      const statusMd = await fs.readFile(run.statusMdPath, "utf8");
+
+      expect(statusJson.provider).toBe("codex");
+      expect(statusJson.model).toBe("gpt-5.4-mini");
+      expect(statusJson.commandSource).toBe("provider-template");
+      expect(statusJson.command).toContain("--model gpt-5.4-mini");
+      expect(statusJson.effectiveCommand).toContain("--model gpt-5.4-mini");
+      expect(statusJson.operatorSession.enabled).toBe(false);
+      expect(statusJson.operatorSession.path).toBe(run.sessionStatePath);
+      expect(statusMd).toContain("- Provider: codex");
+      expect(statusMd).toContain("- Model: gpt-5.4-mini");
+      expect(statusMd).toContain("- Command source: provider-template");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes claude provider selection in operator status artifacts", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-claude-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const fakeBinDir = path.join(tempDir, "bin");
+    const commandLog = path.join(tempDir, "claude-invocations.log");
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await createFakeOperatorExecutable({
+      directory: fakeBinDir,
+      name: "claude",
+      logPath: commandLog,
+    });
+
+    try {
+      const run = await runOperatorLoopWithOptions(workflowPath, {
+        args: ["--provider", "claude"],
+        env: {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+      createdPaths.add(tempDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      const statusJson = JSON.parse(
+        await fs.readFile(run.statusJsonPath, "utf8"),
+      ) as {
+        readonly provider: string;
+        readonly model: string | null;
+        readonly command: string;
+        readonly commandSource: string;
+      };
+
+      expect(statusJson.provider).toBe("claude");
+      expect(statusJson.model).toBeNull();
+      expect(statusJson.command).toContain("claude -p");
+      expect(statusJson.commandSource).toBe("provider-template");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses a stored claude session on later wake-up cycles when resumable mode is enabled", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-resume-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const fakeBinDir = path.join(tempDir, "bin");
+    const commandLog = path.join(tempDir, "claude-resume.log");
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await createFakeOperatorExecutable({
+      directory: fakeBinDir,
+      name: "claude",
+      logPath: commandLog,
+    });
+
+    try {
+      await runOperatorLoopWithArgs(
+        workflowPath,
+        [
+          "--provider",
+          "claude",
+          "--model",
+          "claude-sonnet-4-5",
+          "--resume-session",
+        ],
+        {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      );
+      const firstState = deriveOperatorInstanceStatePaths({
+        operatorRepoRoot: repoRoot,
+        instanceKey: deriveSymphonyInstanceKey(path.dirname(workflowPath)),
+      });
+      const firstStatus = JSON.parse(
+        await fs.readFile(firstState.statusJsonPath, "utf8"),
+      ) as {
+        readonly operatorSession: {
+          readonly mode: string;
+          readonly backendSessionId: string | null;
+        };
+      };
+
+      await runOperatorLoopWithArgs(
+        workflowPath,
+        [
+          "--provider",
+          "claude",
+          "--model",
+          "claude-sonnet-4-5",
+          "--resume-session",
+        ],
+        {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      );
+      createdPaths.add(tempDir);
+      createdPaths.add(firstState.operatorStateRoot);
+
+      const secondStatus = JSON.parse(
+        await fs.readFile(firstState.statusJsonPath, "utf8"),
+      ) as {
+        readonly operatorSession: {
+          readonly mode: string;
+          readonly backendSessionId: string | null;
+          readonly summary: string;
+        };
+      };
+      const commandInvocations = await fs.readFile(commandLog, "utf8");
+
+      expect(firstStatus.operatorSession.mode).toBe("fresh");
+      expect(firstStatus.operatorSession.backendSessionId).toBe(
+        "claude-session-claude-sonnet-4-5",
+      );
+      expect(secondStatus.operatorSession.mode).toBe("resuming");
+      expect(secondStatus.operatorSession.backendSessionId).toBe(
+        "claude-session-claude-sonnet-4-5",
+      );
+      expect(secondStatus.operatorSession.summary).toContain(
+        "refreshed the stored record",
+      );
+      expect(commandInvocations).toContain(
+        "--resume claude-session-claude-sonnet-4-5",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears a stored claude session when the selected model changes", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-model-reset-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const fakeBinDir = path.join(tempDir, "bin");
+    const commandLog = path.join(tempDir, "claude-model-reset.log");
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await createFakeOperatorExecutable({
+      directory: fakeBinDir,
+      name: "claude",
+      logPath: commandLog,
+    });
+
+    try {
+      await runOperatorLoopWithArgs(
+        workflowPath,
+        [
+          "--provider",
+          "claude",
+          "--model",
+          "claude-sonnet-4-5",
+          "--resume-session",
+        ],
+        {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      );
+
+      await runOperatorLoopWithArgs(
+        workflowPath,
+        [
+          "--provider",
+          "claude",
+          "--model",
+          "claude-haiku-4-5",
+          "--resume-session",
+        ],
+        {
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+      );
+      createdPaths.add(tempDir);
+      const paths = deriveOperatorInstanceStatePaths({
+        operatorRepoRoot: repoRoot,
+        instanceKey: deriveSymphonyInstanceKey(path.dirname(workflowPath)),
+      });
+      createdPaths.add(paths.operatorStateRoot);
+
+      const status = JSON.parse(
+        await fs.readFile(paths.statusJsonPath, "utf8"),
+      ) as {
+        readonly operatorSession: {
+          readonly mode: string;
+          readonly summary: string;
+          readonly backendSessionId: string | null;
+          readonly resetReason: string | null;
+        };
+      };
+      const invocations = await fs.readFile(commandLog, "utf8");
+
+      expect(status.operatorSession.mode).toBe("fresh");
+      expect(status.operatorSession.resetReason).toContain(
+        "stored model claude-sonnet-4-5 does not match selected model claude-haiku-4-5",
+      );
+      expect(status.operatorSession.summary).toContain(
+        "Captured reusable operator session",
+      );
+      expect(status.operatorSession.backendSessionId).toBe(
+        "claude-session-claude-haiku-4-5",
+      );
+      expect(invocations).not.toContain(
+        "--resume claude-session-claude-sonnet-4-5",
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/unit/instance-identity.test.ts
+++ b/tests/unit/instance-identity.test.ts
@@ -55,5 +55,8 @@ describe("instance identity helpers", () => {
     expect(paths.reportReviewStatePath).toBe(
       path.join(paths.operatorStateRoot, "report-review-state.json"),
     );
+    expect(paths.sessionStatePath).toBe(
+      path.join(paths.operatorStateRoot, "operator-session.json"),
+    );
   });
 });

--- a/tests/unit/operator-loop-config.test.ts
+++ b/tests/unit/operator-loop-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveOperatorLoopConfig } from "../../src/config/operator-loop.js";
+
+describe("operator loop config resolution", () => {
+  it("builds a codex provider-template command when provider and model are selected", () => {
+    const resolved = resolveOperatorLoopConfig({
+      argv: ["--provider", "codex", "--model", "gpt-5.4-mini"],
+      env: {},
+    });
+
+    expect(resolved.provider).toBe("codex");
+    expect(resolved.model).toBe("gpt-5.4-mini");
+    expect(resolved.commandSource).toBe("provider-template");
+    expect(resolved.baseCommand).toContain("codex exec");
+    expect(resolved.baseCommand).toContain("--model gpt-5.4-mini");
+  });
+
+  it("builds a claude provider-template command when claude is selected", () => {
+    const resolved = resolveOperatorLoopConfig({
+      argv: ["--provider", "claude"],
+      env: {},
+    });
+
+    expect(resolved.provider).toBe("claude");
+    expect(resolved.model).toBeNull();
+    expect(resolved.commandSource).toBe("provider-template");
+    expect(resolved.baseCommand).toContain("claude -p");
+    expect(resolved.baseCommand).toContain("--output-format json");
+  });
+
+  it("lets explicit provider/model flags override SYMPHONY_OPERATOR_COMMAND", () => {
+    const resolved = resolveOperatorLoopConfig({
+      argv: ["--provider", "codex", "--model", "gpt-5.4-mini"],
+      env: {
+        SYMPHONY_OPERATOR_COMMAND:
+          "claude -p --output-format json --permission-mode bypassPermissions --model sonnet",
+      },
+    });
+
+    expect(resolved.provider).toBe("codex");
+    expect(resolved.commandSource).toBe("provider-template");
+    expect(resolved.baseCommand).toContain("gpt-5.4-mini");
+    expect(resolved.baseCommand).not.toContain("claude");
+  });
+
+  it("uses a raw cli operator command as the highest-precedence escape hatch", () => {
+    const resolved = resolveOperatorLoopConfig({
+      argv: [
+        "--operator-command",
+        "claude -p --output-format json --permission-mode bypassPermissions --model sonnet",
+      ],
+      env: {
+        SYMPHONY_OPERATOR_COMMAND:
+          "codex exec --dangerously-bypass-approvals-and-sandbox -C . -",
+      },
+    });
+
+    expect(resolved.provider).toBe("claude");
+    expect(resolved.model).toBe("sonnet");
+    expect(resolved.commandSource).toBe("cli-command");
+    expect(resolved.baseCommand).toContain("claude -p");
+  });
+
+  it("rejects mixing the raw command escape hatch with model flags", () => {
+    expect(() =>
+      resolveOperatorLoopConfig({
+        argv: [
+          "--operator-command",
+          "codex exec --dangerously-bypass-approvals-and-sandbox -C . -",
+          "--model",
+          "gpt-5.4-mini",
+        ],
+        env: {},
+      }),
+    ).toThrowError("--operator-command cannot be combined with --model");
+  });
+});

--- a/tests/unit/operator-session-state.test.ts
+++ b/tests/unit/operator-session-state.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  describeOperatorSessionCompatibility,
+  fingerprintOperatorCommand,
+  readOperatorSessionState,
+  writeOperatorSessionState,
+} from "../../src/observability/operator-session-state.js";
+import { prepareOperatorCycle } from "../../src/runner/operator-session.js";
+import { createTempDir } from "../support/git.js";
+
+describe("operator session state", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    for (const root of tempRoots) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+    tempRoots.length = 0;
+  });
+
+  it("stores and reloads persisted operator session records", async () => {
+    const tempDir = await createTempDir("symphony-operator-session-");
+    tempRoots.push(tempDir);
+    const filePath = path.join(tempDir, "operator-session.json");
+
+    await writeOperatorSessionState(filePath, {
+      version: 1,
+      provider: "claude",
+      model: "claude-sonnet-4-5",
+      baseCommandFingerprint: fingerprintOperatorCommand({
+        provider: "claude",
+        baseCommand:
+          "claude -p --output-format json --permission-mode bypassPermissions --model claude-sonnet-4-5",
+      }),
+      backendSessionId: "claude-session-1",
+      createdAt: "2026-03-31T00:00:00Z",
+      lastUsedAt: "2026-03-31T00:05:00Z",
+      lastMode: "fresh",
+      lastSummary: "Captured reusable operator session.",
+    });
+
+    await expect(readOperatorSessionState(filePath)).resolves.toEqual({
+      version: 1,
+      provider: "claude",
+      model: "claude-sonnet-4-5",
+      baseCommandFingerprint: fingerprintOperatorCommand({
+        provider: "claude",
+        baseCommand:
+          "claude -p --output-format json --permission-mode bypassPermissions --model claude-sonnet-4-5",
+      }),
+      backendSessionId: "claude-session-1",
+      createdAt: "2026-03-31T00:00:00Z",
+      lastUsedAt: "2026-03-31T00:05:00Z",
+      lastMode: "fresh",
+      lastSummary: "Captured reusable operator session.",
+    });
+  });
+
+  it("reports model mismatches as incompatible", () => {
+    const compatibility = describeOperatorSessionCompatibility({
+      stored: {
+        version: 1,
+        provider: "claude",
+        model: "claude-sonnet-4-5",
+        baseCommandFingerprint: "fingerprint",
+        backendSessionId: "claude-session-1",
+        createdAt: "2026-03-31T00:00:00Z",
+        lastUsedAt: "2026-03-31T00:05:00Z",
+        lastMode: "fresh",
+        lastSummary: "Captured reusable operator session.",
+      },
+      provider: "claude",
+      model: "claude-haiku-4-5",
+      baseCommand:
+        "claude -p --output-format json --permission-mode bypassPermissions --model claude-haiku-4-5",
+    });
+
+    expect(compatibility.compatible).toBe(false);
+    expect(compatibility.reason).toContain("stored model");
+  });
+
+  it("clears malformed stored session files and runs fresh", async () => {
+    const tempDir = await createTempDir("symphony-operator-session-bad-");
+    tempRoots.push(tempDir);
+    const filePath = path.join(tempDir, "operator-session.json");
+    await fs.writeFile(filePath, '{"version":"bad"}\n', "utf8");
+
+    const prepared = await prepareOperatorCycle({
+      provider: "claude",
+      model: "claude-sonnet-4-5",
+      baseCommand:
+        "claude -p --output-format json --permission-mode bypassPermissions --model claude-sonnet-4-5",
+      resumeSession: true,
+      sessionStatePath: filePath,
+    });
+
+    expect(prepared.sessionMode).toBe("fresh");
+    expect(prepared.sessionSummary).toContain("unreadable");
+    await expect(readOperatorSessionState(filePath)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add first-class operator loop config resolution for provider, model, raw command, and resumable session flags
- persist operator session state per instance and resume compatible Codex/Claude sessions across wake-up cycles
- publish provider/model/command/session metadata in operator status artifacts and document the new operator workflows

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test

Closes #296
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
