### PR TITLE
Fix factory TUI contrast for light terminal themes

### DIFF
--- a/docs/plans/320-tui-light-theme-contrast/plan.md
+++ b/docs/plans/320-tui-light-theme-contrast/plan.md
@@ -130,13 +130,13 @@ This slice does not change orchestration state, retries, continuations, reconcil
 
 ## Contrast Decision Matrix
 
-| Observed render condition | Current render behavior | Expected render behavior |
-| --- | --- | --- |
-| Recovery posture summary/detail on a light terminal | summary text and detail rely on dim gray | operator-critical summary/detail text uses default or otherwise high-contrast foreground |
-| Recovery posture entry metadata | issue family/id/detail all rely heavily on colored/dim text | compact status tags may stay colored, but the explanatory text remains readable without depending on dim styling |
-| Ticket table row for active/waiting items | large text spans inherit status colors, with adjacent dim metadata | color is limited to short status cues while row content remains readable on light themes |
-| Empty-state rows such as `No active tickets` | empty-state text uses dim gray | empty-state text remains muted but still legible on light backgrounds |
-| Dark terminal rendering | current palette is readable | dark-mode readability remains acceptable after neutralizing the low-contrast choices |
+| Observed render condition                           | Current render behavior                                            | Expected render behavior                                                                                         |
+| --------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Recovery posture summary/detail on a light terminal | summary text and detail rely on dim gray                           | operator-critical summary/detail text uses default or otherwise high-contrast foreground                         |
+| Recovery posture entry metadata                     | issue family/id/detail all rely heavily on colored/dim text        | compact status tags may stay colored, but the explanatory text remains readable without depending on dim styling |
+| Ticket table row for active/waiting items           | large text spans inherit status colors, with adjacent dim metadata | color is limited to short status cues while row content remains readable on light themes                         |
+| Empty-state rows such as `No active tickets`        | empty-state text uses dim gray                                     | empty-state text remains muted but still legible on light backgrounds                                            |
+| Dark terminal rendering                             | current palette is readable                                        | dark-mode readability remains acceptable after neutralizing the low-contrast choices                             |
 
 ## Observability Requirements
 

