### PR TITLE
Add operator loop terminal lifecycle trace

### DIFF
--- a/docs/plans/314-operator-terminal-trace/plan.md
+++ b/docs/plans/314-operator-terminal-trace/plan.md
@@ -1,0 +1,50 @@
+# Issue 314 Plan
+
+- Status: waived
+- Issue: #314
+- Branch: `symphony/314`
+- Plan path: `docs/plans/314-operator-terminal-trace/plan.md`
+
+## Scope
+
+Add a small foreground terminal trace to the operator loop so operators can see when a wake-up begins, whether it is resuming a stored session, and when the loop returns to sleep.
+
+## Non-goals
+
+- Redesign operator status artifacts, wake-up logs, or instance state layout.
+- Change operator queue logic, prompt content, or release-state semantics.
+- Change resumable-session behavior beyond surfacing the current mode and backend session id.
+
+## Layer Mapping
+
+- Observability: emit a concise terminal-facing trace with timestamps for human operators.
+- Coordination: keep the loop/sleep lifecycle unchanged while surfacing state transitions.
+- Execution: preserve the existing operator command and resumable-session preparation path.
+- Not in scope: tracker integration, workflow parsing, factory orchestration, or runner transport changes.
+
+## Current Gaps
+
+- Foreground `pnpm operator` runs do not show when a cycle wakes up.
+- Operators cannot tell from the terminal whether a cycle is starting fresh or resuming a stored session.
+- The loop returning to sleep is only visible through instance status artifacts, not the foreground terminal.
+
+## Implementation Steps
+
+1. Add small timestamped terminal-trace helpers in `skills/symphony-operator/operator-loop.sh`.
+2. Emit a wake-up line before each cycle starts, including fresh vs resuming mode and the backend session id when present.
+3. Emit a sleep line after successful and retry cycles in continuous mode, including the next wake time.
+4. Cover the trace in `tests/integration/operator-loop.test.ts` without changing the canonical status-file assertions.
+
+## Tests
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- focused integration assertions in `tests/integration/operator-loop.test.ts`
+
+## Acceptance
+
+- Foreground operator runs print a timestamped wake-up line for each cycle.
+- The wake-up line includes whether the cycle is fresh or resuming, plus the backend session id when one exists.
+- Continuous runs print a timestamped sleep line before waiting for the next cycle.
+- Existing machine-readable operator status artifacts remain unchanged in meaning.

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -102,6 +102,29 @@ now_utc() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+emit_terminal_trace() {
+  local message="$1"
+  printf '[%s] operator-loop: %s\n' "$(now_utc)" "$message" >&2
+}
+
+describe_cycle_terminal_mode() {
+  case "$OPERATOR_SESSION_MODE" in
+    resuming)
+      if [ -n "$OPERATOR_SESSION_ID" ]; then
+        printf 'resuming from %s' "$OPERATOR_SESSION_ID"
+      else
+        printf 'resuming'
+      fi
+      ;;
+    fresh)
+      printf 'starting fresh'
+      ;;
+    *)
+      printf '%s' "$OPERATOR_SESSION_MODE"
+      ;;
+  esac
+}
+
 future_utc() {
   node -e 'const interval = Number(process.argv[1]); if (!Number.isInteger(interval) || interval <= 0) process.exit(1); console.log(new Date(Date.now() + interval * 1000).toISOString().replace(/\.\d{3}Z$/, "Z"));' "$1"
 }
