### PR TITLE
Tighten issue transition reporting follow-up

### DIFF
--- a/docs/plans/307-restore-issue-transition-reporting/plan.md
+++ b/docs/plans/307-restore-issue-transition-reporting/plan.md
@@ -1,0 +1,57 @@
+# Issue 307 Plan
+
+- Status: waived
+- Issue: #307
+- Branch: `symphony/307`
+- Plan path: `docs/plans/307-restore-issue-transition-reporting/plan.md`
+
+## Scope
+
+Restore the missing per-issue transition-history reporting path after #290 merged incompletely, while tightening a few low-risk correctness edges called out in review.
+
+## Non-goals
+
+- Redefine overall GitHub activity completeness semantics beyond the transition-specific fields.
+- Rework campaign/token pricing behavior unrelated to transition history.
+- Broaden the artifact contract beyond tracker state, tracker labels, and derived transitions.
+
+## Layer Mapping
+
+- Observability: restore issue-report transition rendering and campaign compatibility.
+- Coordination: keep terminal failure artifact capture aligned with tracker-side label changes and warn when degraded.
+- Integration: preserve tracker-side snapshots as the source for transition derivation; do not add tracker-specific policy here.
+- Not in scope: configuration, execution, runner transport, or tracker transport changes.
+
+## Current Gaps
+
+- `buildGitHubActivity` in `src/observability/issue-report.ts` still reports transition history as unavailable on `main`.
+- Legacy summaries can emit a synthetic null-to-open baseline transition when the first tracker snapshot is written after upgrade.
+- Tracker label-set equality depends on pre-normalized arrays without documenting or enforcing the invariant.
+- The post-failure tracker refresh falls back silently when `getIssue` fails, making degraded transition capture invisible.
+
+## Implementation Steps
+
+1. Restore per-issue transition-history derivation in `src/observability/issue-report.ts` without disturbing the newer token/pricing logic from #289.
+2. Update `src/observability/issue-artifacts.ts` so legacy summaries establish a baseline without recording synthetic transitions, and make label-set comparison robust to unsorted inputs.
+3. Add a warning in `src/orchestrator/service.ts` when post-failure tracker refresh fails and the terminal artifact must fall back to the pre-failure snapshot.
+4. Keep campaign/markdown surfaces aligned with the restored issue-report shape and clean up any small transition-status accounting nits that stay in-scope.
+5. Update focused unit tests for artifact transition derivation, issue reports, campaign aggregation, and orchestrator failure capture.
+
+## Tests
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- targeted assertions in:
+  - `tests/unit/issue-artifacts.test.ts`
+  - `tests/unit/issue-report.test.ts`
+  - `tests/unit/campaign-report.test.ts`
+  - `tests/unit/orchestrator.test.ts`
+
+## Acceptance
+
+- Issue reports surface observed issue transitions when canonical artifacts contain tracker snapshots/transitions.
+- Legacy artifact upgrades do not report a misleading null-to-open baseline transition.
+- Label transition derivation remains deterministic even if inputs are not pre-normalized.
+- Terminal failure capture warns when tracker refresh fails and transitions may be absent.
+- Full repo validation passes.

--- a/src/observability/campaign-report.ts
+++ b/src/observability/campaign-report.ts
@@ -588,7 +588,7 @@ function buildCampaignGitHubActivity(
       storedReport.report.githubActivity.issueStateTransitionsStatus ===
       "unavailable",
   ).length;
