### PR TITLE
Fix nested operator-loop wake-up recursion

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -47,6 +47,7 @@ When resumable mode is enabled, the operator state root also carries
 `operator-session.json`, and `status.json` / `status.md` expose the resolved
 provider, model, command source, effective command, session mode, and any
 automatic reset reason.
+
 Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`
 from inside an active wake-up shell. Use the supported factory-control and
 status commands when you need deeper inspection during a cycle.

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -47,6 +47,9 @@ When resumable mode is enabled, the operator state root also carries
 `operator-session.json`, and `status.json` / `status.md` expose the resolved
 provider, model, command source, effective command, session mode, and any
 automatic reset reason.
+Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`
+from inside an active wake-up shell. Use the supported factory-control and
+status commands when you need deeper inspection during a cycle.
 
 ## Third-Party Onboarding
 

--- a/docs/plans/324-operator-loop-wake-up-nesting/plan.md
+++ b/docs/plans/324-operator-loop-wake-up-nesting/plan.md
@@ -290,14 +290,14 @@ state must stay explicit.
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected decision |
-| --- | --- | --- |
-| Top-level operator launch from repo root | no inherited parent-loop marker; normal config/instance metadata available | continue through startup, acquire the instance lock, and run normally |
-| Descendant shell inside an active wake-up launches `pnpm operator` or `operator-loop.sh` | inherited parent-loop marker present in environment | fail immediately with a clear nested-launch error; do not acquire a second lock or start a second wake-up |
-| Nested launch targets a different checkout or different selected workflow | inherited parent-loop marker present even though state-root/instance-key may differ | still fail closed because the child is inside an already-running wake-up process tree |
-| Second top-level launch from another terminal for the same instance | no inherited parent-loop marker; same instance lock already owned by a live process | keep existing behavior: exit with the current "already running" lock message |
-| Stale lock found for a valid top-level launch | no inherited parent-loop marker; lock owner not live | keep existing stale-lock recovery behavior |
-| Operator command fails for non-nesting reasons | top-level launch succeeded; wake-up command exits non-zero | keep existing failed-cycle and retry behavior; this issue does not change ordinary cycle failure handling |
+| Observed condition                                                                       | Local facts available                                                               | Expected decision                                                                                         |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Top-level operator launch from repo root                                                 | no inherited parent-loop marker; normal config/instance metadata available          | continue through startup, acquire the instance lock, and run normally                                     |
+| Descendant shell inside an active wake-up launches `pnpm operator` or `operator-loop.sh` | inherited parent-loop marker present in environment                                 | fail immediately with a clear nested-launch error; do not acquire a second lock or start a second wake-up |
+| Nested launch targets a different checkout or different selected workflow                | inherited parent-loop marker present even though state-root/instance-key may differ | still fail closed because the child is inside an already-running wake-up process tree                     |
+| Second top-level launch from another terminal for the same instance                      | no inherited parent-loop marker; same instance lock already owned by a live process | keep existing behavior: exit with the current "already running" lock message                              |
+| Stale lock found for a valid top-level launch                                            | no inherited parent-loop marker; lock owner not live                                | keep existing stale-lock recovery behavior                                                                |
+| Operator command fails for non-nesting reasons                                           | top-level launch succeeded; wake-up command exits non-zero                          | keep existing failed-cycle and retry behavior; this issue does not change ordinary cycle failure handling |
 
 ## Storage / Persistence Contract
 

