### PR TITLE
Refactor operator control-state flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ local/generated-only for per-instance standing context, append-only wake-up
 history, loop status, logs, and lock files under
 `.ralph/instances/<instance-key>/`, including the
 machine-readable completed-run review ledger `report-review-state.json`.
+The same state root now also carries `control-state.json`, the generated
+checkpoint snapshot that the operator prompt reads instead of restating the
+entire wake-up algorithm.
 The same operator state root now also carries `release-state.json`, the typed
 record of configured release dependencies plus the current blocked or clear
 release-advancement posture for that instance.

--- a/bin/refresh-operator-control-state.ts
+++ b/bin/refresh-operator-control-state.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  refreshOperatorControlState,
+  renderOperatorControlState,
+} from "../src/observability/operator-control-state.js";
+
+interface Args {
+  readonly workflowPath?: string;
+  readonly operatorRepoRoot: string;
+  readonly json: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const workflowPath = readOptionalOptionValue(argv, "--workflow");
+  return {
+    ...(workflowPath === null ? {} : { workflowPath }),
+    operatorRepoRoot: path.resolve(
+      readOptionalOptionValue(argv, "--operator-repo-root") ?? process.cwd(),
+    ),
+    json: argv.includes("--json"),
+  };
+}
+
+function readOptionalOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const document = await refreshOperatorControlState({
+    workflowPath: path.resolve(args.workflowPath ?? "WORKFLOW.md"),
+    operatorRepoRoot: args.operatorRepoRoot,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(document)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${renderOperatorControlState(document)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -47,6 +47,9 @@ When resumable mode is enabled, the operator state root also carries
 `operator-session.json`, and `status.json` / `status.md` expose the resolved
 provider, model, command source, effective command, session mode, and any
 automatic reset reason.
+Each wake-up also refreshes `control-state.json`, the code-owned checkpoint
+snapshot that summarizes runtime health, report-review backlog, release gates,
+and pending plan-review or landing actions for that cycle.
 
 Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`
 from inside an active wake-up shell. Use the supported factory-control and
@@ -87,39 +90,40 @@ Normal path rules:
 
 Run this sequence at the start of each operator pass:
 
-1. Inspect `pnpm tsx bin/symphony.ts factory status --json`, appending `--workflow <path>` whenever the operator checkout is not the target instance root.
-2. Before ordinary queue work, inspect completed-run report review state with:
+1. Read `.ralph/instances/<instance-key>/control-state.json` first. Treat it as the code-owned checkpoint ordering for the cycle, not just as a hint.
+2. Inspect `pnpm tsx bin/symphony.ts factory status --json` when you need the underlying factory-health evidence behind the runtime checkpoint, appending `--workflow <path>` whenever the operator checkout is not the target instance root.
+3. Before ordinary queue work, inspect completed-run report review state with:
 
 ```bash
 pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-checkout> --json
 pnpm tsx bin/symphony-report.ts review-pending --workflow ../target-repo/WORKFLOW.md --operator-repo-root <operator-checkout> --json
 ```
 
-3. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
+4. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
    - read the generated evidence under `.var/reports/issues/<issue-number>/`
    - record a no-follow-up decision with `symphony-report.ts review-record`
    - or create a tracked follow-up issue with `symphony-report.ts review-follow-up`
    - and record durable guidance in standing context plus per-cycle findings in the wake-up log
-4. Before downstream release advancement work, inspect release dependency state with:
+5. Before downstream release advancement work, inspect release dependency state with:
 
 ```bash
 pnpm tsx bin/check-operator-release-state.ts --operator-repo-root <operator-checkout> --json
 pnpm tsx bin/check-operator-release-state.ts --workflow ../target-repo/WORKFLOW.md --operator-repo-root <operator-checkout> --json
 ```
 
-5. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
-6. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Read the stored `promotion` section in `release-state.json` when you need the latest eligible downstream issues or the exact `symphony:ready` labels that were added or removed.
-7. If ready promotion reports `sync-failed`, treat that as a release-advancement blocker alongside `blocked-by-prerequisite-failure` and `blocked-review-needed` until the label-sync failure is repaired.
-8. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
-9. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
-10. Check for operator-gated work the factory cannot clear by itself:
+6. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. If it reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure or metadata gap is resolved.
+7. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Read the stored `promotion` section in `release-state.json` when you need the latest eligible downstream issues or the exact `symphony:ready` labels that were added or removed.
+8. If ready promotion reports `sync-failed`, treat that as a release-advancement blocker alongside `blocked-by-prerequisite-failure` and `blocked-review-needed` until the label-sync failure is repaired.
+9. If useful, compare the live watch surface with `pnpm tsx bin/symphony.ts factory watch`, using the same explicit workflow selector.
+10. Use `pnpm tsx bin/symphony.ts factory attach` only when you need the real full-screen TUI for deeper live inspection; `Ctrl-C` exits the attach client only.
+11. Check for operator-gated work the factory cannot clear by itself:
 
 - active issues in `awaiting-human-handoff`
 - active issues or PRs in `awaiting-landing-command`
 
-11. If the detached runtime is stopped or degraded, repair that first.
-12. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite, unresolved dependency metadata, or a ready-promotion sync failure. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
-13. After a merge, fast-forward the instance root checkout to `origin/main`, rerun `bin/check-factory-runtime-freshness.ts`, and restart the detached factory only when the assessment reports that the runtime engine or selected `WORKFLOW.md` is stale. Self-hosting merges should normally produce runtime drift; external instances should stay up when the merge changed unrelated repository files only.
+12. If the detached runtime is stopped or degraded, repair that first.
+13. If a PR is green, review-clean, and required approved bot review has been observed on the current head, post `/land`. Do not do that for work the release-state artifact says is blocked by a failed prerequisite, unresolved dependency metadata, or a ready-promotion sync failure. If expected reviewer-app output is still missing after checks settle, treat that as degraded infrastructure instead of a normal wait.
+14. After a merge, fast-forward the instance root checkout to `origin/main`, rerun `bin/check-factory-runtime-freshness.ts`, and restart the detached factory only when the assessment reports that the runtime engine or selected `WORKFLOW.md` is stale. Self-hosting merges should normally produce runtime drift; external instances should stay up when the merge changed unrelated repository files only.
 
 Do not act as a second scheduler. If the factory is healthy, let it own dispatch, retries, and PR follow-up.
 
@@ -251,6 +255,8 @@ Operator-loop generated state is separate from that runtime surface. It stays
 under the operator checkout's `.ralph/instances/<instance-key>/` tree so two
 operator loops targeting different instances do not overwrite each other's
 standing context, wake-up log, status, logs, or lock files.
+`control-state.json` lives there as the cycle-local checkpoint surface that the
+prompt should read before any queue or landing work.
 Completed-run report review state also lives there in
 `report-review-state.json`; this is the machine-readable ledger for which
 generated reports are pending review, reviewed, or blocked, and which follow-up

--- a/docs/plans/300-operator-control-state/plan.md
+++ b/docs/plans/300-operator-control-state/plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- plan-ready
+- approved
 
 ## Goal
 
@@ -301,16 +301,16 @@ operator-loop-local checkpoint posture model for one wake-up cycle.
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Normalized tracker / artifact facts available | Expected decision |
-| --- | --- | --- | --- |
-| Detached runtime is stopped, degraded, or unreadable | `factory status --json` control state | current active issue state may be stale | classify `runtime-blocked`; repair runtime before ordinary queue work |
-| Freshness reports stale `*-idle` | runtime-freshness result and selected instance paths | merge or workflow drift facts | classify `runtime-blocked`; restart before queue advancement |
-| Freshness reports stale `*-busy` | runtime-freshness result | live worker still active | record stale-but-busy; do not restart immediately; keep ordinary queue work blocked until the current run reaches a safe checkpoint |
-| Completed-run reports are `report-ready` or `review-blocked` | operator review ledger plus report artifacts | no tracker mutation required yet | classify `report-review-blocked`; review reports before plan review or landing |
-| Release state is `blocked-by-prerequisite-failure`, `blocked-review-needed`, or promotion is `sync-failed` | `release-state.json` and promotion result | downstream issue/PR metadata | classify `release-blocked`; do not promote or `/land` blocked release work |
-| Active issue is `awaiting-human-handoff` and earlier blockers are clear | factory status plus selected instance docs | normalized plan-review lifecycle | classify `action-required`; prompt should review the plan using repo-owned policy |
-| PR or active issue is `awaiting-landing-command` and earlier blockers are clear | factory status plus review/check summaries | normalized landing-ready lifecycle | classify `action-required`; prompt should consider posting `/land` if the guard conditions are satisfied |
-| No blockers and no operator-gated action remain | all checkpoint inputs clear | no pending handoff work | classify `clear`; operator should record the cycle and stop |
+| Observed condition                                                                                         | Local facts available                                | Normalized tracker / artifact facts available | Expected decision                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Detached runtime is stopped, degraded, or unreadable                                                       | `factory status --json` control state                | current active issue state may be stale       | classify `runtime-blocked`; repair runtime before ordinary queue work                                                               |
+| Freshness reports stale `*-idle`                                                                           | runtime-freshness result and selected instance paths | merge or workflow drift facts                 | classify `runtime-blocked`; restart before queue advancement                                                                        |
+| Freshness reports stale `*-busy`                                                                           | runtime-freshness result                             | live worker still active                      | record stale-but-busy; do not restart immediately; keep ordinary queue work blocked until the current run reaches a safe checkpoint |
+| Completed-run reports are `report-ready` or `review-blocked`                                               | operator review ledger plus report artifacts         | no tracker mutation required yet              | classify `report-review-blocked`; review reports before plan review or landing                                                      |
+| Release state is `blocked-by-prerequisite-failure`, `blocked-review-needed`, or promotion is `sync-failed` | `release-state.json` and promotion result            | downstream issue/PR metadata                  | classify `release-blocked`; do not promote or `/land` blocked release work                                                          |
+| Active issue is `awaiting-human-handoff` and earlier blockers are clear                                    | factory status plus selected instance docs           | normalized plan-review lifecycle              | classify `action-required`; prompt should review the plan using repo-owned policy                                                   |
+| PR or active issue is `awaiting-landing-command` and earlier blockers are clear                            | factory status plus review/check summaries           | normalized landing-ready lifecycle            | classify `action-required`; prompt should consider posting `/land` if the guard conditions are satisfied                            |
+| No blockers and no operator-gated action remain                                                            | all checkpoint inputs clear                          | no pending handoff work                       | classify `clear`; operator should record the cycle and stop                                                                         |
 
 ## Storage / Persistence Contract
 
@@ -399,8 +399,8 @@ operator-loop-local checkpoint posture model for one wake-up cycle.
    - release blocked
    - plan-review required
    - landing required
-   through the generated control-state artifact without changing tracker
-   lifecycle kinds
+     through the generated control-state artifact without changing tracker
+     lifecycle kinds
 
 ## Exit Criteria
 

--- a/docs/plans/300-operator-control-state/plan.md
+++ b/docs/plans/300-operator-control-state/plan.md
@@ -1,0 +1,425 @@
+# Issue 300 Plan: Operator Control State And Prompt-Scope Reduction
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Reduce the checked-in operator skill and prompt to durable policy and human
+judgment rules, while moving deterministic wake-up checkpoints and operator
+gates into a typed code-owned control surface.
+
+The intended outcome of this slice is:
+
+1. the operator loop publishes one inspectable control-state artifact for the
+   current wake-up cycle instead of relying on a long prompt to restate the
+   full deterministic procedure
+2. mandatory checkpoint ordering and queue-gating rules live in code and tests
+3. the operator prompt becomes smaller and more stable because it consumes the
+   control-state artifact rather than being the only place that explains the
+   wake-up algorithm
+4. future operator sub-skill splits can build on that control surface instead
+   of copying more prose into prompts
+
+## Scope
+
+This slice covers:
+
+1. a typed operator control-state model that summarizes the current wake-up
+   checkpoint results for one selected instance
+2. code that evaluates the mandatory operator checkpoints in deterministic
+   order from existing factory, report-review, release-state, and issue/PR
+   evidence
+3. operator-loop wiring that refreshes and publishes that control-state before
+   the operator command runs
+4. prompt and skill edits that remove duplicated deterministic procedure text
+   and point the operator to the generated control-state artifact
+5. operator-facing docs and tests that make the new boundary explicit
+
+## Non-Goals
+
+This slice does not include:
+
+1. fully automating GitHub mutations such as posting plan-review decisions or
+   `/land` from code
+2. redesigning tracker transport, normalization, or lifecycle policy
+3. broad operator-loop shell refactors unrelated to the control-state seam
+4. a full sub-skill taxonomy for operator work before the control surface is
+   stable
+5. replacing the operator's need for judgment on plan quality, review quality,
+   or release-risk tradeoffs
+
+## Current Gaps
+
+1. `skills/symphony-operator/operator-prompt.md` still carries too much
+   deterministic wake-up procedure, including checkpoint order, restart rules,
+   report-review sequencing, release gating, and operator-gated work checks
+2. `skills/symphony-operator/SKILL.md` duplicates much of that same procedure,
+   so durable policy and per-cycle control flow are mixed together
+3. `skills/symphony-operator/operator-loop.sh` already enforces some control
+   behavior in code, such as release-state refresh, ready promotion, wake-up
+   leases, and session handling, but it does not publish one typed checkpoint
+   result that the prompt can consume
+4. existing tests mostly pin prompt wording and string ordering rather than a
+   narrower code-owned contract for "what operator work is required now" and
+   "what blocks ordinary queue advancement"
+5. the current surface makes it hard to tell which operator rules are durable
+   policy that belong in the skill versus deterministic checkpoint behavior
+   that should be inspectable in code and tests
+
+## Decision Notes
+
+1. Treat this as an operator coordination and observability seam, not as a
+   tracker-policy rewrite. The repo already has tracker lifecycle and landing
+   contracts; the missing part is a typed operator-facing control surface.
+2. Move deterministic checkpoint ordering into code first. Only after that
+   surface exists should the repository consider splitting additional
+   operator sub-skills.
+3. Keep the operator prompt responsible for judgment, escalation, and
+   repository-owned policy. Do not try to turn this slice into a fully
+   autonomous operator product.
+4. Reuse existing sources of truth instead of inventing new ones:
+   `factory status --json`, runtime-freshness results, completed-run
+   report-review state, release-state evaluation, and normalized issue/PR
+   lifecycle facts should feed the new control-state artifact.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses
+[`docs/architecture.md`](../../architecture.md).
+
+### Policy Layer
+
+Belongs here:
+
+1. the rule that deterministic wake-up checkpoint ordering is repo-owned
+   behavior and should not depend on prompt luck
+2. the rule that the operator prompt should focus on judgment, escalation, and
+   repo policy rather than re-specifying the entire wake-up algorithm
+3. the rule that release blockers and report-review blockers gate ordinary
+   queue advancement and landing
+
+Does not belong here:
+
+1. shell-only checkpoint ordering hidden in prompt prose
+2. tracker transport or GitHub API details
+
+### Configuration Layer
+
+Belongs here:
+
+1. any typed path derivation for the new operator control-state artifact under
+   the selected instance's operator state root
+2. any explicit environment contract that exposes the control-state artifact to
+   the operator command
+
+Does not belong here:
+
+1. issue/PR policy evaluation logic
+2. tracker parsing embedded in the shell script
+
+### Coordination Layer
+
+Belongs here:
+
+1. the deterministic evaluation order for wake-up checkpoints
+2. the classification of current operator posture such as runtime-blocked,
+   report-review-blocked, release-blocked, action-required, or clear
+3. the action list that distinguishes blocked ordinary queue work from
+   operator-owned follow-up work
+
+Does not belong here:
+
+1. tracker-specific transport concerns
+2. prompt-only ordering rules without typed state
+
+### Execution Layer
+
+Belongs here:
+
+1. operator-loop execution of the control-state evaluator before the operator
+   command runs
+2. exporting the generated control-state path and summary to the operator
+   command environment
+3. prompt consumption of that generated artifact
+
+Does not belong here:
+
+1. runner-provider rewrites unrelated to the operator loop
+2. ad hoc shell branching that duplicates typed evaluator logic
+
+### Integration Layer
+
+Belongs here:
+
+1. reading existing tracker-derived and operator-local artifacts through stable
+   interfaces to build the control-state snapshot
+2. normalization of those inputs into one operator-owned checkpoint summary
+
+Does not belong here:
+
+1. new GitHub transport or review parsing rules
+2. mixing tracker transport, normalization, and operator policy in one broad
+   module
+
+### Observability Layer
+
+Belongs here:
+
+1. the inspectable control-state artifact and any status exposure needed to
+   show the current checkpoint posture
+2. tests and docs that make the new prompt/code boundary explicit
+3. operator-facing summaries that explain which checkpoint currently blocks
+   ordinary queue work
+
+Does not belong here:
+
+1. burying control decisions only in log text
+2. making the prompt the only inspectable source of operator checkpoint order
+
+## Architecture Boundaries
+
+### New focused operator control-state module(s)
+
+Owns:
+
+1. loading the existing operator inputs needed for one wake-up decision pass
+2. evaluating checkpoint posture in deterministic order
+3. producing a typed summary plus a normalized action list and blockers
+
+Does not own:
+
+1. GitHub API transport
+2. posting review comments or `/land`
+3. notebook-writing behavior
+
+### `skills/symphony-operator/operator-loop.sh`
+
+Owns:
+
+1. refreshing the operator control-state artifact at the right point in the
+   cycle
+2. exporting the artifact path and any summary environment values to the
+   operator command
+3. keeping the shell script thin by delegating evaluation logic to focused
+   TypeScript helpers
+
+Does not own:
+
+1. the only definition of checkpoint policy
+2. broad parsing of report-review, release-state, and lifecycle inputs inline
+   in bash
+
+### `skills/symphony-operator/operator-prompt.md`
+
+Owns:
+
+1. concise operator instructions for how to use the generated control-state
+   artifact
+2. durable judgment rules, escalation rules, and repository-policy reminders
+
+Does not own:
+
+1. the full deterministic wake-up sequence in prose
+2. the only source of truth for which actions are currently required
+
+### `skills/symphony-operator/SKILL.md` and operator docs
+
+Owns:
+
+1. durable operator behavior, boundaries, and escalation rules
+2. explaining what stays in policy/docs versus what is now generated in code
+
+Does not own:
+
+1. per-cycle action ordering duplicated from code
+2. hidden control behavior that exists only in prose
+
+## Slice Strategy And PR Seam
+
+Keep this as one reviewable PR focused on one narrow seam: add a typed
+operator control-state artifact and update the checked-in prompt/skill/docs to
+consume that surface instead of embedding the full deterministic wake-up
+procedure.
+
+This stays reviewable because it limits the work to:
+
+1. one new focused evaluation module plus any small supporting path/wiring
+2. targeted operator-loop plumbing
+3. prompt and skill reduction
+4. contract tests for the generated checkpoint surface
+
+Deferred from this PR:
+
+1. any broader automation of plan review or landing
+2. any new operator sub-skills beyond what is required to clarify the new
+   boundary
+3. tracker lifecycle or GitHub integration redesign
+
+## Runtime State Model
+
+This slice does not add new tracker lifecycle kinds. It adds an
+operator-loop-local checkpoint posture model for one wake-up cycle.
+
+### Posture states
+
+1. `runtime-blocked`
+   - detached runtime health or freshness requires repair before ordinary queue
+     work
+2. `report-review-blocked`
+   - completed-run report review has pending `report-ready` or
+     `review-blocked` work that must be handled first
+3. `release-blocked`
+   - release-state or ready-promotion results block downstream advancement or
+     `/land`
+4. `action-required`
+   - operator-gated handoff work exists, such as plan review or `/land`, and
+     earlier blockers are clear
+5. `clear`
+   - no operator-gated work or higher-priority blockers are present for this
+     cycle
+
+### Allowed transitions
+
+1. `runtime-blocked -> report-review-blocked`
+   - runtime health is acceptable and freshness no longer blocks queue work
+2. `report-review-blocked -> release-blocked`
+   - pending completed-run report review is cleared
+3. `release-blocked -> action-required`
+   - release gate no longer blocks queue advancement or landing
+4. `action-required -> clear`
+   - no remaining plan-review or landing action is pending
+5. any state -> `runtime-blocked`
+   - a new runtime health or freshness problem is observed on the next cycle
+
+### Explicit non-changes
+
+1. no new issue lifecycle kinds
+2. no retry-budget or reconciliation changes
+3. no new landing protocol markers or plan-review protocol markers
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Normalized tracker / artifact facts available | Expected decision |
+| --- | --- | --- | --- |
+| Detached runtime is stopped, degraded, or unreadable | `factory status --json` control state | current active issue state may be stale | classify `runtime-blocked`; repair runtime before ordinary queue work |
+| Freshness reports stale `*-idle` | runtime-freshness result and selected instance paths | merge or workflow drift facts | classify `runtime-blocked`; restart before queue advancement |
+| Freshness reports stale `*-busy` | runtime-freshness result | live worker still active | record stale-but-busy; do not restart immediately; keep ordinary queue work blocked until the current run reaches a safe checkpoint |
+| Completed-run reports are `report-ready` or `review-blocked` | operator review ledger plus report artifacts | no tracker mutation required yet | classify `report-review-blocked`; review reports before plan review or landing |
+| Release state is `blocked-by-prerequisite-failure`, `blocked-review-needed`, or promotion is `sync-failed` | `release-state.json` and promotion result | downstream issue/PR metadata | classify `release-blocked`; do not promote or `/land` blocked release work |
+| Active issue is `awaiting-human-handoff` and earlier blockers are clear | factory status plus selected instance docs | normalized plan-review lifecycle | classify `action-required`; prompt should review the plan using repo-owned policy |
+| PR or active issue is `awaiting-landing-command` and earlier blockers are clear | factory status plus review/check summaries | normalized landing-ready lifecycle | classify `action-required`; prompt should consider posting `/land` if the guard conditions are satisfied |
+| No blockers and no operator-gated action remain | all checkpoint inputs clear | no pending handoff work | classify `clear`; operator should record the cycle and stop |
+
+## Storage / Persistence Contract
+
+1. add one inspectable operator-local artifact under the selected instance's
+   operator state root, likely alongside `status.json`, `release-state.json`,
+   and `report-review-state.json`
+2. treat that artifact as a derived checkpoint snapshot, not as a new source of
+   repository policy truth
+3. keep existing sources of truth unchanged:
+   - `factory status --json`
+   - runtime-freshness output
+   - completed-run report-review ledger and reports
+   - `release-state.json`
+   - normalized issue and PR lifecycle facts
+
+## Observability Requirements
+
+1. operators must be able to inspect the current checkpoint posture and action
+   list without reading the full prompt text
+2. prompt-capture tests should prove the prompt now points to the generated
+   control-state surface instead of duplicating the entire wake-up procedure
+3. the operator status or adjacent artifact surface should make it obvious why
+   queue work is blocked and which checkpoint owns that block
+
+## Implementation Steps
+
+1. add the issue plan under
+   `docs/plans/300-operator-control-state/plan.md`
+2. add typed path support for the new operator control-state artifact if the
+   existing instance-state path contract does not already cover it
+3. implement a focused control-state evaluator that:
+   - loads existing runtime-health, freshness, report-review, release-state,
+     and normalized handoff facts
+   - evaluates them in deterministic order
+   - emits one typed posture plus action/blocker summary
+4. add a small CLI/helper entry point so `operator-loop.sh` can refresh that
+   control-state artifact before running the operator command
+5. wire `operator-loop.sh` to export the control-state path and summary to the
+   operator environment
+6. reduce `skills/symphony-operator/operator-prompt.md` so it:
+   - reads the generated control-state artifact
+   - keeps only durable policy and judgment instructions
+   - stops duplicating most deterministic checkpoint order prose
+7. update `skills/symphony-operator/SKILL.md`,
+   `docs/guides/operator-runbook.md`, and nearby operator docs to describe the
+   new boundary and artifact
+8. add tests for:
+   - unit evaluation of checkpoint posture and action ordering
+   - integration coverage that the operator loop writes and exports the
+     control-state artifact
+   - prompt/skill contract coverage proving prompt-scope reduction
+9. run local QA:
+   - `pnpm format`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+
+## Tests And Acceptance Scenarios
+
+### Unit / Contract
+
+1. given runtime degradation or stale-idle freshness, the evaluator emits
+   `runtime-blocked` and does not expose ordinary queue work as the first
+   action
+2. given pending completed-run report review, the evaluator emits
+   `report-review-blocked` ahead of plan review or landing actions
+3. given blocked release-state or ready-promotion failure, the evaluator emits
+   `release-blocked` and marks landing/promotion work as blocked
+4. given `awaiting-human-handoff` or `awaiting-landing-command` with earlier
+   blockers clear, the evaluator emits `action-required` with the normalized
+   action kind
+
+### Integration
+
+1. the operator loop writes the control-state artifact into the instance-scoped
+   operator state root and exports its path to the operator command
+2. prompt capture shows the prompt reading that artifact and no longer carrying
+   the full deterministic checkpoint sequence verbatim
+3. self-hosting and selected-instance behavior remain intact
+
+### End-to-End
+
+1. a one-cycle operator wake-up against fixture data can surface:
+   - runtime blocked
+   - report-review blocked
+   - release blocked
+   - plan-review required
+   - landing required
+   through the generated control-state artifact without changing tracker
+   lifecycle kinds
+
+## Exit Criteria
+
+1. deterministic operator checkpoint ordering is owned by code and tests rather
+   than mainly by prompt prose
+2. the operator prompt and skill are materially smaller and focus on policy,
+   judgment, and escalation
+3. the current checkpoint posture and required operator actions are inspectable
+   from a generated artifact
+4. local validation passes
+
+## Deferred Work
+
+1. automatic execution of plan-review or landing actions from code
+2. additional operator sub-skills once the control-state seam is proven
+3. broader operator-loop productization beyond this checkpoint surface
+4. tracker or orchestrator lifecycle changes unrelated to operator prompt scope
+
+## Revision Log
+
+- 2026-04-08: Initial plan created for issue `#300` and prepared for the
+  `plan-ready` handoff.

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -27,7 +27,9 @@ loop lock files under `.ralph/instances/<instance-key>/`. Release dependency
 metadata and the current release advancement posture also live there in
 `release-state.json`. When resumable mode is enabled, that same root also
 carries `operator-session.json`, the typed record of the compatible reusable
-provider session for that instance.
+provider session for that instance. The same root now also carries
+`control-state.json`, the code-owned checkpoint snapshot for one wake-up
+cycle.
 
 ## Scope
 
@@ -41,36 +43,35 @@ provider session for that instance.
   - `.ralph/instances/<instance-key>/wake-up-log.md` for append-only wake-up history
   - `.ralph/instances/<instance-key>/release-state.json` for typed release dependency metadata and blocked/clear advancement posture
 
-## Wake-Up Workflow
+## Control Surface
 
-1. Read the selected instance's standing context first, then read the wake-up log so durable guidance and recent history both survive session loss.
-2. Inspect the current repo state, open ready/running issues, open PRs, CI, and review comments.
-3. Use `pnpm tsx bin/symphony.ts factory status --json` as the primary factory-health check and determine whether the detached runtime is healthy, degraded, stopped, stuck, crashed, or misconfigured.
-4. Immediately after the factory-health read, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root <operator-repo-root> --json` for the selected instance, and append `--workflow <selected-workflow>` when operating on a non-default instance.
-5. If the freshness check reports any stale `*-idle` state, refresh the checkout that actually drifted, restart the detached factory before ordinary queue work, and record whether the restart was caused by runtime drift, workflow drift, or both. If it reports any stale `*-busy` state, record that fact in the wake-up log and defer restart until the next idle or post-merge checkpoint. If it reports `fresh`, do not restart just because a repository merge happened.
-6. Before any ordinary queue-advancement work after the freshness check is clear, run `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root <operator-repo-root> --json` for the selected instance and treat any `report-ready` or `review-blocked` entry as the first operator checkpoint after the factory-health read.
-7. For each pending completed-run report review:
-   - read the generated report under `.var/reports/issues/<issue-number>/`
-   - decide whether the report yields no tracked follow-up, a concrete follow-up issue, or a blocked review state
-   - persist the decision through `symphony-report review-record` or `symphony-report review-follow-up`
-   - and record what the report taught the factory in standing context or in the append-only wake-up log as appropriate
-8. Before any downstream release advancement work after completed-run report review is clear, run `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root <operator-repo-root> --json` for the selected instance.
-9. Treat `.ralph/instances/<instance-key>/release-state.json` as the canonical operator-local release artifact. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` after that checkpoint so the stored `promotion` section records the latest eligible downstream set plus any `symphony:ready` labels added or removed.
-10. If the release-state artifact reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync failure is resolved.
-11. Use bounded, one-shot probes during the wake-up cycle. Avoid long-running `watch`, follow, or sleep-heavy commands in the critical wake-up path; if extra inspection is needed, prefer short single reads and proceed from the latest successful control snapshot instead of waiting indefinitely for secondary surfaces.
-12. Compare the supported live watch/TUI surface against `factory status --json` whenever practical, but only with bounded probes. Treat `factory status --json` as source of truth and treat meaningful TUI mismatches as bugs to fix or track.
-13. Before moving on, explicitly check for operator-gated work that the factory cannot clear by itself:
-    - any active issue waiting in `plan-ready` / `awaiting-human-handoff`
-    - any PR or active issue waiting in `awaiting-landing-command`
-14. If the factory is unhealthy, fix the concrete problem and restart it.
-15. If a PR has actionable CI or review feedback, fix it on the PR branch, rerun local QA, push, and continue watching.
-16. AGENTS.md and WORKFLOW.md treat checks that remain non-terminal for more than 30 minutes as blocked infrastructure by default. For operator wake-ups, use this narrower carve-out: if the same stuck-check behavior is locally reproducible, treat it as active operator-owned work instead of passive infrastructure waiting, and continue debugging until the PR is actually green or the remaining blocker is clearly external.
-17. If an active issue is waiting in `plan-ready`, inspect the selected workflow's configured `tracker.plan_review` markers, then review the plan against the selected instance root at `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT`. Read that repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist; if the selected instance differs from the operator checkout, do not import `symphony-ts` planning standards into that external repository. Post an explicit review decision comment using the selected workflow's protocol. When no override is configured, the defaults remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
+The operator loop refreshes `control-state.json` before the operator command
+runs. Treat that artifact as the code-owned source of truth for deterministic
+wake-up ordering.
 
-18. If a PR is green, review-clean, and waiting in `awaiting-landing-command`, post `/land` on the PR as part of the wake-up cycle unless the user has explicitly told you not to land work automatically.
-19. After posting a review decision or `/land`, verify the factory acknowledges it and transitions correctly.
-20. When a `/land` completes and the PR actually merges, fast-forward the selected instance root checkout to the latest `origin/main`, rerun the freshness check, and restart the detached factory only when it reports a stale `*-idle` state. Self-hosting merges should normally surface runtime drift; external instances should not restart when the merge left both the runtime engine and selected `WORKFLOW.md` unchanged.
-21. Only seed or relabel the next issue when the queue is empty or the factory would otherwise be idle.
+`control-state.json` summarizes, in fixed order:
+
+1. factory health and runtime freshness
+2. completed-run report-review backlog
+3. release-state and ready-promotion gates
+4. pending plan-review or landing actions
+
+The prompt should consume that artifact rather than restating the full
+checkpoint algorithm. When the checked-in prompt and `control-state.json`
+disagree, trust the generated artifact and fix the prompt or code through the
+normal PR flow.
+
+## Wake-Up Expectations
+
+1. Read the selected instance's standing context first, then the wake-up log.
+2. Read `control-state.json` and follow its highest-priority blocked or pending checkpoint before ordinary queue work.
+3. If the runtime checkpoint is blocked, repair the concrete runtime or freshness problem first. Stale `*-idle` means restart before queue work; stale `*-busy` means record the drift and defer restart until the next safe checkpoint.
+4. If completed-run report review is blocked, read the generated report evidence, persist a review decision with `symphony-report review-record` or `symphony-report review-follow-up`, and record durable lessons in the right notebook surface.
+5. If the release checkpoint is blocked, do not promote downstream tickets or post `/land` for blocked release work until the prerequisite failure, metadata gap, or label-sync failure is resolved.
+6. If operator-gated actions are pending and earlier checkpoints are clear, handle `awaiting-human-handoff` plan review and `awaiting-landing-command` `/land` work during the cycle.
+7. After posting a plan-review decision or `/land`, verify the factory observes it and transitions correctly.
+8. After a merge, fast-forward the selected instance root to `origin/main`, rerun the freshness checkpoint, and restart only when the runtime engine or selected `WORKFLOW.md` is actually stale.
+9. Use bounded, one-shot probes during the wake-up cycle. Prefer short reads over long-running watchers in the critical path.
 
 ## Operational Rules
 

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -704,50 +704,35 @@ write_status() {
       CONTROL_STATE="$CONTROL_STATE" node -e '
 const fs = require("node:fs");
 const defaults = {
-  posture: "runtime-blocked",
-  summary: "Operator control state is unavailable.",
-  blockingCheckpoint: "",
-  nextActionSummary: "",
+  OPERATOR_CONTROL_POSTURE: "runtime-blocked",
+  OPERATOR_CONTROL_SUMMARY: "Operator control state is unavailable.",
+  OPERATOR_CONTROL_BLOCKING_CHECKPOINT: "",
+  OPERATOR_CONTROL_NEXT_ACTION_SUMMARY: "",
 };
 try {
   const raw = fs.readFileSync(process.env.CONTROL_STATE, "utf8");
   const parsed = JSON.parse(raw);
-  defaults.posture =
-    typeof parsed.posture === "string" ? parsed.posture : defaults.posture;
-  defaults.summary =
-    typeof parsed.summary === "string" ? parsed.summary : defaults.summary;
-  defaults.blockingCheckpoint =
+  defaults.OPERATOR_CONTROL_POSTURE =
+    typeof parsed.posture === "string"
+      ? parsed.posture
+      : defaults.OPERATOR_CONTROL_POSTURE;
+  defaults.OPERATOR_CONTROL_SUMMARY =
+    typeof parsed.summary === "string"
+      ? parsed.summary
+      : defaults.OPERATOR_CONTROL_SUMMARY;
+  defaults.OPERATOR_CONTROL_BLOCKING_CHECKPOINT =
     typeof parsed.blockingCheckpoint === "string"
       ? parsed.blockingCheckpoint
-      : defaults.blockingCheckpoint;
-  defaults.nextActionSummary =
+      : defaults.OPERATOR_CONTROL_BLOCKING_CHECKPOINT;
+  defaults.OPERATOR_CONTROL_NEXT_ACTION_SUMMARY =
     typeof parsed.nextActionSummary === "string"
       ? parsed.nextActionSummary
-      : defaults.nextActionSummary;
+      : defaults.OPERATOR_CONTROL_NEXT_ACTION_SUMMARY;
 } catch (error) {
-  defaults.summary = `Operator control state could not be read: ${error instanceof Error ? error.message : String(error)}`;
+  defaults.OPERATOR_CONTROL_SUMMARY = `Operator control state could not be read: ${error instanceof Error ? error.message : String(error)}`;
 }
 for (const [key, value] of Object.entries(defaults)) {
   console.log(`${key}=${JSON.stringify(value)}`);
-}
-' \
-        | node -e '
-const fs = require("node:fs");
-const lines = fs.readFileSync(0, "utf8").trim().split(/\n/u);
-for (const line of lines) {
-  if (!line) {
-    continue;
-  }
-  const index = line.indexOf("=");
-  const key = line.slice(0, index);
-  const value = JSON.parse(line.slice(index + 1));
-  const mapping = {
-    posture: "OPERATOR_CONTROL_POSTURE",
-    summary: "OPERATOR_CONTROL_SUMMARY",
-    blockingCheckpoint: "OPERATOR_CONTROL_BLOCKING_CHECKPOINT",
-    nextActionSummary: "OPERATOR_CONTROL_NEXT_ACTION_SUMMARY",
-  };
-  console.log(`${mapping[key]}=${JSON.stringify(value)}`);
 }
 '
     )"
@@ -1081,7 +1066,9 @@ run_cycle() {
   if ! run_ready_promotion_nonfatal; then
     :
   fi
-  refresh_operator_control_state
+  if ! refresh_operator_control_state; then
+    :
+  fi
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -10,6 +10,7 @@ INSTANCE_STATE_RESOLVER="$REPO_ROOT/bin/resolve-operator-instance.ts"
 OPERATOR_CONFIG_RESOLVER="$REPO_ROOT/bin/resolve-operator-loop-config.ts"
 PREPARE_OPERATOR_CYCLE="$REPO_ROOT/bin/prepare-operator-loop-cycle.ts"
 RECORD_OPERATOR_CYCLE="$REPO_ROOT/bin/record-operator-loop-cycle.ts"
+CONTROL_STATE_REFRESHER="$REPO_ROOT/bin/refresh-operator-control-state.ts"
 RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
 INSTANCE_KEY=""
@@ -21,6 +22,7 @@ LOCK_DIR=""
 LOCK_INFO_FILE=""
 STATUS_JSON=""
 STATUS_MD=""
+CONTROL_STATE=""
 STANDING_CONTEXT=""
 WAKE_UP_LOG=""
 LEGACY_SCRATCHPAD=""
@@ -68,6 +70,10 @@ READY_PROMOTION_ELIGIBLE_ISSUES=""
 READY_PROMOTION_ADDED=""
 READY_PROMOTION_REMOVED=""
 ACTIVE_WAKE_UP_LEASE_HELD=0
+OPERATOR_CONTROL_POSTURE="runtime-blocked"
+OPERATOR_CONTROL_SUMMARY="Operator control state is unavailable."
+OPERATOR_CONTROL_BLOCKING_CHECKPOINT=""
+OPERATOR_CONTROL_NEXT_ACTION_SUMMARY=""
 
 usage() {
   cat <<'EOF'
@@ -185,6 +191,7 @@ const data = JSON.parse(fs.readFileSync(0, "utf8"));
   lockInfoFile: "LOCK_INFO_FILE",
   statusJsonPath: "STATUS_JSON",
   statusMdPath: "STATUS_MD",
+  controlStatePath: "CONTROL_STATE",
   standingContextPath: "STANDING_CONTEXT",
   wakeUpLogPath: "WAKE_UP_LOG",
   legacyScratchpadPath: "LEGACY_SCRATCHPAD",
@@ -325,6 +332,36 @@ for (const [jsonKey, shellKey] of Object.entries(mappings)) {
   eval "$recorded_exports"
 }
 
+refresh_operator_control_state() {
+  local control_json control_exports
+  control_json="$(
+    pnpm tsx "$CONTROL_STATE_REFRESHER" \
+      --workflow "$WORKFLOW_PATH" \
+      --operator-repo-root "$REPO_ROOT" \
+      --json
+  )"
+  control_exports="$(
+    printf '%s' "$control_json" | node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const mapping = {
+  posture: "OPERATOR_CONTROL_POSTURE",
+  summary: "OPERATOR_CONTROL_SUMMARY",
+  blockingCheckpoint: "OPERATOR_CONTROL_BLOCKING_CHECKPOINT",
+  nextActionSummary: "OPERATOR_CONTROL_NEXT_ACTION_SUMMARY",
+};
+for (const [jsonKey, shellKey] of Object.entries(mapping)) {
+  const value = data[jsonKey];
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`Expected string|null for ${jsonKey}`);
+  }
+  console.log(`${shellKey}=${JSON.stringify(value ?? "")}`);
+}
+'
+  )"
+  eval "$control_exports"
+}
+
 write_cycle_log_header() {
   local log_file="$1"
 
@@ -337,6 +374,9 @@ write_cycle_log_header() {
     printf 'selected_instance_root=%s\n' "$SELECTED_INSTANCE_ROOT"
     printf 'operator_state_root=%s\n' "$INSTANCE_STATE_ROOT"
     printf 'selected_workflow=%s\n' "${WORKFLOW_PATH:-}"
+    printf 'control_state=%s\n' "$CONTROL_STATE"
+    printf 'control_posture=%s\n' "$OPERATOR_CONTROL_POSTURE"
+    printf 'control_summary=%s\n' "$OPERATOR_CONTROL_SUMMARY"
     printf 'provider=%s\n' "$OPERATOR_PROVIDER"
     printf 'model=%s\n' "${OPERATOR_MODEL:-}"
     printf 'command_source=%s\n' "$OPERATOR_COMMAND_SOURCE"
@@ -658,6 +698,66 @@ write_status() {
   local updated_at
   updated_at="$(now_utc)"
   load_release_state_snapshot
+  if [ -f "$CONTROL_STATE" ]; then
+    local control_state_exports
+    control_state_exports="$(
+      CONTROL_STATE="$CONTROL_STATE" node -e '
+const fs = require("node:fs");
+const defaults = {
+  posture: "runtime-blocked",
+  summary: "Operator control state is unavailable.",
+  blockingCheckpoint: "",
+  nextActionSummary: "",
+};
+try {
+  const raw = fs.readFileSync(process.env.CONTROL_STATE, "utf8");
+  const parsed = JSON.parse(raw);
+  defaults.posture =
+    typeof parsed.posture === "string" ? parsed.posture : defaults.posture;
+  defaults.summary =
+    typeof parsed.summary === "string" ? parsed.summary : defaults.summary;
+  defaults.blockingCheckpoint =
+    typeof parsed.blockingCheckpoint === "string"
+      ? parsed.blockingCheckpoint
+      : defaults.blockingCheckpoint;
+  defaults.nextActionSummary =
+    typeof parsed.nextActionSummary === "string"
+      ? parsed.nextActionSummary
+      : defaults.nextActionSummary;
+} catch (error) {
+  defaults.summary = `Operator control state could not be read: ${error instanceof Error ? error.message : String(error)}`;
+}
+for (const [key, value] of Object.entries(defaults)) {
+  console.log(`${key}=${JSON.stringify(value)}`);
+}
+' \
+        | node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync(0, "utf8").trim().split(/\n/u);
+for (const line of lines) {
+  if (!line) {
+    continue;
+  }
+  const index = line.indexOf("=");
+  const key = line.slice(0, index);
+  const value = JSON.parse(line.slice(index + 1));
+  const mapping = {
+    posture: "OPERATOR_CONTROL_POSTURE",
+    summary: "OPERATOR_CONTROL_SUMMARY",
+    blockingCheckpoint: "OPERATOR_CONTROL_BLOCKING_CHECKPOINT",
+    nextActionSummary: "OPERATOR_CONTROL_NEXT_ACTION_SUMMARY",
+  };
+  console.log(`${mapping[key]}=${JSON.stringify(value)}`);
+}
+'
+    )"
+    eval "$control_state_exports"
+  else
+    OPERATOR_CONTROL_POSTURE="runtime-blocked"
+    OPERATOR_CONTROL_SUMMARY="Operator control state has not been generated yet."
+    OPERATOR_CONTROL_BLOCKING_CHECKPOINT=""
+    OPERATOR_CONTROL_NEXT_ACTION_SUMMARY=""
+  fi
   if [ -n "$RELEASE_STATE_REFRESH_ERROR" ]; then
     RELEASE_ADVANCEMENT_STATE="unavailable"
     RELEASE_STATE_SUMMARY="$RELEASE_STATE_REFRESH_ERROR"
@@ -686,6 +786,13 @@ write_status() {
   "command": "$(json_escape "$BASE_OPERATOR_COMMAND")",
   "effectiveCommand": "$(json_escape "$EFFECTIVE_OPERATOR_COMMAND")",
   "promptFile": "$(json_escape "$PROMPT_FILE")",
+  "operatorControl": {
+    "path": "$(json_escape "$CONTROL_STATE")",
+    "posture": "$(json_escape "$OPERATOR_CONTROL_POSTURE")",
+    "summary": "$(json_escape "$OPERATOR_CONTROL_SUMMARY")",
+    "blockingCheckpoint": $(if [ -n "$OPERATOR_CONTROL_BLOCKING_CHECKPOINT" ]; then printf '"%s"' "$(json_escape "$OPERATOR_CONTROL_BLOCKING_CHECKPOINT")"; else printf 'null'; fi),
+    "nextActionSummary": $(if [ -n "$OPERATOR_CONTROL_NEXT_ACTION_SUMMARY" ]; then printf '"%s"' "$(json_escape "$OPERATOR_CONTROL_NEXT_ACTION_SUMMARY")"; else printf 'null'; fi)
+  },
   "standingContext": "$(json_escape "$STANDING_CONTEXT")",
   "wakeUpLog": "$(json_escape "$WAKE_UP_LOG")",
   "operatorSession": {
@@ -763,6 +870,11 @@ EOF
 - Ready promotion removed: ${READY_PROMOTION_REMOVED:-none}
 - Report review state: $REPORT_REVIEW_STATE
 - Prompt: $PROMPT_FILE
+- Operator control state: $CONTROL_STATE
+- Operator control posture: $OPERATOR_CONTROL_POSTURE
+- Operator control summary: $OPERATOR_CONTROL_SUMMARY
+- Operator control blocking checkpoint: ${OPERATOR_CONTROL_BLOCKING_CHECKPOINT:-none}
+- Operator control next action: ${OPERATOR_CONTROL_NEXT_ACTION_SUMMARY:-n/a}
 - Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
 - Last cycle finished: ${LAST_CYCLE_FINISHED_AT:-n/a}
 - Last cycle exit code: ${LAST_CYCLE_EXIT_CODE:-n/a}
@@ -906,6 +1018,7 @@ run_cycle() {
     :
   fi
   prepare_operator_cycle
+  refresh_operator_control_state
   write_cycle_log_header "$log_file"
   emit_terminal_trace "waking up (${OPERATOR_PROVIDER}${OPERATOR_MODEL:+/$OPERATOR_MODEL}; $(describe_cycle_terminal_mode))"
   write_status "acting" "Running operator wake-up cycle"
@@ -934,6 +1047,9 @@ run_cycle() {
     export SYMPHONY_OPERATOR_STANDING_CONTEXT="$STANDING_CONTEXT"
     export SYMPHONY_OPERATOR_WAKE_UP_LOG="$WAKE_UP_LOG"
     export SYMPHONY_OPERATOR_LEGACY_SCRATCHPAD="$LEGACY_SCRATCHPAD"
+    export SYMPHONY_OPERATOR_CONTROL_STATE="$CONTROL_STATE"
+    export SYMPHONY_OPERATOR_CONTROL_POSTURE="$OPERATOR_CONTROL_POSTURE"
+    export SYMPHONY_OPERATOR_CONTROL_SUMMARY="$OPERATOR_CONTROL_SUMMARY"
     export SYMPHONY_OPERATOR_RELEASE_STATE="$RELEASE_STATE"
     export SYMPHONY_OPERATOR_STATUS_JSON="$STATUS_JSON"
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
@@ -965,6 +1081,7 @@ run_cycle() {
   if ! run_ready_promotion_nonfatal; then
     :
   fi
+  refresh_operator_control_state
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"
@@ -1009,6 +1126,11 @@ fi
 
 if [ ! -f "$RECORD_OPERATOR_CYCLE" ]; then
   echo "operator-loop: operator cycle recorder not found: $RECORD_OPERATOR_CYCLE" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONTROL_STATE_REFRESHER" ]; then
+  echo "operator-loop: operator control-state refresher not found: $CONTROL_STATE_REFRESHER" >&2
   exit 1
 fi
 

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -2,42 +2,40 @@ You are the operator for the local Symphony factory tooling in this repository.
 
 Run exactly one wake-up cycle, then stop.
 
-Required workflow:
+Required reads, in order:
 
 1. Read `skills/symphony-operator/SKILL.md`.
-2. Read the instance-scoped standing context at `SYMPHONY_OPERATOR_STANDING_CONTEXT` and the wake-up log at `SYMPHONY_OPERATOR_WAKE_UP_LOG` if they exist.
-3. Treat `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT` as the repository that owns this wake-up's runtime contract and planning rubric. When it differs from `SYMPHONY_OPERATOR_REPO_ROOT`, review `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs from the selected instance root if they exist, and do not apply `symphony-ts` planning standards to that external repository.
-4. If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, append `--workflow "$SYMPHONY_OPERATOR_WORKFLOW_PATH"` to each `symphony` factory-control command that targets an instance.
-5. Inspect the detached factory via `pnpm tsx bin/symphony.ts factory status --json` as the primary source of truth.
-6. Immediately after the factory-health check, run `pnpm tsx bin/check-factory-runtime-freshness.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-7. If the freshness check reports any stale `*-idle` state, refresh the checkout that actually drifted, restart the detached factory before ordinary queue work, and record whether the restart was caused by runtime drift, workflow drift, or both. If it reports any stale `*-busy` state, record that the instance is stale-but-busy and defer restart until the next idle or post-merge checkpoint. If it reports `fresh`, do not restart just because a repository merge happened.
-8. Immediately after the freshness check is clear, inspect completed-run report review state before any ordinary queue-advancement work by running `pnpm tsx bin/symphony-report.ts review-pending --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-9. If `review-pending` reports any `report-ready` or `review-blocked` entries, handle those completed-run reports first:
-   - read the report evidence under `.var/reports/issues/<issue-number>/`,
-   - record a no-follow-up decision with `pnpm tsx bin/symphony-report.ts review-record --issue <number> --status reviewed-no-follow-up --summary <...>`,
-   - or create a tracked follow-up issue with `pnpm tsx bin/symphony-report.ts review-follow-up --issue <number> --title <...> --body-file <...> --summary <...>`,
-   - and record what was learned and queued in the standing context or wake-up log as appropriate before moving on.
-10. Before any downstream release advancement work after the completed-run report-review checkpoint is clear, inspect release advancement state by running `pnpm tsx bin/check-operator-release-state.ts --operator-repo-root "$SYMPHONY_OPERATOR_REPO_ROOT" --json` plus the selected workflow path when needed.
-11. The operator loop now runs `pnpm tsx bin/promote-operator-ready-issues.ts` immediately after that checkpoint. Treat `SYMPHONY_OPERATOR_RELEASE_STATE` as the canonical operator-local release artifact, including its stored `promotion` result with eligible downstream issues plus any `symphony:ready` labels added or removed.
-12. If the release-state check reports `blocked-by-prerequisite-failure` or `blocked-review-needed`, or if ready promotion reports `sync-failed`, do not promote downstream tickets or post `/land` for downstream PRs in that release until the blocking prerequisite failure, metadata gap, or label-sync error is resolved.
-13. Use bounded, one-shot inspection commands during this wake-up. Do not use long-running watch/follow commands in the critical path; if a secondary probe is slow or non-terminal, proceed from the latest successful control snapshot.
-14. Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh` from inside this wake-up shell. Use the supported factory-control and status commands for deeper inspection instead of nesting the operator loop.
-15. Inspect the live watch surface only when useful and only with bounded probes, but treat `factory status --json` as canonical.
-16. Review active issues, PRs, CI, and automated review feedback after the completed-run report-review checkpoint and release-state checkpoint are clear.
-17. If a required CI check appears stuck but the same behavior is locally reproducible, treat the reproducible hang as active operator-owned work; keep debugging until the PR is actually green or the remaining blocker is clearly external.
-18. Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers; review the plan against the selected instance repository's own planning contract and docs, not the operator repo's defaults. When no override is configured, the default markers remain `Plan review: approved`, `Plan review: changes-requested`, and `Plan review: waived`.
-19. As mandatory operator checkpoints for this wake-up, explicitly:
+2. Read `SYMPHONY_OPERATOR_STANDING_CONTEXT` and `SYMPHONY_OPERATOR_WAKE_UP_LOG` if they exist.
+3. Read the generated operator control-state artifact at `SYMPHONY_OPERATOR_CONTROL_STATE`.
 
-- review any active `plan-ready` / `awaiting-human-handoff` issue against the selected instance repository's own checked-in planning rules and post a plan decision,
-- post `/land` on any PR waiting in `awaiting-landing-command` once it is green and review-clean,
-- and after any successful landing, fast-forward the selected instance root checkout to latest `origin/main`, rerun the freshness check, and restart the detached factory only when it reports a stale `*-idle` state. For self-hosting merges, that should normally surface as runtime drift. For external instances, do not restart when only unrelated repository files changed.
+Treat `SYMPHONY_OPERATOR_CONTROL_STATE` as the code-owned source of truth for
+this cycle's deterministic checkpoint ordering. It already summarizes:
 
-20. Repair concrete factory/operator problems, or advance review/landing work, using the rules in the skill.
-21. Before finishing the cycle, append a new timestamped journal entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG` and update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.
+- factory health and runtime freshness
+- completed-run report-review backlog
+- release-state and ready-promotion gates
+- pending plan-review and `/land` actions
 
-Constraints:
+Use that artifact to decide what must happen first. Do not reconstruct the
+checkpoint order from memory or from older prompt wording.
+
+Repository and policy rules:
+
+- `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT` is the repository that owns this wake-up's runtime contract and planning rubric.
+- If `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT` differs from `SYMPHONY_OPERATOR_REPO_ROOT`, read that selected repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist. Do not apply `symphony-ts` planning standards to an external repository unless its own checked-in instructions say to.
+- If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, use it when calling Symphony factory-control commands for the selected instance.
+- Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers.
+- Before posting `/land`, respect the release checkpoint and only land work when CI is green, review is clean, and the usual landing guard conditions are satisfied.
+
+Operational constraints:
 
 - Do not act as a second scheduler.
-- Do not replace the product factory-control commands with ad hoc process management unless the control surface is unavailable or inconsistent.
+- Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh` from inside this wake-up shell.
+- Use the checked-in factory-control surface instead of ad hoc process management unless that control surface is unavailable or inconsistent.
 - Keep runner assumptions provider-neutral; the factory may use `codex`, `claude-code`, or `generic-command`.
 - If durable repo changes are required, make them through the normal branch/PR flow instead of leaving the fix only in local notes.
+
+Before finishing the cycle:
+
+1. Append a timestamped entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG`.
+2. Update `SYMPHONY_OPERATOR_STANDING_CONTEXT` only when durable guidance truly changed.

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -18,6 +18,9 @@ this cycle's deterministic checkpoint ordering. It already summarizes:
 
 Use that artifact to decide what must happen first. Do not reconstruct the
 checkpoint order from memory or from older prompt wording.
+If the artifact is missing, stale, or unreadable, fall back to the checked-in
+operator runbook at `docs/guides/operator-runbook.md` before improvising any
+manual checkpoint commands.
 
 Repository and policy rules:
 

--- a/src/domain/instance-identity.ts
+++ b/src/domain/instance-identity.ts
@@ -20,6 +20,7 @@ export interface OperatorInstanceStatePaths {
   readonly lockInfoFile: string;
   readonly statusJsonPath: string;
   readonly statusMdPath: string;
+  readonly controlStatePath: string;
   readonly standingContextPath: string;
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
@@ -75,6 +76,7 @@ export function deriveOperatorInstanceStatePaths(args: {
     lockInfoFile: path.join(lockDir, "owner"),
     statusJsonPath: path.join(operatorStateRoot, "status.json"),
     statusMdPath: path.join(operatorStateRoot, "status.md"),
+    controlStatePath: path.join(operatorStateRoot, "control-state.json"),
     standingContextPath: path.join(operatorStateRoot, "standing-context.md"),
     wakeUpLogPath: path.join(operatorStateRoot, "wake-up-log.md"),
     legacyScratchpadPath: path.join(

--- a/src/observability/operator-control-state.ts
+++ b/src/observability/operator-control-state.ts
@@ -284,7 +284,7 @@ async function loadRuntimeCheckpoint(args: {
       currentWorkflowIdentity,
     });
     return {
-      checkpoint: checkpointFromFreshness(freshness),
+      checkpoint: runtimeCheckpointFromFreshness(freshness),
       activeIssues: status.statusSnapshot?.activeIssues ?? [],
     };
   } catch (error) {
@@ -305,12 +305,12 @@ async function loadRuntimeCheckpoint(args: {
   }
 }
 
-function checkpointFromFreshness(
+export function runtimeCheckpointFromFreshness(
   freshness: OperatorRuntimeFreshnessSnapshot,
 ): OperatorControlRuntimeCheckpoint {
   return {
     kind: "runtime",
-    state: freshness.kind === "fresh" ? "clear" : "blocked",
+    state: runtimeCheckpointState(freshness),
     summary: summarizeRuntimeCheckpoint(freshness),
     controlState: freshness.controlState,
     freshnessKind: freshness.kind,
@@ -318,6 +318,18 @@ function checkpointFromFreshness(
     factoryState: freshness.factoryState,
     activeIssueCount: freshness.activeIssueCount,
   };
+}
+
+function runtimeCheckpointState(
+  freshness: OperatorRuntimeFreshnessSnapshot,
+): OperatorControlRuntimeCheckpoint["state"] {
+  if (freshness.kind === "fresh") {
+    return "clear";
+  }
+  if (freshness.kind === "stopped" || freshness.kind === "unavailable") {
+    return "blocked";
+  }
+  return freshness.shouldRestart ? "blocked" : "clear";
 }
 
 function summarizeRuntimeCheckpoint(
@@ -332,7 +344,10 @@ function summarizeRuntimeCheckpoint(
   if (freshness.kind === "stopped") {
     return `Runtime checkpoint is blocked: ${freshness.summary}`;
   }
-  return `Runtime checkpoint is blocked: ${freshness.summary}`;
+  if (freshness.shouldRestart) {
+    return `Runtime checkpoint is blocked: ${freshness.summary}`;
+  }
+  return freshness.summary;
 }
 
 async function loadReportReviewCheckpoint(args: {

--- a/src/observability/operator-control-state.ts
+++ b/src/observability/operator-control-state.ts
@@ -1,0 +1,581 @@
+import path from "node:path";
+import { inspectFactoryControl } from "../cli/factory-control.js";
+import { loadWorkflowInstancePaths } from "../config/workflow.js";
+import {
+  deriveOperatorInstanceStatePaths,
+  deriveSymphonyInstanceIdentity,
+} from "../domain/instance-identity.js";
+import type { FactoryActiveIssueSnapshot } from "./status.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
+import {
+  deriveOperatorReportReviewStateFile,
+  syncOperatorReportReviews,
+  type PendingOperatorReportReview,
+} from "./operator-report-review.js";
+import {
+  assessOperatorRuntimeFreshness,
+  type OperatorRuntimeFreshnessSnapshot,
+} from "./operator-runtime-freshness.js";
+import {
+  collectFactoryRuntimeIdentity,
+  renderFactoryRuntimeIdentity,
+} from "./runtime-identity.js";
+import {
+  collectFactoryWorkflowIdentity,
+  renderFactoryWorkflowIdentity,
+} from "./workflow-identity.js";
+import {
+  readOperatorReleaseState,
+  type OperatorReadyPromotionState,
+  type OperatorReleaseAdvancementState,
+} from "./operator-release-state.js";
+
+export const OPERATOR_CONTROL_STATE_SCHEMA_VERSION = 1 as const;
+
+export type OperatorControlPosture =
+  | "runtime-blocked"
+  | "report-review-blocked"
+  | "release-blocked"
+  | "action-required"
+  | "clear";
+
+export type OperatorControlBlockingCheckpoint =
+  | "runtime"
+  | "report-review"
+  | "release";
+
+export type OperatorControlActionKind = "review-plan" | "post-land-command";
+
+export interface OperatorControlPaths {
+  readonly operatorRepoRoot: string;
+  readonly selectedInstanceRoot: string;
+  readonly workflowPath: string;
+  readonly controlStateFile: string;
+  readonly releaseStateFile: string;
+  readonly reportReviewStateFile: string;
+}
+
+export interface OperatorControlRuntimeCheckpoint {
+  readonly kind: "runtime";
+  readonly state: "clear" | "blocked";
+  readonly summary: string;
+  readonly controlState: string;
+  readonly freshnessKind: string;
+  readonly shouldRestart: boolean;
+  readonly factoryState: string | null;
+  readonly activeIssueCount: number;
+}
+
+export interface OperatorControlReportReviewCheckpoint {
+  readonly kind: "report-review";
+  readonly state: "clear" | "blocked";
+  readonly summary: string;
+  readonly reviewStateFile: string;
+  readonly pending: readonly PendingOperatorReportReview[];
+}
+
+export interface OperatorControlReleaseCheckpoint {
+  readonly kind: "release";
+  readonly state: "clear" | "blocked";
+  readonly summary: string;
+  readonly releaseStateFile: string;
+  readonly advancementState: OperatorReleaseAdvancementState | "unavailable";
+  readonly promotionState: OperatorReadyPromotionState | "unavailable";
+  readonly blockingPrerequisiteNumber: number | null;
+}
+
+export interface OperatorControlActionCandidate {
+  readonly kind: OperatorControlActionKind;
+  readonly issueNumber: number;
+  readonly issueIdentifier: string;
+  readonly title: string;
+  readonly sourceStatus: "awaiting-human-handoff" | "awaiting-landing-command";
+  readonly summary: string;
+  readonly pullRequestNumber: number | null;
+}
+
+export interface OperatorControlActionItem extends OperatorControlActionCandidate {
+  readonly state: "pending" | "blocked";
+  readonly blockedBy: OperatorControlBlockingCheckpoint | null;
+}
+
+export interface OperatorControlActionCheckpoint {
+  readonly kind: "actions";
+  readonly state: "clear" | "pending" | "blocked";
+  readonly summary: string;
+  readonly items: readonly OperatorControlActionItem[];
+}
+
+export interface OperatorControlStateDocument {
+  readonly version: typeof OPERATOR_CONTROL_STATE_SCHEMA_VERSION;
+  readonly updatedAt: string;
+  readonly posture: OperatorControlPosture;
+  readonly summary: string;
+  readonly blockingCheckpoint: OperatorControlBlockingCheckpoint | null;
+  readonly nextActionSummary: string | null;
+  readonly paths: OperatorControlPaths;
+  readonly runtime: OperatorControlRuntimeCheckpoint;
+  readonly reportReview: OperatorControlReportReviewCheckpoint;
+  readonly release: OperatorControlReleaseCheckpoint;
+  readonly actions: OperatorControlActionCheckpoint;
+}
+
+export function deriveOperatorControlStateFile(paths: {
+  readonly controlStatePath: string;
+}): string {
+  return paths.controlStatePath;
+}
+
+export function collectOperatorControlActionCandidates(
+  activeIssues: readonly FactoryActiveIssueSnapshot[],
+): readonly OperatorControlActionCandidate[] {
+  const candidates: OperatorControlActionCandidate[] = [];
+  for (const issue of activeIssues) {
+    if (issue.status === "awaiting-human-handoff") {
+      candidates.push({
+        kind: "review-plan",
+        issueNumber: issue.issueNumber,
+        issueIdentifier: issue.issueIdentifier,
+        title: issue.title,
+        sourceStatus: issue.status,
+        summary: `Review the plan for issue #${issue.issueNumber.toString()} against the selected instance contract and post the configured decision marker.`,
+        pullRequestNumber: issue.pullRequest?.number ?? null,
+      });
+      continue;
+    }
+    if (issue.status === "awaiting-landing-command") {
+      candidates.push({
+        kind: "post-land-command",
+        issueNumber: issue.issueNumber,
+        issueIdentifier: issue.issueIdentifier,
+        title: issue.title,
+        sourceStatus: issue.status,
+        summary:
+          issue.pullRequest === null
+            ? `Inspect issue #${issue.issueNumber.toString()} and post /land only if the guard conditions are satisfied.`
+            : `Inspect PR #${issue.pullRequest.number.toString()} for issue #${issue.issueNumber.toString()} and post /land only if required CI is green and review is clean.`,
+        pullRequestNumber: issue.pullRequest?.number ?? null,
+      });
+    }
+  }
+  return candidates.sort((left, right) => left.issueNumber - right.issueNumber);
+}
+
+export function evaluateOperatorControlState(args: {
+  readonly updatedAt: string;
+  readonly paths: OperatorControlPaths;
+  readonly runtime: OperatorControlRuntimeCheckpoint;
+  readonly reportReview: OperatorControlReportReviewCheckpoint;
+  readonly release: OperatorControlReleaseCheckpoint;
+  readonly actionCandidates: readonly OperatorControlActionCandidate[];
+}): OperatorControlStateDocument {
+  const blockingCheckpoint = determineBlockingCheckpoint(args);
+  const posture = determinePosture(args, blockingCheckpoint);
+  const actions = buildActionCheckpoint(
+    args.actionCandidates,
+    blockingCheckpoint,
+  );
+
+  return {
+    version: OPERATOR_CONTROL_STATE_SCHEMA_VERSION,
+    updatedAt: args.updatedAt,
+    posture,
+    summary: summarizePosture({
+      posture,
+      runtime: args.runtime,
+      reportReview: args.reportReview,
+      release: args.release,
+      actions,
+    }),
+    blockingCheckpoint,
+    nextActionSummary: determineNextActionSummary({
+      posture,
+      runtime: args.runtime,
+      reportReview: args.reportReview,
+      release: args.release,
+      actions,
+    }),
+    paths: args.paths,
+    runtime: args.runtime,
+    reportReview: args.reportReview,
+    release: args.release,
+    actions,
+  };
+}
+
+export async function writeOperatorControlState(
+  filePath: string,
+  document: OperatorControlStateDocument,
+): Promise<void> {
+  await writeJsonFileAtomic(filePath, document, {
+    tempPrefix: ".operator-control-state",
+  });
+}
+
+export async function refreshOperatorControlState(args: {
+  readonly workflowPath: string;
+  readonly operatorRepoRoot: string;
+}): Promise<OperatorControlStateDocument> {
+  const workflowPath = path.resolve(args.workflowPath);
+  const operatorRepoRoot = path.resolve(args.operatorRepoRoot);
+  const identity = deriveSymphonyInstanceIdentity(workflowPath);
+  const operatorPaths = deriveOperatorInstanceStatePaths({
+    operatorRepoRoot,
+    instanceKey: identity.instanceKey,
+  });
+  const paths: OperatorControlPaths = {
+    operatorRepoRoot,
+    selectedInstanceRoot: identity.instanceRoot,
+    workflowPath,
+    controlStateFile: deriveOperatorControlStateFile(operatorPaths),
+    releaseStateFile: operatorPaths.releaseStatePath,
+    reportReviewStateFile: deriveOperatorReportReviewStateFile(operatorPaths),
+  };
+  const updatedAt = new Date().toISOString();
+
+  const runtimeResult = await loadRuntimeCheckpoint({
+    workflowPath,
+    operatorRepoRoot,
+  });
+  const instance = await loadWorkflowInstancePaths(workflowPath);
+
+  const reportReview = await loadReportReviewCheckpoint({
+    instance,
+    reviewStateFile: paths.reportReviewStateFile,
+  });
+  const release = await loadReleaseCheckpoint({
+    releaseStateFile: paths.releaseStateFile,
+  });
+
+  const document = evaluateOperatorControlState({
+    updatedAt,
+    paths,
+    runtime: runtimeResult.checkpoint,
+    reportReview,
+    release,
+    actionCandidates: collectOperatorControlActionCandidates(
+      runtimeResult.activeIssues,
+    ),
+  });
+  await writeOperatorControlState(paths.controlStateFile, document);
+  return document;
+}
+
+async function loadRuntimeCheckpoint(args: {
+  readonly workflowPath: string;
+  readonly operatorRepoRoot: string;
+}): Promise<{
+  readonly checkpoint: OperatorControlRuntimeCheckpoint;
+  readonly activeIssues: readonly FactoryActiveIssueSnapshot[];
+}> {
+  try {
+    const status = await inspectFactoryControl({
+      workflowPath: args.workflowPath,
+    });
+    const engineRuntimeIdentity = await collectFactoryRuntimeIdentity(
+      args.operatorRepoRoot,
+    );
+    const currentWorkflowIdentity = await collectFactoryWorkflowIdentity(
+      status.paths.workflowPath,
+    );
+    const freshness = assessOperatorRuntimeFreshness({
+      status,
+      engineRuntimeIdentity,
+      currentWorkflowIdentity,
+    });
+    return {
+      checkpoint: checkpointFromFreshness(freshness),
+      activeIssues: status.statusSnapshot?.activeIssues ?? [],
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      checkpoint: {
+        kind: "runtime",
+        state: "blocked",
+        summary: `Operator control state could not inspect factory status: ${message}`,
+        controlState: "unavailable",
+        freshnessKind: "unavailable",
+        shouldRestart: false,
+        factoryState: null,
+        activeIssueCount: 0,
+      },
+      activeIssues: [],
+    };
+  }
+}
+
+function checkpointFromFreshness(
+  freshness: OperatorRuntimeFreshnessSnapshot,
+): OperatorControlRuntimeCheckpoint {
+  return {
+    kind: "runtime",
+    state: freshness.kind === "fresh" ? "clear" : "blocked",
+    summary: summarizeRuntimeCheckpoint(freshness),
+    controlState: freshness.controlState,
+    freshnessKind: freshness.kind,
+    shouldRestart: freshness.shouldRestart,
+    factoryState: freshness.factoryState,
+    activeIssueCount: freshness.activeIssueCount,
+  };
+}
+
+function summarizeRuntimeCheckpoint(
+  freshness: OperatorRuntimeFreshnessSnapshot,
+): string {
+  if (freshness.kind === "fresh") {
+    return freshness.summary;
+  }
+  if (freshness.kind === "unavailable") {
+    return `Runtime checkpoint is unavailable: ${freshness.summary}`;
+  }
+  if (freshness.kind === "stopped") {
+    return `Runtime checkpoint is blocked: ${freshness.summary}`;
+  }
+  return `Runtime checkpoint is blocked: ${freshness.summary}`;
+}
+
+async function loadReportReviewCheckpoint(args: {
+  readonly instance: Awaited<ReturnType<typeof loadWorkflowInstancePaths>>;
+  readonly reviewStateFile: string;
+}): Promise<OperatorControlReportReviewCheckpoint> {
+  try {
+    const synced = await syncOperatorReportReviews({
+      instance: args.instance,
+      reviewStateFile: args.reviewStateFile,
+    });
+    if (synced.pending.length === 0) {
+      return {
+        kind: "report-review",
+        state: "clear",
+        summary:
+          "Completed-run report review is clear for this cycle; no report-ready or review-blocked entries are pending.",
+        reviewStateFile: args.reviewStateFile,
+        pending: [],
+      };
+    }
+    const first = synced.pending[0];
+    if (first === undefined) {
+      throw new Error("Pending report review summary was missing.");
+    }
+    return {
+      kind: "report-review",
+      state: "blocked",
+      summary: `Completed-run report review must be handled before ordinary queue work. ${synced.pending.length.toString()} review item(s) are pending; first is issue #${first.issueNumber.toString()} [${first.status}].`,
+      reviewStateFile: args.reviewStateFile,
+      pending: synced.pending,
+    };
+  } catch (error) {
+    return {
+      kind: "report-review",
+      state: "blocked",
+      summary: `Completed-run report review could not be inspected: ${error instanceof Error ? error.message : String(error)}`,
+      reviewStateFile: args.reviewStateFile,
+      pending: [],
+    };
+  }
+}
+
+async function loadReleaseCheckpoint(args: {
+  readonly releaseStateFile: string;
+}): Promise<OperatorControlReleaseCheckpoint> {
+  try {
+    const releaseState = await readOperatorReleaseState(args.releaseStateFile);
+    const advancementState = releaseState.evaluation.advancementState;
+    const promotionState = releaseState.promotion.state;
+    const blocked =
+      advancementState === "blocked-by-prerequisite-failure" ||
+      advancementState === "blocked-review-needed" ||
+      promotionState === "blocked-review-needed" ||
+      promotionState === "sync-failed";
+    return {
+      kind: "release",
+      state: blocked ? "blocked" : "clear",
+      summary: blocked
+        ? `Release checkpoint blocks downstream advancement or landing: ${releaseState.evaluation.summary} Promotion: ${releaseState.promotion.summary}`
+        : releaseState.evaluation.summary,
+      releaseStateFile: args.releaseStateFile,
+      advancementState,
+      promotionState,
+      blockingPrerequisiteNumber:
+        releaseState.evaluation.blockingPrerequisite?.issueNumber ?? null,
+    };
+  } catch (error) {
+    return {
+      kind: "release",
+      state: "blocked",
+      summary: `Release checkpoint could not be inspected: ${error instanceof Error ? error.message : String(error)}`,
+      releaseStateFile: args.releaseStateFile,
+      advancementState: "unavailable",
+      promotionState: "unavailable",
+      blockingPrerequisiteNumber: null,
+    };
+  }
+}
+
+function determineBlockingCheckpoint(args: {
+  readonly runtime: OperatorControlRuntimeCheckpoint;
+  readonly reportReview: OperatorControlReportReviewCheckpoint;
+  readonly release: OperatorControlReleaseCheckpoint;
+}): OperatorControlBlockingCheckpoint | null {
+  if (args.runtime.state === "blocked") {
+    return "runtime";
+  }
+  if (args.reportReview.state === "blocked") {
+    return "report-review";
+  }
+  if (args.release.state === "blocked") {
+    return "release";
+  }
+  return null;
+}
+
+function determinePosture(
+  args: {
+    readonly runtime: OperatorControlRuntimeCheckpoint;
+    readonly reportReview: OperatorControlReportReviewCheckpoint;
+    readonly release: OperatorControlReleaseCheckpoint;
+    readonly actionCandidates: readonly OperatorControlActionCandidate[];
+  },
+  blockingCheckpoint: OperatorControlBlockingCheckpoint | null,
+): OperatorControlPosture {
+  if (blockingCheckpoint === "runtime") {
+    return "runtime-blocked";
+  }
+  if (blockingCheckpoint === "report-review") {
+    return "report-review-blocked";
+  }
+  if (blockingCheckpoint === "release") {
+    return "release-blocked";
+  }
+  return args.actionCandidates.length > 0 ? "action-required" : "clear";
+}
+
+function buildActionCheckpoint(
+  candidates: readonly OperatorControlActionCandidate[],
+  blockingCheckpoint: OperatorControlBlockingCheckpoint | null,
+): OperatorControlActionCheckpoint {
+  const itemState: OperatorControlActionItem["state"] =
+    blockingCheckpoint === null ? "pending" : "blocked";
+  const items: OperatorControlActionItem[] = candidates.map((candidate) => ({
+    ...candidate,
+    state: itemState,
+    blockedBy: blockingCheckpoint,
+  }));
+  if (items.length === 0) {
+    return {
+      kind: "actions",
+      state: "clear",
+      summary:
+        "No operator-gated plan-review or landing action is pending after the earlier checkpoints.",
+      items,
+    };
+  }
+  if (blockingCheckpoint !== null) {
+    return {
+      kind: "actions",
+      state: "blocked",
+      summary: `${items.length.toString()} operator-gated action(s) are waiting behind the ${blockingCheckpoint} checkpoint.`,
+      items,
+    };
+  }
+  return {
+    kind: "actions",
+    state: "pending",
+    summary: `${items.length.toString()} operator-gated action(s) are pending for this cycle.`,
+    items,
+  };
+}
+
+function summarizePosture(args: {
+  readonly posture: OperatorControlPosture;
+  readonly runtime: OperatorControlRuntimeCheckpoint;
+  readonly reportReview: OperatorControlReportReviewCheckpoint;
+  readonly release: OperatorControlReleaseCheckpoint;
+  readonly actions: OperatorControlActionCheckpoint;
+}): string {
+  switch (args.posture) {
+    case "runtime-blocked":
+      return args.runtime.summary;
+    case "report-review-blocked":
+      return args.reportReview.summary;
+    case "release-blocked":
+      return args.release.summary;
+    case "action-required":
+      return args.actions.items[0]?.summary ?? args.actions.summary;
+    case "clear":
+      return "All mandatory operator checkpoints are clear for this cycle.";
+  }
+}
+
+function determineNextActionSummary(args: {
+  readonly posture: OperatorControlPosture;
+  readonly runtime: OperatorControlRuntimeCheckpoint;
+  readonly reportReview: OperatorControlReportReviewCheckpoint;
+  readonly release: OperatorControlReleaseCheckpoint;
+  readonly actions: OperatorControlActionCheckpoint;
+}): string | null {
+  switch (args.posture) {
+    case "runtime-blocked":
+      return args.runtime.summary;
+    case "report-review-blocked":
+      return args.reportReview.pending[0]?.summary ?? args.reportReview.summary;
+    case "release-blocked":
+      return args.release.summary;
+    case "action-required":
+      return args.actions.items[0]?.summary ?? null;
+    case "clear":
+      return null;
+  }
+}
+
+export function renderOperatorControlState(
+  document: OperatorControlStateDocument,
+): string {
+  const lines = [
+    `Posture: ${document.posture}`,
+    `Summary: ${document.summary}`,
+    `Blocking checkpoint: ${document.blockingCheckpoint ?? "none"}`,
+    `Workflow: ${document.paths.workflowPath}`,
+    `Selected instance root: ${document.paths.selectedInstanceRoot}`,
+    "",
+    "Runtime checkpoint:",
+    `  State: ${document.runtime.state}`,
+    `  Summary: ${document.runtime.summary}`,
+    `  Factory control: ${document.runtime.controlState}`,
+    `  Freshness: ${document.runtime.freshnessKind}`,
+    "",
+    "Report review checkpoint:",
+    `  State: ${document.reportReview.state}`,
+    `  Summary: ${document.reportReview.summary}`,
+    `  Review state file: ${document.reportReview.reviewStateFile}`,
+    "",
+    "Release checkpoint:",
+    `  State: ${document.release.state}`,
+    `  Summary: ${document.release.summary}`,
+    `  Release state file: ${document.release.releaseStateFile}`,
+    "",
+    "Operator-gated actions:",
+  ];
+  if (document.actions.items.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const item of document.actions.items) {
+      lines.push(
+        `  - [${item.state}] ${item.kind} issue #${item.issueNumber.toString()}${item.pullRequestNumber === null ? "" : ` pr #${item.pullRequestNumber.toString()}`}: ${item.summary}`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+export function describeRuntimeEvidence(
+  freshness: OperatorRuntimeFreshnessSnapshot,
+): string {
+  return [
+    `running runtime: ${renderFactoryRuntimeIdentity(freshness.runningRuntimeIdentity)}`,
+    `current runtime: ${renderFactoryRuntimeIdentity(freshness.currentRuntimeIdentity)}`,
+    `running workflow: ${renderFactoryWorkflowIdentity(freshness.runningWorkflowIdentity)}`,
+    `current workflow: ${renderFactoryWorkflowIdentity(freshness.currentWorkflowIdentity)}`,
+  ].join("; ");
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -680,6 +680,7 @@ describe("operator loop workflow selection", () => {
         "Treat `SYMPHONY_OPERATOR_CONTROL_STATE` as the code-owned source of truth",
       );
       expect(prompt).toContain("pending plan-review and `/land` actions");
+      expect(prompt).toContain("docs/guides/operator-runbook.md");
       expect(prompt).toContain("SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT");
       expect(prompt).toContain(
         "Do not apply `symphony-ts` planning standards to an external repository",

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -92,6 +92,7 @@ async function runOperatorLoop(workflowPath: string): Promise<{
   readonly stateRoot: string;
   readonly statusJsonPath: string;
   readonly statusMdPath: string;
+  readonly controlStatePath: string;
   readonly standingContextPath: string;
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
@@ -114,6 +115,7 @@ async function runOperatorLoopWithOptions(
   readonly stateRoot: string;
   readonly statusJsonPath: string;
   readonly statusMdPath: string;
+  readonly controlStatePath: string;
   readonly standingContextPath: string;
   readonly wakeUpLogPath: string;
   readonly legacyScratchpadPath: string;
@@ -159,6 +161,7 @@ async function runOperatorLoopWithOptions(
     stateRoot: paths.operatorStateRoot,
     statusJsonPath: paths.statusJsonPath,
     statusMdPath: paths.statusMdPath,
+    controlStatePath: paths.controlStatePath,
     standingContextPath: paths.standingContextPath,
     wakeUpLogPath: paths.wakeUpLogPath,
     legacyScratchpadPath: paths.legacyScratchpadPath,
@@ -500,6 +503,10 @@ describe("operator loop workflow selection", () => {
         readonly selectedWorkflowPath: string | null;
         readonly selectedInstanceRoot: string;
         readonly operatorStateRoot: string;
+        readonly operatorControl: {
+          readonly path: string;
+          readonly posture: string;
+        };
         readonly standingContext: string;
         readonly wakeUpLog: string;
         readonly releaseState: {
@@ -517,6 +524,8 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.selectedWorkflowPath).toBe(workflowPath);
       expect(statusJson.selectedInstanceRoot).toBe(path.dirname(workflowPath));
       expect(statusJson.operatorStateRoot).toBe(run.stateRoot);
+      expect(statusJson.operatorControl.path).toBe(run.controlStatePath);
+      expect(statusJson.operatorControl.posture).toBe("runtime-blocked");
       expect(statusJson.standingContext).toBe(run.standingContextPath);
       expect(statusJson.wakeUpLog).toBe(run.wakeUpLogPath);
       expect(statusJson.releaseState.path).toBe(run.releaseStatePath);
@@ -635,7 +644,7 @@ describe("operator loop workflow selection", () => {
     }
   });
 
-  it("prompts the operator to read the notebook first and review completed-run reports before other queue work", async () => {
+  it("prompts the operator to read the generated control state instead of restating the full checkpoint loop", async () => {
     const tempDir = await createTempDir("symphony-operator-loop-prompt-");
     const workflowPath = await writeWorkflow(tempDir);
     const promptCapture = path.join(tempDir, "operator-prompt.txt");
@@ -647,16 +656,9 @@ describe("operator loop workflow selection", () => {
       );
       createdPaths.add(tempDir);
       const prompt = await fs.readFile(promptCapture, "utf8");
-      const freshnessIndex = prompt.indexOf(
-        "bin/check-factory-runtime-freshness.ts",
+      const controlStateIndex = prompt.indexOf(
+        "SYMPHONY_OPERATOR_CONTROL_STATE",
       );
-      const reportReviewIndex = prompt.indexOf(
-        "bin/symphony-report.ts review-pending",
-      );
-      const releaseStateIndex = prompt.indexOf(
-        "bin/check-operator-release-state.ts",
-      );
-      const queueWorkIndex = prompt.indexOf("review any active `plan-ready`");
       const standingContextIndex = prompt.indexOf(
         "SYMPHONY_OPERATOR_STANDING_CONTEXT",
       );
@@ -664,40 +666,30 @@ describe("operator loop workflow selection", () => {
       const nestedLoopIndex = prompt.indexOf(
         "Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`",
       );
-      const appendIndex = prompt.indexOf(
-        "append a new timestamped journal entry",
-      );
+      const appendIndex = prompt.indexOf("Append a timestamped entry");
 
-      expect(freshnessIndex).toBeGreaterThanOrEqual(0);
-      expect(reportReviewIndex).toBeGreaterThanOrEqual(0);
-      expect(releaseStateIndex).toBeGreaterThanOrEqual(0);
-      expect(queueWorkIndex).toBeGreaterThanOrEqual(0);
+      expect(controlStateIndex).toBeGreaterThanOrEqual(0);
       expect(standingContextIndex).toBeGreaterThanOrEqual(0);
       expect(wakeUpLogIndex).toBeGreaterThanOrEqual(0);
       expect(nestedLoopIndex).toBeGreaterThanOrEqual(0);
       expect(appendIndex).toBeGreaterThanOrEqual(0);
-      expect(freshnessIndex).toBeLessThan(reportReviewIndex);
-      expect(reportReviewIndex).toBeLessThan(releaseStateIndex);
-      expect(releaseStateIndex).toBeLessThan(queueWorkIndex);
-      expect(prompt).toContain("bin/check-factory-runtime-freshness.ts");
-      expect(prompt).toContain("stale `*-idle` state");
-      expect(prompt).toContain(
-        "external instances, do not restart when only unrelated repository files changed",
-      );
-      expect(prompt).toContain(
-        "For self-hosting merges, that should normally surface as runtime drift",
-      );
+      expect(controlStateIndex).toBeGreaterThan(standingContextIndex);
       expect(standingContextIndex).toBeLessThan(appendIndex);
-      expect(prompt).toContain("bin/symphony-report.ts review-pending");
-      expect(prompt).toContain("bin/check-operator-release-state.ts");
-      expect(prompt).toContain("Read the instance-scoped standing context");
+      expect(prompt).toContain("Read `SYMPHONY_OPERATOR_STANDING_CONTEXT`");
+      expect(prompt).toContain(
+        "Treat `SYMPHONY_OPERATOR_CONTROL_STATE` as the code-owned source of truth",
+      );
+      expect(prompt).toContain("pending plan-review and `/land` actions");
       expect(prompt).toContain("SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT");
       expect(prompt).toContain(
-        "selected instance root if they exist, and do not apply `symphony-ts` planning standards",
+        "Do not apply `symphony-ts` planning standards to an external repository",
       );
       expect(prompt).toContain(
         "Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh`",
       );
+      expect(prompt).not.toContain("bin/check-factory-runtime-freshness.ts");
+      expect(prompt).not.toContain("bin/symphony-report.ts review-pending");
+      expect(prompt).not.toContain("bin/check-operator-release-state.ts");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -718,6 +710,57 @@ describe("operator loop workflow selection", () => {
       expect(await fs.readFile(capturePath, "utf8")).toBe(
         path.dirname(workflowPath),
       );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes and exports the operator control-state artifact", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-control-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const capturePath = path.join(tempDir, "control-state-path.txt");
+
+    try {
+      const run = await runOperatorLoopWithOptions(workflowPath, {
+        env: {
+          SYMPHONY_OPERATOR_COMMAND: `node -e ${JSON.stringify(`require("node:fs").writeFileSync(${JSON.stringify(capturePath)}, process.env.SYMPHONY_OPERATOR_CONTROL_STATE ?? "")`)}`,
+        },
+      });
+      createdPaths.add(tempDir);
+      createdPaths.add(run.stateRoot);
+      if (run.logFile !== null) {
+        createdPaths.add(run.logFile);
+      }
+
+      const exportedPath = await fs.readFile(capturePath, "utf8");
+      const controlState = JSON.parse(
+        await fs.readFile(run.controlStatePath, "utf8"),
+      ) as {
+        readonly posture: string;
+        readonly summary: string;
+        readonly actions: {
+          readonly state: string;
+        };
+      };
+      const statusJson = JSON.parse(
+        await fs.readFile(run.statusJsonPath, "utf8"),
+      ) as {
+        readonly operatorControl: {
+          readonly path: string;
+          readonly posture: string;
+          readonly summary: string;
+        };
+      };
+
+      expect(exportedPath).toBe(run.controlStatePath);
+      expect(controlState.posture).toBe("runtime-blocked");
+      expect(controlState.summary).toContain(
+        "Factory is not currently running",
+      );
+      expect(controlState.actions.state).toBe("clear");
+      expect(statusJson.operatorControl.path).toBe(run.controlStatePath);
+      expect(statusJson.operatorControl.posture).toBe("runtime-blocked");
+      expect(statusJson.operatorControl.summary).toBe(controlState.summary);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/operator-control-state.test.ts
+++ b/tests/unit/operator-control-state.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   evaluateOperatorControlState,
+  runtimeCheckpointFromFreshness,
   type OperatorControlActionCandidate,
   type OperatorControlPaths,
   type OperatorControlReleaseCheckpoint,
@@ -96,6 +97,56 @@ function actionCandidate(
 }
 
 describe("evaluateOperatorControlState", () => {
+  it("keeps stale busy runtime drift actionable until the next safe restart checkpoint", () => {
+    const checkpoint = runtimeCheckpointFromFreshness({
+      kind: "stale-runtime-busy",
+      shouldRestart: false,
+      runningRuntimeIdentity: null,
+      currentRuntimeIdentity: null,
+      runtimeHeadSha: "runtime-sha",
+      engineHeadSha: "engine-sha",
+      runningWorkflowIdentity: null,
+      currentWorkflowIdentity: null,
+      runtimeChanged: true,
+      workflowChanged: false,
+      unavailableReasons: [],
+      controlState: "running",
+      factoryState: "running",
+      activeIssueCount: 1,
+      summary:
+        "Factory runtime drift is present, but the factory is busy so restart should wait for a safe checkpoint.",
+    });
+
+    expect(checkpoint.state).toBe("clear");
+    expect(checkpoint.shouldRestart).toBe(false);
+    expect(checkpoint.summary).toContain("restart should wait");
+  });
+
+  it("blocks stale idle runtime drift until the operator restarts the factory", () => {
+    const checkpoint = runtimeCheckpointFromFreshness({
+      kind: "stale-runtime-idle",
+      shouldRestart: true,
+      runningRuntimeIdentity: null,
+      currentRuntimeIdentity: null,
+      runtimeHeadSha: "runtime-sha",
+      engineHeadSha: "engine-sha",
+      runningWorkflowIdentity: null,
+      currentWorkflowIdentity: null,
+      runtimeChanged: true,
+      workflowChanged: false,
+      unavailableReasons: [],
+      controlState: "running",
+      factoryState: "idle",
+      activeIssueCount: 0,
+      summary:
+        "Factory runtime drift is present and the factory is idle, so restart should happen before queue work.",
+    });
+
+    expect(checkpoint.state).toBe("blocked");
+    expect(checkpoint.shouldRestart).toBe(true);
+    expect(checkpoint.summary).toContain("Runtime checkpoint is blocked");
+  });
+
   it("prioritizes runtime blockers over later checkpoints", () => {
     const document = evaluateOperatorControlState({
       updatedAt: "2026-04-08T00:00:00Z",

--- a/tests/unit/operator-control-state.test.ts
+++ b/tests/unit/operator-control-state.test.ts
@@ -1,0 +1,234 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  evaluateOperatorControlState,
+  type OperatorControlActionCandidate,
+  type OperatorControlPaths,
+  type OperatorControlReleaseCheckpoint,
+  type OperatorControlReportReviewCheckpoint,
+  type OperatorControlRuntimeCheckpoint,
+} from "../../src/observability/operator-control-state.js";
+
+const paths: OperatorControlPaths = {
+  operatorRepoRoot: "/operator",
+  selectedInstanceRoot: "/instance",
+  workflowPath: "/instance/WORKFLOW.md",
+  controlStateFile: path.join(
+    "/operator",
+    ".ralph",
+    "instances",
+    "x",
+    "control-state.json",
+  ),
+  releaseStateFile: path.join(
+    "/operator",
+    ".ralph",
+    "instances",
+    "x",
+    "release-state.json",
+  ),
+  reportReviewStateFile: path.join(
+    "/operator",
+    ".ralph",
+    "instances",
+    "x",
+    "report-review-state.json",
+  ),
+};
+
+function runtimeCheckpoint(
+  overrides: Partial<OperatorControlRuntimeCheckpoint> = {},
+): OperatorControlRuntimeCheckpoint {
+  return {
+    kind: "runtime",
+    state: "clear",
+    summary: "Runtime is healthy.",
+    controlState: "running",
+    freshnessKind: "fresh",
+    shouldRestart: false,
+    factoryState: "idle",
+    activeIssueCount: 0,
+    ...overrides,
+  };
+}
+
+function reportReviewCheckpoint(
+  overrides: Partial<OperatorControlReportReviewCheckpoint> = {},
+): OperatorControlReportReviewCheckpoint {
+  return {
+    kind: "report-review",
+    state: "clear",
+    summary: "No pending report reviews.",
+    reviewStateFile: paths.reportReviewStateFile,
+    pending: [],
+    ...overrides,
+  };
+}
+
+function releaseCheckpoint(
+  overrides: Partial<OperatorControlReleaseCheckpoint> = {},
+): OperatorControlReleaseCheckpoint {
+  return {
+    kind: "release",
+    state: "clear",
+    summary: "Release state is clear.",
+    releaseStateFile: paths.releaseStateFile,
+    advancementState: "configured-clear",
+    promotionState: "labels-synchronized",
+    blockingPrerequisiteNumber: null,
+    ...overrides,
+  };
+}
+
+function actionCandidate(
+  overrides: Partial<OperatorControlActionCandidate> = {},
+): OperatorControlActionCandidate {
+  return {
+    kind: "review-plan",
+    issueNumber: 300,
+    issueIdentifier: "sociotechnica-org/symphony-ts#300",
+    title: "Issue 300",
+    sourceStatus: "awaiting-human-handoff",
+    summary: "Review the plan for issue #300.",
+    pullRequestNumber: null,
+    ...overrides,
+  };
+}
+
+describe("evaluateOperatorControlState", () => {
+  it("prioritizes runtime blockers over later checkpoints", () => {
+    const document = evaluateOperatorControlState({
+      updatedAt: "2026-04-08T00:00:00Z",
+      paths,
+      runtime: runtimeCheckpoint({
+        state: "blocked",
+        summary: "Restart before queue work.",
+        freshnessKind: "stale-runtime-idle",
+        shouldRestart: true,
+      }),
+      reportReview: reportReviewCheckpoint({
+        state: "blocked",
+        summary: "Report review is pending.",
+      }),
+      release: releaseCheckpoint({
+        state: "blocked",
+        summary: "Release is blocked.",
+      }),
+      actionCandidates: [actionCandidate()],
+    });
+
+    expect(document.posture).toBe("runtime-blocked");
+    expect(document.blockingCheckpoint).toBe("runtime");
+    expect(document.actions.state).toBe("blocked");
+    expect(document.actions.items[0]?.blockedBy).toBe("runtime");
+  });
+
+  it("blocks on pending completed-run report review before plan review or landing", () => {
+    const document = evaluateOperatorControlState({
+      updatedAt: "2026-04-08T00:00:00Z",
+      paths,
+      runtime: runtimeCheckpoint(),
+      reportReview: reportReviewCheckpoint({
+        state: "blocked",
+        summary: "One report review is pending.",
+        pending: [
+          {
+            issueNumber: 44,
+            issueIdentifier: "sociotechnica-org/symphony-ts#44",
+            issueTitle: "Issue 44",
+            issueOutcome: "succeeded",
+            issueUpdatedAt: "2026-04-08T00:00:00Z",
+            reportGeneratedAt: "2026-04-08T00:00:00Z",
+            reportJsonFile: "/tmp/report.json",
+            reportMarkdownFile: "/tmp/report.md",
+            status: "report-ready",
+            summary: "Issue #44 has a report ready for review.",
+            note: null,
+            blockedStage: null,
+            followUpIssues: [],
+            draftFollowUpIssue: null,
+          },
+        ],
+      }),
+      release: releaseCheckpoint(),
+      actionCandidates: [actionCandidate()],
+    });
+
+    expect(document.posture).toBe("report-review-blocked");
+    expect(document.blockingCheckpoint).toBe("report-review");
+    expect(document.nextActionSummary).toContain("#44");
+    expect(document.actions.items[0]?.state).toBe("blocked");
+  });
+
+  it("surfaces release blockers ahead of landing work", () => {
+    const document = evaluateOperatorControlState({
+      updatedAt: "2026-04-08T00:00:00Z",
+      paths,
+      runtime: runtimeCheckpoint(),
+      reportReview: reportReviewCheckpoint(),
+      release: releaseCheckpoint({
+        state: "blocked",
+        summary: "Release gate blocks downstream landing.",
+        advancementState: "blocked-by-prerequisite-failure",
+        blockingPrerequisiteNumber: 111,
+      }),
+      actionCandidates: [
+        actionCandidate({
+          kind: "post-land-command",
+          sourceStatus: "awaiting-landing-command",
+          issueNumber: 112,
+          issueIdentifier: "sociotechnica-org/symphony-ts#112",
+          summary: "Post /land for PR #112.",
+          pullRequestNumber: 112,
+        }),
+      ],
+    });
+
+    expect(document.posture).toBe("release-blocked");
+    expect(document.blockingCheckpoint).toBe("release");
+    expect(document.actions.items[0]?.blockedBy).toBe("release");
+  });
+
+  it("emits action-required when plan review or landing work is pending", () => {
+    const document = evaluateOperatorControlState({
+      updatedAt: "2026-04-08T00:00:00Z",
+      paths,
+      runtime: runtimeCheckpoint(),
+      reportReview: reportReviewCheckpoint(),
+      release: releaseCheckpoint(),
+      actionCandidates: [
+        actionCandidate(),
+        actionCandidate({
+          kind: "post-land-command",
+          sourceStatus: "awaiting-landing-command",
+          issueNumber: 301,
+          issueIdentifier: "sociotechnica-org/symphony-ts#301",
+          title: "Issue 301",
+          summary: "Post /land for PR #301.",
+          pullRequestNumber: 301,
+        }),
+      ],
+    });
+
+    expect(document.posture).toBe("action-required");
+    expect(document.blockingCheckpoint).toBeNull();
+    expect(document.actions.state).toBe("pending");
+    expect(document.actions.items).toHaveLength(2);
+  });
+
+  it("emits clear when no blockers or operator-gated actions remain", () => {
+    const document = evaluateOperatorControlState({
+      updatedAt: "2026-04-08T00:00:00Z",
+      paths,
+      runtime: runtimeCheckpoint(),
+      reportReview: reportReviewCheckpoint(),
+      release: releaseCheckpoint(),
+      actionCandidates: [],
+    });
+
+    expect(document.posture).toBe("clear");
+    expect(document.blockingCheckpoint).toBeNull();
+    expect(document.nextActionSummary).toBeNull();
+    expect(document.actions.state).toBe("clear");
+  });
+});


### PR DESCRIPTION
## Summary
- move deterministic operator checkpoint logic into a generated `control-state.json` artifact and CLI refresh command
- slim the operator prompt/skill so they consume the control-state surface instead of restating the full checkpoint loop
- publish the control-state path and summary in operator status artifacts and cover the new seam with unit and integration tests

## Testing
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Closes #300.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