-  const partialIssueTransitionCount = reports.filter(
+  const nonCompleteIssueTransitionCount = reports.filter(
     (storedReport) =>
       storedReport.report.githubActivity.issueStateTransitionsStatus !==
       "complete",
@@ -610,7 +610,7 @@ function buildCampaignGitHubActivity(
     issueTransitionStatus:
       reports.length === 0 || unavailableIssueTransitionCount === reports.length
         ? "unavailable"
-        : partialIssueTransitionCount === 0
+        : nonCompleteIssueTransitionCount === 0
           ? "complete"
           : "partial",
     issueTransitionSummary:
@@ -654,23 +654,24 @@ function buildCampaignGitHubActivity(
 function buildIssueTransitionNotes(
   reports: readonly StoredIssueReportDocument[],
 ): readonly string[] {
-  const unavailableCount = reports.filter(
-    (storedReport) =>
-      storedReport.report.githubActivity.issueStateTransitionsStatus ===
-      "unavailable",
-  ).length;
-  const completeCount = reports.filter(
-    (storedReport) =>
-      storedReport.report.githubActivity.issueStateTransitionsStatus ===
-      "complete",
-  ).length;
+  const counts = reports.reduce(
+    (summary, storedReport) => {
+      const status =
+        storedReport.report.githubActivity.issueStateTransitionsStatus;
+      return {
+        unavailable: summary.unavailable + (status === "unavailable" ? 1 : 0),
+        complete: summary.complete + (status === "complete" ? 1 : 0),
+      };
+    },
+    { unavailable: 0, complete: 0 },
+  );
   return dedupeStrings([
-    unavailableCount === 0
+    counts.unavailable === 0
       ? ""
-      : `Issue transition history was unavailable for ${unavailableCount.toString()} selected issue report${unavailableCount === 1 ? "" : "s"}.`,
-    completeCount === 0
+      : `Issue transition history was unavailable for ${counts.unavailable.toString()} selected issue report${counts.unavailable === 1 ? "" : "s"}.`,
+    counts.complete === 0
       ? ""
-      : `Issue transition history was preserved for ${completeCount.toString()} selected issue report${completeCount === 1 ? "" : "s"}.`,
+      : `Issue transition history was preserved for ${counts.complete.toString()} selected issue report${counts.complete === 1 ? "" : "s"}.`,
   ]);
 }
 

--- a/src/observability/issue-artifacts.ts
+++ b/src/observability/issue-artifacts.ts
@@ -652,6 +652,10 @@ function deriveIssueTransitions(
       ? existing.trackerLabels
       : normalizeTrackerLabels(update.trackerLabels);
 
+  if (!hasEstablishedTrackerTransitionBaseline(existing)) {
+    return [];
+  }
+
   const transitions: IssueArtifactTransition[] = [...existing.issueTransitions];
   if (existing.trackerState !== nextState) {
     transitions.push({
@@ -663,8 +667,8 @@ function deriveIssueTransitions(
   }
 
   if (!areLabelSetsEqual(existing.trackerLabels, nextLabels)) {
-    const fromLabels = normalizeTrackerLabels(existing.trackerLabels);
-    const toLabels = normalizeTrackerLabels(nextLabels);
+    const fromLabels = existing.trackerLabels;
+    const toLabels = nextLabels;
     transitions.push({
       observedAt: update.observedAt,
       kind: "labels-changed",
@@ -682,14 +686,28 @@ function normalizeTrackerLabels(labels: readonly string[]): readonly string[] {
   return [...new Set(labels)].sort((left, right) => left.localeCompare(right));
 }
 
+function hasEstablishedTrackerTransitionBaseline(
+  summary: IssueArtifactSummary,
+): boolean {
+  return !(
+    summary.issueTransitions.length === 0 &&
+    summary.trackerState === null &&
+    summary.trackerLabels.length === 0
+  );
+}
+
 function areLabelSetsEqual(
   left: readonly string[],
   right: readonly string[],
 ): boolean {
-  if (left.length !== right.length) {
+  const normalizedLeft = normalizeTrackerLabels(left);
+  const normalizedRight = normalizeTrackerLabels(right);
+  if (normalizedLeft.length !== normalizedRight.length) {
     return false;
   }
-  return left.every((label, index) => label === right[index]);
+  return normalizedLeft.every(
+    (label, index) => label === normalizedRight[index],
+  );
 }
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {

--- a/src/orchestrator/service.ts
+++ b/src/orchestrator/service.ts
@@ -2343,7 +2343,13 @@ export class BootstrapOrchestrator implements Orchestrator {
         .then((nextIssue) =>
           hasRuntimeIssueIdentity(nextIssue) ? nextIssue : issue,
         )
-        .catch(() => issue),
+        .catch((error) => {
+          this.#logger.warn("Failed to refresh issue after completion", {
+            issueNumber: issue.number,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return issue;
+        }),
       options?.lifecycle === undefined
         ? this.#tracker.inspectIssueHandoff(branchName).catch(() => null)
         : Promise.resolve(options.lifecycle),
@@ -2982,7 +2988,13 @@ export class BootstrapOrchestrator implements Orchestrator {
       .then((nextIssue) =>
         hasRuntimeIssueIdentity(nextIssue) ? nextIssue : issue,
       )
-      .catch(() => issue);
+      .catch((error) => {
+        this.#logger.warn("Failed to refresh issue after marking failed", {
+          issueNumber: issue.number,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return issue;
+      });
     clearRetryState(this.#state.retries, issue.number);
     clearPreferredHost(this.#state.hostDispatch, issue.number);
     clearWatchdogIssueState(this.#state.watchdog, issue.number);

--- a/tests/unit/issue-artifacts.test.ts
+++ b/tests/unit/issue-artifacts.test.ts
@@ -303,6 +303,56 @@ describe("issue artifacts", () => {
     ]);
   });
 
+  it("treats the first tracker snapshot on a legacy summary as baseline instead of a transition", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const instance = deriveInstanceFromWorkspaceRoot(workspaceRoot);
+    const paths = deriveIssueArtifactPaths(instance, 43);
+    await fs.mkdir(paths.issueRoot, { recursive: true });
+    await fs.writeFile(
+      paths.issueFile,
+      JSON.stringify({
+        version: ISSUE_ARTIFACT_SCHEMA_VERSION,
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        branch: "symphony/43",
+        currentOutcome: "claimed",
+        currentSummary: "Claimed issue",
+        firstObservedAt: "2026-03-09T10:00:00.000Z",
+        lastUpdatedAt: "2026-03-09T10:00:00.000Z",
+        mergedAt: null,
+        closedAt: null,
+        latestAttemptNumber: null,
+        latestSessionId: null,
+      }),
+      "utf8",
+    );
+
+    const store = new LocalIssueArtifactStore(instance);
+    await store.recordObservation({
+      issue: {
+        issueNumber: 43,
+        issueIdentifier: "sociotechnica-org/symphony-ts#43",
+        repo: "sociotechnica-org/symphony-ts",
+        title: "Local Issue Reporting Artifact Contract",
+        issueUrl: "https://example.test/issues/43",
+        branch: "symphony/43",
+        currentOutcome: "running",
+        currentSummary: "Runner active",
+        observedAt: "2026-03-09T10:05:00.000Z",
+        trackerState: "open",
+        trackerLabels: ["symphony:running"],
+      },
+    });
+
+    const summary = await readIssueArtifactSummary(instance, 43);
+    expect(summary.trackerState).toBe("open");
+    expect(summary.trackerLabels).toEqual(["symphony:running"]);
+    expect(summary.issueTransitions).toEqual([]);
+  });
+
   it("deduplicates keyed operator intervention events across non-consecutive writes", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const instance = deriveInstanceFromWorkspaceRoot(workspaceRoot);

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -548,6 +548,18 @@ class FailedIssueTracker extends SequencedTracker {
   }
 }
 
+class UnrefreshableFailedIssueTracker extends FailedIssueTracker {
+  override async getIssue(_issueNumber: number): Promise<RuntimeIssue> {
+    throw new Error("tracker unavailable");
+  }
+}
+
+class UnrefreshableClosedIssueTracker extends ClosedIssueTracker {
+  override async getIssue(_issueNumber: number): Promise<RuntimeIssue> {
+    throw new Error("tracker unavailable");
+  }
+}
+
 class FlakyTracker extends SequencedTracker {
   override async ensureLabels(): Promise<void> {
     await super.ensureLabels();
@@ -4026,6 +4038,61 @@ describe("BootstrapOrchestrator", () => {
     ).toBeDefined();
   });
 
+  it("warns when post-success tracker refresh fails and falls back to the pre-completion snapshot", async () => {
+    const tracker = new UnrefreshableClosedIssueTracker({
+      ready: [createIssue(86)],
+    });
+    tracker.setLifecycleSequence(86, [
+      {
+        ...lifecycle("handoff-ready", "symphony/86"),
+        pullRequest: {
+          number: 1,
+          url: "https://example.test/pulls/symphony/86",
+          branchName: "symphony/86",
+          headSha: "test-head-sha",
+          latestCommitAt: "2026-03-11T12:05:00.000Z",
+          mergedAt: "2026-03-11T12:05:27.000Z",
+        },
+      },
+    ]);
+    const artifactStore = new RecordingIssueArtifactStore();
+    const logger = new NullLogger();
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunnerExecutionResult> {
+          throw new Error("runner should not be called");
+        },
+      },
+      logger,
+      artifactStore,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(
+      logger.warnings.find(
+        (entry) => entry.message === "Failed to refresh issue after completion",
+      ),
+    ).toBeDefined();
+    expect(
+      artifactStore.observations.find(
+        (observation) =>
+          observation.issue.issueNumber === 86 &&
+          observation.issue.currentOutcome === "succeeded" &&
+          observation.issue.closedAt === null,
+      ),
+    ).toBeDefined();
+  });
+
   it("persists the post-failure tracker labels in the terminal failure observation", async () => {
     const tracker = new FailedIssueTracker({
       ready: [createIssue(87)],
@@ -4081,6 +4148,66 @@ describe("BootstrapOrchestrator", () => {
           observation.issue.issueNumber === 87 &&
           observation.issue.currentOutcome === "failed" &&
           observation.issue.trackerLabels?.includes("symphony:failed") === true,
+      ),
+    ).toBeDefined();
+  });
+
+  it("warns when post-failure tracker refresh fails and falls back to the pre-failure snapshot", async () => {
+    const tracker = new UnrefreshableFailedIssueTracker({
+      ready: [createIssue(88)],
+    });
+    tracker.setLifecycleSequence(88, [
+      lifecycle("missing-target", "symphony/88"),
+    ]);
+    const artifactStore = new RecordingIssueArtifactStore();
+    const logger = new NullLogger();
+    const orchestrator = new BootstrapOrchestrator(
+      {
+        ...baseConfig,
+        polling: {
+          ...baseConfig.polling,
+          retry: {
+            maxAttempts: 1,
+            backoffMs: 0,
+          },
+        },
+      },
+      staticPromptBuilder,
+      tracker,
+      new StaticWorkspaceManager(),
+      {
+        describeSession() {
+          return createRunnerSessionDescription();
+        },
+        async run(): Promise<RunnerExecutionResult> {
+          const timestamp = "2026-03-11T12:05:27.000Z";
+          return {
+            exitCode: 17,
+            stdout: "",
+            stderr: "simulated failure",
+            startedAt: timestamp,
+            finishedAt: timestamp,
+          };
+        },
+      },
+      logger,
+      artifactStore,
+    );
+
+    await orchestrator.runOnce();
+
+    expect(
+      logger.warnings.find(
+        (entry) =>
+          entry.message === "Failed to refresh issue after marking failed",
+      ),
+    ).toBeDefined();
+    expect(
+      artifactStore.observations.find(
+        (observation) =>
+          observation.issue.issueNumber === 88 &&
+          observation.issue.currentOutcome === "failed" &&
+          observation.issue.trackerLabels?.includes("symphony:failed") !== true,
       ),
     ).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- suppress synthetic issue transitions when legacy summaries are upgraded with their first tracker snapshot
- harden tracker label comparison and clean up campaign transition counting/note generation
- warn when post-failure tracker refresh fails so degraded transition capture is visible

## Why
PR #306 landed the transition-history slice, but Devin surfaced a few follow-up correctness and clarity issues around the upgrade path and degraded failure capture. This PR finishes that cleanup without broadening the reporting model further.

## Validation
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
