### PR TITLE
Fix dispatch slot filling while runs stay active

### DIFF
--- a/docs/plans/297-fill-available-dispatch-slots/plan.md
+++ b/docs/plans/297-fill-available-dispatch-slots/plan.md
@@ -271,14 +271,14 @@ This issue changes long-running orchestration behavior, so slot-consumption stat
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
-| --- | --- | --- | --- |
-| One issue is already active locally, one slot remains free, another ready issue exists | one slot already reserved/active, one slot free | ready issue is still claimable | reserve the free slot and dispatch the ready issue on the next poll without waiting for the first run to finish |
-| One issue has been selected for dispatch but is still in claim/startup work when the next poll begins | slot is already reserved for that issue | tracker may still show ready or newly running | do not treat the slot as free and do not over-dispatch another issue into the same capacity |
-| Active local run count already equals `maxConcurrentRuns` | all slots reserved/active | ready issues may still exist | keep polling/reconciling status, but do not dispatch new ready work |
-| Background dispatch fails before the run becomes active | reserved slot plus startup/claim failure | issue may remain ready or move back out of running | release the slot, record the failure path, and let a later poll reconsider capacity normally |
-| Factory halt or dispatch pressure becomes active while another run is still active | one or more slots active | ready issues may exist | keep inspecting running work but block new slot reservations until halt/pressure clears |
-| Shutdown is requested while background runs are active | active slots and abort controllers exist | tracker state unchanged or running | stop reserving new slots, abort active runs through existing shutdown paths, and release slots only after cleanup |
+| Observed condition                                                                                    | Local facts available                           | Normalized tracker facts available                 | Expected decision                                                                                                 |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| One issue is already active locally, one slot remains free, another ready issue exists                | one slot already reserved/active, one slot free | ready issue is still claimable                     | reserve the free slot and dispatch the ready issue on the next poll without waiting for the first run to finish   |
+| One issue has been selected for dispatch but is still in claim/startup work when the next poll begins | slot is already reserved for that issue         | tracker may still show ready or newly running      | do not treat the slot as free and do not over-dispatch another issue into the same capacity                       |
+| Active local run count already equals `maxConcurrentRuns`                                             | all slots reserved/active                       | ready issues may still exist                       | keep polling/reconciling status, but do not dispatch new ready work                                               |
+| Background dispatch fails before the run becomes active                                               | reserved slot plus startup/claim failure        | issue may remain ready or move back out of running | release the slot, record the failure path, and let a later poll reconsider capacity normally                      |
+| Factory halt or dispatch pressure becomes active while another run is still active                    | one or more slots active                        | ready issues may exist                             | keep inspecting running work but block new slot reservations until halt/pressure clears                           |
+| Shutdown is requested while background runs are active                                                | active slots and abort controllers exist        | tracker state unchanged or running                 | stop reserving new slots, abort active runs through existing shutdown paths, and release slots only after cleanup |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/297-fill-available-dispatch-slots/plan.md
+++ b/docs/plans/297-fill-available-dispatch-slots/plan.md
@@ -1,0 +1,348 @@
+# Issue 297 Plan: Fill Available Dispatch Slots While Another Runner Turn Is Active
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Let the factory keep polling and dispatching additional ready work up to `polling.max_concurrent_runs` even while another locally started runner turn is still active.
+
+The intended outcome of this slice is:
+
+1. one live active run consumes only one local dispatch slot
+2. the poll loop continues on schedule while background runs remain active
+3. a free slot is filled by the next eligible ready issue instead of waiting for the active run to finish
+4. slot accounting stays explicit and inspectable instead of depending on whether the current poll is still awaiting a promise
+5. tracker policy, tracker transport, and runner transport remain unchanged
+
+## Scope
+
+This slice covers:
+
+1. orchestration poll-loop behavior for locally active runs when `maxConcurrentRuns > 1`
+2. explicit local slot-accounting/runtime-state updates needed so capacity stays correct while runs continue in the background
+3. status/observability updates only if needed to keep `activeLocalRuns` and live-run visibility accurate after the orchestration change
+4. focused unit coverage for slot accounting and continued polling with an active run
+5. at least one realistic end-to-end regression scenario that proves a second ready issue dispatches while the first run is still active
+6. small doc updates where the checked-in operator/runtime guidance should describe the now-enforced concurrency behavior more explicitly
+
+## Non-Goals
+
+This slice does not include:
+
+1. changing tracker label semantics or handoff lifecycle policy
+2. changing runner continuation-turn behavior, app-server transport, or prompt construction
+3. broad shutdown/watchdog/recovery redesign outside the slot-accounting seam required here
+4. remote-worker scheduling changes beyond preserving the existing host-dispatch contract
+5. broader queue-priority or dependency-promotion policy changes
+6. introducing a new durable coordination store beyond the current local runtime state and lease/status artifacts
+
+## Current Gaps
+
+Today the orchestration loop still couples polling progress to dispatched run completion:
+
+1. `src/orchestrator/service.ts` computes available slots from `this.#state.runningIssueNumbers.size`, dispatches work, and then `await`s `Promise.all(runs)` before `runOnce()` returns
+2. `runLoop()` waits for `runOnce()` to finish before sleeping and starting the next poll, so one long-running live runner turn can delay all future polling
+3. `runningIssueNumbers` currently mixes local active-run bookkeeping with per-dispatch lease lifetime in a way that becomes fragile once dispatch promises are allowed to outlive the poll cycle
+4. the current implementation proves parallel dispatch inside one poll, but it does not prove continued polling while a prior dispatched run remains active in the background
+5. the issue symptom matches that shape exactly: with `max_concurrent_runs: 2`, one live running issue blocked dispatch of another ready issue until the live turn ended
+
+## Decision Notes
+
+1. Keep the seam in the orchestrator. The bug is coordination behavior, not tracker policy and not runner transport.
+2. Make local slot state explicit. Do not let one set or counter continue to mean “lease held”, “background promise exists”, and “capacity consumed” unless code and tests make those transitions explicit.
+3. Preserve existing normalized tracker behavior. Running issues still take precedence in queue ordering and reconciliation; the fix is about continued polling, not changing issue ordering policy.
+4. Prefer a small focused runtime-state helper if the service code would otherwise gain more inline counters/flags. This follows the repo rule against hiding orchestration behavior in loose maps and branches.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that one live active run should consume one slot, not stall unrelated free capacity
+2. the rule that ready work should continue dispatching while other runs are legitimately active
+3. the rule that tracker running-state inspection still happens every poll even when no dispatch capacity remains
+
+Does not belong here:
+
+1. promise-lifecycle plumbing
+2. lease-manager filesystem details
+3. runner transport mechanics
+
+### Configuration Layer
+
+Belongs here:
+
+1. the existing `polling.max_concurrent_runs` contract as the capacity ceiling this issue must honor
+
+Does not belong here:
+
+1. new workflow fields for this fix
+2. tracker-specific concurrency overrides
+3. background task bookkeeping
+
+### Coordination Layer
+
+Belongs here:
+
+1. explicit local slot reservation and release rules
+2. decoupling poll cadence from dispatched-run completion
+3. dispatch decisions that combine queue ordering, local slot usage, factory halt state, and dispatch-pressure state
+4. explicit transitions for scheduled, active, and completed local dispatch work
+
+Does not belong here:
+
+1. tracker transport parsing
+2. runner-specific event parsing
+3. status rendering logic beyond consuming normalized state
+
+### Execution Layer
+
+Belongs here:
+
+1. unchanged workspace preparation and runner execution once a slot has been reserved and a dispatch begins
+2. preserving the current execution lifecycle for each individual run
+
+Does not belong here:
+
+1. deciding whether another ready issue should start
+2. defining poll cadence
+3. tracker reconciliation policy
+
+### Integration Layer
+
+Belongs here:
+
+1. unchanged tracker reads for ready/running issues and unchanged tracker claim semantics
+2. unchanged runner transport/session contracts
+
+Does not belong here:
+
+1. local slot accounting
+2. background poll scheduling
+3. compensating for orchestration races with tracker-specific behavior
+
+### Observability Layer
+
+Belongs here:
+
+1. keeping `activeLocalRuns`, running-ticket visibility, and queue/status snapshots correct after polling continues during active runs
+2. logging the new dispatch/slot transitions clearly enough to explain why capacity is or is not available
+
+Does not belong here:
+
+1. being the source of truth for slot state
+2. inventing fallback capacity calculations separate from the orchestrator
+
+## Architecture Boundaries
+
+### `src/orchestrator/service.ts`
+
+Owns:
+
+1. poll scheduling
+2. queue selection
+3. coordination between explicit local slot state, leases, dispatch pressure, and halt state
+4. background dispatch task lifecycle and cleanup
+
+Does not own:
+
+1. tracker transport changes
+2. runner protocol changes
+3. observability-only derived capacity rules
+
+### New or extracted focused orchestrator runtime-state helper(s)
+
+Owns:
+
+1. explicit local slot reservation/release transitions
+2. distinguishing “slot consumed by an active local dispatch” from unrelated tracker running counts
+3. any tracked background-dispatch promise bookkeeping if needed to keep `service.ts` legible
+
+Does not own:
+
+1. tracker queue ordering
+2. prompt/runner behavior
+3. status formatting
+
+### `src/orchestrator/status-state.ts` and related status snapshot wiring
+
+Owns:
+
+1. projecting the active local run count and active issue surface from the normalized orchestration state
+
+Does not own:
+
+1. primary slot-allocation decisions
+2. reconstructing background dispatch state from tracker labels alone
+
+### Tests
+
+Own:
+
+1. proving the continued-polling behavior under a blocked/long-running first run
+2. proving the slot-accounting edge cases for dispatch start, completion, and failure
+
+Do not own:
+
+1. introducing tracker-specific workarounds that hide orchestration races
+
+## Layering Notes
+
+- `config/workflow`
+  - owns the existing concurrency limit input
+  - does not gain new knobs for this bug fix
+- `tracker`
+  - keeps supplying normalized ready/running issue lists and claim operations
+  - does not absorb orchestration slot policy
+- `workspace`
+  - keeps preparing per-issue execution state after dispatch starts
+  - does not reserve global capacity
+- `runner`
+  - keeps executing one issue run at a time per dispatched session
+  - does not decide whether more issues should start
+- `orchestrator`
+  - owns local-capacity accounting, background dispatch lifecycle, and poll cadence
+  - must not lean on tracker running counts as a proxy for local available slots
+- `observability`
+  - reports the orchestrator’s chosen slot state and active runs
+  - does not infer capacity independently
+
+## Slice Strategy And PR Seam
+
+This should fit in one reviewable PR by staying on one orchestration seam:
+
+1. make poll cycles non-blocking with respect to already-dispatched active runs
+2. introduce explicit local slot accounting/background task tracking as needed to keep that behavior correct
+3. update focused tests and narrow docs/status wording on the same seam
+
+Deferred from this PR:
+
+1. larger restart-recovery or shutdown refactors unless they are directly required by the new background-dispatch lifecycle
+2. queue-priority redesign
+3. tracker contract changes
+4. runner transport redesign
+
+This seam is reviewable on its own because it changes one observable factory behavior: continued filling of available dispatch slots while prior work remains active.
+
+## Runtime State Machine
+
+This issue changes long-running orchestration behavior, so slot-consumption state must be explicit.
+
+### Local dispatch slot states
+
+1. `idle`
+   - no local slot reserved for the issue
+2. `reserved`
+   - the orchestrator has decided to dispatch the issue and capacity is consumed for that in-flight local work
+3. `claiming-or-resuming`
+   - local coordination work is underway: lease acquisition, tracker claim or running-issue inspection, and run startup bookkeeping
+4. `active`
+   - the issue has a live locally owned dispatch path still running, including continuation turns or waiting inside the run lifecycle
+5. `releasing`
+   - terminal cleanup/failure/shutdown is unwinding and the slot is about to become available again
+
+### Allowed transitions
+
+1. `idle -> reserved`
+   - poll cycle chooses the issue for dispatch because capacity exists
+2. `reserved -> claiming-or-resuming`
+   - background dispatch task starts and begins local coordination work
+3. `claiming-or-resuming -> active`
+   - the issue reaches its live locally owned execution path
+4. `claiming-or-resuming -> releasing`
+   - claim/inspection/startup fails after the slot was reserved
+5. `active -> releasing`
+   - run completes, waits out of the live path, fails terminally, or shuts down
+6. `releasing -> idle`
+   - cleanup finishes and the slot becomes available for a later poll
+
+### Contract Rules
+
+1. slot reservation must happen before a later poll can observe the slot as free
+2. poll cadence must not depend on background dispatch promises finishing
+3. a slot consumed by one issue must not allow a second issue to over-dispatch during claim/startup races
+4. tracker running counts and local slot counts are related observability facts, not interchangeable control inputs
+5. halt and dispatch-pressure rules still block new `idle -> reserved` transitions, but they do not stop inspection of already active running issues
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker facts available | Expected decision |
+| --- | --- | --- | --- |
+| One issue is already active locally, one slot remains free, another ready issue exists | one slot already reserved/active, one slot free | ready issue is still claimable | reserve the free slot and dispatch the ready issue on the next poll without waiting for the first run to finish |
+| One issue has been selected for dispatch but is still in claim/startup work when the next poll begins | slot is already reserved for that issue | tracker may still show ready or newly running | do not treat the slot as free and do not over-dispatch another issue into the same capacity |
+| Active local run count already equals `maxConcurrentRuns` | all slots reserved/active | ready issues may still exist | keep polling/reconciling status, but do not dispatch new ready work |
+| Background dispatch fails before the run becomes active | reserved slot plus startup/claim failure | issue may remain ready or move back out of running | release the slot, record the failure path, and let a later poll reconsider capacity normally |
+| Factory halt or dispatch pressure becomes active while another run is still active | one or more slots active | ready issues may exist | keep inspecting running work but block new slot reservations until halt/pressure clears |
+| Shutdown is requested while background runs are active | active slots and abort controllers exist | tracker state unchanged or running | stop reserving new slots, abort active runs through existing shutdown paths, and release slots only after cleanup |
+
+## Storage / Persistence Contract
+
+No new durable external store is needed for this issue.
+
+Required contract:
+
+1. local slot state remains runtime-owned orchestration state
+2. status snapshots continue to expose `activeLocalRuns` from the explicit orchestration slot state rather than from tracker running counts
+3. existing lease, issue-artifact, and tracker persistence remain the source of truth for issue/run ownership and lifecycle, not a new background-task registry on disk
+
+## Observability Requirements
+
+1. structured logs should explain slot reservation, background dispatch start, slot release, and why dispatch was blocked when capacity is full
+2. status snapshots must keep showing active local run count correctly while polls continue during active runs
+3. live running entries should remain visible even though the main poll loop no longer waits for their promises before the next cycle
+4. if a slot is reserved but the run has not yet reached full active execution, the status path should remain inspectable enough to explain the temporary capacity usage
+
+## Implementation Steps
+
+1. introduce or extract explicit orchestrator runtime state for local slot reservation/background dispatch tracking
+2. refactor `runOnce()` so it starts eligible dispatch work up to free capacity and returns without awaiting all active run promises
+3. ensure background dispatch completion is observed safely so failures still flow through existing orchestration error handling and do not produce unhandled promise rejections
+4. keep shutdown, halt, and dispatch-pressure behavior coherent with the new background-dispatch lifecycle
+5. update status/log projection only where the new explicit slot state requires it
+6. add focused unit tests for slot reservation, continued polling, and no-overdispatch races
+7. add or extend an end-to-end test that reproduces the reported `max_concurrent_runs: 2` scenario with one live active run and one later-ready issue
+8. update checked-in docs if the behavior or operator evidence needs clearer wording after the fix lands
+
+## Tests And Acceptance Scenarios
+
+### Unit coverage
+
+1. a long-running first dispatch does not block a later poll from dispatching a second ready issue when one slot remains
+2. slot reservation prevents over-dispatch while a selected issue is still in claim/startup work
+3. full local capacity blocks new ready dispatch but still allows running-issue inspection/reconciliation
+4. slot release after startup failure or run completion makes capacity available to a later poll
+5. halt/dispatch-pressure state blocks new reservations even while active runs continue
+
+### Integration / end-to-end coverage
+
+1. with `max_concurrent_runs: 2`, one live runner turn stays active while the factory later claims and starts another ready issue
+2. the status snapshot remains inspectable during that overlap and reports both the active run visibility and the consumed local slot count correctly
+
+### Named acceptance scenarios
+
+1. `active-turn-does-not-stall-free-slot`
+   - first issue is already in a live runner turn, second issue becomes ready, factory claims the second issue before the first finishes
+2. `startup-race-does-not-overdispatch`
+   - one issue has consumed a slot but is still in claim/startup, later poll does not start too many additional issues
+3. `full-capacity-still-polls`
+   - all slots are consumed, factory still refreshes running status and observability without new dispatch
+
+## Exit Criteria
+
+1. the orchestrator keeps polling while previously dispatched runs remain active
+2. a free slot is filled by later ready work without waiting for another live run to finish
+3. slot accounting is explicit in code and covered by tests
+4. `pnpm typecheck`, `pnpm lint`, and `pnpm test` pass
+5. the reviewed PR stays on the orchestration seam and does not pull in unrelated tracker/runner changes
+
+## Deferred To Later Issues Or PRs
+
+1. any broader refactor of restart recovery, shutdown orchestration, or watchdog ownership beyond what this slot-accounting change directly needs
+2. queue-policy changes unrelated to filling free slots
+3. durable multi-instance slot coordination
+4. runner transport redesign or new tracker backends