--- a/docs/plans/320-tui-light-theme-contrast/plan.md
+++ b/docs/plans/320-tui-light-theme-contrast/plan.md
@@ -1,0 +1,213 @@
+# Issue 320 Plan: Fix Factory TUI Contrast For Light Terminal Themes
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make the factory status TUI readable in both dark and light terminal themes by replacing low-contrast color choices in the recovery and tickets sections with a small semantic palette that preserves status meaning without washing out key text.
+
+## Scope
+
+- audit the current ANSI color usage in `src/observability/tui.ts` for recovery posture rows, ticket table rows, and adjacent header/detail text
+- replace low-contrast presentation with observability-local semantic color helpers for primary text, secondary metadata, separators, and status emphasis
+- preserve the existing layout, snapshot contract, and ticket/recovery content while changing only the presentation layer needed for contrast
+- add regression coverage that explicitly checks light-theme-safe rendering decisions
+- update the TUI QA fixture/workflow so light-theme contrast is part of the documented verification path
+
+## Non-goals
+
+- changing tracker data, orchestrator snapshot shape, retry policy, or runner visibility contracts
+- redesigning the TUI layout, column model, or section ordering
+- adding runtime theme detection or workflow configuration for light vs dark terminals in this slice
+- introducing true-color or terminal-specific palette negotiation
+- refactoring unrelated observability/reporting code outside the status TUI seam
+
+## Current Gaps
+
+- `src/observability/tui.ts` uses `GRAY = "\x1b[2;37m"` for recovery summaries, empty-state rows, separators, and several detail strings; that dim-white choice is nearly invisible on light backgrounds
+- recovery posture rows color both the summary line and issue-entry detail with faint gray even though those lines carry primary operator information
+- ticket table rows color large spans of meaningful text with status colors and pair them with dim metadata, which reduces readability on common light terminal palettes
+- the current tests assert content and layout, but they do not pin the contrast-sensitive ANSI choices that caused the regression
+- `tests/fixtures/tui-qa-dump.ts` documents visual QA generally, but it does not call out a specific light-theme contrast check
+
+## Decision Notes
+
+- The first reviewable slice should stay entirely inside observability. The issue is presentation-specific, so it should not widen into snapshot or workflow changes unless the existing TUI seam proves insufficient.
+- The safest fix is to reduce dependence on dim text and use color only for compact status cues, while leaving most operator-critical text in default/high-contrast foreground styling.
+- This slice should introduce semantic TUI color roles rather than swapping a few literals ad hoc. That keeps the contrast policy legible and makes later TUI adjustments less brittle.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses `docs/architecture.md`.
+
+- Policy Layer
+  - belongs: the operator-facing rule that the status TUI must remain readable across common terminal themes
+  - does not belong: changing issue lifecycle policy, retry posture meaning, or review/landing behavior
+- Configuration Layer
+  - belongs: none in this slice; existing observability config remains unchanged
+  - does not belong: new workflow knobs for theme selection or palette overrides
+- Coordination Layer
+  - belongs: untouched; the orchestrator continues to publish the same normalized snapshot data
+  - does not belong: snapshot-shape churn, retry-state changes, or extra runtime bookkeeping solely for presentation
+- Execution Layer
+  - belongs: untouched; runner/workspace behavior is not part of this contrast bug
+  - does not belong: subprocess, workspace, or execution-session changes
+- Integration Layer
+  - belongs: untouched; tracker transport/normalization stays out of this PR
+  - does not belong: tracker-specific formatting or adapter changes
+- Observability Layer
+  - belongs: ANSI palette roles, row/header rendering changes, and regression coverage for readable light-theme output
+  - does not belong: tracker inspection, lifecycle policy, or runner transport changes
+
+## Architecture Boundaries
+
+### `src/observability/tui.ts`
+
+- owns semantic color-role definitions and the render-time choice of which text is neutral vs emphasized
+- may refactor existing raw ANSI constants into named presentation helpers if that keeps usage clearer
+- should not gain tracker-policy logic or snapshot normalization work
+
+### `tests/unit/tui.test.ts`
+
+- owns focused regression tests for ANSI choices that materially affect readability
+- should assert behavior at the semantic/rendered-output level rather than snapshot-internal details unrelated to contrast
+
+### `tests/fixtures/tui-qa-dump.ts`
+
+- owns the manual visual QA path for TUI inspection
+- should explicitly surface a light-theme verification step or fixture note
+- should not become an alternate renderer or a heavy snapshot-testing framework
+
+### Does not belong in this slice
+
+- `src/orchestrator/*`
+- `src/tracker/*`
+- `src/runner/*`
+- workflow schema/docs beyond a QA note tied directly to the TUI verification path
+
+## Layering Notes
+
+- `config/workflow`
+  - remains unchanged
+  - does not gain theme settings in this issue
+- `tracker`
+  - remains the source of normalized ticket/recovery facts
+  - does not participate in ANSI styling decisions
+- `workspace`
+  - untouched
+- `runner`
+  - untouched
+  - does not own ticket-row coloring
+- `orchestrator`
+  - continues to expose the same TUI snapshot facts
+  - does not become a carrier for theme-specific presentation flags
+- `observability`
+  - owns readable ANSI styling and the test/QA guardrails for that styling
+  - does not become a second source of truth for lifecycle semantics
+
+## Slice Strategy And PR Seam
+
+This issue fits in one reviewable PR if it stays inside the status-TUI presentation seam:
+
+1. replace low-contrast ANSI choices with a semantic palette in `src/observability/tui.ts`
+2. update unit coverage to pin readable rendering decisions for recovery rows and ticket rows
+3. update the QA dump or observability docs so light-theme contrast is an explicit verification step
+
+Deferred from this PR:
+
+- runtime theme detection
+- user-configurable palettes
+- broader TUI redesign or accessibility framework work
+- contrast changes in other CLI/report surfaces unless the same low-contrast pattern is discovered there and can be fixed without widening the seam materially
+
+This seam is reviewable on its own because it is a pure observability correctness change with no tracker, orchestrator, or runner contract movement.
+
+## Runtime State Model
+
+This slice does not change orchestration state, retries, continuations, reconciliation, leases, or handoff transitions. It is a read-only presentation fix over the existing `TuiSnapshot`.
+
+## Contrast Decision Matrix
+
+| Observed render condition | Current render behavior | Expected render behavior |
+| --- | --- | --- |
+| Recovery posture summary/detail on a light terminal | summary text and detail rely on dim gray | operator-critical summary/detail text uses default or otherwise high-contrast foreground |
+| Recovery posture entry metadata | issue family/id/detail all rely heavily on colored/dim text | compact status tags may stay colored, but the explanatory text remains readable without depending on dim styling |
+| Ticket table row for active/waiting items | large text spans inherit status colors, with adjacent dim metadata | color is limited to short status cues while row content remains readable on light themes |
+| Empty-state rows such as `No active tickets` | empty-state text uses dim gray | empty-state text remains muted but still legible on light backgrounds |
+| Dark terminal rendering | current palette is readable | dark-mode readability remains acceptable after neutralizing the low-contrast choices |
+
+## Observability Requirements
+
+- the recovery posture summary and per-issue recovery entries must remain readable in common light terminal themes
+- ticket table rows must keep their status meaning without washing out ID, activity, runner, token, or detail text
+- section headers and separators should remain visually distinct without depending on barely visible dim-white text
+- regression coverage should make the light-theme-sensitive color policy visible in tests, not only in a human screenshot
+
+## Implementation Steps
+
+1. Audit `src/observability/tui.ts` and group existing raw ANSI constants into semantic roles such as:
+   - primary text
+   - muted but readable metadata
+   - separators
+   - success/warning/error/accent cues
+2. Replace uses of the current dim-gray helper in recovery rows, ticket headers, ticket empty states, and other operator-critical lines with the new semantic roles.
+3. Narrow status-color usage in ticket rows so long detail strings and other primary content do not depend entirely on light-theme-fragile colors.
+4. Keep the existing layout and snapshot content stable while adjusting only the render-time styling choices.
+5. Add focused unit tests in `tests/unit/tui.test.ts` that cover:
+   - recovery posture rows avoiding dim/washed-out styling for primary text
+   - ticket rows keeping readable neutral text for the main row content
+   - empty-state and header/separator output remaining explicit and readable
+6. Update `tests/fixtures/tui-qa-dump.ts` and, if needed, `src/observability/README.md` so the manual QA path explicitly includes a light-terminal contrast inspection.
+7. Run repository-required checks plus the TUI visual QA command.
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+- `tests/unit/tui.test.ts`
+  - recovery posture summary/detail render without the dim-gray treatment on primary text
+  - ticket rows do not render all operator-critical fields using the status color
+  - empty-state rows remain readable without disappearing into light backgrounds
+  - dark-mode-safe status cues such as status dots or compact tags still render distinctly
+
+### Visual QA
+
+- `npx tsx tests/fixtures/tui-qa-dump.ts`
+  - inspect the rendered dump while using a light terminal theme and confirm that recovery posture rows, ticket rows, and muted metadata remain readable
+  - repeat a quick check in a dark terminal theme to confirm the palette change did not collapse contrast there
+
+### Repository checks
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Acceptance Scenarios
+
+1. The factory has one or more recovery posture entries and the operator opens the TUI in a light terminal theme.
+   - Expected: the family tag may remain colored, but the issue identifier and summary text are clearly readable.
+2. The tickets table includes active, waiting, and review-related rows in a light terminal theme.
+   - Expected: ID, status, age/turn, runner, tokens, and detail text remain legible without relying on faint gray or washed-out row-wide coloring.
+3. The same snapshot is rendered in a dark terminal theme.
+   - Expected: readability remains intact and status cues are still visually distinct.
+4. A future refactor reintroduces dim-gray styling to primary recovery or ticket-row text.
+   - Expected: unit coverage fails before the regression ships silently.
+
+## Exit Criteria
+
+- plan is explicitly `approved` or `waived`
+- the status TUI uses readable light-theme-safe styling for recovery posture and ticket rows
+- explicit regression coverage exists for the contrast-sensitive rendering decisions
+- `npx tsx tests/fixtures/tui-qa-dump.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Deferred To Later Issues Or PRs
+
+- automatic dark/light theme detection
+- user-configurable TUI palettes
+- broader accessibility review across non-TUI observability surfaces
+- richer screenshot-based visual regression infrastructure if the repo later decides this class of issue warrants it

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -579,10 +579,7 @@ function formatRefreshLine(
   nowMs: number,
 ): string {
   if (polling === null) {
-    return (
-      colorize("│ Next refresh: ", BOLD) +
-      colorize("n/a", SECONDARY_TEXT)
-    );
+    return colorize("│ Next refresh: ", BOLD) + colorize("n/a", SECONDARY_TEXT);
   }
   if (polling.checkingNow) {
     return colorize("│ Next refresh: ", BOLD) + colorize("checking now…", CYAN);

--- a/src/observability/tui.ts
+++ b/src/observability/tui.ts
@@ -17,14 +17,17 @@ import { setLogFile, getLogFilePath } from "./logger.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
-const DIM = "\x1b[2m";
-const RED = "\x1b[31m";
-const GREEN = "\x1b[32m";
-const YELLOW = "\x1b[33m";
-const BLUE = "\x1b[34m";
-const MAGENTA = "\x1b[35m";
-const CYAN = "\x1b[36m";
-const GRAY = "\x1b[2;37m"; // dim white — visible on dark terminals unlike \x1b[90m (bright black)
+const DEFAULT_FOREGROUND = "\x1b[39m";
+const RED = "\x1b[1;31m";
+const GREEN = "\x1b[1;32m";
+const YELLOW = "\x1b[1;33m";
+const BLUE = "\x1b[1;34m";
+const MAGENTA = "\x1b[1;35m";
+const CYAN = BLUE;
+const PRIMARY_TEXT = DEFAULT_FOREGROUND;
+const SECONDARY_TEXT = DEFAULT_FOREGROUND;
+const SEPARATOR_TEXT = BLUE;
+const ACCENT_TEXT = BLUE;
 
 function colorize(text: string, code: string): string {
   return `${code}${text}${RESET}`;
@@ -427,12 +430,12 @@ export function formatSnapshotContent(
     colorize("╭─ SYMPHONY STATUS", BOLD),
     colorize("│ Tickets: ", BOLD) +
       colorize(String(renderedTickets.length), GREEN) +
-      colorize(" active", GRAY) +
-      colorize(" | ", GRAY) +
+      colorize(" active", SECONDARY_TEXT) +
+      colorize(" | ", SEPARATOR_TEXT) +
       colorize("agents ", BOLD) +
       colorize(String(liveRunCount), GREEN) +
-      colorize("/", GRAY) +
-      colorize(String(maxConcurrentRuns), GRAY),
+      colorize("/", SEPARATOR_TEXT) +
+      colorize(String(maxConcurrentRuns), SECONDARY_TEXT),
     colorize("│ Throughput: ", BOLD) +
       colorize(`${formatTps(tps)} tps`, CYAN) +
       sparklineSuffix,
@@ -474,12 +477,14 @@ function formatRecoveryRows(
 ): string[] {
   const rows = [
     "│  " +
-      colorize(recoveryPosture.summary.family, CYAN) +
-      colorize(" | ", GRAY) +
-      colorize(recoveryPosture.summary.summary, GRAY),
+      colorize(recoveryPosture.summary.family, ACCENT_TEXT) +
+      colorize(" | ", SEPARATOR_TEXT) +
+      colorize(recoveryPosture.summary.summary, PRIMARY_TEXT),
   ];
   if (recoveryPosture.entries.length === 0) {
-    rows.push("│  " + colorize("No issue-level recovery entries", GRAY));
+    rows.push(
+      "│  " + colorize("No issue-level recovery entries", SECONDARY_TEXT),
+    );
     return rows;
   }
   for (const entry of recoveryPosture.entries.slice(0, 4)) {
@@ -491,9 +496,9 @@ function formatRecoveryRows(
       "│  " +
         colorize(`[${entry.family}]`, YELLOW) +
         " " +
-        colorize(issuePrefix, CYAN) +
-        colorize(" ", GRAY) +
-        colorize(truncate(entry.summary, 92), GRAY),
+        colorize(issuePrefix, PRIMARY_TEXT) +
+        " " +
+        colorize(truncate(entry.summary, 92), PRIMARY_TEXT),
     );
   }
   if (recoveryPosture.entries.length > 4) {
@@ -501,7 +506,7 @@ function formatRecoveryRows(
       "│  " +
         colorize(
           `+${String(recoveryPosture.entries.length - 4)} more recovery entries`,
-          GRAY,
+          SECONDARY_TEXT,
         ),
     );
   }
@@ -529,7 +534,7 @@ function formatDispatchState(
     const pressureSuffix =
       dispatchPressure === null
         ? ""
-        : colorize(" | ", GRAY) +
+        : colorize(" | ", SEPARATOR_TEXT) +
           colorize(
             `pressure ${dispatchPressure.retryClass} until ${formatDueIn(
               Date.parse(dispatchPressure.resumeAt) - nowMs,
@@ -538,8 +543,8 @@ function formatDispatchState(
           );
     return (
       colorize("halted", RED) +
-      colorize(" | ", GRAY) +
-      colorize(detail, GRAY) +
+      colorize(" | ", SEPARATOR_TEXT) +
+      colorize(detail, PRIMARY_TEXT) +
       pressureSuffix
     );
   }
@@ -547,7 +552,7 @@ function formatDispatchState(
     const pressureSuffix =
       dispatchPressure === null
         ? ""
-        : colorize(" | ", GRAY) +
+        : colorize(" | ", SEPARATOR_TEXT) +
           colorize(
             `pressure ${dispatchPressure.retryClass} until ${formatDueIn(
               Date.parse(dispatchPressure.resumeAt) - nowMs,
@@ -556,8 +561,11 @@ function formatDispatchState(
           );
     return (
       colorize("halt degraded", RED) +
-      colorize(" | ", GRAY) +
-      colorize(truncate(halt.detail ?? "unreadable halt state", 80), GRAY) +
+      colorize(" | ", SEPARATOR_TEXT) +
+      colorize(
+        truncate(halt.detail ?? "unreadable halt state", 80),
+        PRIMARY_TEXT,
+      ) +
       pressureSuffix
     );
   }
@@ -571,7 +579,10 @@ function formatRefreshLine(
   nowMs: number,
 ): string {
   if (polling === null) {
-    return colorize("│ Next refresh: ", BOLD) + colorize("n/a", GRAY);
+    return (
+      colorize("│ Next refresh: ", BOLD) +
+      colorize("n/a", SECONDARY_TEXT)
+    );
   }
   if (polling.checkingNow) {
     return colorize("│ Next refresh: ", BOLD) + colorize("checking now…", CYAN);
@@ -585,7 +596,7 @@ function formatRefreshLine(
 
 function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
   if (rateLimits === null) {
-    return colorize("unavailable", GRAY);
+    return colorize("unavailable", SECONDARY_TEXT);
   }
   const { limitId, primary, secondary, credits } = rateLimits;
   const idPart = colorize(limitId ?? "unknown", YELLOW);
@@ -600,11 +611,11 @@ function formatRateLimits(rateLimits: TuiSnapshot["rateLimits"]): string {
   const creditsPart = colorize(credits ?? "credits n/a", GREEN);
   return (
     idPart +
-    colorize(" | ", GRAY) +
+    colorize(" | ", SEPARATOR_TEXT) +
     primaryPart +
-    colorize(" | ", GRAY) +
+    colorize(" | ", SEPARATOR_TEXT) +
     secondaryPart +
-    colorize(" | ", GRAY) +
+    colorize(" | ", SEPARATOR_TEXT) +
     creditsPart
   );
 }
@@ -634,10 +645,10 @@ function formatDispatchPressure(
   );
   return (
     colorize(dispatchPressure.retryClass, YELLOW) +
-    colorize(" until ", GRAY) +
+    colorize(" until ", SEPARATOR_TEXT) +
     colorize(formatDueIn(remainingMs), CYAN) +
-    colorize(" | ", GRAY) +
-    colorize(truncate(dispatchPressure.reason, 80), GRAY)
+    colorize(" | ", SEPARATOR_TEXT) +
+    colorize(truncate(dispatchPressure.reason, 80), PRIMARY_TEXT)
   );
 }
 
@@ -655,7 +666,12 @@ function formatLastActionLine(
   if (detail === "") {
     return line + elapsedSuffix;
   }
-  return line + colorize(" | ", GRAY) + colorize(detail, GRAY) + elapsedSuffix;
+  return (
+    line +
+    colorize(" | ", SEPARATOR_TEXT) +
+    colorize(detail, PRIMARY_TEXT) +
+    elapsedSuffix
+  );
 }
 
 // ─── Ticket table ─────────────────────────────────────────────────────────
@@ -669,7 +685,7 @@ function ticketTableHeaderRow(detailWidth: number): string {
     formatCell("TOKENS", TOKENS_WIDTH),
     formatCell("DETAIL", detailWidth),
   ].join(" ");
-  return "│   " + colorize(header, GRAY);
+  return "│   " + colorize(header, ACCENT_TEXT);
 }
 
 function ticketTableSeparatorRow(detailWidth: number): string {
@@ -681,7 +697,7 @@ function ticketTableSeparatorRow(detailWidth: number): string {
     TOKENS_WIDTH +
     detailWidth +
     5;
-  return "│   " + colorize("─".repeat(width), GRAY);
+  return "│   " + colorize("─".repeat(width), SEPARATOR_TEXT);
 }
 
 function formatTicketRows(
@@ -692,7 +708,7 @@ function formatTicketRows(
   trackerKind: TuiSnapshot["trackerKind"],
 ): string[] {
   if (tickets.length === 0) {
-    return ["│  " + colorize("No active tickets", GRAY), "│"];
+    return ["│  " + colorize("No active tickets", SECONDARY_TEXT), "│"];
   }
   return tickets.map((entry) =>
     formatTicketRow(entry, detailWidth, nowMs, maxTurns, trackerKind),
@@ -723,17 +739,17 @@ function formatTicketRow(
     "│ " +
     colorize("●", statusColor) +
     " " +
-    colorize(issue, CYAN) +
+    colorize(issue, PRIMARY_TEXT) +
     " " +
-    colorize(stage, statusColor) +
+    colorize(stage, PRIMARY_TEXT) +
     " " +
     colorize(activity, ageColor) +
     " " +
-    colorize(runner, CYAN) +
+    colorize(runner, ACCENT_TEXT) +
     " " +
-    colorize(tokens, YELLOW) +
+    colorize(tokens, MAGENTA) +
     " " +
-    colorize(detail, statusColor)
+    colorize(detail, PRIMARY_TEXT)
   );
 }
 
@@ -758,7 +774,7 @@ function statusDotColor(
       case "running":
         return BLUE;
       case "idle":
-        return GRAY;
+        return SECONDARY_TEXT;
     }
     return unreachableVisibilityState(visibility.state);
   }
@@ -778,26 +794,26 @@ function formatHeaderTokens(codexTotals: TuiSnapshot["codexTotals"]): string {
   ) {
     return (
       colorize("in pending", YELLOW) +
-      colorize(" | ", GRAY) +
+      colorize(" | ", SEPARATOR_TEXT) +
       colorize("out pending", YELLOW) +
-      colorize(" | ", GRAY) +
+      colorize(" | ", SEPARATOR_TEXT) +
       colorize("total pending", YELLOW) +
-      colorize(" | ", GRAY) +
+      colorize(" | ", SEPARATOR_TEXT) +
       colorize(`${String(codexTotals.pendingRunCount)} pending`, YELLOW)
     );
   }
 
   const pendingSuffix =
     codexTotals.pendingRunCount > 0
-      ? colorize(" | ", GRAY) +
+      ? colorize(" | ", SEPARATOR_TEXT) +
         colorize(`${String(codexTotals.pendingRunCount)} pending`, YELLOW)
       : "";
 
   return (
     colorize(`in ${formatCount(codexTotals.inputTokens)}`, YELLOW) +
-    colorize(" | ", GRAY) +
+    colorize(" | ", SEPARATOR_TEXT) +
     colorize(`out ${formatCount(codexTotals.outputTokens)}`, YELLOW) +
-    colorize(" | ", GRAY) +
+    colorize(" | ", SEPARATOR_TEXT) +
     colorize(`total ${formatCount(codexTotals.totalTokens)}`, YELLOW) +
     pendingSuffix
   );
@@ -908,18 +924,23 @@ function unreachableVisibilityState(state: never): never {
 
 function formatRetryRows(retrying: TuiSnapshot["retrying"]): string[] {
   if (retrying.length === 0) {
-    return ["│  " + colorize("No queued retries", GRAY)];
+    return ["│  " + colorize("No queued retries", SECONDARY_TEXT)];
   }
   return retrying.map((entry) => {
     const dueStr = formatDueIn(entry.dueInMs);
-    const classPart = " " + colorize(`class=${entry.retryClass}`, DIM);
+    const classPart =
+      " " + colorize(`class=${entry.retryClass}`, SECONDARY_TEXT);
     const hostPart =
       entry.preferredHost === null
         ? ""
-        : " " + colorize(`host=${entry.preferredHost}`, DIM);
+        : " " + colorize(`host=${entry.preferredHost}`, SECONDARY_TEXT);
     const errorPart =
       entry.lastError.trim() !== ""
-        ? " " + colorize(`error=${sanitizeRetryError(entry.lastError)}`, DIM)
+        ? " " +
+          colorize(
+            `error=${sanitizeRetryError(entry.lastError)}`,
+            SECONDARY_TEXT,
+          )
         : "";
     return (
       "│  " +
@@ -930,7 +951,7 @@ function formatRetryRows(retrying: TuiSnapshot["retrying"]): string[] {
       colorize(`attempt=${String(entry.nextAttempt)}`, YELLOW) +
       classPart +
       hostPart +
-      colorize(" in ", DIM) +
+      colorize(" in ", SEPARATOR_TEXT) +
       colorize(dueStr, CYAN) +
       errorPart
     );
@@ -1285,7 +1306,10 @@ function formatElapsedActionSuffix(
     return "";
   }
   const elapsedSeconds = Math.max(0, Math.floor((nowMs - actionAtMs) / 1000));
-  return colorize(` (${formatRuntimeSeconds(elapsedSeconds)} ago)`, GRAY);
+  return colorize(
+    ` (${formatRuntimeSeconds(elapsedSeconds)} ago)`,
+    SECONDARY_TEXT,
+  );
 }
 
 function formatRuntimeAndTurns(

--- a/tests/fixtures/tui-qa-dump.ts
+++ b/tests/fixtures/tui-qa-dump.ts
@@ -13,7 +13,10 @@
  * event → human-readable label pipeline.
  *
  * Use this to visually QA TUI changes without needing a live factory.
- * Compare output against the Elixir reference in issue #98.
+ * Check the rendered frames in both a light and dark terminal theme and
+ * confirm recovery posture lines, ticket rows, and muted empty-state text
+ * remain readable before comparing layout against the Elixir reference in
+ * issue #98.
  */
 
 import {

--- a/tests/unit/tui.test.ts
+++ b/tests/unit/tui.test.ts
@@ -18,7 +18,23 @@ import {
   type RunnerVisibilitySnapshot,
 } from "../../src/runner/service.js";
 
+const ANSI_DIM_WHITE = "\x1b[2;37m";
+const ANSI_DEFAULT_FOREGROUND = "\x1b[39m";
+const ANSI_WARNING = "\x1b[1;33m";
+
 // ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function findRenderedLine(output: string, plainText: string): string {
+  const line = output
+    .split("\n")
+    .find((candidate) => stripAnsi(candidate).includes(plainText));
+  expect(line).toBeDefined();
+  return line!;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
 
 function makeSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
   const snapshot = {
@@ -206,6 +222,54 @@ describe("formatSnapshotContent", () => {
     expect(output).toContain("Recovery posture");
   });
 
+  it("keeps recovery posture primary text on the default foreground", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        recoveryPosture: {
+          summary: {
+            family: "retry-backoff",
+            summary: "1 issue is queued in retry backoff.",
+            issueCount: 1,
+          },
+          entries: [
+            {
+              family: "retry-backoff",
+              issueNumber: 166,
+              issueIdentifier: "sociotechnica-org/symphony-ts#166",
+              title: "Recovery posture observability",
+              source: "retry-queue",
+              summary:
+                "Retry attempt 2 is queued until 2026-03-17T10:05:00.000Z.",
+              observedAt: "2026-03-17T10:00:00.000Z",
+            },
+          ],
+        },
+      }),
+      0,
+    );
+
+    const summaryLine = findRenderedLine(
+      output,
+      "1 issue is queued in retry backoff.",
+    );
+    const entryLine = findRenderedLine(
+      output,
+      "Retry attempt 2 is queued until 2026-03-17T10:05:00.000Z.",
+    );
+
+    expect(summaryLine).not.toContain(ANSI_DIM_WHITE);
+    expect(summaryLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}1 issue is queued in retry backoff.`,
+    );
+    expect(entryLine).not.toContain(ANSI_DIM_WHITE);
+    expect(entryLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}#166 sociotechnica-org/symphony-ts#166`,
+    );
+    expect(entryLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}Retry attempt 2 is queued until 2026-03-17T10:05:00.000Z.`,
+    );
+  });
+
   it("omits duplicated last-action detail when summary is blank", () => {
     const output = formatSnapshotContent(
       makeSnapshot({
@@ -232,6 +296,71 @@ describe("formatSnapshotContent", () => {
     const output = formatSnapshotContent(makeSnapshot(), 0);
     expect(output).toContain("Tickets");
     expect(output).toContain("No active tickets");
+  });
+
+  it("keeps waiting ticket rows readable by reserving warning color for compact cues", () => {
+    const output = formatSnapshotContent(
+      makeSnapshot({
+        tickets: [
+          {
+            issueNumber: 245,
+            identifier: "sociotechnica-org/symphony-ts#245",
+            title: "Contrast test ticket",
+            status: "awaiting-human-review",
+            summary: "Waiting for plan review approval",
+            startedAt: null,
+            updatedAt: new Date("2026-03-14T10:02:00.000Z"),
+            pullRequest: null,
+            checks: { pendingNames: [], failingNames: [] },
+            review: { actionableCount: 0, unresolvedThreadCount: 0 },
+            blockedReason: "Waiting for plan review approval",
+            runnerAccounting: undefined,
+            runnerVisibility: null,
+            liveRun: null,
+          },
+        ],
+      }),
+      0,
+      220,
+      "",
+      new Date("2026-03-14T10:03:00.000Z").getTime(),
+    );
+
+    const ticketLine = findRenderedLine(output, "Contrast test ticket");
+
+    expect(ticketLine).not.toContain(ANSI_DIM_WHITE);
+    expect(ticketLine).toContain(`${ANSI_WARNING}●`);
+    expect(ticketLine).toContain(`${ANSI_DEFAULT_FOREGROUND}#245`);
+    expect(ticketLine).toContain(`${ANSI_DEFAULT_FOREGROUND}human-review`);
+    expect(ticketLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}Contrast test ticket · Waiting for plan review approval`,
+    );
+    expect(ticketLine).not.toContain(`${ANSI_WARNING}human-review`);
+    expect(ticketLine).not.toContain(`${ANSI_WARNING}Contrast test ticket`);
+  });
+
+  it("renders empty-state rows without dim light-theme styling", () => {
+    const output = formatSnapshotContent(makeSnapshot(), 0);
+
+    const recoveryLine = findRenderedLine(
+      output,
+      "No issue-level recovery entries",
+    );
+    const ticketsLine = findRenderedLine(output, "No active tickets");
+    const retriesLine = findRenderedLine(output, "No queued retries");
+
+    expect(recoveryLine).not.toContain(ANSI_DIM_WHITE);
+    expect(recoveryLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}No issue-level recovery entries`,
+    );
+    expect(ticketsLine).not.toContain(ANSI_DIM_WHITE);
+    expect(ticketsLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}No active tickets`,
+    );
+    expect(retriesLine).not.toContain(ANSI_DIM_WHITE);
+    expect(retriesLine).toContain(
+      `${ANSI_DEFAULT_FOREGROUND}No queued retries`,
+    );
   });
 
   it("renders ticket-first rows with short GitHub identifiers and condensed detail", () => {


### PR DESCRIPTION
Closes #320.

## Summary
- replace low-contrast dim and washed-out TUI text with a stronger observability palette for recovery rows, ticket rows, separators, and empty states
- keep color on compact status cues while returning operator-critical recovery and ticket content to the default foreground
- add ANSI-focused unit regressions and update the TUI QA dump note to call out light-theme inspection

## Root cause
The factory status screen relied on dim white and broad low-contrast ANSI color spans for operator-critical text. That worked acceptably in dark terminals but washed out key recovery and ticket content in common light terminal themes.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `npx tsx tests/fixtures/tui-qa-dump.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
