### PR TITLE
Reset turn budget after approved plan handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,12 @@ agent:
 Use them when the command launches another backend such as Pi so status,
 artifacts, and reports show a stable identity instead of the generic default.
 
-The prompt template below the YAML front matter uses Liquid syntax with access to `issue`, `config`, and `pull_request` variables. See the checked-in [`WORKFLOW.md`](WORKFLOW.md) for the full template.
+The prompt template below the YAML front matter uses Liquid syntax with access
+to `issue`, `config`, `lifecycle`, and `pull_request` variables. `lifecycle`
+is available for any normalized tracker handoff state, including pre-PR states
+such as approved plan-review resumes. `pull_request` stays PR-only so existing
+templates can safely dereference PR fields. See the checked-in
+[`WORKFLOW.md`](WORKFLOW.md) for the full template.
 
 ### Linear Tracker
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -97,6 +97,15 @@ GitHub Prompt Trust Boundary:
 Issue Summary:
 {{ issue.summary }}
 
+{% if lifecycle %}
+Tracker Handoff State:
+
+- Status: {{ lifecycle.kind }}
+- Branch: {{ lifecycle.branchName }}
+- Summary: {{ lifecycle.summary }}
+
+{% endif %}
+
 {% if pull_request %}
 Pull Request State:
 

--- a/docs/guides/workflow-guide.md
+++ b/docs/guides/workflow-guide.md
@@ -140,7 +140,8 @@ This separate reference should eventually cover:
 
 - Explain what the prompt body should and should not do.
 - Explain the trusted context that Symphony injects.
-- Explain how issue/PR lifecycle data appears in the template.
+- Explain how normalized lifecycle data appears through the `lifecycle`
+  variable and how PR-specific data appears through `pull_request`.
 - Explain why prompts should state durable process expectations explicitly.
 
 Key themes to cover:

--- a/docs/plans/299-reset-implementation-turn-budget-after-approved-plan-handoff/plan.md
+++ b/docs/plans/299-reset-implementation-turn-budget-after-approved-plan-handoff/plan.md
@@ -201,14 +201,14 @@ Explicit non-transition:
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts | Normalized tracker facts | Expected decision |
-| --- | --- | --- | --- |
-| Worker stopped at `plan-ready` and no human reply yet | prior attempt exists; no PR | latest signal is `plan-ready` | wait in `awaiting-human-handoff`; do not retry or rerun |
-| Human approved after `plan-ready`; no PR exists yet | new run attempt scheduled or issue requeued | latest signal is `approved`; no PR | rerun on same branch with turn 1 of a fresh run and prompt-visible "approved plan, continue implementation" context |
-| Human waived after `plan-ready`; no PR exists yet | same as above | latest signal is `waived`; no PR | same as approved: rerun implementation with fresh run budget and explicit resume context |
-| Human requested changes after `plan-ready`; no PR exists yet | new run attempt scheduled | latest signal is `changes-requested`; no PR | rerun to revise the plan, not generic implementation, with prompt-visible revision context |
-| No PR exists and no valid plan-review handoff exists | ordinary fresh issue or malformed comments | no relevant plan-review signal | use existing generic `missing-target` behavior |
-| Resumed implementation run still finishes with no PR after its new run budget | attempt turns exhausted again | latest lifecycle still actionable pre-PR state | preserve existing failure/retry path, but with the new run actually having had the correct prompt context |
+| Observed condition                                                            | Local facts                                 | Normalized tracker facts                       | Expected decision                                                                                                   |
+| ----------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Worker stopped at `plan-ready` and no human reply yet                         | prior attempt exists; no PR                 | latest signal is `plan-ready`                  | wait in `awaiting-human-handoff`; do not retry or rerun                                                             |
+| Human approved after `plan-ready`; no PR exists yet                           | new run attempt scheduled or issue requeued | latest signal is `approved`; no PR             | rerun on same branch with turn 1 of a fresh run and prompt-visible "approved plan, continue implementation" context |
+| Human waived after `plan-ready`; no PR exists yet                             | same as above                               | latest signal is `waived`; no PR               | same as approved: rerun implementation with fresh run budget and explicit resume context                            |
+| Human requested changes after `plan-ready`; no PR exists yet                  | new run attempt scheduled                   | latest signal is `changes-requested`; no PR    | rerun to revise the plan, not generic implementation, with prompt-visible revision context                          |
+| No PR exists and no valid plan-review handoff exists                          | ordinary fresh issue or malformed comments  | no relevant plan-review signal                 | use existing generic `missing-target` behavior                                                                      |
+| Resumed implementation run still finishes with no PR after its new run budget | attempt turns exhausted again               | latest lifecycle still actionable pre-PR state | preserve existing failure/retry path, but with the new run actually having had the correct prompt context           |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/299-reset-implementation-turn-budget-after-approved-plan-handoff/plan.md
+++ b/docs/plans/299-reset-implementation-turn-budget-after-approved-plan-handoff/plan.md
@@ -1,0 +1,321 @@
+# Issue 299 Plan: Reset Implementation Turn Budget After Approved Plan Handoff
+
+## Goal
+
+Make a post-plan-review implementation rerun deterministic and usable: once a
+worker has reached `plan-ready` and a human replies with `Plan review:
+approved` or `Plan review: waived`, the next worker run must resume with a
+fresh implementation turn budget and prompt-visible context that the plan gate
+has already been satisfied.
+
+## Scope
+
+In scope:
+
+- GitHub bootstrap plan-review normalization for approved, waived, and
+  changes-requested replies after a `plan-ready` handoff
+- prompt/context plumbing so pre-PR lifecycle facts remain visible to the next
+  worker run instead of collapsing to a generic null PR state
+- orchestrator handling for pre-PR implementation resumes after approved plan
+  handoff
+- regression coverage for the `#289` control path, including a prompt-sensitive
+  e2e fixture that proves the resumed run receives usable implementation
+  context and can make progress
+
+Out of scope:
+
+- redesigning the overall plan review workflow or accepted review markers
+- changing `agent.max_turns` schema or turning it into separate configurable
+  plan-phase and implementation-phase budgets
+- Linear tracker lifecycle redesign beyond any shared prompt-context helpers
+- runner transport changes, workspace retention changes, or unrelated retry
+  backoff policy changes
+
+## Non-Goals
+
+- invent a new tracker transport protocol for plan review
+- add a durable orchestrator-side ledger of every prior turn across runs
+- change how PR review, CI follow-up, or landing states work
+- backfill or rewrite historical issue artifacts for already completed runs
+
+## Symphony Layer Mapping
+
+- Policy Layer
+  - Belongs here: the repo-owned rule that approved or waived plan review means
+    "resume implementation on the same issue branch with a fresh worker run",
+    while changes-requested means "revise the plan and post a fresh
+    `plan-ready` handoff".
+  - Does not belong here: runner transport details or workspace bootstrap
+    mechanics.
+- Configuration Layer
+  - Belongs here: prompt-builder contract changes required to expose normalized
+    lifecycle kind/summary to the worker prompt even when no PR exists yet.
+  - Does not belong here: tracker-specific comment parsing rules or retry
+    queues.
+- Coordination Layer
+  - Belongs here: orchestrator handling for a new worker run after
+    `awaiting-human-handoff`, including keeping the implementation rerun on a
+    fresh run attempt and passing normalized lifecycle context into the prompt
+    and continuation guidance.
+  - Does not belong here: raw GitHub comment parsing or issue-comment wording.
+- Execution Layer
+  - Belongs here: none beyond preserving the existing per-run `agent.max_turns`
+    contract.
+  - Does not belong here: any new runner session-reuse or workspace-retention
+    behavior; this issue is not a runner/workspace fix.
+- Integration Layer
+  - Belongs here: GitHub plan-review normalization that distinguishes "waiting
+    for review" from "approved/waived, resume implementation" and
+    "changes-requested, revise plan", while still using existing GitHub issue
+    comments as the system of record.
+  - Does not belong here: orchestrator retry counters or prompt rendering.
+- Observability Layer
+  - Belongs here: status/artifact assertions needed to keep the resumed
+    implementation phase inspectable in tests.
+  - Does not belong here: inventing a new operator dashboard feature for this
+    fix.
+
+## Current Gap
+
+Issue `#289` exposed a control-path bug after the repo adopted the mandatory
+plan-review station:
+
+1. attempt 1 used the full `agent.max_turns` budget while producing the plan
+   and posting `Plan status: plan-ready`
+2. a human approved the plan on the issue thread
+3. the next worker run re-entered the issue with no PR yet, but Symphony
+   normalized that state back to a generic `missing-target`
+4. the orchestrator then dropped that `missing-target` lifecycle to `null`
+   when building the prompt, so the resumed worker prompt could not see that
+   the plan gate had already been satisfied
+5. the rerun therefore did not receive explicit "resume implementation now"
+   context, and the issue could fail again with the same max-turn
+   `missing-target` outcome without implementation progress
+
+The repo already treats `agent.max_turns` as a per-run budget. The gap is that
+the post-approval rerun does not carry forward the phase boundary that should
+make the fresh implementation budget usable.
+
+## Architecture Boundaries
+
+Keep the fix on one reviewable seam:
+
+- `src/tracker/plan-review-policy.ts` should own normalization of issue-thread
+  plan-review decisions into stable pre-PR lifecycle summaries.
+- `src/tracker/github.ts` should keep using normalized lifecycle facts from the
+  tracker edge instead of inventing orchestrator-specific special cases.
+- `src/config/workflow.ts`, `src/domain/prompt-context.ts`, and
+  `src/tracker/prompt-context.ts` should own the worker prompt contract for
+  lifecycle visibility.
+- `src/orchestrator/service.ts` should pass normalized lifecycle context into
+  worker turns and continuation prompts without treating pre-PR implementation
+  resumes as tracker-specific shell lore.
+
+What does not belong in this slice:
+
+- mixing GitHub comment fetching/parsing with prompt rendering logic
+- adding workspace markers, local files, or runner metadata just to remember
+  that plan review was approved
+- creating a brand-new lifecycle family for every plan-review subcase unless
+  the existing normalized lifecycle kinds cannot express the behavior cleanly
+
+## Slice Strategy And PR Seam
+
+Land one PR focused on "approved plan handoff resumes implementation with
+prompt-visible context":
+
+1. normalize approved/waived/changes-requested plan-review decisions into
+   actionable pre-PR lifecycle summaries at the tracker edge
+2. surface general lifecycle context to the worker prompt independently from
+   PR-only context
+3. add regression tests that fail on the current bug and pass once resumed
+   implementation receives the right context
+
+This is reviewable in one PR because it stays on one runtime seam:
+plan-review lifecycle normalization plus the prompt/orchestrator contract that
+consumes it. It does not mix workspace cleanup, runner transport, and tracker
+transport changes.
+
+Deferred from this PR:
+
+- configurable separate plan-budget and implementation-budget knobs
+- richer operator UI for "approved plan, implementation not yet started"
+- Linear-specific plan-review resume semantics unless the shared prompt-context
+  contract needs a small follow-on adjustment
+
+## Runtime State Machine
+
+This issue changes orchestration around retries, continuations, and handoff
+states, so the runtime model must stay explicit.
+
+States:
+
+1. `missing-target / initial`
+   - no PR exists and no valid plan-review handoff has been observed yet
+2. `awaiting-human-handoff`
+   - latest valid issue-thread signal is `Plan status: plan-ready`
+3. `missing-target / approved-plan-resume`
+   - no PR exists, but the latest relevant plan-review signal is
+     `approved` or `waived`, so the next worker run should resume
+     implementation on the same branch with a fresh run attempt
+4. `missing-target / revise-plan`
+   - no PR exists, but the latest relevant plan-review signal is
+     `changes-requested`, so the next worker run should revise the plan rather
+     than start implementation
+5. `rework-required`
+   - PR exists and actionable review/check feedback requires more code changes
+6. `awaiting-system-checks` / `awaiting-human-review` / `awaiting-landing*`
+   - existing post-PR handoff states remain unchanged
+7. `handoff-ready`
+   - PR merged / terminal success
+8. `attempt-failed`
+   - worker run exhausted its per-run budget or otherwise failed and entered
+     retry/failure handling
+
+Transitions:
+
+1. initial `missing-target` -> `awaiting-human-handoff`
+   - worker posts `Plan status: plan-ready`
+2. `awaiting-human-handoff` -> `missing-target / approved-plan-resume`
+   - human posts `Plan review: approved` or `Plan review: waived`
+3. `awaiting-human-handoff` -> `missing-target / revise-plan`
+   - human posts `Plan review: changes-requested`
+4. `missing-target / approved-plan-resume` -> implementation worker run
+   - next run attempt starts with turn 1 of `agent.max_turns` and prompt-visible
+     lifecycle summary that plan review is already satisfied
+5. `missing-target / revise-plan` -> plan revision worker run
+   - next run attempt starts with turn 1 and prompt-visible lifecycle summary
+     that the plan must be revised and re-posted
+6. any active worker run -> `attempt-failed`
+   - run exits unsuccessfully or finishes with actionable work still remaining
+     after its per-run `agent.max_turns`
+7. post-approval/pre-PR implementation -> `rework-required` /
+   `awaiting-system-checks` / `handoff-ready`
+   - once the worker opens a PR or completes the issue, existing handoff logic
+     resumes unchanged
+
+Explicit non-transition:
+
+- `awaiting-human-handoff` must not consume the next run's prompt context after
+  approval by collapsing back to a generic null PR state with no phase summary
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts | Normalized tracker facts | Expected decision |
+| --- | --- | --- | --- |
+| Worker stopped at `plan-ready` and no human reply yet | prior attempt exists; no PR | latest signal is `plan-ready` | wait in `awaiting-human-handoff`; do not retry or rerun |
+| Human approved after `plan-ready`; no PR exists yet | new run attempt scheduled or issue requeued | latest signal is `approved`; no PR | rerun on same branch with turn 1 of a fresh run and prompt-visible "approved plan, continue implementation" context |
+| Human waived after `plan-ready`; no PR exists yet | same as above | latest signal is `waived`; no PR | same as approved: rerun implementation with fresh run budget and explicit resume context |
+| Human requested changes after `plan-ready`; no PR exists yet | new run attempt scheduled | latest signal is `changes-requested`; no PR | rerun to revise the plan, not generic implementation, with prompt-visible revision context |
+| No PR exists and no valid plan-review handoff exists | ordinary fresh issue or malformed comments | no relevant plan-review signal | use existing generic `missing-target` behavior |
+| Resumed implementation run still finishes with no PR after its new run budget | attempt turns exhausted again | latest lifecycle still actionable pre-PR state | preserve existing failure/retry path, but with the new run actually having had the correct prompt context |
+
+## Storage / Persistence Contract
+
+Do not introduce new durable files for this bug.
+
+The system of record remains:
+
+- GitHub issue comments for `plan-ready` and human review replies
+- normalized tracker lifecycle facts derived from those comments
+- existing issue artifacts/status snapshots for attempt and lifecycle
+  observations
+
+If extra state is needed, prefer a typed in-memory runtime seam over a new
+workspace sentinel file. The desired behavior should be recoverable from the
+tracker plus current code, not from local-only hidden state.
+
+## Observability Requirements
+
+- The resumed run should remain inspectable as a new attempt in status and
+  issue artifacts.
+- Tests should assert that the resumed attempt actually executes code work
+  rather than silently recycling the old plan-only outcome.
+- Prompt/context tests should make it obvious whether the worker sees:
+  - generic missing-target with no plan context
+  - approved-plan resume context
+  - changes-requested revise-plan context
+
+## Implementation Steps
+
+1. Extend plan-review policy evaluation so approved/waived/changes-requested
+   replies can produce a normalized actionable pre-PR lifecycle summary instead
+   of always collapsing to `null` and then to the generic "No open pull
+   request found" summary.
+2. Refine the prompt-context contract so worker prompts can render lifecycle
+   kind/summary for any normalized handoff state, while keeping PR-only facts
+   separate from lifecycle facts that exist before a PR is opened.
+3. Update orchestrator prompt plumbing so the initial prompt and continuation
+   prompt both receive the normalized lifecycle context even when the lifecycle
+   kind is `missing-target`.
+4. Add unit coverage for:
+   - plan-review policy after approved/waived/changes-requested replies
+   - prompt rendering for pre-PR lifecycle context
+   - orchestrator behavior that no longer drops `missing-target` lifecycle
+     context on resumed runs
+5. Add integration/e2e coverage that reproduces the `#289` path:
+   - attempt 1 reaches `plan-ready`
+   - a human approval is posted
+   - a resumed attempt sees prompt-visible approved-plan context and can create
+     implementation changes / a PR instead of failing immediately with inherited
+     plan-only behavior
+
+## Tests
+
+- `pnpm exec vitest run tests/unit/plan-review-policy.test.ts`
+- `pnpm exec vitest run tests/unit/workflow.test.ts`
+- `pnpm exec vitest run tests/unit/orchestrator.test.ts`
+- `pnpm exec vitest run tests/integration/github-bootstrap.test.ts`
+- `pnpm exec vitest run tests/e2e/bootstrap-factory.test.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. Given a worker that has already posted `Plan status: plan-ready`, when a
+   human replies `Plan review: approved`, then the next implementation run gets
+   prompt-visible context that plan review is satisfied and starts with a fresh
+   run turn budget.
+2. Given the same setup with `Plan review: waived`, when the next run starts,
+   then it also resumes implementation with fresh run-turn counting and without
+   re-entering generic plan-only behavior.
+3. Given `Plan review: changes-requested`, when the next run starts, then the
+   prompt indicates that the plan must be revised rather than hiding that state
+   behind a generic no-PR summary.
+4. Given a fresh issue with no valid plan-review signals, when the worker runs,
+   then existing generic `missing-target` behavior is unchanged.
+5. Given the concrete `#289` repro path in an automated harness, when approval
+   is posted after a plan-only first attempt, then the resumed attempt can make
+   implementation progress instead of immediately terminating with the same
+   plan-only max-turn failure mode.
+
+## Exit Criteria
+
+- approved or waived plan-review replies no longer disappear behind a generic
+  null pre-PR prompt context
+- a rerun after plan approval has explicit, trusted lifecycle context telling
+  it to continue implementation on the existing branch
+- regression tests reproduce and prevent the `#289` stuck-after-approval path
+- no new tracker transport/prompt/orchestrator coupling is introduced beyond
+  the normalized lifecycle seam
+
+## Deferred
+
+- explicit separate config knobs like `agent.plan_max_turns` and
+  `agent.implementation_max_turns`
+- richer lifecycle-specific operator surfaces for "approved plan, awaiting
+  first implementation commit"
+- any broader refactor of all prompt context sections beyond the lifecycle vs
+  PR separation required for this fix
+
+## Decision Notes
+
+1. Prefer preserving the existing `missing-target` lifecycle kind with richer
+   normalized summary/context over introducing a brand-new top-level lifecycle
+   kind unless implementation proves that the current kind cannot represent the
+   approved-plan resume seam cleanly.
+2. Treat the bug as a prompt-visible lifecycle/context bug at the
+   tracker-orchestrator boundary, not as a runner-session reuse bug. The fix
+   should keep `agent.max_turns` per-run and make that fresh run budget usable
+   by preserving the plan-review phase boundary into the next prompt.

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -8,6 +8,7 @@ import type { PromptIssueContext } from "../domain/prompt-context.js";
 import { parseLocalRunnerCommand } from "../runner/local-command.js";
 import {
   buildPromptIssueContext,
+  buildPromptLifecycleContext,
   buildPromptPullRequestContext,
 } from "../tracker/prompt-context.js";
 import {
@@ -86,6 +87,7 @@ type SupportedGitHubReviewerAppKey =
 interface PromptRenderInput {
   readonly issue: PromptIssueContext;
   readonly attempt: number | null;
+  readonly lifecycle: ReturnType<typeof buildPromptLifecycleContext>;
   readonly pullRequest: ReturnType<typeof buildPromptPullRequestContext>;
   readonly config: ResolvedConfig;
 }
@@ -1382,6 +1384,7 @@ async function renderPromptTemplate(
     return await liquid.parseAndRender(definition.promptTemplate, {
       issue: input.issue,
       attempt: input.attempt,
+      lifecycle: input.lifecycle,
       pull_request: input.pullRequest,
       config: redactPromptConfig(input.config),
     });
@@ -1426,6 +1429,7 @@ export function createPromptBuilder(
       return await renderPromptTemplate(definition, {
         issue: buildPromptIssueContext(input.issue, definition.config.tracker),
         attempt: input.attempt,
+        lifecycle: buildPromptLifecycleContext(input.pullRequest),
         pullRequest: buildPromptPullRequestContext(input.pullRequest),
         config: definition.config,
       });

--- a/src/domain/prompt-context.ts
+++ b/src/domain/prompt-context.ts
@@ -24,11 +24,14 @@ export interface PromptReviewFeedbackContext {
   readonly summary: string;
 }
 
-export interface PromptPullRequestContext {
+export interface PromptLifecycleContext {
   readonly kind: HandoffLifecycleKind;
+  readonly branchName: string;
   readonly summary: string;
   readonly pullRequest: PullRequestHandle | null;
   readonly pendingCheckNames: readonly string[];
   readonly failingCheckNames: readonly string[];
   readonly actionableReviewFeedback: readonly PromptReviewFeedbackContext[];
 }
+
+export type PromptPullRequestContext = PromptLifecycleContext;

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -1266,7 +1266,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       attempt,
       lockDir,
       issueSource,
-      lifecycle.kind === "missing-target" ? null : lifecycle,
+      lifecycle,
     );
   }
 
@@ -1734,7 +1734,8 @@ export class BootstrapOrchestrator implements Orchestrator {
           session,
           liveRunnerSession,
         );
-        let currentLifecycle = pullRequest;
+        let currentLifecycle =
+          pullRequest?.kind === "missing-target" ? null : pullRequest;
         let turnNumber = 1;
 
         while (true) {

--- a/src/tracker/plan-review-policy.ts
+++ b/src/tracker/plan-review-policy.ts
@@ -3,6 +3,7 @@ import {
   parsePlanReviewSignal,
   type PlanReviewSignal,
 } from "./plan-review-signal.js";
+import { missingPullRequestLifecycle } from "./pull-request-policy.js";
 
 export interface IssueCommentSnapshot {
   readonly id: number;
@@ -123,22 +124,39 @@ function buildPlanReviewAcknowledgement(
   ].join("\n");
 }
 
+function sortPlanReviewComments(
+  left: ParsedPlanReviewComment,
+  right: ParsedPlanReviewComment,
+): number {
+  const timeDiff =
+    Date.parse(left.comment.createdAt) - Date.parse(right.comment.createdAt);
+  return timeDiff !== 0 ? timeDiff : left.comment.id - right.comment.id;
+}
+
+function buildPlanReviewResumeLifecycle(
+  branchName: string,
+  signal: PlanReviewDecisionSignal,
+): HandoffLifecycle {
+  const summary =
+    signal === "changes-requested"
+      ? `Plan review requested changes for ${branchName}; revise the plan and post a fresh plan-ready handoff before implementation.`
+      : signal === "approved"
+        ? `Plan review approved for ${branchName}; resume implementation before opening a pull request.`
+        : `Plan review waived for ${branchName}; resume implementation before opening a pull request.`;
+
+  return missingPullRequestLifecycle(branchName, summary);
+}
+
 export function evaluatePlanReviewProtocol(
   branchName: string,
   issueUrl: string,
   comments: readonly IssueCommentSnapshot[],
 ): PlanReviewProtocolEvaluation {
-  const latestSignal =
-    comments
-      .map(parsePlanReviewComment)
-      .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
-      .sort((left, right) => {
-        const timeDiff =
-          Date.parse(left.comment.createdAt) -
-          Date.parse(right.comment.createdAt);
-        return timeDiff !== 0 ? timeDiff : left.comment.id - right.comment.id;
-      })
-      .at(-1) ?? null;
+  const parsedSignals = comments
+    .map(parsePlanReviewComment)
+    .filter((entry): entry is ParsedPlanReviewComment => entry !== null)
+    .sort(sortPlanReviewComments);
+  const latestSignal = parsedSignals.at(-1) ?? null;
 
   if (latestSignal === null) {
     return {
@@ -149,6 +167,22 @@ export function evaluatePlanReviewProtocol(
   }
 
   if (latestSignal.signal !== "plan-ready") {
+    const anchoredPlanReady = [...parsedSignals]
+      .reverse()
+      .find(
+        (entry) =>
+          entry.signal === "plan-ready" &&
+          sortPlanReviewComments(entry, latestSignal) < 0,
+      );
+
+    if (anchoredPlanReady === undefined) {
+      return {
+        latestSignal,
+        lifecycle: null,
+        acknowledgement: null,
+      };
+    }
+
     const acknowledgement = hasAcknowledgedLatestSignal(
       latestSignal.signal,
       latestSignal.comment.id,
@@ -166,7 +200,10 @@ export function evaluatePlanReviewProtocol(
 
     return {
       latestSignal,
-      lifecycle: null,
+      lifecycle: buildPlanReviewResumeLifecycle(
+        branchName,
+        latestSignal.signal,
+      ),
       acknowledgement,
     };
   }

--- a/src/tracker/prompt-context.ts
+++ b/src/tracker/prompt-context.ts
@@ -2,6 +2,7 @@ import type { HandoffLifecycle, ReviewFeedback } from "../domain/handoff.js";
 import type { RuntimeIssue } from "../domain/issue.js";
 import type {
   PromptIssueContext,
+  PromptLifecycleContext,
   PromptPullRequestContext,
   PromptReviewFeedbackContext,
 } from "../domain/prompt-context.js";
@@ -28,19 +29,30 @@ export function buildPromptIssueContext(
 }
 
 export function buildPromptPullRequestContext(
-  pullRequest: HandoffLifecycle | null,
+  lifecycle: HandoffLifecycle | null,
 ): PromptPullRequestContext | null {
-  if (pullRequest === null) {
+  if (lifecycle === null || lifecycle.pullRequest === null) {
+    return null;
+  }
+
+  return buildPromptLifecycleContext(lifecycle);
+}
+
+export function buildPromptLifecycleContext(
+  lifecycle: HandoffLifecycle | null,
+): PromptLifecycleContext | null {
+  if (lifecycle === null) {
     return null;
   }
 
   return {
-    kind: pullRequest.kind,
-    summary: pullRequest.summary,
-    pullRequest: pullRequest.pullRequest,
-    pendingCheckNames: pullRequest.pendingCheckNames,
-    failingCheckNames: pullRequest.failingCheckNames,
-    actionableReviewFeedback: pullRequest.actionableReviewFeedback.map(
+    kind: lifecycle.kind,
+    branchName: lifecycle.branchName,
+    summary: lifecycle.summary,
+    pullRequest: lifecycle.pullRequest,
+    pendingCheckNames: lifecycle.pendingCheckNames,
+    failingCheckNames: lifecycle.failingCheckNames,
+    actionableReviewFeedback: lifecycle.actionableReviewFeedback.map(
       buildPromptReviewFeedbackContext,
     ),
   };

--- a/src/tracker/pull-request-policy.ts
+++ b/src/tracker/pull-request-policy.ts
@@ -44,6 +44,7 @@ function summarizeLifecycle(
 
 export function missingPullRequestLifecycle(
   branchName: string,
+  summary = `No open pull request found for ${branchName}`,
 ): HandoffLifecycle {
   return {
     kind: "missing-target",
@@ -58,7 +59,7 @@ export function missingPullRequestLifecycle(
     reviewerVerdict: "no-blocking-verdict",
     blockingReviewerKeys: [],
     requiredReviewerState: "not-required",
-    summary: `No open pull request found for ${branchName}`,
+    summary,
   };
 }
 

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -229,6 +229,11 @@ ${agentEnvBlock}${
     }---
 You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 Issue summary: {{ issue.summary }}
+{% if lifecycle %}
+Tracker lifecycle: {{ lifecycle.kind }}
+Tracker branch: {{ lifecycle.branchName }}
+Tracker lifecycle summary: {{ lifecycle.summary }}
+{% endif %}
 {% if pull_request %}
 Pull request lifecycle: {{ pull_request.kind }}
 Pull request URL: {{ pull_request.pullRequest.url }}
@@ -1577,6 +1582,67 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     );
 
     expect(await countRemoteBranchCommits(remotePath, "symphony/53")).toBe(1);
+  });
+
+  it("resumes implementation after approved plan review with a fresh run budget and prompt-visible lifecycle context", async () => {
+    server.seedIssue({
+      number: 289,
+      title: "Resume implementation after approved plan review",
+      body: "Reset the implementation turn budget after the approved plan handoff.",
+      labels: ["symphony:ready"],
+    });
+
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve(
+        "tests/fixtures/fake-agent-approved-plan-resume.sh",
+      ),
+      maxTurns: 1,
+      maxAttempts: 1,
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+
+    await orchestrator.runOnce();
+
+    server.addIssueComment({
+      issueNumber: 289,
+      authorLogin: "jessmartin",
+      body: "Plan review: approved\n\nSummary\n- Approved to implement.",
+    });
+
+    await orchestrator.runOnce();
+
+    const issue = server.getIssue(289);
+    expect(
+      issue.comments.some((body) =>
+        body.startsWith("Plan review acknowledged: approved"),
+      ),
+    ).toBe(true);
+
+    const pullRequests = server.getPullRequests();
+    expect(pullRequests).toHaveLength(1);
+    expect(pullRequests[0]?.head).toBe("symphony/289");
+
+    const promptFile = await readRemoteBranchFile(
+      remotePath,
+      "symphony/289",
+      ".agent-prompt.txt",
+    );
+    expect(promptFile).toContain("Tracker lifecycle: missing-target");
+    expect(promptFile).toContain("Tracker branch: symphony/289");
+    expect(promptFile).toContain(
+      "Tracker lifecycle summary: Plan review approved for symphony/289; resume implementation before opening a pull request.",
+    );
+    expect(promptFile).not.toContain("Pull request URL:");
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.lastAction?.kind).toBe("awaiting-system-checks");
+    expect(status.activeIssues[0]?.issueNumber).toBe(289);
+    expect(status.activeIssues[0]?.status).toBe("awaiting-system-checks");
   });
 
   it("runs a complete GitHub factory handoff loop through the Claude Code runner", async () => {

--- a/tests/fixtures/fake-agent-approved-plan-resume.sh
+++ b/tests/fixtures/fake-agent-approved-plan-resume.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT="$(cat)"
+printf '%s' "$PROMPT" > .agent-prompt.txt
+
+git config user.name "Symphony Test Agent"
+git config user.email "symphony-agent@example.com"
+
+PLAN_PATH="docs/plans/${SYMPHONY_ISSUE_NUMBER}-approved-plan-resume/plan.md"
+
+if [[ ! -f "$PLAN_PATH" ]]; then
+  mkdir -p "$(dirname "$PLAN_PATH")"
+  cat > "$PLAN_PATH" <<EOF
+# Issue ${SYMPHONY_ISSUE_NUMBER} Plan
+
+## Goal
+
+Exercise the approved-plan resume path.
+
+## Summary
+
+- Stop at plan-ready on the first run.
+- Resume implementation only when the prompt shows approved plan lifecycle context.
+EOF
+
+  git add .agent-prompt.txt "$PLAN_PATH"
+  git commit -m "Draft plan for ${SYMPHONY_ISSUE_IDENTIFIER}"
+  git push origin "HEAD:${SYMPHONY_BRANCH_NAME}"
+
+  cat > .plan-ready-comment.md <<EOF
+Plan status: plan-ready
+
+Plan path: \`${PLAN_PATH}\`
+Issue branch: \`${SYMPHONY_BRANCH_NAME}\`
+Plan link: https://github.com/sociotechnica-org/symphony-ts/blob/${SYMPHONY_BRANCH_NAME}/${PLAN_PATH}
+Branch URL: https://github.com/sociotechnica-org/symphony-ts/tree/${SYMPHONY_BRANCH_NAME}
+Compare URL: https://github.com/sociotechnica-org/symphony-ts/compare/main...${SYMPHONY_BRANCH_NAME}
+
+Summary
+
+- Ready for human review.
+EOF
+
+  gh issue comment "${SYMPHONY_ISSUE_NUMBER}" \
+    --repo sociotechnica-org/symphony-ts \
+    --body-file .plan-ready-comment.md
+  exit 0
+fi
+
+if ! grep -q "Tracker lifecycle: missing-target" .agent-prompt.txt; then
+  exit 0
+fi
+
+if ! grep -qi "Tracker lifecycle summary: Plan review approved" .agent-prompt.txt; then
+  exit 0
+fi
+
+echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER} after approved plan review" > IMPLEMENTED.txt
+git add .agent-prompt.txt IMPLEMENTED.txt
+git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER} after approved plan review"
+git push origin "HEAD:${SYMPHONY_BRANCH_NAME}"
+curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
+  -H 'content-type: application/json' \
+  -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
+
+gh pr create \
+  --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --base main \
+  --head "${SYMPHONY_BRANCH_NAME}"

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -238,9 +238,10 @@ describe("GitHubTracker", () => {
     const second = await tracker.inspectIssueHandoff("symphony/7");
 
     expect(first.kind).toBe("missing-target");
-    expect(first.summary).toMatch(/no open pull request/i);
+    expect(first.summary).toMatch(/plan review approved/i);
+    expect(first.summary).toMatch(/resume implementation/i);
     expect(second.kind).toBe("missing-target");
-    expect(second.summary).toMatch(/no open pull request/i);
+    expect(second.summary).toMatch(/plan review approved/i);
     expect(
       server
         .getIssue(7)
@@ -318,6 +319,8 @@ describe("GitHubTracker", () => {
 
     expect(first.kind).toBe("missing-target");
     expect(second.kind).toBe("missing-target");
+    expect(first.summary).toMatch(/requested changes/i);
+    expect(second.summary).toMatch(/revise the plan/i);
     expect(server.countRequests("GET issues/7")).toBe(2);
     expect(server.countRequests("GET issues/7/comments")).toBe(2);
     expect(
@@ -349,6 +352,8 @@ describe("GitHubTracker", () => {
 
     expect(first.kind).toBe("missing-target");
     expect(second.kind).toBe("missing-target");
+    expect(first.summary).toMatch(/plan review waived/i);
+    expect(second.summary).toMatch(/resume implementation/i);
     expect(
       server
         .getIssue(7)
@@ -356,6 +361,29 @@ describe("GitHubTracker", () => {
           body.startsWith("Plan review acknowledged: waived"),
         ),
     ).toHaveLength(1);
+  });
+
+  it("ignores unanchored plan-review decisions that lack a prior plan-ready handoff", async () => {
+    const tracker = createTracker(server);
+
+    server.addIssueComment({
+      issueNumber: 7,
+      authorLogin: "jessmartin",
+      body: "Plan review: approved\n\nSummary\n- Proceed.",
+      createdAt: "2026-03-07T10:05:00.000Z",
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("missing-target");
+    expect(lifecycle.summary).toMatch(/no open pull request/i);
+    expect(
+      server
+        .getIssue(7)
+        .comments.filter((body) =>
+          body.startsWith("Plan review acknowledged: approved"),
+        ),
+    ).toHaveLength(0);
   });
 
   it("reports awaiting-system-checks while checks are pending", async () => {

--- a/tests/support/pull-request.ts
+++ b/tests/support/pull-request.ts
@@ -32,6 +32,7 @@ export function createLifecycle(
     pendingCheckNames?: readonly string[];
     actionableReviewFeedback?: readonly ReviewFeedback[];
     unresolvedThreadIds?: readonly string[];
+    summary?: string;
   },
 ): HandoffLifecycle {
   return {
@@ -56,6 +57,6 @@ export function createLifecycle(
     reviewerVerdict: "no-blocking-verdict",
     blockingReviewerKeys: [],
     requiredReviewerState: "not-required",
-    summary: `${kind} for ${branchName}`,
+    summary: options?.summary ?? `${kind} for ${branchName}`,
   };
 }

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -450,6 +450,9 @@ class SequencedTracker implements Tracker {
     if (lifecycle === null) {
       const issueNumber = Number(branchName.split("/").at(-1));
       const sequence = this.lifecycleSequences.get(issueNumber);
+      // Ready issues start with a synthetic missing-target lifecycle before the
+      // tracker sequence is consulted, so continuation tests need one queued
+      // missing-target state consumed before the next tracker lifecycle.
       if (sequence?.[0]?.kind === "missing-target") {
         sequence.shift();
       }
@@ -1457,7 +1460,9 @@ describe("BootstrapOrchestrator", () => {
       ready: [createIssue(34)],
     });
     tracker.setLifecycleSequence(34, [
-      lifecycle("missing-target", "symphony/34"),
+      lifecycle("missing-target", "symphony/34", {
+        summary: "No open pull request found for symphony/34",
+      }),
       lifecycle("missing-target", "symphony/34", {
         summary:
           "Plan review approved for symphony/34; resume implementation before opening a pull request.",

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1452,6 +1452,78 @@ describe("BootstrapOrchestrator", () => {
     }
   });
 
+  it("preserves approved pre-PR lifecycle context in the next prompt after plan review", async () => {
+    const tracker = new SequencedTracker({
+      ready: [createIssue(34)],
+    });
+    tracker.setLifecycleSequence(34, [
+      lifecycle("missing-target", "symphony/34"),
+      lifecycle("missing-target", "symphony/34", {
+        summary:
+          "Plan review approved for symphony/34; resume implementation before opening a pull request.",
+      }),
+      lifecycle("handoff-ready", "symphony/34"),
+    ]);
+
+    const runner = new RecordingRunner();
+    const lifecyclePromptBuilder: PromptBuilder = {
+      async build({ issue, attempt, pullRequest }): Promise<string> {
+        return JSON.stringify({
+          issue: issue.identifier,
+          attempt,
+          lifecycleKind: pullRequest?.kind ?? null,
+          lifecycleSummary: pullRequest?.summary ?? null,
+          pullRequestNumber: pullRequest?.pullRequest?.number ?? null,
+        });
+      },
+      async buildContinuation({
+        issue,
+        turnNumber,
+        maxTurns,
+        pullRequest,
+      }): Promise<string> {
+        return JSON.stringify({
+          issue: issue.identifier,
+          turnNumber,
+          maxTurns,
+          lifecycleKind: pullRequest?.kind ?? null,
+          lifecycleSummary: pullRequest?.summary ?? null,
+          mode: "continuation",
+        });
+      },
+    };
+
+    const orchestrator = new BootstrapOrchestrator(
+      baseConfig,
+      lifecyclePromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      runner,
+      new NullLogger(),
+    );
+
+    await orchestrator.runOnce();
+
+    expect(runner.prompts).toEqual([
+      JSON.stringify({
+        issue: "sociotechnica-org/symphony-ts#34",
+        attempt: null,
+        lifecycleKind: "missing-target",
+        lifecycleSummary: "No open pull request found for symphony/34",
+        pullRequestNumber: null,
+      }),
+      JSON.stringify({
+        issue: "sociotechnica-org/symphony-ts#34",
+        turnNumber: 2,
+        maxTurns: 3,
+        lifecycleKind: "missing-target",
+        lifecycleSummary:
+          "Plan review approved for symphony/34; resume implementation before opening a pull request.",
+        mode: "continuation",
+      }),
+    ]);
+  });
+
   it("warns when continuation turns fall back to cold-start subprocesses", async () => {
     const tempRoot = await createTempDir("symphony-cold-start-warning-test-");
     try {
@@ -2797,7 +2869,7 @@ describe("BootstrapOrchestrator", () => {
       JSON.stringify({
         issue: "sociotechnica-org/symphony-ts#13",
         attempt: null,
-        pullRequest: null,
+        pullRequest: "missing-target",
       }),
       JSON.stringify({
         issue: "sociotechnica-org/symphony-ts#13",

--- a/tests/unit/plan-review-policy.test.ts
+++ b/tests/unit/plan-review-policy.test.ts
@@ -88,7 +88,9 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle).toBeNull();
+    expect(lifecycle?.kind).toBe("missing-target");
+    expect(lifecycle?.summary).toMatch(/plan review approved/i);
+    expect(lifecycle?.summary).toMatch(/resume implementation/i);
   });
 
   it("does not wait when the latest signal is waived", () => {
@@ -109,7 +111,9 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle).toBeNull();
+    expect(lifecycle?.kind).toBe("missing-target");
+    expect(lifecycle?.summary).toMatch(/plan review waived/i);
+    expect(lifecycle?.summary).toMatch(/resume implementation/i);
   });
 
   it("does not wait when the latest signal is changes-requested", () => {
@@ -130,7 +134,9 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(lifecycle).toBeNull();
+    expect(lifecycle?.kind).toBe("missing-target");
+    expect(lifecycle?.summary).toMatch(/requested changes/i);
+    expect(lifecycle?.summary).toMatch(/revise the plan/i);
   });
 
   it("returns to waiting when a revised plan-ready comment is newer than prior feedback", () => {
@@ -177,7 +183,7 @@ describe("plan-review-policy", () => {
       ],
     );
 
-    expect(protocol.lifecycle).toBeNull();
+    expect(protocol.lifecycle?.kind).toBe("missing-target");
     expect(protocol.acknowledgement?.signal).toBe("approved");
     expect(protocol.acknowledgement?.reviewCommentId).toBe(3);
     expect(protocol.acknowledgement?.body).toContain(
@@ -191,6 +197,11 @@ describe("plan-review-policy", () => {
       "symphony/32",
       "https://example.test/issues/32",
       [
+        comment(
+          "Plan status: plan-ready\n\nWaiting for review.",
+          "2026-03-07T10:05:00.000Z",
+          2,
+        ),
         comment(
           "Plan review: changes-requested\n\nRequired changes\n- Split the issue.",
           "2026-03-07T10:06:00.000Z",
@@ -208,6 +219,23 @@ describe("plan-review-policy", () => {
           ].join("\n"),
           "2026-03-07T10:07:00.000Z",
           4,
+        ),
+      ],
+    );
+
+    expect(protocol.lifecycle?.kind).toBe("missing-target");
+    expect(protocol.acknowledgement).toBeNull();
+  });
+
+  it("ignores review decisions that are not anchored to a prior plan-ready handoff", () => {
+    const protocol = evaluatePlanReviewProtocol(
+      "symphony/32",
+      "https://example.test/issues/32",
+      [
+        comment(
+          "Plan review: approved\n\nSummary\n- Proceed.",
+          "2026-03-07T10:06:00.000Z",
+          3,
         ),
       ],
     );

--- a/tests/unit/workflow.test.ts
+++ b/tests/unit/workflow.test.ts
@@ -765,6 +765,74 @@ ${buildSharedWorkflowSections()}`,
     expect(rendered).not.toContain("Developer:");
   });
 
+  it("renders lifecycle context separately from PR-only context", async () => {
+    const dir = await createTempDir("workflow-lifecycle-prompt-context-");
+    const workflowPath = path.join(dir, "WORKFLOW.md");
+    await fs.writeFile(
+      workflowPath,
+      buildWorkflow(
+        `tracker:
+  repo: sociotechnica-org/symphony-ts
+  api_url: https://api.github.com
+  ready_label: symphony:ready
+  running_label: symphony:running
+  failed_label: symphony:failed
+  success_comment: done
+${buildSharedWorkflowSections()}`,
+        [
+          "{% if lifecycle %}",
+          "Lifecycle kind: {{ lifecycle.kind }}",
+          "Lifecycle branch: {{ lifecycle.branchName }}",
+          "Lifecycle summary: {{ lifecycle.summary }}",
+          "{% endif %}",
+          "{% if pull_request %}",
+          "PR URL: {{ pull_request.pullRequest.url }}",
+          "{% endif %}",
+        ].join("\n"),
+      ),
+      "utf8",
+    );
+
+    const workflow = await loadWorkflow(workflowPath);
+    const promptBuilder = createPromptBuilder(workflow);
+    const rendered = await promptBuilder.build({
+      issue: {
+        id: "1",
+        identifier: "repo#1",
+        number: 1,
+        title: "T",
+        description: "D",
+        labels: ["a"],
+        state: "open",
+        url: "https://example.test/issues/1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        queuePriority: null,
+      },
+      attempt: 2,
+      pullRequest: {
+        kind: "missing-target",
+        branchName: "symphony/1",
+        pullRequest: null,
+        checks: [],
+        pendingCheckNames: [],
+        failingCheckNames: [],
+        actionableReviewFeedback: [],
+        unresolvedThreadIds: [],
+        reviewerVerdict: "no-blocking-verdict",
+        blockingReviewerKeys: [],
+        requiredReviewerState: "not-required",
+        summary:
+          "Plan review approved for symphony/1; resume implementation before opening a pull request.",
+      },
+    });
+
+    expect(rendered).toContain("Lifecycle kind: missing-target");
+    expect(rendered).toContain("Lifecycle branch: symphony/1");
+    expect(rendered).toContain("Lifecycle summary: Plan review approved");
+    expect(rendered).not.toContain("PR URL:");
+  });
+
   it("rejects workflow templates that still reference raw tracker issue descriptions", async () => {
     const dir = await createTempDir("workflow-legacy-description-");
     const workflowPath = path.join(dir, "WORKFLOW.md");


### PR DESCRIPTION
## Summary
- normalize approved, waived, and changes-requested plan-review replies into anchored pre-PR `missing-target` lifecycle summaries instead of collapsing back to a generic no-PR state
- expose tracker handoff lifecycle context separately from PR-only prompt context so approved plan resumes are visible in prompts without breaking existing `pull_request` templates
- add regression coverage for the `#289` control path, including a prompt-sensitive e2e fixture that proves implementation resumes after approval

## Root cause
The repo already treated `agent.max_turns` as a per-run budget, but after a plan-only run finished at `plan-ready`, the next run lost the approved-plan phase boundary. The tracker returned a generic missing-target state, the orchestrator dropped that state before prompt construction, and resumed runs had no prompt-visible signal that plan review was already satisfied.

## Impact
- approved or waived plan review now resumes implementation with explicit pre-PR lifecycle context
- changes-requested replies now surface a revise-the-plan lifecycle instead of falling back to a generic no-PR summary
- prompt templates can use `lifecycle` for any handoff state while `pull_request` remains PR-only and backward compatible

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #299.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