--- a/src/orchestrator/local-dispatch-state.ts
+++ b/src/orchestrator/local-dispatch-state.ts
@@ -1,0 +1,63 @@
+export interface LocalDispatchRuntimeState {
+  readonly reservedIssueNumbers: Set<number>;
+  readonly backgroundTasks: Map<number, Promise<void>>;
+}
+
+export function createLocalDispatchRuntimeState(): LocalDispatchRuntimeState {
+  return {
+    reservedIssueNumbers: new Set<number>(),
+    backgroundTasks: new Map<number, Promise<void>>(),
+  };
+}
+
+export function countReservedLocalDispatches(
+  state: LocalDispatchRuntimeState,
+): number {
+  return state.reservedIssueNumbers.size;
+}
+
+export function hasReservedLocalDispatch(
+  state: LocalDispatchRuntimeState,
+  issueNumber: number,
+): boolean {
+  return state.reservedIssueNumbers.has(issueNumber);
+}
+
+export function reserveLocalDispatch(
+  state: LocalDispatchRuntimeState,
+  issueNumber: number,
+): boolean {
+  if (state.reservedIssueNumbers.has(issueNumber)) {
+    return false;
+  }
+  state.reservedIssueNumbers.add(issueNumber);
+  return true;
+}
+
+export function noteBackgroundDispatchTask(
+  state: LocalDispatchRuntimeState,
+  issueNumber: number,
+  task: Promise<void>,
+): void {
+  state.backgroundTasks.set(issueNumber, task);
+}
+
+export function releaseLocalDispatch(
+  state: LocalDispatchRuntimeState,
+  issueNumber: number,
+): void {
+  state.reservedIssueNumbers.delete(issueNumber);
+  state.backgroundTasks.delete(issueNumber);
+}
+
+export function listReservedLocalDispatches(
+  state: LocalDispatchRuntimeState,
+): readonly number[] {
+  return [...state.reservedIssueNumbers];
+}
+
+export function listBackgroundDispatchTasks(
+  state: LocalDispatchRuntimeState,
+): readonly Promise<void>[] {
+  return [...state.backgroundTasks.values()];
+}

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -617,8 +617,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       signal.addEventListener("abort", handleAbort!, { once: true });
     }
     try {
-      await this.#runOnceInner();
-      await this.#waitForBackgroundDispatches();
+      const startedDispatchTasks = await this.#runOnceInner();
+      await this.#waitForDispatchTasks(startedDispatchTasks, {
+        propagateErrors: true,
+      });
     } finally {
       if (signal !== undefined) {
         signal.removeEventListener("abort", handleAbort!);
@@ -629,7 +631,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
   }
 
-  async #runOnceInner(): Promise<void> {
+  async #runOnceInner(): Promise<readonly Promise<void>[]> {
     this.#state.polling.checkingNow = true;
     this.#recoveredRunningLifecycles.clear();
     this.#notifyDashboard();
@@ -732,9 +734,10 @@ export class BootstrapOrchestrator implements Orchestrator {
     await this.#reconcileTerminalIssueReporting();
 
     if (availableSlots <= 0) {
-      return;
+      return [];
     }
 
+    const startedDispatchTasks: Promise<void>[] = [];
     let startedDispatches = 0;
     for (const entry of queue) {
       if (startedDispatches >= availableSlots) {
@@ -745,8 +748,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       ) {
         continue;
       }
-      if (this.#startDispatchTask(entry)) {
+      const task = this.#startDispatchTask(entry);
+      if (task !== null) {
         startedDispatches += 1;
+        startedDispatchTasks.push(task);
       }
     }
 
@@ -754,11 +759,13 @@ export class BootstrapOrchestrator implements Orchestrator {
       this.#notifyDashboard();
       await this.#persistStatusSnapshot();
     }
+
+    return startedDispatchTasks;
   }
 
-  #startDispatchTask(entry: QueueEntry): boolean {
+  #startDispatchTask(entry: QueueEntry): Promise<void> | null {
     if (!reserveLocalDispatch(this.#state.localDispatch, entry.issue.number)) {
-      return false;
+      return null;
     }
 
     const task = (async (): Promise<void> => {
@@ -774,19 +781,21 @@ export class BootstrapOrchestrator implements Orchestrator {
           source: entry.source,
           error: this.#normalizeFailure(error as Error),
         });
+        throw error;
       } finally {
         releaseLocalDispatch(this.#state.localDispatch, entry.issue.number);
         this.#notifyDashboard();
         await this.#persistStatusSnapshot();
       }
     })();
+    void task.catch(() => {});
 
     noteBackgroundDispatchTask(
       this.#state.localDispatch,
       entry.issue.number,
       task,
     );
-    return true;
+    return task;
   }
 
   async #waitForBackgroundDispatches(): Promise<void> {
@@ -794,7 +803,26 @@ export class BootstrapOrchestrator implements Orchestrator {
     if (tasks.length === 0) {
       return;
     }
-    await Promise.allSettled(tasks);
+    await this.#waitForDispatchTasks(tasks, { propagateErrors: false });
+  }
+
+  async #waitForDispatchTasks(
+    tasks: readonly Promise<void>[],
+    options: { readonly propagateErrors: boolean },
+  ): Promise<void> {
+    if (tasks.length === 0) {
+      return;
+    }
+    const results = await Promise.allSettled(tasks);
+    if (!options.propagateErrors) {
+      return;
+    }
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (rejected !== undefined) {
+      throw rejected.reason;
+    }
   }
 
   async #reconcileTerminalIssueReporting(): Promise<void> {