@@ -716,6 +739,7 @@ run_cycle() {
     :
   fi
   prepare_operator_cycle
+  emit_terminal_trace "waking up (${OPERATOR_PROVIDER}${OPERATOR_MODEL:+/$OPERATOR_MODEL}; $(describe_cycle_terminal_mode))"
   write_status "acting" "Running operator wake-up cycle"
 
   {
@@ -864,6 +888,7 @@ if [ "$RUN_ONCE" -eq 1 ]; then
 fi
 
 write_status "sleeping" "Operator loop started"
+emit_terminal_trace "going to sleep until the first wake-up cycle"
 
 while [ "$STOPPING" -eq 0 ]; do
   if run_cycle; then
@@ -872,12 +897,14 @@ while [ "$STOPPING" -eq 0 ]; do
     fi
     NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
     write_status "sleeping" "Sleeping until next operator wake-up cycle"
+    emit_terminal_trace "going to sleep until $NEXT_WAKE_AT"
   else
     if [ "$STOPPING" -eq 1 ]; then
       break
     fi
     NEXT_WAKE_AT="$(future_utc "$INTERVAL_SECONDS")"
     write_status "retrying" "Cycle failed; sleeping before retrying operator loop"
+    emit_terminal_trace "cycle failed; sleeping until $NEXT_WAKE_AT"
   fi
 
   sleep_until_next_cycle

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -897,8 +897,16 @@ describe("operator loop workflow selection", () => {
   it("emits sleep trace lines in continuous mode", async () => {
     const tempDir = await createTempDir("symphony-operator-loop-sleep-");
     const workflowPath = await writeWorkflow(tempDir);
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
 
     try {
+      createdPaths.add(tempDir);
+      createdPaths.add(paths.operatorStateRoot);
+
       const stderr = await new Promise<string>((resolve, reject) => {
         const child = spawn(
           "bash",
@@ -919,17 +927,35 @@ describe("operator loop workflow selection", () => {
           },
         );
         let collectedStderr = "";
+        let shutdownRequested = false;
+        const timeout = setTimeout(() => {
+          shutdownRequested = true;
+          child.kill("SIGTERM");
+        }, 10000);
+        const maybeRequestShutdown = () => {
+          if (
+            shutdownRequested ||
+            !collectedStderr.includes(
+              "operator-loop: going to sleep until the first wake-up cycle",
+            ) ||
+            !collectedStderr.includes("operator-loop: waking up")
+          ) {
+            return;
+          }
+
+          shutdownRequested = true;
+          child.kill("SIGTERM");
+        };
         child.stderr.setEncoding("utf8");
         child.stderr.on("data", (chunk: string) => {
           collectedStderr += chunk;
+          maybeRequestShutdown();
         });
         child.on("error", reject);
         child.on("close", () => {
+          clearTimeout(timeout);
           resolve(collectedStderr);
         });
-        setTimeout(() => {
-          child.kill("SIGTERM");
-        }, 2000);
       });
 
       expect(stderr).toContain(

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -71,6 +71,8 @@ async function runOperatorLoop(workflowPath: string): Promise<{
   readonly releaseStatePath: string;
   readonly sessionStatePath: string;
   readonly logFile: string | null;
+  readonly stdout: string;
+  readonly stderr: string;
 }> {
   return await runOperatorLoopWithOptions(workflowPath);
 }
@@ -91,8 +93,10 @@ async function runOperatorLoopWithOptions(
   readonly releaseStatePath: string;
   readonly sessionStatePath: string;
   readonly logFile: string | null;
+  readonly stdout: string;
+  readonly stderr: string;
 }> {
-  await execFileAsync(
+  const result = await execFileAsync(
     "bash",
     [
       path.join("skills", "symphony-operator", "operator-loop.sh"),
@@ -135,6 +139,8 @@ async function runOperatorLoopWithOptions(
     releaseStatePath: paths.releaseStatePath,
     sessionStatePath: paths.sessionStatePath,
     logFile: statusJson.lastCycle.logFile,
+    stdout: result.stdout,
+    stderr: result.stderr,
   };
 }
 
@@ -153,8 +159,11 @@ async function runOperatorLoopWithArgs(
   workflowPath: string,
   args: readonly string[],
   env?: NodeJS.ProcessEnv,
-): Promise<void> {
-  await execFileAsync(
+): Promise<{
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  const result = await execFileAsync(
     "bash",
     [
       path.join("skills", "symphony-operator", "operator-loop.sh"),
@@ -172,6 +181,11 @@ async function runOperatorLoopWithArgs(
       },
     },
   );
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
 }
 
 function buildAppendWakeUpLogCommand(entryTitle: string): string {
@@ -739,6 +753,8 @@ describe("operator loop workflow selection", () => {
       expect(statusMd).toContain("- Provider: codex");
       expect(statusMd).toContain("- Model: gpt-5.4-mini");
       expect(statusMd).toContain("- Command source: provider-template");
+      expect(run.stderr).toContain("operator-loop: waking up");
+      expect(run.stderr).toContain("codex/gpt-5.4-mini; disabled");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -800,7 +816,7 @@ describe("operator loop workflow selection", () => {
     });
 
     try {
-      await runOperatorLoopWithArgs(
+      const firstRun = await runOperatorLoopWithArgs(
         workflowPath,
         [
           "--provider",
@@ -826,7 +842,7 @@ describe("operator loop workflow selection", () => {
         };
       };
 
-      await runOperatorLoopWithArgs(
+      const secondRun = await runOperatorLoopWithArgs(
         workflowPath,
         [
           "--provider",
@@ -867,6 +883,59 @@ describe("operator loop workflow selection", () => {
       expect(commandInvocations).toContain(
         "--resume claude-session-claude-sonnet-4-5",
       );
+      expect(firstRun.stderr).toContain(
+        "claude/claude-sonnet-4-5; starting fresh",
+      );
+      expect(secondRun.stderr).toContain(
+        "claude/claude-sonnet-4-5; resuming from claude-session-claude-sonnet-4-5",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits sleep trace lines in continuous mode", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-sleep-");
+    const workflowPath = await writeWorkflow(tempDir);
+
+    try {
+      const stderr = await new Promise<string>((resolve, reject) => {
+        const child = spawn(
+          "bash",
+          [
+            path.join("skills", "symphony-operator", "operator-loop.sh"),
+            "--interval-seconds",
+            "60",
+            "--workflow",
+            workflowPath,
+          ],
+          {
+            cwd: repoRoot,
+            env: {
+              ...process.env,
+              GH_TOKEN: "test-token",
+              SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+            },
+          },
+        );
+        let collectedStderr = "";
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk: string) => {
+          collectedStderr += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", () => {
+          resolve(collectedStderr);
+        });
+        setTimeout(() => {
+          child.kill("SIGTERM");
+        }, 2000);
+      });
+
+      expect(stderr).toContain(
+        "operator-loop: going to sleep until the first wake-up cycle",
+      );
+      expect(stderr).toContain("operator-loop: waking up");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- emit timestamped operator-loop wake and sleep traces to stderr for foreground runs
- include fresh vs resumed session context in the wake-up line
- cover the terminal trace behavior in operator-loop integration tests

Closes #314

## Testing
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
