### PR TITLE
Issue 325: Only restart external-instance factories when runtime/workflow changes

### DIFF
--- a/bin/check-factory-runtime-freshness.ts
+++ b/bin/check-factory-runtime-freshness.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { inspectFactoryControl } from "../src/cli/factory-control.js";
 import { collectFactoryRuntimeIdentity } from "../src/observability/runtime-identity.js";
 import { assessOperatorRuntimeFreshness } from "../src/observability/operator-runtime-freshness.js";
+import {
+  collectFactoryWorkflowIdentity,
+  renderFactoryWorkflowIdentity,
+} from "../src/observability/workflow-identity.js";
+import { renderFactoryRuntimeIdentity } from "../src/observability/runtime-identity.js";
 
 interface Args {
   readonly workflowPath?: string;
@@ -40,9 +45,11 @@ function renderText(
   result: ReturnType<typeof assessOperatorRuntimeFreshness>,
 ): string {
   return [
-    `Freshness: ${result.kind}`,
-    `Runtime head: ${result.runtimeHeadSha ?? "unavailable"}`,
-    `Engine head: ${result.engineHeadSha ?? "unavailable"}`,
+    `Restart assessment: ${result.kind}`,
+    `Running runtime: ${renderFactoryRuntimeIdentity(result.runningRuntimeIdentity ?? null)}`,
+    `Current runtime: ${renderFactoryRuntimeIdentity(result.currentRuntimeIdentity ?? null)}`,
+    `Running workflow: ${renderFactoryWorkflowIdentity(result.runningWorkflowIdentity)}`,
+    `Current workflow: ${renderFactoryWorkflowIdentity(result.currentWorkflowIdentity)}`,
     `Control state: ${result.controlState}`,
     `Factory state: ${result.factoryState ?? "unavailable"}`,
     `Active issues: ${result.activeIssueCount.toString()}`,
@@ -61,9 +68,13 @@ async function main(): Promise<void> {
   const engineRuntimeIdentity = await collectFactoryRuntimeIdentity(
     args.operatorRepoRoot,
   );
+  const currentWorkflowIdentity = await collectFactoryWorkflowIdentity(
+    status.paths.workflowPath,
+  );
   const result = assessOperatorRuntimeFreshness({
     status,
     engineRuntimeIdentity,
+    currentWorkflowIdentity,
   });
 
   if (args.json) {

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -115,7 +115,7 @@ pnpm tsx bin/check-operator-release-state.ts --workflow ../target-repo/WORKFLOW.
 
 11. If the detached runtime is stopped or degraded, repair that first.
 12. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite, unresolved dependency metadata, or a ready-promotion sync failure. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
-13. After a merge, fast-forward the instance root checkout and `<instance-root>/.tmp/factory-main` to `origin/main`, then restart the detached factory from merged code.
+13. After a merge, fast-forward the instance root checkout to `origin/main`, rerun `bin/check-factory-runtime-freshness.ts`, and restart the detached factory only when the assessment reports that the runtime engine or selected `WORKFLOW.md` is stale. Self-hosting merges should normally produce runtime drift; external instances should stay up when the merge changed unrelated repository files only.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
 

--- a/docs/plans/325-external-instance-conditional-restart/plan.md
+++ b/docs/plans/325-external-instance-conditional-restart/plan.md
@@ -1,0 +1,265 @@
+# Issue 325 Plan: Conditional External-Instance Factory Restarts
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Stop the operator from restarting detached factories for external instances after every successful landing when neither the running `symphony-ts` runtime nor the selected instance `WORKFLOW.md` contract actually changed.
+
+## Scope
+
+1. define an explicit operator-facing restart assessment that distinguishes runtime-engine drift from selected-workflow drift instead of treating every post-merge checkpoint as a restart trigger
+2. record enough startup/runtime identity for the running detached factory to tell whether it started against the current engine checkout and the current selected `WORKFLOW.md`
+3. update operator guidance so self-hosting keeps its current merged-code restart behavior, while external instances restart only when the runtime or workflow contract is stale
+4. add tests that pin the new decision contract and prevent regressions back to unconditional external-instance restarts
+
+## Non-goals
+
+1. changing tracker lifecycle states, landing semantics, or the guarded-landing policy
+2. redesigning the detached factory-control commands or the operator wake-up sequence outside the restart decision seam
+3. hot-reloading workflow changes without a restart
+4. treating arbitrary target-repository changes as restart triggers when `WORKFLOW.md` did not change
+5. moving repository-owned runtime-contract rules out of `WORKFLOW.md`
+
+## Current Gaps
+
+1. [`src/observability/operator-runtime-freshness.ts`](../../../src/observability/operator-runtime-freshness.ts) only compares the running factory runtime `HEAD` against the operator checkout `HEAD`, so it cannot tell whether an external-instance workflow changed or whether an external merge was otherwise a no-op for runtime purposes
+2. [`src/startup/service.ts`](../../../src/startup/service.ts) persists runtime engine identity in the startup snapshot, but it does not record the selected `WORKFLOW.md` identity the running process actually loaded
+3. [`skills/symphony-operator/operator-prompt.md`](../../../skills/symphony-operator/operator-prompt.md) and [`skills/symphony-operator/SKILL.md`](../../../skills/symphony-operator/SKILL.md) still instruct the operator to restart after any successful landing, which is correct for self-hosting but too broad for external repositories
+4. [`docs/guides/operator-runbook.md`](../../guides/operator-runbook.md) still describes the post-merge restart as unconditional instead of conditional for external instances
+5. current tests cover runtime-head freshness and operator prompt ordering, but they do not pin the external-instance case where a landed PR changes neither the engine checkout nor `WORKFLOW.md`
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses the mapping in [`docs/architecture.md`](../../architecture.md).
+
+- Policy Layer
+  - belongs: the rule that external-instance restarts happen only when the running engine or the selected `WORKFLOW.md` contract is stale
+  - does not belong: treating every merge in the target repository as if it changed the runtime
+- Configuration Layer
+  - belongs: deriving the selected workflow path and any normalized workflow-identity input needed for restart assessment
+  - does not belong: tracker lifecycle decisions or operator wake-up sequencing rules
+- Coordination Layer
+  - belongs: the restart-assessment state model that decides `restart now`, `defer`, or `no restart`
+  - does not belong: tracker transport details or raw git probing scattered through the operator prompt
+- Execution Layer
+  - belongs: startup-time capture of the running process's workflow identity plus prompt/skill instructions for when to restart the detached runtime
+  - does not belong: tracker comment parsing or landing-command policy
+- Integration Layer
+  - belongs: collecting current engine/workflow identities from the operator checkout and selected instance root at the boundary
+  - does not belong: broad target-repository diff inspection unrelated to the runtime/workflow seam
+- Observability Layer
+  - belongs: surfacing why a restart is or is not required so operators can inspect the decision
+  - does not belong: a second hidden policy store outside snapshots, status, docs, and tests
+
+## Architecture Boundaries
+
+### Belongs in this issue
+
+1. startup and observability identity capture
+   - persist the running engine identity and the selected `WORKFLOW.md` identity together in the startup snapshot or adjacent status-visible contract
+   - make the running-versus-current comparison inspectable and testable
+2. restart assessment policy
+   - refactor the current freshness helper into an explicit runtime/workflow restart assessment for external instances
+   - preserve self-hosting behavior as the natural case where a merged `symphony-ts` PR changes the runtime engine
+3. operator guidance
+   - update the prompt, skill, and runbook so post-merge restart instructions for external instances are conditional instead of automatic
+4. tests
+   - pin unit decision outcomes
+   - pin startup/status parsing for the new recorded identity
+   - pin operator prompt wording for the conditional external-instance path
+
+### Does not belong in this issue
+
+1. tracker-side merge detection or landing-state redesign
+2. a generic repository change classifier for files outside `WORKFLOW.md`
+3. orchestrator retry, reconciliation, or lease refactors unrelated to operator restart decisions
+4. broader operator prompt cleanup unrelated to restart policy
+
+## Layering Notes
+
+- `config/workflow`
+  - may expose a small helper for canonical workflow-path resolution or workflow-content identity
+  - should not own post-merge restart policy
+- `tracker`
+  - remains unchanged for this slice
+  - should not become the source of runtime/workflow freshness decisions
+- `workspace`
+  - remains unchanged apart from continuing to provide the selected instance/runtime roots already derived from the workflow
+  - should not absorb operator restart heuristics
+- `runner`
+  - remains unchanged
+  - should not infer when detached factories must restart after merge
+- `orchestrator`
+  - consumes the selected workflow at startup but should not gain special external-instance restart branches for this issue
+  - should not compensate for missing operator/runtime identity observability
+- `observability`
+  - owns the normalized restart assessment and the recorded runtime/workflow identity surface
+  - should not turn into a tracker or operator command runner
+
+## Slice Strategy And PR Seam
+
+Land this as one reviewable PR focused on one seam: replace unconditional external-instance post-merge restart guidance with a typed runtime/workflow restart assessment backed by recorded startup identity.
+
+This stays reviewable because it limits the patch to:
+
+1. one identity-capture seam for the running process
+2. one assessment helper for restart decisions
+3. prompt/skill/runbook wording that consumes that helper's contract
+4. targeted unit and integration coverage
+
+This issue should not expand into landing automation redesign, tracker changes, or a generic target-repo diff framework.
+
+## Runtime State Model
+
+This behavior is stateful because the operator must compare what the detached runtime started with against what is current on disk after a merge or checkout update.
+
+### State inputs
+
+1. running engine identity
+   - the `symphony-ts` checkout identity recorded by the detached runtime at startup
+2. current engine identity
+   - the operator checkout identity currently on disk
+3. running workflow identity
+   - the selected `WORKFLOW.md` identity recorded by the detached runtime at startup
+4. current workflow identity
+   - the selected `WORKFLOW.md` identity currently on disk
+5. control state
+   - whether the detached runtime is running, stopped, or degraded
+6. factory activity
+   - whether the instance is idle or busy when a restart-worthy drift is detected
+
+### Decision states
+
+1. `fresh`
+   - running engine and running workflow both match current on-disk identities
+   - no restart is needed
+2. `stale-runtime-idle`
+   - engine changed, factory is idle
+   - restart now
+3. `stale-runtime-busy`
+   - engine changed, factory is busy
+   - defer restart until a safe checkpoint
+4. `stale-workflow-idle`
+   - `WORKFLOW.md` changed, factory is idle
+   - restart now so the detached runtime reloads the repository-owned contract
+5. `stale-workflow-busy`
+   - `WORKFLOW.md` changed, factory is busy
+   - defer restart until a safe checkpoint
+6. `stale-runtime-and-workflow`
+   - both changed
+   - same idle/busy split as above, but the summary must make both causes explicit
+7. `unavailable`
+   - one or more required identities cannot be determined
+   - do not guess; surface the missing fact and require inspection
+8. `stopped`
+   - detached runtime is not running
+   - follow the normal health-recovery flow instead of freshness restart logic
+
+### Allowed transitions
+
+1. startup writes `fresh` baseline identities for the running detached runtime
+2. a merge or local update can change current engine identity, current workflow identity, or both
+3. operator assessment maps those drift facts plus current activity into `restart now`, `defer`, or `no restart`
+4. after a restart, the new startup snapshot becomes the baseline for the next comparison
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Recorded running facts available | Expected decision |
+| --- | --- | --- | --- |
+| External-instance PR merged, operator checkout unchanged, selected `WORKFLOW.md` unchanged | current engine identity matches prior engine; current workflow identity matches prior workflow | running engine identity and running workflow identity present | no restart; record that the merge did not change runtime/workflow inputs |
+| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory idle | current workflow identity differs; engine identity matches | running workflow identity present | restart now so the detached runtime reloads the new workflow contract |
+| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory busy | same as above plus active work exists | running workflow identity present | defer restart and surface workflow-stale busy posture |
+| `symphony-ts` engine checkout advanced, external instance still runs old runtime, factory idle | current engine identity differs; workflow identity matches | running engine identity present | restart now |
+| `symphony-ts` engine checkout advanced, factory busy | current engine identity differs; active work exists | running engine identity present | defer restart until safe checkpoint |
+| Either running workflow identity or current workflow identity is unavailable | one side missing | startup snapshot incomplete or current file unreadable | do not guess from merge events alone; surface unavailable assessment |
+| Detached runtime stopped or degraded | control state is not `running` | any recorded identities may be stale | use normal recovery/start flow first, not freshness restart logic |
+
+## Storage / Persistence Contract
+
+1. the startup snapshot remains the canonical persisted record of what identities the currently running detached runtime started with
+2. the selected `WORKFLOW.md` identity must be stored alongside the existing runtime engine identity so later operator passes can compare running versus current inputs without inferring from merge events
+3. the current operator-side comparison may read the selected `WORKFLOW.md` from disk and compute its identity on demand
+4. no new durable operator-local policy store should be introduced for this slice
+
+## Observability Requirements
+
+1. the restart assessment summary must say whether drift is from the engine, the workflow, or both
+2. startup/status parsing must preserve inspectable recorded workflow identity, not only runtime engine identity
+3. operator-facing docs and prompt text must make the external-instance conditional restart rule explicit
+4. tests must fail if guidance regresses to unconditional external-instance restarts
+
+## Implementation Steps
+
+1. define a small normalized identity shape for the selected `WORKFLOW.md` that is stable enough for comparison, likely including canonical path plus a content fingerprint and any error classification needed for unavailable cases
+2. capture that workflow identity during startup alongside the existing runtime engine identity and thread it through startup parsing plus any status/control surfaces that already expose startup identity
+3. refactor [`src/observability/operator-runtime-freshness.ts`](../../../src/observability/operator-runtime-freshness.ts) into an operator restart assessment that:
+   - compares running versus current engine identity
+   - compares running versus current workflow identity
+   - keeps stopped/unavailable handling explicit
+   - distinguishes idle versus busy restart-worthy drift
+4. update [`bin/check-factory-runtime-freshness.ts`](../../../bin/check-factory-runtime-freshness.ts) and nearby call sites to emit the richer assessment without changing the bounded probe workflow
+5. update operator guidance in:
+   - [`skills/symphony-operator/operator-prompt.md`](../../../skills/symphony-operator/operator-prompt.md)
+   - [`skills/symphony-operator/SKILL.md`](../../../skills/symphony-operator/SKILL.md)
+   - [`docs/guides/operator-runbook.md`](../../guides/operator-runbook.md)
+   so self-hosting still restarts after merged runtime code while external instances restart only when runtime/workflow drift is detected
+6. add or update tests for the new identity parsing and restart decision contract
+7. run local QA: `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test`
+
+## Tests And Acceptance Scenarios
+
+### Unit
+
+1. restart assessment reports `fresh` when running/current engine identities and running/current workflow identities all match
+2. restart assessment requests restart when only workflow identity changed and the instance is idle
+3. restart assessment defers restart when only workflow identity changed and the instance is busy
+4. restart assessment requests restart when only runtime engine identity changed and the instance is idle
+5. restart assessment surfaces an unavailable state instead of guessing when workflow identity cannot be read
+6. startup snapshot parsing round-trips the recorded workflow identity
+
+### Integration
+
+1. operator-loop prompt capture for an external workflow instructs conditional restart based on runtime/workflow drift instead of unconditional restart after any landing
+2. operator-loop prompt capture for self-hosting still instructs restart from merged code after self-hosted merges
+3. CLI freshness output/json includes enough detail to distinguish runtime drift from workflow drift
+
+### End-to-end / User-visible Contract
+
+1. given an external instance where a merged PR changes files outside `WORKFLOW.md` and the engine checkout is unchanged, the checked-in operator contract does not instruct an automatic detached-factory restart
+2. given an external instance where `WORKFLOW.md` changes, the checked-in operator contract and restart assessment both require a restart before ordinary queue work resumes
+
+### Local Gate
+
+1. `pnpm format`
+2. `pnpm lint`
+3. `pnpm typecheck`
+4. `pnpm test`
+5. local self-review if a reliable review command is available
+
+## Exit Criteria
+
+1. external-instance restart policy is conditional on actual runtime/workflow drift instead of unconditional post-merge restart
+2. the running detached runtime records enough identity to compare against the current selected `WORKFLOW.md`
+3. operator docs and prompt text explain the conditional restart rule clearly
+4. automated tests cover the no-op external merge case plus restart-worthy runtime/workflow changes
+5. self-hosting behavior remains intact
+
+## Deferred Work
+
+1. broader restart triggers for repository-owned docs outside `WORKFLOW.md`
+2. automatic runtime hot-reload without restart
+3. generic repo-diff reporting for external-instance merges
+4. any redesign of the operator wake-up order beyond this restart decision seam
+
+## Decision Notes
+
+1. Use `WORKFLOW.md` as the external-instance restart contract boundary because repo instructions already define it as the repository-owned runtime contract. Comparing whole-repo `HEAD`s would be too broad and would recreate the same false-positive restart problem on unrelated merges.
+2. Keep the comparison in a focused observability/operator helper rather than scattering raw git checks through prompt text. The operator should consume a typed assessment, not re-derive policy ad hoc.
+3. Preserve self-hosting behavior by making it a consequence of the same rule: when `symphony-ts` lands runtime code, engine drift exists, so restart remains required.
+
+## Revision Log
+
+- 2026-04-02: Initial plan created for issue `#325` and prepared for plan-review handoff.

--- a/docs/plans/325-external-instance-conditional-restart/plan.md
+++ b/docs/plans/325-external-instance-conditional-restart/plan.md
@@ -167,15 +167,15 @@ This behavior is stateful because the operator must compare what the detached ru
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Recorded running facts available | Expected decision |
-| --- | --- | --- | --- |
-| External-instance PR merged, operator checkout unchanged, selected `WORKFLOW.md` unchanged | current engine identity matches prior engine; current workflow identity matches prior workflow | running engine identity and running workflow identity present | no restart; record that the merge did not change runtime/workflow inputs |
-| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory idle | current workflow identity differs; engine identity matches | running workflow identity present | restart now so the detached runtime reloads the new workflow contract |
-| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory busy | same as above plus active work exists | running workflow identity present | defer restart and surface workflow-stale busy posture |
-| `symphony-ts` engine checkout advanced, external instance still runs old runtime, factory idle | current engine identity differs; workflow identity matches | running engine identity present | restart now |
-| `symphony-ts` engine checkout advanced, factory busy | current engine identity differs; active work exists | running engine identity present | defer restart until safe checkpoint |
-| Either running workflow identity or current workflow identity is unavailable | one side missing | startup snapshot incomplete or current file unreadable | do not guess from merge events alone; surface unavailable assessment |
-| Detached runtime stopped or degraded | control state is not `running` | any recorded identities may be stale | use normal recovery/start flow first, not freshness restart logic |
+| Observed condition                                                                             | Local facts available                                                                          | Recorded running facts available                              | Expected decision                                                        |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| External-instance PR merged, operator checkout unchanged, selected `WORKFLOW.md` unchanged     | current engine identity matches prior engine; current workflow identity matches prior workflow | running engine identity and running workflow identity present | no restart; record that the merge did not change runtime/workflow inputs |
+| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory idle    | current workflow identity differs; engine identity matches                                     | running workflow identity present                             | restart now so the detached runtime reloads the new workflow contract    |
+| External-instance PR merged, selected `WORKFLOW.md` changed, engine unchanged, factory busy    | same as above plus active work exists                                                          | running workflow identity present                             | defer restart and surface workflow-stale busy posture                    |
+| `symphony-ts` engine checkout advanced, external instance still runs old runtime, factory idle | current engine identity differs; workflow identity matches                                     | running engine identity present                               | restart now                                                              |
+| `symphony-ts` engine checkout advanced, factory busy                                           | current engine identity differs; active work exists                                            | running engine identity present                               | defer restart until safe checkpoint                                      |
+| Either running workflow identity or current workflow identity is unavailable                   | one side missing                                                                               | startup snapshot incomplete or current file unreadable        | do not guess from merge events alone; surface unavailable assessment     |
+| Detached runtime stopped or degraded                                                           | control state is not `running`                                                                 | any recorded identities may be stale                          | use normal recovery/start flow first, not freshness restart logic        |
 
 ## Storage / Persistence Contract
 
@@ -205,7 +205,7 @@ This behavior is stateful because the operator must compare what the detached ru
    - [`skills/symphony-operator/operator-prompt.md`](../../../skills/symphony-operator/operator-prompt.md)
    - [`skills/symphony-operator/SKILL.md`](../../../skills/symphony-operator/SKILL.md)
    - [`docs/guides/operator-runbook.md`](../../guides/operator-runbook.md)
-   so self-hosting still restarts after merged runtime code while external instances restart only when runtime/workflow drift is detected
+     so self-hosting still restarts after merged runtime code while external instances restart only when runtime/workflow drift is detected
 6. add or update tests for the new identity parsing and restart decision contract
 7. run local QA: `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test`
 

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -47,7 +47,7 @@ provider session for that instance.
 2. Inspect the current repo state, open ready/running issues, open PRs, CI, and review comments.
 3. Use `pnpm tsx bin/symphony.ts factory status --json` as the primary factory-health check and determine whether the detached runtime is healthy, degraded, stopped, stuck, crashed, or misconfigured.
 4. Immediately after the factory-health read, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root <operator-repo-root> --json` for the selected instance, and append `--workflow <selected-workflow>` when operating on a non-default instance.
-5. If the freshness check reports `stale-idle`, refresh the operator repo checkout plus the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that fact in the wake-up log and defer restart until the next idle or post-merge checkpoint.
+5. If the freshness check reports any stale `*-idle` state, refresh the checkout that actually drifted, restart the detached factory before ordinary queue work, and record whether the restart was caused by runtime drift, workflow drift, or both. If it reports any stale `*-busy` state, record that fact in the wake-up log and defer restart until the next idle or post-merge checkpoint. If it reports `fresh`, do not restart just because a repository merge happened.
 6. Before any ordinary queue-advancement work after the freshness check is clear, run `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-repo-root> --json` for the selected instance and treat any `report-ready` or `review-blocked` entry as the first operator checkpoint after the factory-health read.
 7. For each pending completed-run report review:
    - read the generated report under `.var/reports/issues/<issue-number>/`
@@ -69,7 +69,7 @@ provider session for that instance.
 
 18. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
 19. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
-20. When a `/land` completes and the PR actually merges, fast-forward the root checkout and `.tmp/factory-main` to the latest `origin/main`, then restart the detached factory so the next issue runs on merged code.
+20. When a `/land` completes and the PR actually merges, fast-forward the selected instance root checkout to the latest `origin/main`, rerun the freshness check, and restart the detached factory only when it reports a stale `*-idle` state. Self-hosting merges should normally surface runtime drift; external instances should not restart when the merge left both the runtime engine and selected `WORKFLOW.md` unchanged.
 21. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
 
 ## Operational Rules
@@ -123,8 +123,8 @@ Do not leave local-only tracked fixes sitting outside the normal PR flow. Worker
   - each wake-up should check for `plan-ready` issues and decide `approved`, `changes-requested`, or `waived`
   - each wake-up should check for review-clean PRs waiting on `/land` and post it when the guard conditions are satisfied
 - Landing is not complete at merge observation alone:
-  - after a landed PR merges, the operator should pull the latest `origin/main` into the root checkout and `.tmp/factory-main`
-  - then restart the detached factory from that refreshed runtime before allowing the next queued issue to proceed
+  - after a landed PR merges, the operator should fast-forward the selected instance root checkout to the latest `origin/main`
+  - then rerun the freshness check and restart only when runtime or selected-workflow drift actually requires it before allowing the next queued issue to proceed
 - When a PR is green and review-clean, the operator should issue `/land` on the PR without waiting for separate human intervention unless the user has explicitly reserved landing for themselves. This is the normal way to keep the factory moving overnight.
 - `/land` is appropriate only when:
   - required CI is green,

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -10,7 +10,7 @@ Required workflow:
 4. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
 5. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
 6. Immediately after the factory-health check, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-7. If the freshness check reports `stale-idle`, refresh the operator repo checkout and the selected instance runtime checkout to latest `origin/main`, then restart the detached factory before ordinary queue work. If it reports `stale-busy`, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint.
+7. If the freshness check reports any stale `*-idle` state, refresh the checkout that actually drifted, restart the detached factory before ordinary queue work, and record whether the restart was caused by runtime drift, workflow drift, or both. If it reports any stale `*-busy` state, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint. If it reports `fresh`, do not restart just because a repository merge happened.
 8. Immediately after the freshness check is clear, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
 9. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
    - read the report evidence under `.var/reports/issues/<issue-number>/`,
@@ -29,7 +29,7 @@ Required workflow:
 
 - review any active `plan-ready` / `awaiting-human-handoff` issue against the selected instance repository's own checked-in planning rules and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
-- and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
+- and after any successful landing, fast-forward the selected instance root checkout to latest `origin/main`, rerun the freshness check, and restart the detached factory only when it reports a stale `*-idle` state. For self-hosting merges, that should normally surface as runtime drift. For external instances, do not restart when only unrelated repository files changed.
 
 19. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
 20. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.

--- a/src/cli/factory-control.ts
+++ b/src/cli/factory-control.ts
@@ -29,6 +29,10 @@ import {
   type FactoryRuntimeIdentity,
 } from "../observability/runtime-identity.js";
 import {
+  renderFactoryWorkflowIdentity,
+  type FactoryWorkflowIdentity,
+} from "../observability/workflow-identity.js";
+import {
   deriveStartupFilePath,
   parseStartupSnapshotContent,
   type StartupSnapshot,
@@ -86,6 +90,7 @@ export interface FactoryStartupAssessment {
   readonly workerAlive: boolean;
   readonly stale: boolean;
   readonly runtimeIdentity: FactoryRuntimeIdentity | null;
+  readonly workflowIdentity: FactoryWorkflowIdentity | null;
 }
 
 export interface FactoryControlStatusSnapshot {
@@ -434,6 +439,11 @@ export function renderFactoryControlStatus(
       lines.push(
         `Runtime version: ${renderFactoryRuntimeIdentity(
           snapshot.startup.runtimeIdentity,
+        )}`,
+      );
+      lines.push(
+        `Workflow contract: ${renderFactoryWorkflowIdentity(
+          snapshot.startup.workflowIdentity,
         )}`,
       );
     }
@@ -1162,6 +1172,7 @@ function assessStartupSnapshot(
     workerAlive,
     stale,
     runtimeIdentity: snapshot.runtimeIdentity ?? null,
+    workflowIdentity: snapshot.workflowIdentity ?? null,
   };
 }
 

--- a/src/observability/operator-runtime-freshness.ts
+++ b/src/observability/operator-runtime-freshness.ts
@@ -3,20 +3,31 @@ import type {
   FactoryControlStatusSnapshot,
 } from "../cli/factory-control.js";
 import type { FactoryRuntimeIdentity } from "./runtime-identity.js";
+import type { FactoryWorkflowIdentity } from "./workflow-identity.js";
 
 export type OperatorRuntimeFreshnessKind =
   | "fresh"
-  | "stale-idle"
-  | "stale-busy"
+  | "stale-runtime-idle"
+  | "stale-runtime-busy"
+  | "stale-workflow-idle"
+  | "stale-workflow-busy"
+  | "stale-runtime-and-workflow-idle"
+  | "stale-runtime-and-workflow-busy"
   | "stopped"
-  | "engine-head-unavailable"
-  | "runtime-head-unavailable";
+  | "unavailable";
 
 export interface OperatorRuntimeFreshnessSnapshot {
   readonly kind: OperatorRuntimeFreshnessKind;
   readonly shouldRestart: boolean;
+  readonly runningRuntimeIdentity: FactoryRuntimeIdentity | null;
+  readonly currentRuntimeIdentity: FactoryRuntimeIdentity | null;
   readonly runtimeHeadSha: string | null;
   readonly engineHeadSha: string | null;
+  readonly runningWorkflowIdentity: FactoryWorkflowIdentity | null;
+  readonly currentWorkflowIdentity: FactoryWorkflowIdentity | null;
+  readonly runtimeChanged: boolean;
+  readonly workflowChanged: boolean;
+  readonly unavailableReasons: readonly string[];
   readonly controlState: FactoryControlState;
   readonly factoryState: string | null;
   readonly activeIssueCount: number;
@@ -26,9 +37,12 @@ export interface OperatorRuntimeFreshnessSnapshot {
 export function assessOperatorRuntimeFreshness(args: {
   readonly status: FactoryControlStatusSnapshot;
   readonly engineRuntimeIdentity: FactoryRuntimeIdentity | null;
+  readonly currentWorkflowIdentity: FactoryWorkflowIdentity | null;
 }): OperatorRuntimeFreshnessSnapshot {
   const runtimeHeadSha = args.status.startup?.runtimeIdentity?.headSha ?? null;
   const engineHeadSha = args.engineRuntimeIdentity?.headSha ?? null;
+  const runningWorkflowIdentity = args.status.startup?.workflowIdentity ?? null;
+  const currentWorkflowIdentity = args.currentWorkflowIdentity;
   const controlState = args.status.controlState;
   const factoryState = args.status.statusSnapshot?.factoryState ?? null;
   const activeIssueCount = args.status.statusSnapshot?.activeIssues.length ?? 0;
@@ -37,8 +51,15 @@ export function assessOperatorRuntimeFreshness(args: {
     return {
       kind: "stopped",
       shouldRestart: false,
+      runningRuntimeIdentity: args.status.startup?.runtimeIdentity ?? null,
+      currentRuntimeIdentity: args.engineRuntimeIdentity,
       runtimeHeadSha,
       engineHeadSha,
+      runningWorkflowIdentity,
+      currentWorkflowIdentity,
+      runtimeChanged: false,
+      workflowChanged: false,
+      unavailableReasons: [],
       controlState,
       factoryState,
       activeIssueCount,
@@ -47,70 +68,190 @@ export function assessOperatorRuntimeFreshness(args: {
     };
   }
 
-  if (engineHeadSha === null) {
+  const unavailableReasons = collectUnavailableReasons({
+    engineHeadSha,
+    runtimeHeadSha,
+    runningWorkflowIdentity,
+    currentWorkflowIdentity,
+  });
+  if (unavailableReasons.length > 0) {
     return {
-      kind: "engine-head-unavailable",
+      kind: "unavailable",
       shouldRestart: false,
+      runningRuntimeIdentity: args.status.startup?.runtimeIdentity ?? null,
+      currentRuntimeIdentity: args.engineRuntimeIdentity,
       runtimeHeadSha,
       engineHeadSha,
+      runningWorkflowIdentity,
+      currentWorkflowIdentity,
+      runtimeChanged: false,
+      workflowChanged: false,
+      unavailableReasons,
       controlState,
       factoryState,
       activeIssueCount,
-      summary:
-        "Could not determine the engine checkout head; investigate the operator repo checkout before applying freshness restarts.",
+      summary: `Could not determine whether a restart is required: ${unavailableReasons.join("; ")}`,
     };
   }
 
-  if (runtimeHeadSha === null) {
-    return {
-      kind: "runtime-head-unavailable",
-      shouldRestart: false,
-      runtimeHeadSha,
-      engineHeadSha,
-      controlState,
-      factoryState,
-      activeIssueCount,
-      summary:
-        "Could not determine the running factory head; investigate startup/runtime identity before applying freshness restarts.",
-    };
-  }
+  const runtimeChanged = runtimeHeadSha !== engineHeadSha;
+  const workflowChanged = workflowIdentityChanged(
+    runningWorkflowIdentity,
+    currentWorkflowIdentity,
+  );
 
-  if (runtimeHeadSha === engineHeadSha) {
+  if (!runtimeChanged && !workflowChanged) {
     return {
       kind: "fresh",
       shouldRestart: false,
+      runningRuntimeIdentity: args.status.startup?.runtimeIdentity ?? null,
+      currentRuntimeIdentity: args.engineRuntimeIdentity,
       runtimeHeadSha,
       engineHeadSha,
-      controlState,
-      factoryState,
-      activeIssueCount,
-      summary: "Factory runtime is already on the current engine head.",
-    };
-  }
-
-  if (factoryState === "idle") {
-    return {
-      kind: "stale-idle",
-      shouldRestart: true,
-      runtimeHeadSha,
-      engineHeadSha,
+      runningWorkflowIdentity,
+      currentWorkflowIdentity,
+      runtimeChanged,
+      workflowChanged,
+      unavailableReasons: [],
       controlState,
       factoryState,
       activeIssueCount,
       summary:
-        "Factory runtime is behind the current engine head and the instance is idle; restart it before ordinary queue work.",
+        "Factory runtime and selected workflow already match the current engine and repository-owned workflow contract.",
     };
   }
 
   return {
-    kind: "stale-busy",
-    shouldRestart: false,
+    kind: deriveStaleKind({ runtimeChanged, workflowChanged, factoryState }),
+    shouldRestart: factoryState === "idle",
+    runningRuntimeIdentity: args.status.startup?.runtimeIdentity ?? null,
+    currentRuntimeIdentity: args.engineRuntimeIdentity,
     runtimeHeadSha,
     engineHeadSha,
+    runningWorkflowIdentity,
+    currentWorkflowIdentity,
+    runtimeChanged,
+    workflowChanged,
+    unavailableReasons: [],
     controlState,
     factoryState,
     activeIssueCount,
-    summary:
-      "Factory runtime is behind the current engine head but the instance is busy; defer restart until the next idle or post-merge checkpoint.",
+    summary: summarizeStaleness({
+      runtimeChanged,
+      workflowChanged,
+      factoryState,
+    }),
   };
+}
+
+function collectUnavailableReasons(args: {
+  readonly engineHeadSha: string | null;
+  readonly runtimeHeadSha: string | null;
+  readonly runningWorkflowIdentity: FactoryWorkflowIdentity | null;
+  readonly currentWorkflowIdentity: FactoryWorkflowIdentity | null;
+}): string[] {
+  const reasons: string[] = [];
+  if (args.engineHeadSha === null) {
+    reasons.push(
+      "current engine checkout head is unavailable; inspect the operator repo checkout",
+    );
+  }
+  if (args.runtimeHeadSha === null) {
+    reasons.push(
+      "running factory runtime head is unavailable; inspect the startup snapshot",
+    );
+  }
+  if (args.runningWorkflowIdentity?.contentHash === null) {
+    reasons.push(
+      summarizeWorkflowUnavailable(
+        "running workflow identity",
+        args.runningWorkflowIdentity,
+      ),
+    );
+  }
+  if (args.currentWorkflowIdentity?.contentHash === null) {
+    reasons.push(
+      summarizeWorkflowUnavailable(
+        "current workflow identity",
+        args.currentWorkflowIdentity,
+      ),
+    );
+  }
+  if (args.runningWorkflowIdentity === null) {
+    reasons.push(
+      "running workflow identity is unavailable; inspect the startup snapshot",
+    );
+  }
+  if (args.currentWorkflowIdentity === null) {
+    reasons.push(
+      "current workflow identity is unavailable; inspect the selected WORKFLOW.md",
+    );
+  }
+  return reasons;
+}
+
+function summarizeWorkflowUnavailable(
+  label: string,
+  identity: FactoryWorkflowIdentity | null,
+): string {
+  if (identity === null) {
+    return `${label} is unavailable`;
+  }
+  const source =
+    identity.detail === null
+      ? identity.source
+      : `${identity.source}: ${identity.detail}`;
+  return `${label} is unavailable for ${identity.workflowPath} (${source})`;
+}
+
+function workflowIdentityChanged(
+  running: FactoryWorkflowIdentity | null,
+  current: FactoryWorkflowIdentity | null,
+): boolean {
+  if (
+    running === null ||
+    current === null ||
+    running.contentHash === null ||
+    current.contentHash === null
+  ) {
+    return false;
+  }
+  return (
+    running.workflowPath !== current.workflowPath ||
+    running.contentHash !== current.contentHash
+  );
+}
+
+function deriveStaleKind(args: {
+  readonly runtimeChanged: boolean;
+  readonly workflowChanged: boolean;
+  readonly factoryState: string | null;
+}): OperatorRuntimeFreshnessKind {
+  const suffix = args.factoryState === "idle" ? "idle" : "busy";
+  if (args.runtimeChanged && args.workflowChanged) {
+    return suffix === "idle"
+      ? "stale-runtime-and-workflow-idle"
+      : "stale-runtime-and-workflow-busy";
+  }
+  if (args.runtimeChanged) {
+    return suffix === "idle" ? "stale-runtime-idle" : "stale-runtime-busy";
+  }
+  return suffix === "idle" ? "stale-workflow-idle" : "stale-workflow-busy";
+}
+
+function summarizeStaleness(args: {
+  readonly runtimeChanged: boolean;
+  readonly workflowChanged: boolean;
+  readonly factoryState: string | null;
+}): string {
+  const cause =
+    args.runtimeChanged && args.workflowChanged
+      ? "the engine checkout and selected workflow contract changed"
+      : args.runtimeChanged
+        ? "the engine checkout changed"
+        : "the selected workflow contract changed";
+  if (args.factoryState === "idle") {
+    return `Factory restart is required because ${cause} and the instance is idle; restart before ordinary queue work.`;
+  }
+  return `Factory restart is required because ${cause}, but the instance is busy; defer restart until the next idle or post-merge checkpoint.`;
 }

--- a/src/observability/workflow-identity.ts
+++ b/src/observability/workflow-identity.ts
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const FACTORY_WORKFLOW_IDENTITY_SOURCES = [
+  "file",
+  "missing",
+  "read-error",
+] as const;
+
+export type FactoryWorkflowIdentitySource =
+  (typeof FACTORY_WORKFLOW_IDENTITY_SOURCES)[number];
+
+export interface FactoryWorkflowIdentity {
+  readonly workflowPath: string;
+  readonly contentHash: string | null;
+  readonly source: FactoryWorkflowIdentitySource;
+  readonly detail: string | null;
+}
+
+export async function collectFactoryWorkflowIdentity(
+  workflowPath: string,
+): Promise<FactoryWorkflowIdentity> {
+  const resolvedWorkflowPath = path.resolve(workflowPath);
+
+  try {
+    const raw = await fs.readFile(resolvedWorkflowPath);
+    return {
+      workflowPath: resolvedWorkflowPath,
+      contentHash: createHash("sha256").update(raw).digest("hex"),
+      source: "file",
+      detail: null,
+    };
+  } catch (error) {
+    return buildUnavailableIdentity(resolvedWorkflowPath, error);
+  }
+}
+
+export function renderFactoryWorkflowIdentity(
+  identity: FactoryWorkflowIdentity | null | undefined,
+): string {
+  if (identity === null || identity === undefined) {
+    return "unavailable";
+  }
+  if (identity.contentHash === null) {
+    const reason =
+      identity.detail === null
+        ? identity.source
+        : `${identity.source}: ${identity.detail}`;
+    return `${identity.workflowPath} | unavailable (${reason})`;
+  }
+
+  return `${identity.workflowPath} | sha256 ${identity.contentHash}`;
+}
+
+export function factoryWorkflowIdentityLogFields(
+  identity: FactoryWorkflowIdentity | null | undefined,
+): Record<string, unknown> {
+  if (identity === null || identity === undefined) {
+    return {
+      workflowPath: null,
+      workflowContentHash: null,
+      workflowIdentitySource: null,
+      workflowIdentityDetail: null,
+    };
+  }
+
+  return {
+    workflowPath: identity.workflowPath,
+    workflowContentHash: identity.contentHash,
+    workflowIdentitySource: identity.source,
+    workflowIdentityDetail: identity.detail,
+  };
+}
+
+export function parseFactoryWorkflowIdentity(
+  value: unknown,
+  filePath: string,
+  field: string,
+): FactoryWorkflowIdentity | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const identity = expectObject(value, filePath, field);
+  return {
+    workflowPath: expectString(
+      identity.workflowPath,
+      filePath,
+      `${field}.workflowPath`,
+    ),
+    contentHash: expectNullableString(
+      identity.contentHash,
+      filePath,
+      `${field}.contentHash`,
+    ),
+    source: expectEnum(
+      identity.source,
+      FACTORY_WORKFLOW_IDENTITY_SOURCES,
+      filePath,
+      `${field}.source`,
+    ),
+    detail: expectNullableString(identity.detail, filePath, `${field}.detail`),
+  };
+}
+
+function buildUnavailableIdentity(
+  workflowPath: string,
+  error: unknown,
+): FactoryWorkflowIdentity {
+  const err = error as NodeJS.ErrnoException;
+  if (err.code === "ENOENT") {
+    return {
+      workflowPath,
+      contentHash: null,
+      source: "missing",
+      detail: "workflow file does not exist",
+    };
+  }
+
+  return {
+    workflowPath,
+    contentHash: null,
+    source: "read-error",
+    detail: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function expectObject(
+  value: unknown,
+  filePath: string,
+  field: string,
+): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `Expected object for ${field} in workflow identity snapshot ${filePath}.`,
+    );
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function expectString(value: unknown, filePath: string, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Expected string for ${field} in workflow identity snapshot ${filePath}.`,
+    );
+  }
+  return value;
+}
+
+function expectNullableString(
+  value: unknown,
+  filePath: string,
+  field: string,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(
+      `Expected string or null for ${field} in workflow identity snapshot ${filePath}.`,
+    );
+  }
+  return value;
+}
+
+function expectEnum<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  filePath: string,
+  field: string,
+): T[number] {
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw new Error(
+      `Expected one of ${allowed.join(", ")} for ${field} in workflow identity snapshot ${filePath}.`,
+    );
+  }
+  return value as T[number];
+}