@@ -1008,7 +1036,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     try {
       while (!signal?.aborted) {
         try {
-          await this.#runOnceInner();
+          void (await this.#runOnceInner());
         } catch (error) {
           this.#logger.error("Poll cycle failed", {
             error: this.#normalizeFailure(error as Error),
@@ -1026,10 +1054,10 @@ export class BootstrapOrchestrator implements Orchestrator {
       // signal is optional — keep ?. for safety even though TypeScript narrows
       // it to non-null after the while loop (the loop runs forever if undefined).
       signal?.removeEventListener("abort", handleAbort);
+      await this.#waitForBackgroundDispatches();
       if (this.#shutdownSignal === signal) {
         this.#shutdownSignal = undefined;
       }
-      await this.#waitForBackgroundDispatches();
     }
   }
 

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -134,6 +134,15 @@ import {
   reserveHostForIssue,
 } from "./host-dispatch-state.js";
 import {
+  countReservedLocalDispatches,
+  hasReservedLocalDispatch,
+  listBackgroundDispatchTasks,
+  listReservedLocalDispatches,
+  noteBackgroundDispatchTask,
+  releaseLocalDispatch,
+  reserveLocalDispatch,
+} from "./local-dispatch-state.js";
+import {
   clearRetryState,
   collectDueRetries,
   hasQueuedRetry,
@@ -609,6 +618,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     }
     try {
       await this.#runOnceInner();
+      await this.#waitForBackgroundDispatches();
     } finally {
       if (signal !== undefined) {
         signal.removeEventListener("abort", handleAbort!);
@@ -679,7 +689,7 @@ export class BootstrapOrchestrator implements Orchestrator {
       );
       availableSlots =
         this.#config.polling.maxConcurrentRuns -
-        this.#state.runningIssueNumbers.size;
+        countReservedLocalDispatches(this.#state.localDispatch);
       this.#logger.info("Poll candidates fetched", {
         readyCount: readyCandidates.length,
         runningCount: runningCandidates.length,
@@ -725,22 +735,66 @@ export class BootstrapOrchestrator implements Orchestrator {
       return;
     }
 
-    const runs: Promise<void>[] = [];
+    let startedDispatches = 0;
     for (const entry of queue) {
-      if (runs.length >= availableSlots) {
+      if (startedDispatches >= availableSlots) {
         break;
       }
-      if (this.#state.runningIssueNumbers.has(entry.issue.number)) {
+      if (
+        hasReservedLocalDispatch(this.#state.localDispatch, entry.issue.number)
+      ) {
         continue;
       }
-      runs.push(
-        entry.source === "ready"
-          ? this.#processReadyIssue(entry.issue, entry.attempt)
-          : this.#processRunningIssue(entry.issue, entry.attempt),
-      );
+      if (this.#startDispatchTask(entry)) {
+        startedDispatches += 1;
+      }
     }
 
-    await Promise.all(runs);
+    if (startedDispatches > 0) {
+      this.#notifyDashboard();
+      await this.#persistStatusSnapshot();
+    }
+  }
+
+  #startDispatchTask(entry: QueueEntry): boolean {
+    if (!reserveLocalDispatch(this.#state.localDispatch, entry.issue.number)) {
+      return false;
+    }
+
+    const task = (async (): Promise<void> => {
+      try {
+        if (entry.source === "ready") {
+          await this.#processReadyIssue(entry.issue, entry.attempt);
+        } else {
+          await this.#processRunningIssue(entry.issue, entry.attempt);
+        }
+      } catch (error) {
+        this.#logger.error("Dispatch task failed", {
+          issueNumber: entry.issue.number,
+          source: entry.source,
+          error: this.#normalizeFailure(error as Error),
+        });
+      } finally {
+        releaseLocalDispatch(this.#state.localDispatch, entry.issue.number);
+        this.#notifyDashboard();
+        await this.#persistStatusSnapshot();
+      }
+    })();
+
+    noteBackgroundDispatchTask(
+      this.#state.localDispatch,
+      entry.issue.number,
+      task,
+    );
+    return true;
+  }
+
+  async #waitForBackgroundDispatches(): Promise<void> {
+    const tasks = listBackgroundDispatchTasks(this.#state.localDispatch);
+    if (tasks.length === 0) {
+      return;
+    }
+    await Promise.allSettled(tasks);
   }
 
   async #reconcileTerminalIssueReporting(): Promise<void> {
@@ -951,28 +1005,31 @@ export class BootstrapOrchestrator implements Orchestrator {
       this.#abortActiveRuns();
     };
     signal?.addEventListener("abort", handleAbort, { once: true });
-    while (!signal?.aborted) {
-      try {
-        await this.runOnce();
-      } catch (error) {
-        this.#logger.error("Poll cycle failed", {
-          error: this.#normalizeFailure(error as Error),
-        });
+    try {
+      while (!signal?.aborted) {
+        try {
+          await this.#runOnceInner();
+        } catch (error) {
+          this.#logger.error("Poll cycle failed", {
+            error: this.#normalizeFailure(error as Error),
+          });
+        }
+        if (signal?.aborted) {
+          break;
+        }
+        this.#state.polling.nextPollAtMs =
+          Date.now() + this.#config.polling.intervalMs;
+        this.#notifyDashboard();
+        await this.#sleep(this.#config.polling.intervalMs, signal);
       }
-      if (signal?.aborted) {
-        break;
+    } finally {
+      // signal is optional — keep ?. for safety even though TypeScript narrows
+      // it to non-null after the while loop (the loop runs forever if undefined).
+      signal?.removeEventListener("abort", handleAbort);
+      if (this.#shutdownSignal === signal) {
+        this.#shutdownSignal = undefined;
       }
-      this.#state.polling.nextPollAtMs =
-        Date.now() + this.#config.polling.intervalMs;
-      this.#notifyDashboard();
-      await this.#sleep(this.#config.polling.intervalMs, signal);
-    }
-    // signal is optional — keep ?. for safety even though TypeScript narrows
-    // it to non-null after the while loop (the loop runs forever if undefined).
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    signal?.removeEventListener("abort", handleAbort);
-    if (this.#shutdownSignal === signal) {
-      this.#shutdownSignal = undefined;
+      await this.#waitForBackgroundDispatches();
     }
   }
 
@@ -1174,14 +1231,12 @@ export class BootstrapOrchestrator implements Orchestrator {
     if (!lease) {
       return;
     }
-    this.#state.runningIssueNumbers.add(issue.number);
     let preserveLease = false;
     try {
       preserveLease = await work(lease);
     } catch (error) {
       await this.#handleUnexpectedFailure(issue, attempt, error as Error);
     } finally {
-      this.#state.runningIssueNumbers.delete(issue.number);
       if (!preserveLease) {
         await this.#leaseManager.release(lease);
       }
@@ -2581,7 +2636,7 @@ export class BootstrapOrchestrator implements Orchestrator {
     const retainedIssueNumbers = new Set<number>([
       ...readyIssues.map((issue) => issue.number),
       ...runningIssues.map((issue) => issue.number),
-      ...this.#state.runningIssueNumbers,
+      ...listReservedLocalDispatches(this.#state.localDispatch),
       ...listQueuedRetries(this.#state.retries).map(
         (retry) => retry.issue.number,
       ),
@@ -4605,7 +4660,9 @@ export class BootstrapOrchestrator implements Orchestrator {
           workerPid: process.pid,
           pollIntervalMs: this.#config.polling.intervalMs,
           maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
-          activeLocalRuns: this.#state.runningIssueNumbers.size,
+          activeLocalRuns: countReservedLocalDispatches(
+            this.#state.localDispatch,
+          ),
           retries: this.#state.retries,
           hostDispatch: this.#state.hostDispatch,
           dispatchPressure: getActiveDispatchPressure(
@@ -4655,7 +4712,9 @@ export class BootstrapOrchestrator implements Orchestrator {
           workerPid: process.pid,
           pollIntervalMs: this.#config.polling.intervalMs,
           maxConcurrentRuns: this.#config.polling.maxConcurrentRuns,
-          activeLocalRuns: this.#state.runningIssueNumbers.size,
+          activeLocalRuns: countReservedLocalDispatches(
+            this.#state.localDispatch,
+          ),
           retries: this.#state.retries,
           hostDispatch: this.#state.hostDispatch,
           dispatchPressure: getActiveDispatchPressure(

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -16,6 +16,10 @@ import {
   createHostDispatchState,
   type HostDispatchRuntimeState,
 } from "./host-dispatch-state.js";
+import {
+  createLocalDispatchRuntimeState,
+  type LocalDispatchRuntimeState,
+} from "./local-dispatch-state.js";
 import type { RunningEntry } from "./running-entry.js";
 import {
   createLandingRuntimeState,
@@ -47,7 +51,7 @@ export interface PollingState {
 }
 
 export interface OrchestratorState {
-  readonly runningIssueNumbers: Set<number>;
+  readonly localDispatch: LocalDispatchRuntimeState;
   readonly terminalIssueReporting: TerminalIssueReportingRuntimeState;
   readonly runAbortControllers: Map<number, AbortController>;
   readonly retries: RetryRuntimeState;
@@ -69,7 +73,7 @@ export function createOrchestratorState(
   hostDispatchWorkerHosts: readonly SshWorkerHostConfig[] = [],
 ): OrchestratorState {
   return {
-    runningIssueNumbers: new Set<number>(),
+    localDispatch: createLocalDispatchRuntimeState(),
     terminalIssueReporting: createTerminalIssueReportingRuntimeState(),
     runAbortControllers: new Map<number, AbortController>(),
     retries: createRetryRuntimeState(),

--- a/tests/e2e/bootstrap-factory.test.ts
+++ b/tests/e2e/bootstrap-factory.test.ts
@@ -1051,6 +1051,64 @@ describe("Phase 1.2 PR lifecycle factory", () => {
     );
   });
 
+  it("fills a later-ready dispatch slot while another runner turn is still active", async () => {
+    server.seedIssue({
+      number: 96,
+      title: "Long-running active turn",
+      body: "Stay active long enough for a later poll to fill the spare slot.",
+      labels: ["symphony:ready"],
+    });
+    server.seedIssue({
+      number: 97,
+      title: "Later-ready issue",
+      body: "Become ready after another issue is already running.",
+      labels: [],
+    });
+
+    const startedFile = path.join(tempDir, "issue-96-started");
+    const releaseFile = path.join(tempDir, "issue-96-release");
+    const workflowPath = await writeWorkflow({
+      rootDir: tempDir,
+      remotePath,
+      apiUrl: server.baseUrl,
+      agentCommand: path.resolve(
+        "tests/fixtures/fake-agent-selective-block-success.sh",
+      ),
+      maxConcurrentRuns: 2,
+      agentEnv: {
+        SYMPHONY_TEST_BLOCK_ISSUE_NUMBER: "96",
+        SYMPHONY_TEST_START_FILE: startedFile,
+        SYMPHONY_TEST_RELEASE_FILE: releaseFile,
+      },
+    });
+    const orchestrator = await createOrchestrator(workflowPath);
+    const controller = new AbortController();
+    const loop = orchestrator.runLoop(controller.signal);
+
+    await waitForFile(startedFile);
+    server.setIssueLabels(97, ["symphony:ready"]);
+    await waitForPullRequestHead(server, "symphony/97");
+
+    expect(server.getIssue(96).labels.map((label) => label.name)).toContain(
+      "symphony:running",
+    );
+    expect(
+      server.getPullRequests().map((pullRequest) => pullRequest.head),
+    ).toContain("symphony/97");
+
+    await fs.writeFile(releaseFile, "release", "utf8");
+    await waitForPullRequestHead(server, "symphony/96");
+
+    controller.abort();
+    await loop;
+
+    const status = await readFactoryStatusSnapshot(
+      path.join(tempDir, ".tmp", "status.json"),
+    );
+    expect(status.worker.maxConcurrentRuns).toBe(2);
+    expect(server.getPullRequests()).toHaveLength(2);
+  });
+
   it("preserves the watchdog stall reason instead of flattening it to shutdown", async () => {
     server.seedIssue({
       number: 83,

--- a/tests/fixtures/fake-agent-selective-block-success.sh
+++ b/tests/fixtures/fake-agent-selective-block-success.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT="$(cat)"
+printf '%s' "$PROMPT" > .agent-prompt.txt
+
+git config user.name "Symphony Test Agent"
+git config user.email "symphony-agent@example.com"
+
+if [[ "${SYMPHONY_ISSUE_NUMBER}" == "${SYMPHONY_TEST_BLOCK_ISSUE_NUMBER:-}" ]]; then
+  if [[ -n "${SYMPHONY_TEST_START_FILE:-}" ]]; then
+    touch "${SYMPHONY_TEST_START_FILE}"
+  fi
+
+  if [[ -n "${SYMPHONY_TEST_RELEASE_FILE:-}" ]]; then
+    for _ in $(seq 1 300); do
+      if [[ -f "${SYMPHONY_TEST_RELEASE_FILE}" ]]; then
+        break
+      fi
+      sleep 0.1
+    done
+  fi
+fi
+
+echo "implemented ${SYMPHONY_ISSUE_IDENTIFIER}" > IMPLEMENTED.txt
+git add .agent-prompt.txt IMPLEMENTED.txt
+git commit -m "Implement ${SYMPHONY_ISSUE_IDENTIFIER}"
+git push origin HEAD:${SYMPHONY_BRANCH_NAME}
+curl -sS -X POST "${MOCK_GITHUB_API_URL}/mock/branch-pushes" \
+  -H 'content-type: application/json' \
+  -d "{\"head\":\"${SYMPHONY_BRANCH_NAME}\"}" >/dev/null
+
+gh pr create \
+  --title "Implement ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --body "Automated PR for ${SYMPHONY_ISSUE_IDENTIFIER}" \
+  --base main \
+  --head "${SYMPHONY_BRANCH_NAME}"

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -85,6 +85,36 @@ function createDeferred<T>(): {
   return { promise, resolve };
 }
 
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (check()) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function rejectOnShutdownAbort(
+  signal: AbortSignal | undefined,
+  reject: (reason?: unknown) => void,
+): void {
+  const handleAbort = (): void => {
+    reject(new RunnerShutdownError("Runner cancelled by shutdown", "graceful"));
+  };
+  if (signal?.aborted) {
+    handleAbort();
+    return;
+  }
+  signal?.addEventListener("abort", handleAbort, { once: true });
+}
+
 function createObservableStalledProbe(): LivenessProbe {
   return {
     async capture(options) {
@@ -508,6 +538,35 @@ class FlakyTracker extends SequencedTracker {
     if (this.ensureLabelsCalls === 1) {
       throw new Error("transient label failure");
     }
+  }
+}
+
+class BlockingClaimTracker extends SequencedTracker {
+  readonly claimStarted = createDeferred<void>();
+  readonly #releaseClaim = createDeferred<void>();
+  readonly #blockedIssueNumber: number;
+
+  constructor(
+    blockedIssueNumber: number,
+    options: {
+      ready?: readonly RuntimeIssue[];
+      running?: readonly RuntimeIssue[];
+    },
+  ) {
+    super(options);
+    this.#blockedIssueNumber = blockedIssueNumber;
+  }
+
+  releaseClaim(): void {
+    this.#releaseClaim.resolve();
+  }
+
+  override async claimIssue(issueNumber: number): Promise<RuntimeIssue | null> {
+    if (issueNumber === this.#blockedIssueNumber) {
+      this.claimStarted.resolve();
+      await this.#releaseClaim.promise;
+    }
+    return await super.claimIssue(issueNumber);
   }
 }
 
@@ -1063,6 +1122,118 @@ describe("BootstrapOrchestrator", () => {
       expect(
         [...tracker.completed].sort((left, right) => left - right),
       ).toEqual([1, 2]);
+    } finally {
+      await removeTempRoot(tempRoot);
+    }
+  });
+
+  it("keeps polling and fills a later-ready slot while another run stays active", async () => {
+    const tempRoot = await createTempDir("symphony-active-slot-fill-test-");
+    try {
+      const tracker = new SequencedTracker({
+        ready: [createIssue(1)],
+      });
+      tracker.setLifecycleSequence(1, [
+        lifecycle("missing-target", "symphony/1"),
+        lifecycle("handoff-ready", "symphony/1"),
+      ]);
+      tracker.setLifecycleSequence(2, [
+        lifecycle("missing-target", "symphony/2"),
+        lifecycle("handoff-ready", "symphony/2"),
+      ]);
+      const runner = new BlockingRecordingRunner([1, 2]);
+      const orchestrator = new BootstrapOrchestrator(
+        withLocalInstanceRoot(
+          {
+            ...baseConfig,
+            polling: { ...baseConfig.polling, intervalMs: 1 },
+          },
+          tempRoot,
+        ),
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        runner,
+        new NullLogger(),
+      );
+
+      const controller = new AbortController();
+      const loop = orchestrator.runLoop(controller.signal);
+
+      await runner.waitForIssue(1);
+      tracker.readyIssues.set(2, createIssue(2));
+      await runner.waitForIssue(2);
+
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(deriveTestInstance(tempRoot)),
+      );
+      expect(snapshot.counts.activeLocalRuns).toBe(2);
+      expect(
+        [...runner.startedIssues].sort((left, right) => left - right),
+      ).toEqual([1, 2]);
+
+      runner.release();
+      controller.abort();
+      await loop;
+    } finally {
+      await removeTempRoot(tempRoot);
+    }
+  });
+
+  it("reserves a slot before claim completes so later polls do not over-dispatch", async () => {
+    const tempRoot = await createTempDir(
+      "symphony-claim-reservation-slot-test-",
+    );
+    try {
+      const tracker = new BlockingClaimTracker(1, {
+        ready: [createIssue(1), createIssue(2)],
+      });
+      tracker.setLifecycleSequence(1, [
+        lifecycle("missing-target", "symphony/1"),
+        lifecycle("handoff-ready", "symphony/1"),
+      ]);
+      tracker.setLifecycleSequence(2, [
+        lifecycle("missing-target", "symphony/2"),
+        lifecycle("handoff-ready", "symphony/2"),
+      ]);
+      const runner = new BlockingRecordingRunner([1, 2]);
+      const orchestrator = new BootstrapOrchestrator(
+        withLocalInstanceRoot(
+          {
+            ...baseConfig,
+            polling: {
+              ...baseConfig.polling,
+              intervalMs: 1,
+              maxConcurrentRuns: 1,
+            },
+          },
+          tempRoot,
+        ),
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        runner,
+        new NullLogger(),
+      );
+
+      const controller = new AbortController();
+      const loop = orchestrator.runLoop(controller.signal);
+
+      await tracker.claimStarted.promise;
+      await waitForCondition(() => tracker.ensureLabelsCalls >= 2);
+
+      expect(tracker.readyIssues.has(2)).toBe(true);
+      expect(runner.startedIssues).not.toContain(2);
+
+      const snapshot = await readFactoryStatusSnapshot(
+        deriveStatusFilePath(deriveTestInstance(tempRoot)),
+      );
+      expect(snapshot.counts.activeLocalRuns).toBe(1);
+
+      tracker.releaseClaim();
+      runner.release();
+      controller.abort();
+      await loop;
     } finally {
       await removeTempRoot(tempRoot);
     }
@@ -4021,18 +4192,7 @@ describe("BootstrapOrchestrator", () => {
             started.resolve();
             return await new Promise<RunnerExecutionResult>(
               (_resolve, reject) => {
-                options?.signal?.addEventListener(
-                  "abort",
-                  () => {
-                    reject(
-                      new RunnerShutdownError(
-                        "Runner cancelled by shutdown",
-                        "graceful",
-                      ),
-                    );
-                  },
-                  { once: true },
-                );
+                rejectOnShutdownAbort(options?.signal, reject);
               },
             );
           },
@@ -4082,18 +4242,7 @@ describe("BootstrapOrchestrator", () => {
           started.resolve();
           return await new Promise<RunnerExecutionResult>(
             (_resolve, reject) => {
-              options?.signal?.addEventListener(
-                "abort",
-                () => {
-                  reject(
-                    new RunnerShutdownError(
-                      "Runner cancelled by shutdown",
-                      "graceful",
-                    ),
-                  );
-                },
-                { once: true },
-              );
+              rejectOnShutdownAbort(options?.signal, reject);
             },
           );
         },
@@ -4153,18 +4302,7 @@ describe("BootstrapOrchestrator", () => {
             async runTurn(_turn, options): Promise<RunnerTurnResult> {
               started.resolve();
               return await new Promise<RunnerTurnResult>((_resolve, reject) => {
-                options?.signal?.addEventListener(
-                  "abort",
-                  () => {
-                    reject(
-                      new RunnerShutdownError(
-                        "Runner cancelled by shutdown",
-                        "graceful",
-                      ),
-                    );
-                  },
-                  { once: true },
-                );
+                rejectOnShutdownAbort(options?.signal, reject);
               });
             },
             async close(): Promise<void> {},

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1127,6 +1127,54 @@ describe("BootstrapOrchestrator", () => {
     }
   });
 
+  it("surfaces background dispatch errors to runOnce callers", async () => {
+    const tempRoot = await createTempDir("symphony-run-once-dispatch-error-");
+    try {
+      const workspaceRootFile = path.join(tempRoot, "workspace-root-file");
+      await fs.writeFile(workspaceRootFile, "not-a-directory", "utf8");
+      const tracker = new SequencedTracker({
+        ready: [createIssue(1)],
+      });
+      let runnerStarted = false;
+      const orchestrator = new BootstrapOrchestrator(
+        {
+          ...withLocalInstanceRoot(baseConfig, tempRoot),
+          workspace: {
+            ...baseConfig.workspace,
+            root: workspaceRootFile,
+          },
+        },
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        {
+          describeSession() {
+            return createRunnerSessionDescription();
+          },
+          async run(): Promise<RunnerExecutionResult> {
+            runnerStarted = true;
+            const startedAt = new Date().toISOString();
+            return {
+              startedAt,
+              exitCode: 0,
+              stdout: "",
+              stderr: "",
+              finishedAt: new Date().toISOString(),
+            };
+          },
+        },
+        new NullLogger(),
+      );
+
+      await expect(orchestrator.runOnce()).rejects.toMatchObject({
+        code: "ENOTDIR",
+      });
+      expect(runnerStarted).toBe(false);
+    } finally {
+      await removeTempRoot(tempRoot);
+    }
+  });
+
   it("keeps polling and fills a later-ready slot while another run stays active", async () => {
     const tempRoot = await createTempDir("symphony-active-slot-fill-test-");
     try {
@@ -1175,6 +1223,79 @@ describe("BootstrapOrchestrator", () => {
       runner.release();
       controller.abort();
       await loop;
+    } finally {
+      await removeTempRoot(tempRoot);
+    }
+  });
+
+  it("keeps the shutdown signal visible until a claim-blocked dispatch starts", async () => {
+    const tempRoot = await createTempDir(
+      "symphony-claim-blocked-shutdown-test-",
+    );
+    try {
+      const tracker = new BlockingClaimTracker(1, {
+        ready: [createIssue(1)],
+      });
+      tracker.setLifecycleSequence(1, [
+        lifecycle("missing-target", "symphony/1"),
+      ]);
+      const runStartedWithAbort = createDeferred<boolean>();
+      const orchestrator = new BootstrapOrchestrator(
+        withLocalInstanceRoot(
+          {
+            ...baseConfig,
+            polling: { ...baseConfig.polling, intervalMs: 1 },
+          },
+          tempRoot,
+        ),
+        staticPromptBuilder,
+        tracker,
+        new StaticWorkspaceManager(),
+        {
+          describeSession() {
+            return createRunnerSessionDescription();
+          },
+          async run(_session, options): Promise<RunnerExecutionResult> {
+            const startedAborted = options?.signal?.aborted ?? false;
+            runStartedWithAbort.resolve(startedAborted);
+            if (startedAborted) {
+              return await new Promise<RunnerExecutionResult>(
+                (_resolve, reject) => {
+                  rejectOnShutdownAbort(options?.signal, reject);
+                },
+              );
+            }
+            const startedAt = new Date().toISOString();
+            return {
+              startedAt,
+              exitCode: 0,
+              stdout: "",
+              stderr: "",
+              finishedAt: new Date().toISOString(),
+            };
+          },
+        },
+        new NullLogger(),
+      );
+
+      const controller = new AbortController();
+      const loop = orchestrator.runLoop(controller.signal);
+
+      await tracker.claimStarted.promise;
+      controller.abort();
+      tracker.releaseClaim();
+
+      await expect(runStartedWithAbort.promise).resolves.toBe(true);
+      await loop;
+
+      const leaseManager = new LocalIssueLeaseManager(
+        tempRoot,
+        new NullLogger(),
+      );
+      const snapshot = await leaseManager.inspect(1);
+
+      expect(tracker.completed).toEqual([]);
+      expect(snapshot.kind).toBe("shutdown-terminated");
     } finally {
       await removeTempRoot(tempRoot);
     }


### PR DESCRIPTION
## Summary
- reserve local dispatch slots before claim/startup work so one active turn only consumes one slot
- keep the poll loop filling additional ready work while background dispatch tasks are still active
- add unit and e2e regressions for later-ready dispatch and pre-claim slot reservation

## Plan
- docs/plans/297-fill-available-dispatch-slots/plan.md

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm vitest run tests/unit/orchestrator.test.ts`
- `pnpm vitest run tests/e2e/bootstrap-factory.test.ts -t "fills a later-ready dispatch slot while another runner turn is still active"`
- `pnpm vitest run tests/e2e/bootstrap-factory.test.ts --reporter=default --reporter=hanging-process`
- `pnpm vitest run --fileParallelism=false`

## Notes
- `pnpm test` still hangs in Vitest's default parallel mode after all test files report passing; the full suite exits cleanly with `--fileParallelism=false`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
