### PR TITLE
Make operator plan review instance-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ session across wake-ups, and `--operator-command` or
 `SYMPHONY_OPERATOR_COMMAND` only as the raw-command escape hatch. Operator
 status artifacts now expose the resolved provider, model, command source,
 effective command, and session mode/reset reason.
+When the operator loop targets an external repository with `--workflow`, treat
+that selected instance repository as the owner of plan-review standards and
+repo policy. The `symphony-ts` checkout supplies operator tooling and local
+state, but plan review should read the selected repository's `WORKFLOW.md`,
+`AGENTS.md`, `README.md`, and relevant docs when they exist instead of
+implicitly importing `symphony-ts` architecture rules.
 
 Generate a per-issue report from local artifacts:
 

--- a/bin/resolve-operator-instance.ts
+++ b/bin/resolve-operator-instance.ts
@@ -50,6 +50,7 @@ process.stdout.write(
   `${JSON.stringify({
     workflowPath: args.workflowPath,
     operatorRepoRoot: args.operatorRepoRoot,
+    selectedInstanceRoot: identity.instanceRoot,
     instanceKey: identity.instanceKey,
     detachedSessionName: identity.detachedSessionName,
     ...operatorState,

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -63,6 +63,13 @@ and use the factory commands in this runbook with `--workflow
 ../target-repo/WORKFLOW.md` whenever your shell is not already inside that
 instance root.
 
+For operator plan review, the selected instance repository is the authority.
+The operator checkout provides the loop, tooling, and local `.ralph/` state,
+but a third-party plan must be judged against that repository's own
+`WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist.
+Do not apply `symphony-ts` planning standards to an external repository unless
+that repository's checked-in instructions explicitly say to do so.
+
 Normal path rules:
 
 - Treat `factory status --json` as the primary source of truth.
@@ -209,16 +216,16 @@ Intervene directly only when the runtime contract is impaired or an explicit hum
 
 Use this table:
 
-| Situation                                                                                        | Operator action                                                                                                             |
-| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `awaiting-human-handoff`                                                                         | Review the plan and post one of the workflow's accepted plan-review decision markers from `tracker.plan_review`             |
-| `degraded-review-infrastructure`                                                                 | Inspect the missing reviewer-app output path before further automation or manual landing                                    |
-| `awaiting-landing-command` with green, review-clean PR and required approved bot review observed | Post `/land` on the PR                                                                                                      |
-| Detached runtime stopped or degraded                                                             | Use `factory status`, then `factory start` or `factory restart`                                                             |
-| Severe failure pattern where continuing automation would be harmful                              | Use `factory pause --reason ...`, inspect `factory status`, then optionally `factory stop` until humans reconcile           |
-| `restart-recovery` visible after startup                                                         | Inspect the recovery summary and per-issue decisions before manual reruns                                                   |
-| `retry-backoff` or `watchdog-recovery`                                                           | Prefer waiting for the queue/recovery path unless the factory is degraded or the posture stops progressing                  |
-| Failed issue with retained workspace                                                             | Inspect artifacts and retained workspace, fix the underlying problem, then relabel or rerun through the normal tracker path |
+| Situation                                                                                        | Operator action                                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awaiting-human-handoff`                                                                         | Review the plan against the selected instance repository's own checked-in planning contract and post one of the workflow's accepted plan-review decision markers from `tracker.plan_review` |
+| `degraded-review-infrastructure`                                                                 | Inspect the missing reviewer-app output path before further automation or manual landing                                                                                                    |
+| `awaiting-landing-command` with green, review-clean PR and required approved bot review observed | Post `/land` on the PR                                                                                                                                                                      |
+| Detached runtime stopped or degraded                                                             | Use `factory status`, then `factory start` or `factory restart`                                                                                                                             |
+| Severe failure pattern where continuing automation would be harmful                              | Use `factory pause --reason ...`, inspect `factory status`, then optionally `factory stop` until humans reconcile                                                                           |
+| `restart-recovery` visible after startup                                                         | Inspect the recovery summary and per-issue decisions before manual reruns                                                                                                                   |
+| `retry-backoff` or `watchdog-recovery`                                                           | Prefer waiting for the queue/recovery path unless the factory is degraded or the posture stops progressing                                                                                  |
+| Failed issue with retained workspace                                                             | Inspect artifacts and retained workspace, fix the underlying problem, then relabel or rerun through the normal tracker path                                                                 |
 
 Avoid manual branch takeovers while the factory is healthy. If the runtime missed CI or review follow-up, treat that as a product problem first.
 

--- a/docs/plans/318-instance-scoped-operator-plan-review/plan.md
+++ b/docs/plans/318-instance-scoped-operator-plan-review/plan.md
@@ -129,13 +129,13 @@ This slice preserves the existing operator and tracker lifecycle states. The beh
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Selected-instance facts available | Expected decision |
-| --- | --- | --- | --- |
-| Operator runs from `symphony-ts` root against `../target-repo/WORKFLOW.md` | operator checkout paths, selected workflow path | selected instance root and repo docs exist | review the plan against `../target-repo` docs, not `symphony-ts` docs |
-| Selected instance has `WORKFLOW.md` but no `AGENTS.md` | workflow path and instance root | no `AGENTS.md`, maybe `README.md` and docs | continue with the selected repository's checked-in instructions that do exist; do not fall back to `symphony-ts` planning rules |
-| Selected instance overrides `tracker.plan_review` markers | workflow config available | selected marker strings resolved | use selected marker protocol plus selected repository rubric |
-| Self-hosting `symphony-ts` workflow is selected | operator checkout equals instance root | local repo docs are the selected repo docs | preserve current self-hosting behavior |
-| Prompt still says "this repository" without selected-instance clarification | operator checkout root visible | external instance root also exists | invalid implementation for this issue; prompt must explicitly distinguish tooling repo from selected instance review authority |
+| Observed condition                                                          | Local facts available                           | Selected-instance facts available          | Expected decision                                                                                                               |
+| --------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| Operator runs from `symphony-ts` root against `../target-repo/WORKFLOW.md`  | operator checkout paths, selected workflow path | selected instance root and repo docs exist | review the plan against `../target-repo` docs, not `symphony-ts` docs                                                           |
+| Selected instance has `WORKFLOW.md` but no `AGENTS.md`                      | workflow path and instance root                 | no `AGENTS.md`, maybe `README.md` and docs | continue with the selected repository's checked-in instructions that do exist; do not fall back to `symphony-ts` planning rules |
+| Selected instance overrides `tracker.plan_review` markers                   | workflow config available                       | selected marker strings resolved           | use selected marker protocol plus selected repository rubric                                                                    |
+| Self-hosting `symphony-ts` workflow is selected                             | operator checkout equals instance root          | local repo docs are the selected repo docs | preserve current self-hosting behavior                                                                                          |
+| Prompt still says "this repository" without selected-instance clarification | operator checkout root visible                  | external instance root also exists         | invalid implementation for this issue; prompt must explicitly distinguish tooling repo from selected instance review authority  |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/318-instance-scoped-operator-plan-review/plan.md
+++ b/docs/plans/318-instance-scoped-operator-plan-review/plan.md
@@ -1,0 +1,212 @@
+# Issue 318 Plan: Instance-Scoped Operator Plan Review For External Repositories
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make operator plan review instance-scoped so that when the checked-in Symphony operator loop is pointed at an external repository, the operator reviews `plan-ready` handoffs against the selected repository's own planning contract and docs instead of implicitly applying `symphony-ts` planning standards.
+
+## Scope
+
+1. make the operator prompt and skill explicit about the selected instance repository being the source of truth for plan-review rubric and relevant planning docs
+2. expose any missing selected-instance path/context needed so the operator can reliably locate the external repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs during a wake-up cycle
+3. update operator-facing docs so third-party operation explains the instance-scoped review rule clearly
+4. add tests that pin the prompt and operator-loop contract so external-repository plan review no longer defaults to `symphony-ts` guidance
+
+## Non-goals
+
+1. changing the tracker-owned `tracker.plan_review` protocol markers, metadata labels, or reply-template contract introduced by issue `#316`
+2. redesigning the operator wake-up sequence, detached runtime control, or release/report checkpoints
+3. changing normalized tracker lifecycle states such as `awaiting-human-handoff`
+4. building a generic cross-repository policy loader beyond the selected instance's checked-in docs and workflow path
+5. changing worker prompt rules for implementation work outside the operator's plan-review checkpoint
+
+## Current Gaps
+
+1. [`skills/symphony-operator/operator-prompt.md`](../../../../skills/symphony-operator/operator-prompt.md) still opens with "this repository", which is accurate for self-hosting but ambiguous or misleading when the operator repo and selected instance repo differ
+2. the operator skill describes the selected workflow's `tracker.plan_review` markers, but it does not explicitly require the review rubric itself to come from the selected repository's own planning docs
+3. the checked-in operator docs are written primarily from the self-hosting perspective and do not clearly separate operator-repo tooling from selected-instance review authority
+4. the operator loop exports the selected workflow path, but it does not yet surface a dedicated selected-instance root/path contract for prompt use
+5. current operator-loop tests pin checkpoint ordering and per-instance state isolation, but they do not pin the external-instance plan-review rubric boundary
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the mapping in [`docs/architecture.md`](../../architecture.md).
+
+- Policy Layer
+  - belongs: the rule that plan-review quality is judged against the selected repository's own planning contract, not the engine checkout's defaults
+  - does not belong: hard-coded `symphony-ts` architecture expectations silently applied to unrelated repositories
+- Configuration Layer
+  - belongs: selected-instance path derivation or exported context needed to make the chosen repository explicit to the operator prompt
+  - does not belong: tracker comment parsing or human-decision marker logic
+- Coordination Layer
+  - belongs: no lifecycle or retry changes for this slice; the operator still reacts to the same `awaiting-human-handoff` checkpoint
+  - does not belong: new orchestration states or retry/reconciliation logic
+- Execution Layer
+  - belongs: operator prompt/skill wording and any instance-scoped environment contract the wake-up loop must provide to let the operator inspect the right repository
+  - does not belong: tracker-specific review parsing or issue-thread mutation rules
+- Integration Layer
+  - belongs: any operator-loop path plumbing that resolves the selected instance root from the workflow path and passes it into the prompt environment
+  - does not belong: GitHub transport or tracker lifecycle policy refactors unrelated to operator context
+- Observability Layer
+  - belongs: operator-facing docs/tests that make the selected-instance review source of truth inspectable
+  - does not belong: a new dashboard, state artifact, or reporting surface for this slice
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+1. operator prompt and skill assets under `skills/symphony-operator/`
+   - make the selected instance repository explicit during plan review
+   - require review against that repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist
+2. operator-loop execution contract
+   - expose any missing selected-instance root/path environment values derived from the chosen workflow path
+   - keep the operator running from the engine checkout while making the review authority instance-scoped
+3. operator-facing docs
+   - update third-party/operator docs to explain that the operator repo provides tooling, while the selected instance repo provides planning standards
+4. tests
+   - pin prompt wording, exported instance context, and external-instance review instructions
+
+### Does not belong in this issue
+
+1. tracker `plan_review` protocol redesign or new workflow frontmatter
+2. orchestrator dispatch/retry/handoff-state changes
+3. worker implementation prompt redesign outside what is required to clarify the operator checkpoint
+4. new durable per-instance policy stores outside the repository-owned checked-in docs
+
+## Layering Notes
+
+- `config/workflow`
+  - may contribute resolved instance-path data if the cleanest seam needs it
+  - should not gain operator-specific plan-review policy logic
+- `tracker`
+  - remains the owner of plan-review markers and lifecycle normalization
+  - should not become the source of plan-review rubric text
+- `workspace`
+  - remains unchanged
+  - should not participate in operator review-rubric selection
+- `runner`
+  - owns the operator-loop launch environment only insofar as selected-instance context must be surfaced cleanly
+  - should not infer repository policy from tracker comments
+- `orchestrator`
+  - remains unchanged and continues to consume normalized handoff lifecycle only
+  - should not branch on whether the operator is self-hosting or reviewing an external repo
+- `observability`
+  - owns clear operator-facing guidance/tests about where review authority comes from
+  - should not invent a second source of truth for repository planning rules
+
+## Slice Strategy And PR Seam
+
+Land this as one reviewable PR focused on one seam: preserve the existing operator loop and plan-review protocol, but make the plan-review rubric explicitly instance-scoped for non-default workflows.
+
+This stays reviewable because it limits the change to:
+
+1. operator prompt/skill wording
+2. small operator-loop context plumbing
+3. targeted operator docs
+4. prompt/loop contract tests
+
+This issue should not expand into tracker protocol changes, new runtime states, or a larger external-repository productization effort.
+
+## Runtime State Model
+
+This slice preserves the existing operator and tracker lifecycle states. The behavior change is which repository supplies the review rubric once the operator reaches the existing human-handoff checkpoint.
+
+### States in play
+
+1. operator wake-up selects an instance via `--workflow`
+2. tracker reports issue lifecycle `awaiting-human-handoff`
+3. operator reviews the plan against the selected repository's planning contract
+4. operator posts the selected workflow's configured decision marker
+
+### Explicit non-changes
+
+1. no new handoff lifecycle kinds
+2. no new operator checkpoint states
+3. no retry, reconciliation, or lease behavior changes
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Selected-instance facts available | Expected decision |
+| --- | --- | --- | --- |
+| Operator runs from `symphony-ts` root against `../target-repo/WORKFLOW.md` | operator checkout paths, selected workflow path | selected instance root and repo docs exist | review the plan against `../target-repo` docs, not `symphony-ts` docs |
+| Selected instance has `WORKFLOW.md` but no `AGENTS.md` | workflow path and instance root | no `AGENTS.md`, maybe `README.md` and docs | continue with the selected repository's checked-in instructions that do exist; do not fall back to `symphony-ts` planning rules |
+| Selected instance overrides `tracker.plan_review` markers | workflow config available | selected marker strings resolved | use selected marker protocol plus selected repository rubric |
+| Self-hosting `symphony-ts` workflow is selected | operator checkout equals instance root | local repo docs are the selected repo docs | preserve current self-hosting behavior |
+| Prompt still says "this repository" without selected-instance clarification | operator checkout root visible | external instance root also exists | invalid implementation for this issue; prompt must explicitly distinguish tooling repo from selected instance review authority |
+
+## Storage / Persistence Contract
+
+1. the selected repository's checked-in `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs remain the canonical plan-review rubric inputs
+2. operator-loop local state under `.ralph/instances/<instance-key>/` remains unchanged and is not a policy source of truth
+3. no new durable policy artifacts should be introduced for this slice
+
+## Observability Requirements
+
+1. operator-facing prompt/doc text must make it obvious which repository owns the review rubric for the current wake-up
+2. external-instance behavior must be pinned in automated tests so future prompt edits do not regress to `symphony-ts`-specific review standards
+3. self-hosting behavior must remain intact and obvious
+
+## Implementation Steps
+
+1. add or refine selected-instance path derivation/export in the operator loop if the current `SYMPHONY_OPERATOR_WORKFLOW_PATH` contract is not explicit enough for prompt consumers
+2. update [`skills/symphony-operator/operator-prompt.md`](../../../../skills/symphony-operator/operator-prompt.md) so plan review explicitly:
+   - distinguishes the operator tooling repo from the selected instance repo
+   - reads planning standards from the selected instance's checked-in docs
+   - avoids implicitly applying `symphony-ts` architecture rules to external repositories
+3. update [`skills/symphony-operator/SKILL.md`](../../../../skills/symphony-operator/SKILL.md) with the same instance-scoped review rule and third-party nuance
+4. update [`docs/guides/operator-runbook.md`](../../guides/operator-runbook.md) and any nearby operator-facing docs that currently imply the operator repo is the review authority
+5. add/update tests for:
+   - operator-loop prompt text for external workflows
+   - exported selected-instance path/context if new env surface is added
+   - third-party/operator docs or contract tests where the checked-in wording is the primary deliverable
+6. run local QA: `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test`
+
+## Tests And Acceptance Scenarios
+
+### Unit / Contract
+
+1. planning/operator contract tests keep the operator guidance explicit that plan review uses the selected repository's own docs and planning standards
+2. if a new selected-instance environment variable is added, unit or integration coverage pins its resolved value
+
+### Integration
+
+1. when the operator loop is launched with `--workflow <external-instance>/WORKFLOW.md`, the prompt captured from the loop instructs the operator to review plans against the selected instance repository rather than "this repository"
+2. self-hosting operator-loop prompt behavior remains valid when the selected workflow belongs to the engine checkout itself
+
+### End-to-end
+
+1. given a third-party instance with its own planning contract, an operator wake-up reviewing a `plan-ready` issue has enough prompt/context to apply that contract instead of `symphony-ts` architecture rules
+
+### Local Gate
+
+1. `pnpm format`
+2. `pnpm lint`
+3. `pnpm typecheck`
+4. `pnpm test`
+5. local self-review if a reliable review command is available
+
+## Exit Criteria
+
+1. operator guidance clearly states that the selected instance repository owns the plan-review rubric
+2. external-instance operator runs have explicit selected-instance path/context instead of relying on ambiguous "this repository" wording
+3. automated tests cover the external-instance prompt/rubric boundary
+4. self-hosting behavior remains unchanged
+
+## Deferred Work
+
+1. generic cross-repository policy discovery beyond checked-in repository docs
+2. any broader operator prompt redesign unrelated to instance-scoped plan review
+3. tracker-side enforcement that a repository publishes particular planning docs
+
+## Decision Notes
+
+1. Keep the review authority in checked-in repository docs instead of inventing a second operator-local policy store. That preserves repo ownership and keeps external repositories inspectable.
+2. Prefer a small operator-loop context seam over tracker or orchestrator changes. The bug is in review context/rubric ownership, not in lifecycle normalization.
+3. Preserve self-hosting behavior as the default case of the same instance-scoped rule: when the selected instance is `symphony-ts`, `symphony-ts` docs are the right rubric; when it is external, they are not.
+
+## Revision Log
+
+- 2026-04-02: Initial plan created for issue `#318` and prepared for plan-review handoff.

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: symphony-operator
-description: Operate and maintain the local Symphony factory in this repository. Use this skill when monitoring the live factory, repairing stalled runs, handling PR review and CI follow-up, or improving the operator loop itself.
+description: Operate and maintain the local Symphony factory from this repository checkout. Use this skill when monitoring the live factory, repairing stalled runs, handling PR review and CI follow-up, or improving the operator loop itself.
 ---
 
 # Symphony Operator
@@ -34,7 +34,7 @@ provider session for that instance.
 - Observe the live factory, not just the repository.
 - Repair broken or stalled execution.
 - Drive PRs through CI and automated review to a mergeable state.
-- Handle `plan-ready` issues using the selected workflow's configured `tracker.plan_review` protocol: review plans, request changes when needed, and approve when ready.
+- Handle `plan-ready` issues using the selected workflow's configured `tracker.plan_review` protocol: review plans against the selected instance repository's own checked-in contract, request changes when needed, and approve when ready.
 - Keep GitHub as a thin queue and rely on Symphony's own polling and concurrency.
 - Maintain the selected instance's persistent local operator notebook as:
   - `.ralph/instances/<instance-key>/standing-context.md` for durable guidance
@@ -65,7 +65,7 @@ provider session for that instance.
 14. If the factory is unhealthy, fix the concrete problem and restart it.
 15. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
 16. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
-17. If an active issue is waiting in `plan-ready`, inspect the selected workflow's configured `tracker.plan_review` markers, review the plan, and post an explicit review decision comment using that protocol. When no override is configured, the defaults remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
+17. If an active issue is waiting in `plan-ready`, inspect the selected workflow's configured `tracker.plan_review` markers, then review the plan against the selected instance root at `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT`. Read that repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist; if the selected instance differs from the operator checkout, do not import `symphony-ts` planning standards into that external repository. Post an explicit review decision comment using the selected workflow's protocol. When no override is configured, the defaults remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
 
 18. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
 19. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
@@ -78,6 +78,7 @@ provider session for that instance.
 - Keep concurrency conservative.
 - Treat `docs/guides/operator-runbook.md` as the canonical daily-use procedure and keep this skill focused on operator policy, checkpoints, and escalation.
 - Treat the factory-control surface as the primary local runtime contract; use ad hoc `screen`, `ps`, or `pkill` inspection only when the control command is unavailable or inconsistent.
+- Treat the operator checkout as tooling, not automatically as policy authority. For plan review and repo-owned rules, the selected instance repository is the source of truth.
 - In a wake-up cycle, favor short, bounded inspection commands over long-running watchers. If a secondary GitHub or watch-surface probe is slow or non-terminal, stop and continue from the latest successful control-surface read instead of waiting indefinitely.
 - Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring and `pnpm tsx bin/symphony.ts factory attach` when you need the full-screen TUI; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
@@ -92,6 +93,7 @@ provider session for that instance.
 - Keep release dependency truth in the typed `release-state.json` artifact, not only in markdown notes. Standing context may explain release sequencing, but prerequisite failure gating must remain inspectable through the typed artifact.
 - Treat plan review as a required operator checkpoint:
   - read the selected workflow's `tracker.plan_review` config first,
+  - read the selected instance repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist,
   - if the plan is sound, post that workflow's approval marker,
   - if revisions are needed, post that workflow's changes-requested marker with concrete guidance,
   - if explicitly bypassing review, post that workflow's waiver marker and record why.

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -14,6 +14,7 @@ RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
 INSTANCE_KEY=""
 DETACHED_SESSION_NAME=""
+SELECTED_INSTANCE_ROOT=""
 INSTANCE_STATE_ROOT=""
 LOG_DIR=""
 LOCK_DIR=""
@@ -146,6 +147,7 @@ const fs = require("node:fs");
 const data = JSON.parse(fs.readFileSync(0, "utf8"));
   const mappings = {
   workflowPath: "WORKFLOW_PATH",
+  selectedInstanceRoot: "SELECTED_INSTANCE_ROOT",
   instanceKey: "INSTANCE_KEY",
   detachedSessionName: "DETACHED_SESSION_NAME",
   operatorStateRoot: "INSTANCE_STATE_ROOT",
@@ -510,6 +512,7 @@ write_status() {
   "repoRoot": "$(json_escape "$REPO_ROOT")",
   "instanceKey": "$(json_escape "$INSTANCE_KEY")",
   "detachedSessionName": "$(json_escape "$DETACHED_SESSION_NAME")",
+  "selectedInstanceRoot": "$(json_escape "$SELECTED_INSTANCE_ROOT")",
   "operatorStateRoot": "$(json_escape "$INSTANCE_STATE_ROOT")",
   "pid": $$,
   "runOnce": $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'true'; else printf 'false'; fi),
@@ -568,6 +571,7 @@ EOF
 - Repo root: $REPO_ROOT
 - Instance key: $INSTANCE_KEY
 - Detached session: $DETACHED_SESSION_NAME
+- Selected instance root: $SELECTED_INSTANCE_ROOT
 - Operator state root: $INSTANCE_STATE_ROOT
 - Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
 - Interval seconds: $INTERVAL_SECONDS
@@ -748,6 +752,7 @@ run_cycle() {
     printf 'repo_root=%s\n' "$REPO_ROOT"
     printf 'instance_key=%s\n' "$INSTANCE_KEY"
     printf 'detached_session=%s\n' "$DETACHED_SESSION_NAME"
+    printf 'selected_instance_root=%s\n' "$SELECTED_INSTANCE_ROOT"
     printf 'operator_state_root=%s\n' "$INSTANCE_STATE_ROOT"
     printf 'selected_workflow=%s\n' "${WORKFLOW_PATH:-}"
     printf 'provider=%s\n' "$OPERATOR_PROVIDER"
@@ -769,6 +774,7 @@ run_cycle() {
     export SYMPHONY_OPERATOR_REPO_ROOT="$REPO_ROOT"
     export SYMPHONY_OPERATOR_INSTANCE_KEY="$INSTANCE_KEY"
     export SYMPHONY_OPERATOR_DETACHED_SESSION_NAME="$DETACHED_SESSION_NAME"
+    export SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT="$SELECTED_INSTANCE_ROOT"
     export SYMPHONY_OPERATOR_STATE_ROOT="$INSTANCE_STATE_ROOT"
     export SYMPHONY_OPERATOR_STANDING_CONTEXT="$STANDING_CONTEXT"
     export SYMPHONY_OPERATOR_WAKE_UP_LOG="$WAKE_UP_LOG"

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -1,4 +1,4 @@
-You are the operator for the local Symphony factory in this repository.
+You are the operator for the local Symphony factory tooling in this repository.
 
 Run exactly one wake-up cycle, then stop.
 
@@ -6,32 +6,33 @@ Required workflow:
 
 1. Read `skills/symphony-operator/SKILL.md`.
 2. Read the instance-scoped standing context at `SYMPHONY_OPERATOR_STANDING_CONTEXT` and the wake-up log at `SYMPHONY_OPERATOR_WAKE_UP_LOG` if they exist.
-3. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
-4. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
-5. Immediately after the factory-health check, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-6. If the freshness check reports `stale-idle`, refresh the operator repo checkout and the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint.
-7. Immediately after the freshness check is clear, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-8. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
+3. Treat `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT` as the repository that owns this wake-up's runtime contract and planning rubric. When it differs from `SYMPHONY_OPERATOR_REPO_ROOT`, review `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs from the selected instance root if they exist, and do not apply `symphony-ts` planning standards to that external repository.
+4. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
+5. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
+6. Immediately after the factory-health check, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+7. If the freshness check reports `stale-idle`, refresh the operator repo checkout and the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint.
+8. Immediately after the freshness check is clear, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+9. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
    - read the report evidence under `.var/reports/issues/<issue-number>/`,
    - record a no-follow-up decision with `pnpm tsx bin/symphony-report.ts review-record --issue <number> --status reviewed-no-follow-up --summary <...>`,
    - or create a tracked follow-up issue with `pnpm tsx bin/symphony-report.ts review-follow-up --issue <number> --title <...> --body-file <...> --summary <...>`,
    - and record what was learned and queued in the standing context or wake-up log as appropriate before moving on.
-9. Before any downstream release advancement work after the completed-run report-review checkpoint is clear, inspect release advancement state by running `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-10. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact, including its stored `promotion` result with eligible downstream issues plus any `symphony:ready` labels added or removed.
-11. If the release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync error is resolved.
-12. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-13. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-14. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
-15. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-16. Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers; when no override is configured, the default markers remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
-17. As mandatory operator checkpoints for this wake-up, explicitly:
+10. Before any downstream release advancement work after the completed-run report-review checkpoint is clear, inspect release advancement state by running `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
+11. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact, including its stored `promotion` result with eligible downstream issues plus any `symphony:ready` labels added or removed.
+12. If the release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync error is resolved.
+13. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
+14. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+15. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
+16. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+17. Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers; review the plan against the selected instance repository's own planning contract and docs, not the operator repo's defaults. When no override is configured, the default markers remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
+18. As mandatory operator checkpoints for this wake-up, explicitly:
 
-- review any active `plan-ready` / `awaiting-human-handoff` issue and post a plan decision,
+- review any active `plan-ready` / `awaiting-human-handoff` issue against the selected instance repository's own checked-in planning rules and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
 - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 
-18. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-19. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
+19. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+20. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
 
 Constraints:
 

--- a/src/domain/instance-identity.ts
+++ b/src/domain/instance-identity.ts
@@ -8,6 +8,7 @@ const MAX_INSTANCE_LABEL_LENGTH = 24;
 const INSTANCE_HASH_LENGTH = 10;
 
 export interface SymphonyInstanceIdentity {
+  readonly instanceRoot: string;
   readonly instanceKey: string;
   readonly detachedSessionName: string;
 }
@@ -33,6 +34,7 @@ export function deriveSymphonyInstanceIdentity(
   const instanceRoot = normalizeInstanceRoot(instanceRootOrWorkflowPath);
   const instanceKey = deriveSymphonyInstanceKey(instanceRoot);
   return {
+    instanceRoot,
     instanceKey,
     detachedSessionName: `${DETACHED_SESSION_PREFIX}-${instanceKey}`,
   };

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -317,6 +317,7 @@ describe("operator loop workflow selection", () => {
       ) as {
         readonly state: string;
         readonly selectedWorkflowPath: string | null;
+        readonly selectedInstanceRoot: string;
         readonly operatorStateRoot: string;
         readonly standingContext: string;
         readonly wakeUpLog: string;
@@ -333,6 +334,7 @@ describe("operator loop workflow selection", () => {
       expect(run.stateRoot.startsWith(ralphInstancesRoot)).toBe(true);
       expect(statusJson.state).toBe("idle");
       expect(statusJson.selectedWorkflowPath).toBe(workflowPath);
+      expect(statusJson.selectedInstanceRoot).toBe(path.dirname(workflowPath));
       expect(statusJson.operatorStateRoot).toBe(run.stateRoot);
       expect(statusJson.standingContext).toBe(run.standingContextPath);
       expect(statusJson.wakeUpLog).toBe(run.wakeUpLogPath);
@@ -340,6 +342,9 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.releaseState.advancementState).toBe("unconfigured");
       expect(statusJson.releaseState.promotion.state).toBe("unconfigured");
       expect(statusMd).toContain(`- Selected workflow: ${workflowPath}`);
+      expect(statusMd).toContain(
+        `- Selected instance root: ${path.dirname(workflowPath)}`,
+      );
       expect(statusMd).toContain(`- Operator state root: ${run.stateRoot}`);
       expect(statusMd).toContain(
         `- Standing context: ${run.standingContextPath}`,
@@ -450,6 +455,30 @@ describe("operator loop workflow selection", () => {
       expect(prompt).toContain("bin/symphony-report.ts review-pending");
       expect(prompt).toContain("bin/check-operator-release-state.ts");
       expect(prompt).toContain("Read the instance-scoped standing context");
+      expect(prompt).toContain("SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT");
+      expect(prompt).toContain(
+        "selected instance root if they exist, and do not apply `symphony-ts` planning standards",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exports the selected instance root to the operator command environment", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-instance-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const capturePath = path.join(tempDir, "instance-root.txt");
+
+    try {
+      await runOperatorLoopWithCommand(
+        workflowPath,
+        `node -e ${JSON.stringify(`require("node:fs").writeFileSync(${JSON.stringify(capturePath)}, process.env.SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT ?? "")`)}`,
+      );
+      createdPaths.add(tempDir);
+
+      expect(await fs.readFile(capturePath, "utf8")).toBe(
+        path.dirname(workflowPath),
+      );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/instance-identity.test.ts
+++ b/tests/unit/instance-identity.test.ts
@@ -21,6 +21,7 @@ describe("instance identity helpers", () => {
       "/tmp/project-a/WORKFLOW.md",
     );
 
+    expect(identity.instanceRoot).toBe("/tmp/project-a");
     expect(identity.instanceKey).toMatch(/^project-a-[0-9a-f]{10}$/);
     expect(identity.detachedSessionName).toBe(
       `symphony-factory-${identity.instanceKey}`,


### PR DESCRIPTION
## Summary
- export the selected instance root into the operator-loop environment and status metadata
- make the operator prompt, skill, README, and runbook review plans against the selected repository's own docs
- add operator-loop and instance-identity coverage for the new instance-scoped review boundary

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm exec vitest run tests/integration/operator-loop.test.ts tests/unit/instance-identity.test.ts
- pnpm test

Closes #318
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