--- a/src/startup/service.ts
+++ b/src/startup/service.ts
@@ -14,6 +14,12 @@ import {
   parseFactoryRuntimeIdentity,
   type FactoryRuntimeIdentity,
 } from "../observability/runtime-identity.js";
+import {
+  collectFactoryWorkflowIdentity,
+  factoryWorkflowIdentityLogFields,
+  parseFactoryWorkflowIdentity,
+  type FactoryWorkflowIdentity,
+} from "../observability/workflow-identity.js";
 import { isAbortError } from "../support/abort.js";
 import { GitHubMirrorStartupPreparer } from "./github-mirror.js";
 
@@ -29,6 +35,7 @@ export interface StartupSnapshot {
   readonly provider: string;
   readonly summary: string | null;
   readonly runtimeIdentity?: FactoryRuntimeIdentity | null;
+  readonly workflowIdentity?: FactoryWorkflowIdentity | null;
 }
 
 export interface StartupPreparationSuccess {
@@ -169,11 +176,15 @@ export async function runStartupPreparation(options: {
   // current worker. This may differ from the repository that owns WORKFLOW.md
   // when one shared engine checkout targets a separate project-local instance.
   const runtimeIdentity = await collectFactoryRuntimeIdentity(process.cwd());
+  const workflowIdentity = await collectFactoryWorkflowIdentity(
+    options.config.workflowPath,
+  );
 
   options.logger.info("Startup preparation started", {
     provider: preparer.id,
     startupFilePath: artifactPath,
     ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+    ...factoryWorkflowIdentityLogFields(workflowIdentity),
   });
   await writeStartupSnapshot(artifactPath, {
     version: 1,
@@ -183,6 +194,7 @@ export async function runStartupPreparation(options: {
     provider: preparer.id,
     summary: "Startup preparation is in progress.",
     runtimeIdentity,
+    workflowIdentity,
   });
 
   try {
@@ -200,12 +212,14 @@ export async function runStartupPreparation(options: {
         provider: preparer.id,
         summary: result.summary,
         runtimeIdentity,
+        workflowIdentity,
       });
       options.logger.error("Startup preparation failed", {
         provider: preparer.id,
         startupFilePath: artifactPath,
         summary: result.summary,
         ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+        ...factoryWorkflowIdentityLogFields(workflowIdentity),
       });
       return {
         kind: "failed",
@@ -225,6 +239,7 @@ export async function runStartupPreparation(options: {
       provider: preparer.id,
       summary: result.summary ?? "Startup preparation completed.",
       runtimeIdentity,
+      workflowIdentity,
     });
     options.logger.info("Startup preparation completed", {
       provider: preparer.id,
@@ -232,6 +247,7 @@ export async function runStartupPreparation(options: {
       summary: result.summary ?? null,
       workspaceSourceOverride: result.workspaceSourceOverride ?? null,
       ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+      ...factoryWorkflowIdentityLogFields(workflowIdentity),
     });
     return {
       kind: "ready",
@@ -255,12 +271,14 @@ export async function runStartupPreparation(options: {
       provider: preparer.id,
       summary,
       runtimeIdentity,
+      workflowIdentity,
     });
     options.logger.error("Startup preparation failed", {
       provider: preparer.id,
       startupFilePath: artifactPath,
       summary,
       ...factoryRuntimeIdentityLogFields(runtimeIdentity),
+      ...factoryWorkflowIdentityLogFields(workflowIdentity),
     });
     return {
       kind: "failed",
@@ -297,6 +315,11 @@ function parseStartupSnapshot(
       snapshot["runtimeIdentity"],
       filePath,
       "runtimeIdentity",
+    ),
+    workflowIdentity: parseFactoryWorkflowIdentity(
+      snapshot["workflowIdentity"],
+      filePath,
+      "workflowIdentity",
     ),
   };
 }

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -451,6 +451,13 @@ describe("operator loop workflow selection", () => {
       expect(reportReviewIndex).toBeLessThan(releaseStateIndex);
       expect(releaseStateIndex).toBeLessThan(queueWorkIndex);
       expect(prompt).toContain("bin/check-factory-runtime-freshness.ts");
+      expect(prompt).toContain("stale `*-idle` state");
+      expect(prompt).toContain(
+        "external instances, do not restart when only unrelated repository files changed",
+      );
+      expect(prompt).toContain(
+        "self-hosting merges should normally produce that stale-runtime result",
+      );
       expect(standingContextIndex).toBeLessThan(appendIndex);
       expect(prompt).toContain("bin/symphony-report.ts review-pending");
       expect(prompt).toContain("bin/check-operator-release-state.ts");

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -456,7 +456,7 @@ describe("operator loop workflow selection", () => {
         "external instances, do not restart when only unrelated repository files changed",
       );
       expect(prompt).toContain(
-        "self-hosting merges should normally produce that stale-runtime result",
+        "For self-hosting merges, that should normally surface as runtime drift",
       );
       expect(standingContextIndex).toBeLessThan(appendIndex);
       expect(prompt).toContain("bin/symphony-report.ts review-pending");

--- a/tests/unit/factory-control.test.ts
+++ b/tests/unit/factory-control.test.ts
@@ -87,6 +87,13 @@ function createStartupSnapshot(
       source: "git",
       detail: null,
     },
+    workflowIdentity: {
+      workflowPath: "/repo/WORKFLOW.md",
+      contentHash:
+        "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+      source: "file",
+      detail: null,
+    },
     ...overrides,
   };
 }
@@ -2407,6 +2414,13 @@ describe("renderFactoryControlStatus", () => {
           source: "git",
           detail: null,
         },
+        workflowIdentity: {
+          workflowPath: "/repo/WORKFLOW.md",
+          contentHash:
+            "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+          source: "file",
+          detail: null,
+        },
       },
       snapshotFreshness: {
         freshness: "unavailable",
@@ -2428,6 +2442,9 @@ describe("renderFactoryControlStatus", () => {
     expect(output).toContain("Runtime root: /repo/.tmp/factory-main");
     expect(output).toContain(
       "Runtime version: 4e5d1350f4b6b48525f4dca84e0d7df5c27f4c26 | committed 2026-03-13T11:57:00.000Z | clean",
+    );
+    expect(output).toContain(
+      "Workflow contract: /repo/WORKFLOW.md | sha256 8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
     );
     expect(output).toContain("Snapshot freshness: unavailable");
     expect(output).toContain(

--- a/tests/unit/operator-runtime-freshness.test.ts
+++ b/tests/unit/operator-runtime-freshness.test.ts
@@ -41,6 +41,13 @@ function buildStatus(
         source: "git",
         detail: null,
       },
+      workflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     },
     snapshotFreshness: {
       freshness: "fresh",
@@ -118,6 +125,13 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git",
         detail: null,
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
     expect(result.kind).toBe("fresh");
@@ -135,10 +149,19 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git",
         detail: null,
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
-    expect(result.kind).toBe("stale-idle");
+    expect(result.kind).toBe("stale-runtime-idle");
     expect(result.shouldRestart).toBe(true);
+    expect(result.runtimeChanged).toBe(true);
+    expect(result.workflowChanged).toBe(false);
   });
 
   it("defers restart when runtime is stale and busy", () => {
@@ -181,11 +204,97 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git",
         detail: null,
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
-    expect(result.kind).toBe("stale-busy");
+    expect(result.kind).toBe("stale-runtime-busy");
     expect(result.shouldRestart).toBe(false);
     expect(result.activeIssueCount).toBe(1);
+  });
+
+  it("requests restart when only the workflow contract changed and the instance is idle", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus(),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "runtime-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "0e14f3b03df8b0a6b946fdd8f0aac546f85d6d58b7615476a8ad5f5d6d6292af",
+        source: "file",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("stale-workflow-idle");
+    expect(result.shouldRestart).toBe(true);
+    expect(result.runtimeChanged).toBe(false);
+    expect(result.workflowChanged).toBe(true);
+  });
+
+  it("defers restart when both runtime and workflow are stale but the instance is busy", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus({
+        statusSnapshot: {
+          ...buildStatus().statusSnapshot!,
+          factoryState: "running",
+          activeIssues: [
+            {
+              issueNumber: 1,
+              issueIdentifier: "repo#1",
+              title: "active",
+              source: "running",
+              runSequence: 1,
+              status: "running",
+              summary: "running",
+              workspacePath: null,
+              branchName: "branch",
+              runSessionId: null,
+              executionOwner: null,
+              ownerPid: 123,
+              runnerPid: null,
+              startedAt: null,
+              updatedAt: "2026-03-30T00:00:00Z",
+              pullRequest: null,
+              checks: { pendingNames: [], failingNames: [] },
+              review: { actionableCount: 0, unresolvedThreadCount: 0 },
+              blockedReason: null,
+              runnerVisibility: null,
+            },
+          ],
+        },
+      }),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "engine-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "0e14f3b03df8b0a6b946fdd8f0aac546f85d6d58b7615476a8ad5f5d6d6292af",
+        source: "file",
+        detail: null,
+      },
+    });
+
+    expect(result.kind).toBe("stale-runtime-and-workflow-busy");
+    expect(result.shouldRestart).toBe(false);
   });
 
   it("reports stopped when factory control is not running", () => {
@@ -201,13 +310,20 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git",
         detail: null,
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
     expect(result.kind).toBe("stopped");
     expect(result.shouldRestart).toBe(false);
   });
 
-  it("reports engine-head-unavailable when the operator checkout head is unavailable", () => {
+  it("reports unavailable when the operator checkout head is unavailable", () => {
     const result = assessOperatorRuntimeFreshness({
       status: buildStatus(),
       engineRuntimeIdentity: {
@@ -218,13 +334,23 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git-error",
         detail: "git unavailable",
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
-    expect(result.kind).toBe("engine-head-unavailable");
+    expect(result.kind).toBe("unavailable");
     expect(result.shouldRestart).toBe(false);
+    expect(result.unavailableReasons).toContain(
+      "current engine checkout head is unavailable; inspect the operator repo checkout",
+    );
   });
 
-  it("reports runtime-head-unavailable when the running factory head is unavailable", () => {
+  it("reports unavailable when the running factory head is unavailable", () => {
     const result = assessOperatorRuntimeFreshness({
       status: buildStatus({
         startup: {
@@ -247,9 +373,45 @@ describe("assessOperatorRuntimeFreshness", () => {
         source: "git",
         detail: null,
       },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash:
+          "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+        source: "file",
+        detail: null,
+      },
     });
 
-    expect(result.kind).toBe("runtime-head-unavailable");
+    expect(result.kind).toBe("unavailable");
     expect(result.shouldRestart).toBe(false);
+    expect(result.unavailableReasons).toContain(
+      "running factory runtime head is unavailable; inspect the startup snapshot",
+    );
+  });
+
+  it("reports unavailable instead of guessing when the current workflow cannot be read", () => {
+    const result = assessOperatorRuntimeFreshness({
+      status: buildStatus(),
+      engineRuntimeIdentity: {
+        checkoutPath: "/tmp/repo",
+        headSha: "runtime-sha",
+        committedAt: "2026-03-30T00:00:00Z",
+        isDirty: false,
+        source: "git",
+        detail: null,
+      },
+      currentWorkflowIdentity: {
+        workflowPath: "/tmp/repo/WORKFLOW.md",
+        contentHash: null,
+        source: "missing",
+        detail: "workflow file does not exist",
+      },
+    });
+
+    expect(result.kind).toBe("unavailable");
+    expect(result.shouldRestart).toBe(false);
+    expect(result.unavailableReasons).toContain(
+      "current workflow identity is unavailable for /tmp/repo/WORKFLOW.md (missing: workflow file does not exist)",
+    );
   });
 });

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -174,7 +174,12 @@ describe("startup service", () => {
         runtimeIdentity: {
           checkoutPath: process.cwd(),
         },
+        workflowIdentity: {
+          workflowPath: config.workflowPath,
+          source: "file",
+        },
       });
+      expect(snapshot.workflowIdentity?.contentHash).toMatch(/^[0-9a-f]{64}$/);
     } finally {
       await fs.rm(runtimeRoot, { recursive: true, force: true });
       await fs.rm(remote.rootDir, { recursive: true, force: true });
@@ -315,6 +320,10 @@ describe("startup service", () => {
         runtimeIdentity: {
           checkoutPath: process.cwd(),
         },
+        workflowIdentity: {
+          workflowPath: config.workflowPath,
+          source: "file",
+        },
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -353,6 +362,10 @@ describe("startup service", () => {
         runtimeIdentity: {
           checkoutPath: process.cwd(),
         },
+        workflowIdentity: {
+          workflowPath: config.workflowPath,
+          source: "file",
+        },
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -374,6 +387,43 @@ describe("startup service", () => {
       ),
     ).toMatchObject({
       summary: null,
+    });
+  });
+
+  it("round-trips recorded workflow identity from startup snapshots", () => {
+    const snapshot = parseStartupSnapshotContent(
+      JSON.stringify({
+        version: 1,
+        state: "ready",
+        updatedAt: "2026-03-14T12:00:00.000Z",
+        workerPid: 6543,
+        provider: "github-bootstrap/test-failure",
+        summary: "ready",
+        runtimeIdentity: {
+          checkoutPath: "/tmp/runtime",
+          headSha: "runtime-sha",
+          committedAt: "2026-03-14T11:00:00.000Z",
+          isDirty: false,
+          source: "git",
+          detail: null,
+        },
+        workflowIdentity: {
+          workflowPath: "/tmp/project/WORKFLOW.md",
+          contentHash:
+            "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+          source: "file",
+          detail: null,
+        },
+      }),
+      "startup.json",
+    );
+
+    expect(snapshot.workflowIdentity).toEqual({
+      workflowPath: "/tmp/project/WORKFLOW.md",
+      contentHash:
+        "8b78342f9d6cb87a4fc8af4f35adf6ec0d8367864e594b0f88ff3a780b3fa929",
+      source: "file",
+      detail: null,
     });
   });
 });

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -94,6 +94,24 @@ function createConfig(
   };
 }
 
+async function writeWorkflowContract(workflowPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(workflowPath), { recursive: true });
+  await fs.writeFile(
+    workflowPath,
+    [
+      "---",
+      "tracker:",
+      "  kind: github-bootstrap",
+      "  repo: sociotechnica-org/symphony-ts",
+      "---",
+      "",
+      "# test workflow",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 async function readFileAtRef(
   repoPath: string,
   ref: string,
@@ -144,6 +162,8 @@ describe("startup service", () => {
     const config = createConfig(runtimeRoot, remote.remotePath);
 
     try {
+      await writeWorkflowContract(config.workflowPath);
+
       const outcome = await runStartupPreparation({
         config,
         logger: new JsonLogger(),
@@ -193,6 +213,8 @@ describe("startup service", () => {
     const logger = new JsonLogger();
 
     try {
+      await writeWorkflowContract(config.workflowPath);
+
       const firstStartup = await runStartupPreparation({
         config,
         logger,
@@ -268,6 +290,8 @@ describe("startup service", () => {
     );
 
     try {
+      await writeWorkflowContract(config.workflowPath);
+
       const outcome = await runStartupPreparation({
         config,
         logger: new JsonLogger(),
@@ -300,6 +324,8 @@ describe("startup service", () => {
     };
 
     try {
+      await writeWorkflowContract(config.workflowPath);
+
       const outcome = await runStartupPreparation({
         config,
         logger: new JsonLogger(),
@@ -343,6 +369,8 @@ describe("startup service", () => {
     };
 
     try {
+      await writeWorkflowContract(config.workflowPath);
+
       await expect(
         runStartupPreparation({
           config,


### PR DESCRIPTION
## Summary
- record the selected `WORKFLOW.md` identity in startup snapshots so the running detached runtime can be compared against the current repository-owned workflow contract
- replace the operator runtime freshness check with a restart assessment that distinguishes runtime drift, workflow drift, both, stopped, and unavailable states
- update operator guidance and tests so external-instance merges do not trigger automatic restarts unless the runtime engine or selected workflow actually changed

## Root Cause
The existing post-merge operator flow treated every successful landing as a detached-factory restart trigger. That worked for self-hosting, where merged PRs usually advance the running `symphony-ts` engine, but it was too broad for external instances because unrelated target-repo merges left the runtime and selected workflow unchanged.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- manual diff review plus `git diff --check` (no dedicated local review command was available)

Closes #325
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