--- a/docs/plans/324-operator-loop-wake-up-nesting/plan.md
+++ b/docs/plans/324-operator-loop-wake-up-nesting/plan.md
@@ -1,0 +1,382 @@
+# Issue 324 Plan: Prevent Nested Operator Loops During Wake-Up Cycles
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Ensure one wake-up loop owns one operator process tree for a selected
+Symphony instance. A wake-up cycle must not be able to spawn a second
+`operator-loop.sh` beneath the already-running loop, even if the child launch
+comes from a descendant shell in another checkout or another instance path.
+
+## Scope
+
+This slice covers:
+
+1. operator-loop coordination guards that detect an inherited active
+   wake-up-cycle context and refuse nested loop startup
+2. operator command environment wiring so descendant shells can see the active
+   parent-loop marker
+3. focused regression coverage for the observed nested-loop shape during a
+   wake-up cycle
+4. operator-facing guidance updates only if the checked-in prompt/skill/runbook
+   need an explicit "do not start another operator loop from inside a wake-up"
+   rule
+
+## Non-Goals
+
+This slice does not include:
+
+1. detached factory restart, watch, attach, or landing workflow changes
+2. tracker transport, normalization, or lifecycle-policy refactors
+3. runner transport changes for Codex, Claude, or generic-command outside the
+   operator-loop wake-up guard
+4. redesigning operator notebooks, release-state promotion, or resumable
+   session storage beyond any small compatibility needed for the guard
+5. multi-machine or multi-operator coordination; this issue is about one local
+   operator process tree during one wake-up cycle
+
+## Current Gaps
+
+Today the checked-in loop only protects startup with an instance-scoped local
+lock under the current checkout's `.ralph/instances/<instance-key>/` state
+root.
+
+That leaves a gap during a live wake-up cycle:
+
+1. the parent loop exports operator context to the spawned wake-up command, and
+   descendant shells inherit that environment
+2. if the wake-up command runs `pnpm operator` or `operator-loop.sh` from a
+   different checkout or against a different selected instance, the child loop
+   can use a different state root and avoid the parent's lock
+3. the current implementation has no explicit "already inside an operator
+   wake-up" guard, so the nested launch can create a second `operator-loop.sh`
+   and a second child agent under the first loop's process tree
+4. integration tests cover lock behavior and per-instance isolation, but they
+   do not prove that a wake-up cycle cannot recursively start another
+   operator loop underneath itself
+
+## Decision Notes
+
+1. Treat this as operator-loop coordination, not as a tracker or factory
+   orchestration bug. The fix should stay at the repo-owned operator-loop
+   boundary.
+2. Prefer an inherited parent-loop marker over heuristics based on process-tree
+   inspection. The marker is explicit, portable across descendant shells, and
+   does not require `ps` parsing.
+3. Fail closed at operator-loop startup with a clear error when a nested launch
+   is detected. Silent best-effort behavior would keep the runtime hard to
+   trust.
+4. Keep the existing instance lock. The new nested-loop guard is an additional
+   protection for descendant wake-up launches, not a replacement for stale-lock
+   recovery or per-instance exclusivity.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses
+`docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the repo-owned rule that one active wake-up loop must not launch another
+   operator loop from inside its own wake-up cycle
+2. the rule that nested wake-up launches fail clearly instead of continuing
+   with duplicate operator ownership
+
+Does not belong here:
+
+1. tracker-specific review or landing policy
+2. ad hoc shell folklore about which commands the operator "probably should not
+   run" without an enforced contract
+
+### Configuration Layer
+
+Belongs here:
+
+1. any explicit environment-marker contract that identifies an active
+   parent operator loop for descendant shells
+2. minimal typed/config-resolved plumbing only if the guard needs it
+
+Does not belong here:
+
+1. process-tree inspection logic
+2. tracker, workspace, or runner policy
+
+### Coordination Layer
+
+Belongs here:
+
+1. the operator-loop outer state model for startup, nested-loop rejection, lock
+   ownership, and one-cycle execution
+2. the decision point that distinguishes a valid top-level launch from an
+   inherited nested launch
+
+Does not belong here:
+
+1. factory dispatch, retry, reconciliation, or issue lifecycle transitions
+2. using tracker state to guess whether a descendant shell is a nested
+   operator-loop attempt
+
+### Execution Layer
+
+Belongs here:
+
+1. shell export of the active parent-loop marker into the operator command
+   environment
+2. operator-loop startup checks that refuse the nested child process before a
+   second wake-up cycle begins
+
+Does not belong here:
+
+1. Codex- or Claude-specific runner rewrites
+2. workspace lifecycle changes
+
+### Integration Layer
+
+Belongs here:
+
+1. none beyond the operator shell boundary and any runner-neutral environment
+   contract needed by descendant shells
+
+Does not belong here:
+
+1. GitHub issue or PR state inspection
+2. tracker transport/normalization changes
+
+### Observability Layer
+
+Belongs here:
+
+1. clear stderr/status evidence when a nested loop launch is rejected
+2. regression tests that make the rejected nested-launch behavior inspectable
+
+Does not belong here:
+
+1. new dashboards or factory status-surface redesign
+2. hiding nested-launch failures in logs without a testable signal
+
+## Architecture Boundaries
+
+### `skills/symphony-operator/operator-loop.sh`
+
+Owns:
+
+1. defining and exporting the inherited parent-loop marker
+2. rejecting nested loop startup before the child can proceed into a wake-up
+   cycle
+3. preserving the current instance-lock behavior for true top-level launches
+
+Does not own:
+
+1. tracker lifecycle decisions
+2. factory runtime restart/reconciliation policy
+3. provider-specific runner semantics
+
+### `tests/integration/operator-loop.test.ts`
+
+Owns:
+
+1. regression coverage for descendant nested launches during a live wake-up
+   cycle
+2. assertions that top-level behavior still works while nested launches fail
+   closed
+
+Does not own:
+
+1. shell-only behavioral assumptions without stable assertions
+2. tracker or orchestrator state-machine coverage unrelated to the operator
+   loop
+
+### `skills/symphony-operator/SKILL.md`, `skills/symphony-operator/operator-prompt.md`, and operator docs
+
+Owns:
+
+1. the operator-facing rule that a wake-up cycle must not start another
+   operator loop
+2. guidance to use factory-control commands instead of nesting the loop when
+   deeper inspection is needed
+
+Does not own:
+
+1. the only enforcement mechanism
+2. hidden recovery logic that exists only in prose
+
+## Slice Strategy And PR Seam
+
+Keep this as one reviewable PR focused on nested operator-loop prevention:
+
+1. add an explicit parent-loop marker and nested-launch rejection path in the
+   operator loop
+2. add focused integration coverage for the observed descendant-launch shape
+3. update checked-in operator guidance only where it clarifies the enforced
+   contract
+
+Deferred from this PR:
+
+1. broader operator-loop refactors
+2. detached runtime/process-tree diagnostics beyond what is required to prove
+   the guard
+3. any cross-instance scheduling policy or multi-host operator coordination
+
+Why this seam is reviewable:
+
+1. it stays inside the repo-owned operator loop and its tests
+2. it does not mix tracker/orchestrator/runtime-control refactors into the same
+   patch
+3. it directly addresses the observed trust issue with one explicit contract:
+   no nested wake-up loops inside a live wake-up cycle
+
+## Operator Loop Runtime State Model
+
+This issue changes operator-loop coordination behavior, so the local runtime
+state must stay explicit.
+
+### States
+
+1. `idle`
+   - no loop process is starting or running
+2. `startup-validating`
+   - a new loop process is resolving config, instance metadata, and nested-loop
+     eligibility
+3. `rejected-nested-launch`
+   - startup detected an inherited active parent-loop marker and refused to
+     continue
+4. `acquiring-lock`
+   - startup is taking the instance-scoped local lock for a valid top-level
+     launch
+5. `sleeping`
+   - the loop is healthy and waiting for the next wake-up
+6. `acting`
+   - one wake-up cycle is running the operator command
+7. `recording`
+   - post-cycle status/log/session bookkeeping is being written
+8. `retrying`
+   - the prior cycle failed and the loop is waiting before the next attempt
+9. `stopping`
+   - the loop is shutting down cleanly
+
+### Allowed transitions
+
+1. `idle -> startup-validating`
+2. `startup-validating -> rejected-nested-launch`
+3. `startup-validating -> acquiring-lock`
+4. `acquiring-lock -> sleeping`
+5. `acquiring-lock -> retrying` only via startup failure that still leaves the
+   top-level loop alive
+6. `sleeping -> acting`
+7. `acting -> recording`
+8. `recording -> sleeping`
+9. `acting -> retrying`
+10. `retrying -> acting`
+11. `sleeping -> stopping`
+12. `acting -> stopping`
+13. `recording -> stopping`
+14. `retrying -> stopping`
+15. `stopping -> idle`
+
+### Contract rules
+
+1. an inherited parent-loop marker is authoritative for descendant-shell nested
+   launches and must be checked before lock acquisition
+2. a rejected nested launch must not start a child wake-up cycle or child agent
+3. a valid top-level launch still relies on the existing per-instance lock to
+   prevent sibling loops in the same state root
+4. the nested-launch guard is process-tree scoped, not the new durable source
+   of truth for operator state
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected decision |
+| --- | --- | --- |
+| Top-level operator launch from repo root | no inherited parent-loop marker; normal config/instance metadata available | continue through startup, acquire the instance lock, and run normally |
+| Descendant shell inside an active wake-up launches `pnpm operator` or `operator-loop.sh` | inherited parent-loop marker present in environment | fail immediately with a clear nested-launch error; do not acquire a second lock or start a second wake-up |
+| Nested launch targets a different checkout or different selected workflow | inherited parent-loop marker present even though state-root/instance-key may differ | still fail closed because the child is inside an already-running wake-up process tree |
+| Second top-level launch from another terminal for the same instance | no inherited parent-loop marker; same instance lock already owned by a live process | keep existing behavior: exit with the current "already running" lock message |
+| Stale lock found for a valid top-level launch | no inherited parent-loop marker; lock owner not live | keep existing stale-lock recovery behavior |
+| Operator command fails for non-nesting reasons | top-level launch succeeded; wake-up command exits non-zero | keep existing failed-cycle and retry behavior; this issue does not change ordinary cycle failure handling |
+
+## Storage / Persistence Contract
+
+Do not add new durable files for this fix.
+
+The enforcement contract should be:
+
+1. inherited environment markers for descendant shells during one active
+   operator-loop process tree
+2. existing instance-scoped lock files for top-level per-instance exclusivity
+3. existing status/log artifacts for human inspection of failures
+
+If metadata beyond a boolean marker is helpful for diagnostics, keep it in the
+process environment or emitted status/log text rather than introducing a new
+durable artifact.
+
+## Observability Requirements
+
+1. nested-launch rejection must emit a clear, grep-friendly error message
+2. integration tests must prove the nested child loop never starts its own
+   wake-up cycle when launched from inside a parent cycle
+3. existing top-level loop status behavior should remain intact for non-nested
+   runs
+
+## Implementation Steps
+
+1. Add the issue `#324` plan under
+   `docs/plans/324-operator-loop-wake-up-nesting/plan.md`.
+2. Update `skills/symphony-operator/operator-loop.sh` to define an explicit
+   active parent-loop marker and reject nested descendant launches during
+   startup.
+3. Export the parent-loop marker into the operator command environment so
+   descendant shells inherit it during a wake-up cycle.
+4. Add integration coverage in `tests/integration/operator-loop.test.ts` for a
+   nested descendant launch that currently slips past the per-instance lock.
+5. Update operator prompt/skill/runbook wording only if needed to match the
+   enforced guard and direct operators back to supported factory-control
+   commands.
+6. Run formatting/lint/typecheck/test gates for the touched surfaces.
+7. Run a local self-review pass, fix findings, then open/update the PR for
+   `#324`.
+
+## Tests
+
+1. integration: a top-level `operator-loop.sh --once` run still succeeds for a
+   normal workflow
+2. integration: a wake-up command that tries to launch a nested operator loop
+   from inside the parent cycle fails closed before the child starts a second
+   wake-up
+3. integration: the nested-launch failure message is explicit enough to explain
+   why the child was rejected
+4. `pnpm lint`
+5. `pnpm typecheck`
+6. `pnpm test`
+
+## Acceptance Scenarios
+
+1. Given one active operator wake-up cycle, when a descendant shell tries to
+   run `pnpm operator` or `operator-loop.sh`, then the child launch exits
+   clearly and no second operator-loop process or child agent is started under
+   the parent loop.
+2. Given a separate top-level terminal launch for the same selected instance,
+   when the first loop already owns the instance lock, then the existing
+   "already running" behavior still applies.
+3. Given an ordinary top-level operator run, when no nested-launch marker is
+   present, then the loop behaves exactly as before.
+
+## Exit Criteria
+
+1. the operator loop has an explicit descendant-shell guard against nested
+   operator-loop startup during a wake-up cycle
+2. regression coverage proves the observed nested-launch shape is blocked
+3. top-level operator-loop behavior and existing lock semantics remain intact
+4. local QA passes
+5. the branch/PR remains scoped to issue `#324`
+
+## Deferred
+
+1. broader operator supervision redesign
+2. cross-host or multi-operator coordination
+3. deeper process-introspection tooling for debugging arbitrary shell trees
+4. factory-runtime changes unrelated to nested operator-loop prevention

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -80,6 +80,7 @@ provider session for that instance.
 - Treat the factory-control surface as the primary local runtime contract; use ad hoc `screen`, `ps`, or `pkill` inspection only when the control command is unavailable or inconsistent.
 - Treat the operator checkout as tooling, not automatically as policy authority. For plan review and repo-owned rules, the selected instance repository is the source of truth.
 - In a wake-up cycle, favor short, bounded inspection commands over long-running watchers. If a secondary GitHub or watch-surface probe is slow or non-terminal, stop and continue from the latest successful control-surface read instead of waiting indefinitely.
+- Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh` from inside an active wake-up shell. Use the supported factory-control and status commands instead of nesting the operator loop.
 - Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring and `pnpm tsx bin/symphony.ts factory attach` when you need the full-screen TUI; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart` over manual `screen` and process cleanup.

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -87,6 +87,31 @@ Examples:
 EOF
 }
 
+reject_nested_launch() {
+  if [ "${SYMPHONY_OPERATOR_ACTIVE_PARENT_LOOP:-}" != "1" ]; then
+    return 0
+  fi
+
+  local message
+  message="operator-loop: nested operator loop launch rejected inside an active wake-up cycle"
+  if [ -n "${SYMPHONY_OPERATOR_PARENT_LOOP_PID:-}" ]; then
+    message="$message; parent_pid=${SYMPHONY_OPERATOR_PARENT_LOOP_PID}"
+  fi
+  if [ -n "${SYMPHONY_OPERATOR_PARENT_INSTANCE_KEY:-}" ]; then
+    message="$message; parent_instance=${SYMPHONY_OPERATOR_PARENT_INSTANCE_KEY}"
+  fi
+  if [ -n "${SYMPHONY_OPERATOR_PARENT_WORKFLOW_PATH:-}" ]; then
+    message="$message; parent_workflow=${SYMPHONY_OPERATOR_PARENT_WORKFLOW_PATH}"
+  fi
+  message="$message; requested_instance=${INSTANCE_KEY}"
+  if [ -n "$WORKFLOW_PATH" ]; then
+    message="$message; requested_workflow=${WORKFLOW_PATH}"
+  fi
+
+  echo "$message" >&2
+  exit 1
+}
+
 json_escape() {
   local value="$1"
   value="${value//\\/\\\\}"
@@ -771,6 +796,12 @@ run_cycle() {
   set +e
   (
     cd "$REPO_ROOT"
+    export SYMPHONY_OPERATOR_ACTIVE_PARENT_LOOP="1"
+    export SYMPHONY_OPERATOR_PARENT_LOOP_PID="$$"
+    export SYMPHONY_OPERATOR_PARENT_INSTANCE_KEY="$INSTANCE_KEY"
+    export SYMPHONY_OPERATOR_PARENT_REPO_ROOT="$REPO_ROOT"
+    export SYMPHONY_OPERATOR_PARENT_SELECTED_INSTANCE_ROOT="$SELECTED_INSTANCE_ROOT"
+    export SYMPHONY_OPERATOR_PARENT_WORKFLOW_PATH="$WORKFLOW_PATH"
     export SYMPHONY_OPERATOR_REPO_ROOT="$REPO_ROOT"
     export SYMPHONY_OPERATOR_INSTANCE_KEY="$INSTANCE_KEY"
     export SYMPHONY_OPERATOR_DETACHED_SESSION_NAME="$DETACHED_SESSION_NAME"
@@ -875,6 +906,7 @@ else
 fi
 
 resolve_instance_state
+reject_nested_launch
 warn_default_command
 ensure_runtime_paths
 trap 'release_lock' EXIT

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -21,18 +21,19 @@ Required workflow:
 11. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact, including its stored `promotion` result with eligible downstream issues plus any `symphony:ready` labels added or removed.
 12. If the release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync error is resolved.
 13. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-14. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-15. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
-16. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-17. Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers; review the plan against the selected instance repository's own planning contract and docs, not the operator repo's defaults. When no override is configured, the default markers remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
-18. As mandatory operator checkpoints for this wake-up, explicitly:
+14. Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh` from inside this wake-up shell. Use the supported factory-control and status commands for deeper inspection instead of nesting the operator loop.
+15. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
+16. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
+17. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
+18. Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers; review the plan against the selected instance repository's own planning contract and docs, not the operator repo's defaults. When no override is configured, the default markers remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
+19. As mandatory operator checkpoints for this wake-up, explicitly:
 
 - review any active `plan-ready` / `awaiting-human-handoff` issue against the selected instance repository's own checked-in planning rules and post a plan decision,
 - post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
 - and after any successful landing, pull latest `origin/main`, refresh `.tmp/factory-main`, and restart the detached factory from that merged code.
 
-19. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-20. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
+20. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
+21. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
 
 Constraints:
 

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -1,4 +1,8 @@
-import { execFile, spawn } from "node:child_process";
+import {
+  execFile,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -186,6 +190,51 @@ async function runOperatorLoopWithArgs(
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+async function runOperatorLoopExpectFailure(
+  workflowPath: string,
+  args: readonly string[] = [],
+  env?: NodeJS.ProcessEnv,
+): Promise<{
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+}> {
+  try {
+    await execFileAsync(
+      "bash",
+      [
+        path.join("skills", "symphony-operator", "operator-loop.sh"),
+        "--once",
+        "--workflow",
+        workflowPath,
+        ...args,
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GH_TOKEN: "test-token",
+          SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+          ...env,
+        },
+      },
+    );
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & {
+      readonly code?: number | string;
+      readonly stdout?: string;
+      readonly stderr?: string;
+    };
+    return {
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+      exitCode: typeof failure.code === "number" ? failure.code : null,
+    };
+  }
+
+  throw new Error("Expected operator loop invocation to fail");
 }
 
 function buildAppendWakeUpLogCommand(entryTitle: string): string {
@@ -436,6 +485,9 @@ describe("operator loop workflow selection", () => {
         "SYMPHONY_OPERATOR_STANDING_CONTEXT",
       );
       const wakeUpLogIndex = prompt.indexOf("SYMPHONY_OPERATOR_WAKE_UP_LOG");
+      const nestedLoopIndex = prompt.indexOf(
+        "Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`",
+      );
       const appendIndex = prompt.indexOf(
         "append a new timestamped journal entry",
       );
@@ -446,6 +498,7 @@ describe("operator loop workflow selection", () => {
       expect(queueWorkIndex).toBeGreaterThanOrEqual(0);
       expect(standingContextIndex).toBeGreaterThanOrEqual(0);
       expect(wakeUpLogIndex).toBeGreaterThanOrEqual(0);
+      expect(nestedLoopIndex).toBeGreaterThanOrEqual(0);
       expect(appendIndex).toBeGreaterThanOrEqual(0);
       expect(freshnessIndex).toBeLessThan(reportReviewIndex);
       expect(reportReviewIndex).toBeLessThan(releaseStateIndex);
@@ -458,6 +511,9 @@ describe("operator loop workflow selection", () => {
       expect(prompt).toContain("SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT");
       expect(prompt).toContain(
         "selected instance root if they exist, and do not apply `symphony-ts` planning standards",
+      );
+      expect(prompt).toContain(
+        "Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`",
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -480,6 +536,153 @@ describe("operator loop workflow selection", () => {
         path.dirname(workflowPath),
       );
     } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a nested operator loop launched from inside a wake-up cycle", async () => {
+    const parentDir = await createTempDir("symphony-operator-loop-parent-");
+    const nestedDir = await createTempDir("symphony-operator-loop-nested-");
+    const parentWorkflow = await writeWorkflow(parentDir);
+    const nestedWorkflow = await writeWorkflow(nestedDir);
+    const nestedResultPath = path.join(parentDir, "nested-result.json");
+    const nestedStdoutPath = path.join(parentDir, "nested-stdout.txt");
+    const nestedStderrPath = path.join(parentDir, "nested-stderr.txt");
+    const nestedCommandPath = path.join(parentDir, "nested-command.sh");
+    const nestedPaths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey: deriveSymphonyInstanceKey(path.dirname(nestedWorkflow)),
+    });
+
+    try {
+      await fs.writeFile(
+        nestedCommandPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+set +e
+bash ${JSON.stringify(path.join(repoRoot, "skills", "symphony-operator", "operator-loop.sh"))} --once --workflow ${JSON.stringify(nestedWorkflow)} >${JSON.stringify(nestedStdoutPath)} 2>${JSON.stringify(nestedStderrPath)}
+status=$?
+set -e
+node -e ${JSON.stringify(`const fs = require("node:fs"); fs.writeFileSync(${JSON.stringify(nestedResultPath)}, JSON.stringify({ error: null, status: Number(process.argv[1]), stdout: fs.readFileSync(${JSON.stringify(nestedStdoutPath)}, "utf8"), stderr: fs.readFileSync(${JSON.stringify(nestedStderrPath)}, "utf8") }, null, 2));`)} "$status"
+`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+      const run = await runOperatorLoopWithOptions(parentWorkflow, {
+        env: {
+          SYMPHONY_OPERATOR_COMMAND: nestedCommandPath,
+        },
+      });
+      createdPaths.add(parentDir);
+      createdPaths.add(nestedDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      const nestedResult = JSON.parse(
+        await fs.readFile(nestedResultPath, "utf8"),
+      ) as {
+        readonly error: string | null;
+        readonly status: number | null;
+        readonly stdout: string;
+        readonly stderr: string;
+      };
+
+      expect(nestedResult.error).toBeNull();
+      expect(nestedResult.status).toBe(1);
+      expect(nestedResult.stderr).toContain(
+        "nested operator loop launch rejected inside an active wake-up cycle",
+      );
+      expect(nestedResult.stderr).toContain("parent_pid=");
+      expect(nestedResult.stderr).toContain("requested_instance=");
+      await expect(fs.access(nestedPaths.statusJsonPath)).rejects.toThrow();
+      await expect(fs.access(nestedPaths.lockDir)).rejects.toThrow();
+    } finally {
+      await fs.rm(parentDir, { recursive: true, force: true });
+      await fs.rm(nestedDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the existing same-instance lock rejection for separate top-level launches", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-lock-");
+    const workflowPath = await writeWorkflow(tempDir);
+
+    const childHolder: { current: ChildProcessWithoutNullStreams | null } = {
+      current: null,
+    };
+    try {
+      createdPaths.add(tempDir);
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(
+          "bash",
+          [
+            path.join("skills", "symphony-operator", "operator-loop.sh"),
+            "--interval-seconds",
+            "60",
+            "--workflow",
+            workflowPath,
+          ],
+          {
+            cwd: repoRoot,
+            env: {
+              ...process.env,
+              GH_TOKEN: "test-token",
+              SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
+            },
+          },
+        );
+        childHolder.current = child;
+
+        let collectedStderr = "";
+        const timeout = setTimeout(() => {
+          reject(
+            new Error(
+              "Timed out waiting for operator loop to acquire the lock",
+            ),
+          );
+        }, 10000);
+
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk: string) => {
+          collectedStderr += chunk;
+          if (
+            collectedStderr.includes(
+              "operator-loop: going to sleep until the first wake-up cycle",
+            )
+          ) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        });
+        child.on("error", (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+        child.on("close", (code) => {
+          if (code !== null && code !== 0) {
+            clearTimeout(timeout);
+            reject(
+              new Error(
+                `Operator loop exited before the lock test completed: ${code.toString()}`,
+              ),
+            );
+          }
+        });
+      });
+
+      const failure = await runOperatorLoopExpectFailure(workflowPath);
+      expect(failure.exitCode).toBe(1);
+      expect(failure.stderr).toContain(
+        "operator-loop: another loop is already running with pid",
+      );
+    } finally {
+      const childProcess = childHolder.current;
+      if (childProcess !== null) {
+        childProcess.kill("SIGTERM");
+        await new Promise<void>((resolve) => {
+          childProcess.once("close", () => resolve());
+        });
+      }
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -20,6 +20,27 @@ import { createTempDir } from "../support/git.js";
 const execFileAsync = promisify(execFile);
 const repoRoot = process.cwd();
 const ralphInstancesRoot = path.join(repoRoot, ".ralph", "instances");
+const inheritedParentLoopEnvKeys = [
+  "SYMPHONY_OPERATOR_ACTIVE_PARENT_LOOP",
+  "SYMPHONY_OPERATOR_PARENT_LOOP_PID",
+  "SYMPHONY_OPERATOR_PARENT_INSTANCE_KEY",
+  "SYMPHONY_OPERATOR_PARENT_REPO_ROOT",
+  "SYMPHONY_OPERATOR_PARENT_SELECTED_INSTANCE_ROOT",
+  "SYMPHONY_OPERATOR_PARENT_WORKFLOW_PATH",
+] as const;
+
+function buildTopLevelOperatorLoopEnv(
+  overrides?: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of inheritedParentLoopEnvKeys) {
+    delete env[key];
+  }
+  return {
+    ...env,
+    ...overrides,
+  };
+}
 
 async function writeWorkflow(rootDir: string): Promise<string> {
   const workflowPath = path.join(rootDir, "WORKFLOW.md");
@@ -111,12 +132,11 @@ async function runOperatorLoopWithOptions(
     ],
     {
       cwd: repoRoot,
-      env: {
-        ...process.env,
+      env: buildTopLevelOperatorLoopEnv({
         SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
         GH_TOKEN: "test-token",
         ...options?.env,
-      },
+      }),
     },
   );
 
@@ -178,11 +198,10 @@ async function runOperatorLoopWithArgs(
     ],
     {
       cwd: repoRoot,
-      env: {
-        ...process.env,
+      env: buildTopLevelOperatorLoopEnv({
         GH_TOKEN: "test-token",
         ...env,
-      },
+      }),
     },
   );
 
@@ -213,12 +232,11 @@ async function runOperatorLoopExpectFailure(
       ],
       {
         cwd: repoRoot,
-        env: {
-          ...process.env,
+        env: buildTopLevelOperatorLoopEnv({
           GH_TOKEN: "test-token",
           SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
           ...env,
-        },
+        }),
       },
     );
   } catch (error) {
@@ -402,6 +420,50 @@ describe("operator loop workflow selection", () => {
       expect(statusMd).toContain(`- Release state: ${run.releaseStatePath}`);
       expect(statusMd).toContain(`- Ready promotion state: unconfigured`);
     } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sanitizes inherited parent-loop markers for top-level test launches", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-sanitized-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const previousParentLoopEnv = Object.fromEntries(
+      inheritedParentLoopEnvKeys.map((key) => [key, process.env[key]]),
+    ) as Record<
+      (typeof inheritedParentLoopEnvKeys)[number],
+      string | undefined
+    >;
+
+    process.env.SYMPHONY_OPERATOR_ACTIVE_PARENT_LOOP = "1";
+    process.env.SYMPHONY_OPERATOR_PARENT_LOOP_PID = "12345";
+    process.env.SYMPHONY_OPERATOR_PARENT_INSTANCE_KEY = "parent-instance";
+    process.env.SYMPHONY_OPERATOR_PARENT_REPO_ROOT = "/tmp/parent-repo";
+    process.env.SYMPHONY_OPERATOR_PARENT_SELECTED_INSTANCE_ROOT =
+      "/tmp/parent-instance";
+    process.env.SYMPHONY_OPERATOR_PARENT_WORKFLOW_PATH =
+      "/tmp/parent-instance/WORKFLOW.md";
+
+    try {
+      const run = await runOperatorLoop(workflowPath);
+      createdPaths.add(tempDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      expect(run.stderr).toContain("operator-loop: waking up");
+      expect(run.stderr).not.toContain(
+        "nested operator loop launch rejected inside an active wake-up cycle",
+      );
+    } finally {
+      for (const key of inheritedParentLoopEnvKeys) {
+        const previousValue = previousParentLoopEnv[key];
+        if (previousValue === undefined) {
+          delete process.env[key];
+          continue;
+        }
+        process.env[key] = previousValue;
+      }
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
@@ -624,11 +686,10 @@ node -e ${JSON.stringify(`const fs = require("node:fs"); fs.writeFileSync(${JSON
           ],
           {
             cwd: repoRoot,
-            env: {
-              ...process.env,
+            env: buildTopLevelOperatorLoopEnv({
               GH_TOKEN: "test-token",
               SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
-            },
+            }),
           },
         );
         childHolder.current = child;
@@ -1151,11 +1212,10 @@ node -e ${JSON.stringify(`const fs = require("node:fs"); fs.writeFileSync(${JSON
           ],
           {
             cwd: repoRoot,
-            env: {
-              ...process.env,
+            env: buildTopLevelOperatorLoopEnv({
               GH_TOKEN: "test-token",
               SYMPHONY_OPERATOR_COMMAND: "cat >/dev/null",
-            },
+            }),
           },
         );
         let collectedStderr = "";


### PR DESCRIPTION
## Summary
- reject nested `operator-loop.sh` launches when a wake-up command inherits an active parent loop context
- export the parent-loop marker only inside the wake-up command environment and keep same-instance top-level lock behavior intact
- document the no-nested-loop rule in the operator prompt/runbook and add integration coverage for both nested and top-level launch paths

## Root Cause
The operator loop only enforced an instance-scoped local lock. A wake-up command could start another `pnpm operator` or `operator-loop.sh` from a descendant shell, target a different instance path, and bypass that lock, which allowed a second loop to appear under the active wake-up process tree.

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run tests/integration/operator-loop.test.ts --reporter=verbose`
- `pnpm test`

Closes #324.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
