### PR TITLE
Expose operator milestone progress during wake-up cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ machine-readable completed-run review ledger `report-review-state.json`.
 The same state root now also carries `control-state.json`, the generated
 checkpoint snapshot that the operator prompt reads instead of restating the
 entire wake-up algorithm.
+That same operator status surface now also exposes live in-cycle milestone
+progress through an additive `progress` block in `status.json` plus matching
+lines in `status.md`, so long wake-up cycles show which checkpoint last
+advanced and when without overloading `control-state.json`.
 The same operator state root now also carries `release-state.json`, the typed
 record of configured release dependencies plus the current blocked or clear
 release-advancement posture for that instance.

--- a/bin/update-operator-progress.ts
+++ b/bin/update-operator-progress.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  updateOperatorStatusProgress,
+  type OperatorProgressMilestone,
+  type OperatorStatusProgressUpdate,
+} from "../src/observability/operator-status.js";
+
+interface Args {
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+  readonly update: OperatorStatusProgressUpdate;
+}
+
+const validMilestones = new Set<OperatorProgressMilestone>([
+  "cycle-start",
+  "checkpoint-runtime",
+  "checkpoint-report-review",
+  "checkpoint-release",
+  "checkpoint-actions",
+  "landing-issued",
+  "post-landing-follow-through",
+  "post-merge-refresh",
+  "wake-up-log",
+  "cycle-finished",
+  "cycle-failed",
+]);
+
+function parseArgs(argv: readonly string[]): Args {
+  const milestoneValue = readRequiredOptionValue(argv, "--milestone");
+  if (!validMilestones.has(milestoneValue as OperatorProgressMilestone)) {
+    throw new Error(`Unknown operator progress milestone: ${milestoneValue}`);
+  }
+  const statusJsonValue =
+    readOptionalOptionValue(argv, "--status-json") ??
+    process.env.SYMPHONY_OPERATOR_STATUS_JSON;
+  const statusMdValue =
+    readOptionalOptionValue(argv, "--status-md") ??
+    process.env.SYMPHONY_OPERATOR_STATUS_MD;
+  if (!statusJsonValue || !statusMdValue) {
+    throw new Error(
+      "Operator status paths are required via --status-json/--status-md or SYMPHONY_OPERATOR_STATUS_JSON/SYMPHONY_OPERATOR_STATUS_MD.",
+    );
+  }
+
+  return {
+    statusJsonPath: path.resolve(statusJsonValue),
+    statusMdPath: path.resolve(statusMdValue),
+    update: {
+      milestone: milestoneValue as OperatorProgressMilestone,
+      summary: readRequiredOptionValue(argv, "--summary"),
+      relatedIssueNumber: readOptionalNumberOptionValue(argv, "--issue-number"),
+      relatedIssueIdentifier: readOptionalOptionValue(
+        argv,
+        "--issue-identifier",
+      ),
+      relatedPullRequestNumber: readOptionalNumberOptionValue(
+        argv,
+        "--pull-request-number",
+      ),
+    },
+  };
+}
+
+function readRequiredOptionValue(
+  argv: readonly string[],
+  option: string,
+): string {
+  const value = readOptionalOptionValue(argv, option);
+  if (value === null || value.length === 0) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function readOptionalOptionValue(
+  argv: readonly string[],
+  option: string,
+): string | null {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function readOptionalNumberOptionValue(
+  argv: readonly string[],
+  option: string,
+): number | null {
+  const value = readOptionalOptionValue(argv, option);
+  if (value === null) {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer for ${option}`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const snapshot = await updateOperatorStatusProgress(
+    {
+      statusJsonPath: args.statusJsonPath,
+      statusMdPath: args.statusMdPath,
+    },
+    args.update,
+  );
+  process.stdout.write(`${JSON.stringify(snapshot.progress)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/bin/write-operator-status.ts
+++ b/bin/write-operator-status.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  writeOperatorStatusSnapshot,
+  type OperatorStatusSnapshot,
+} from "../src/observability/operator-status.js";
+
+interface Args {
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  return {
+    statusJsonPath: path.resolve(
+      readRequiredOptionValue(argv, "--status-json"),
+    ),
+    statusMdPath: path.resolve(readRequiredOptionValue(argv, "--status-md")),
+  };
+}
+
+function readRequiredOptionValue(
+  argv: readonly string[],
+  option: string,
+): string {
+  const index = argv.indexOf(option);
+  if (index === -1) {
+    throw new Error(`Missing required option ${option}`);
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: string[] = [];
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return chunks.join("");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const snapshot = JSON.parse(await readStdin()) as OperatorStatusSnapshot;
+  await writeOperatorStatusSnapshot(
+    {
+      statusJsonPath: args.statusJsonPath,
+      statusMdPath: args.statusMdPath,
+    },
+    snapshot,
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/docs/plans/344-operator-status-milestones/plan.md
+++ b/docs/plans/344-operator-status-milestones/plan.md
@@ -299,14 +299,14 @@ been published during the active cycle.
 
 ## Failure-Class Matrix
 
-| Observed condition | Local facts available | Expected decision |
-| --- | --- | --- |
-| Active cycle started but no in-cycle milestone has been emitted yet | coarse state is `acting`; progress milestone is `cycle-start` | show active cycle start with the initial timestamp; do not infer a hang yet |
-| Operator command emits a new milestone successfully | updater receives a valid milestone payload | atomically update `status.json` and `status.md` so both surfaces reflect the new checkpoint |
-| Operator command keeps running but milestone timestamp stops advancing | coarse state remains `acting`; last milestone timestamp is old | preserve the last known milestone and timestamp so operators can see "active, no new progress since ..." without auto-failing the cycle |
-| Progress update payload is malformed | helper rejects invalid milestone input | leave the last valid progress entry intact and fail the helper call clearly so the prompt/tooling can be corrected |
-| Operator command exits successfully without any mid-cycle update beyond start | coarse state transitions to `recording` then `idle` | still show final completion state; tests should cover that the surface remains valid even if the command emitted no extra milestones |
-| Operator command exits with failure after partial progress | last valid milestone exists; exit code is non-zero | preserve the last valid milestone, mark the cycle as `failed`, and attach a terminal failure milestone/summary |
+| Observed condition                                                            | Local facts available                                          | Expected decision                                                                                                                       |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Active cycle started but no in-cycle milestone has been emitted yet           | coarse state is `acting`; progress milestone is `cycle-start`  | show active cycle start with the initial timestamp; do not infer a hang yet                                                             |
+| Operator command emits a new milestone successfully                           | updater receives a valid milestone payload                     | atomically update `status.json` and `status.md` so both surfaces reflect the new checkpoint                                             |
+| Operator command keeps running but milestone timestamp stops advancing        | coarse state remains `acting`; last milestone timestamp is old | preserve the last known milestone and timestamp so operators can see "active, no new progress since ..." without auto-failing the cycle |
+| Progress update payload is malformed                                          | helper rejects invalid milestone input                         | leave the last valid progress entry intact and fail the helper call clearly so the prompt/tooling can be corrected                      |
+| Operator command exits successfully without any mid-cycle update beyond start | coarse state transitions to `recording` then `idle`            | still show final completion state; tests should cover that the surface remains valid even if the command emitted no extra milestones    |
+| Operator command exits with failure after partial progress                    | last valid milestone exists; exit code is non-zero             | preserve the last valid milestone, mark the cycle as `failed`, and attach a terminal failure milestone/summary                          |
 
 ## Storage Contract
 

--- a/docs/plans/344-operator-status-milestones/plan.md
+++ b/docs/plans/344-operator-status-milestones/plan.md
@@ -1,0 +1,411 @@
+# Issue 344 Plan: Operator Status Milestone Progress During Wake-Up Cycles
+
+## Status
+
+- plan-ready
+
+## Goal
+
+Make long operator wake-up cycles visibly progressive from the outside so
+`status.json` and `status.md` no longer sit at one coarse `acting` state for
+the full duration of a long `codex` turn.
+
+The intended outcome of this slice is:
+
+1. the operator status surface exposes the current wake-up milestone and the
+   last time progress advanced during an active cycle
+2. progress updates happen as the wake-up crosses major checkpoints such as
+   report review, plan review, landing, post-landing verification, and
+   post-merge refresh
+3. operators can distinguish "still progressing" from "still active but has
+   not emitted a new milestone recently" without reading the raw cycle log
+4. the implementation stays within the current operator-loop seam instead of
+   turning this issue into the broader typed-runtime rewrite tracked elsewhere
+
+## Scope
+
+This slice covers:
+
+1. an additive operator-progress contract inside the existing operator status
+   artifacts
+2. a focused helper path the in-cycle operator command can call to publish
+   milestone updates while the shell is blocked inside the long-running wake-up
+   turn
+3. operator-loop wiring that initializes, preserves, and finalizes the progress
+   section of the status artifacts
+4. checked-in operator prompt and guidance updates that require progress
+   publishing at major wake-up checkpoints
+5. focused unit and integration coverage, including a long-cycle regression
+   that inspects status mid-cycle instead of only after the command exits
+
+## Non-Goals
+
+This slice does not include:
+
+1. moving the operator loop out of shell into a fully typed runtime service
+2. redesigning `control-state.json` or changing its checkpoint-order semantics
+3. replacing the wake-up log with a streaming journal
+4. introducing tracker or GitHub transport changes
+5. adding automated failure or watchdog policy that terminates a cycle solely
+   because milestone updates stop advancing
+
+## Current Gaps
+
+1. `skills/symphony-operator/operator-loop.sh` writes `status.json` and
+   `status.md` before the wake-up command starts and again only after it ends,
+   so long healthy cycles look identical to hangs
+2. the shell cannot observe semantic progress inside the active operator
+   command, so shell-only checkpoint writes are not enough for this issue
+3. the checked-in prompt requires wake-up-log updates only at the end of the
+   cycle, which leaves no in-cycle breadcrumb surface
+4. there is no machine-readable "current milestone" or "last progress at"
+   field in the operator status contract
+5. existing operator-loop integration tests mostly assert end-of-cycle status
+   and do not prove that live progress is visible while the wake-up command is
+   still running
+
+## Decision Notes
+
+1. Keep deterministic checkpoint ordering in `control-state.json`, but do not
+   overload that artifact into the live progress surface. `control-state.json`
+   is the pre-cycle checkpoint decision contract; the missing piece here is
+   in-cycle progress visibility.
+2. Prefer additive fields in the existing `status.json` and `status.md`
+   artifacts over inventing a second status sidecar. Operators already read
+   these files, so the first slice should improve the canonical surface rather
+   than scatter state.
+3. Use a small checked-in helper for progress publication rather than asking
+   the prompt to rewrite JSON and markdown directly. The helper keeps the
+   contract typed, reduces prompt drift, and avoids hand-built shell/JSON edits
+   during long cycles.
+4. Keep this issue at the operator status seam. Do not combine it with the
+   broader operator-architecture migration or prompt-policy redesign.
+
+## Spec Alignment By Abstraction Level
+
+`SPEC.md` is not vendored in this clone, so this plan uses
+`docs/architecture.md`.
+
+### Policy Layer
+
+Belongs here:
+
+1. the repo-owned rule that long wake-up cycles must expose milestone progress
+   through the operator status surface
+2. the rule that operator progress should be visible from routine status reads,
+   not only from raw logs
+3. the rule that checkpoint progress must remain inspectable without changing
+   tracker semantics
+
+Does not belong here:
+
+1. GitHub-specific landing or review transport logic
+2. implicit prompt-only expectations with no code-owned contract
+
+### Configuration Layer
+
+Belongs here:
+
+1. the environment contract that gives the active operator command access to
+   the checked-in progress updater and status artifact paths
+2. any typed status-schema additions needed to keep the progress surface stable
+
+Does not belong here:
+
+1. checkpoint decision logic
+2. ad hoc milestone names embedded only in shell snippets
+
+### Coordination Layer
+
+Belongs here:
+
+1. the normalized milestone vocabulary for one wake-up cycle
+2. the allowed progress transitions across the current wake-up checkpoints
+3. the distinction between coarse loop state (`acting`, `recording`, `idle`,
+   `failed`) and in-cycle milestone progress
+
+Does not belong here:
+
+1. tracker transport changes
+2. long prompt prose as the only definition of milestone sequencing
+
+### Execution Layer
+
+Belongs here:
+
+1. operator-loop initialization and finalization of the progress snapshot
+2. in-cycle helper execution from the active operator command to publish new
+   milestones while the shell is blocked in the command
+3. prompt instructions telling the operator when to emit a milestone update
+
+Does not belong here:
+
+1. provider-specific runner rewrites
+2. shell-only JSON mutation without a typed helper
+
+### Integration Layer
+
+Belongs here:
+
+1. local artifact reads and writes needed to refresh the canonical operator
+   status files safely
+2. reuse of existing operator-local artifacts such as `control-state.json` and
+   release/report-review evidence when composing milestone summaries
+
+Does not belong here:
+
+1. new GitHub API flows
+2. mixing tracker transport, normalization, and operator progress policy in
+   one patch
+
+### Observability Layer
+
+Belongs here:
+
+1. the additive progress block in `status.json`
+2. the corresponding human-readable milestone section in `status.md`
+3. timestamps and summaries that make stalled-looking cycles distinguishable
+   from actively progressing cycles
+4. tests and docs for the user-visible status contract
+
+Does not belong here:
+
+1. silently burying progress only in cycle logs
+2. a second competing status source with different semantics
+
+## Architecture Boundaries
+
+### New focused operator-progress helper/module
+
+Owns:
+
+1. the typed progress payload for the current wake-up cycle
+2. validation and atomic writes for additive status updates
+3. rendering the progress fields into both `status.json` and `status.md`
+
+Does not own:
+
+1. checkpoint ordering decisions
+2. tracker reads or GitHub mutations
+3. wake-up-log persistence
+
+### `skills/symphony-operator/operator-loop.sh`
+
+Owns:
+
+1. initializing progress at cycle start
+2. preserving progress while the operator command is active
+3. finalizing progress on success or failure
+4. exporting the progress updater contract to the operator command
+
+Does not own:
+
+1. hand-built parsing or rendering of milestone payloads beyond passing through
+   the typed helper
+2. the only definition of milestone names and summaries
+
+### `skills/symphony-operator/operator-prompt.md` and `SKILL.md`
+
+Owns:
+
+1. telling the operator to emit milestone updates at major checkpoints
+2. naming the required moments that deserve progress publication, including
+   immediately after `/land` and during post-landing work
+
+Does not own:
+
+1. direct editing of status JSON/markdown
+2. the only machine-readable definition of the progress schema
+
+### Operator docs
+
+Owns:
+
+1. describing how to interpret the new progress fields in routine monitoring
+2. clarifying that `control-state.json` is checkpoint ordering while
+   `status.json` / `status.md` show live in-cycle progress
+
+Does not own:
+
+1. the implementation details of the progress updater
+2. prompt-only behavior without code support
+
+## Slice Strategy And PR Seam
+
+Keep this as one reviewable PR focused on one narrow seam: the operator's live
+status contract during a single wake-up cycle.
+
+This stays reviewable because it limits the work to:
+
+1. one focused operator-progress helper and additive status schema update
+2. targeted `operator-loop.sh` wiring
+3. prompt/skill/docs updates that use the new helper
+4. unit and integration coverage for mid-cycle status visibility
+
+Deferred from this PR:
+
+1. stale-progress watchdog policy that automatically escalates or fails a cycle
+2. append-only in-cycle wake-up-log breadcrumbs
+3. broader shell-to-TypeScript operator runtime migration
+4. any automation that turns operator progress milestones into tracker writes
+
+## Runtime State Model
+
+The progress surface should model one wake-up cycle with two related but
+distinct axes:
+
+1. coarse loop state
+2. in-cycle progress milestone
+
+### Coarse loop state
+
+- `sleeping`
+- `acting`
+- `recording`
+- `idle`
+- `retrying`
+- `failed`
+- `stopping`
+
+### In-cycle milestone state
+
+- `cycle-start`
+- `checkpoint-runtime`
+- `checkpoint-report-review`
+- `checkpoint-release`
+- `checkpoint-actions`
+- `landing-issued`
+- `post-landing-follow-through`
+- `post-merge-refresh`
+- `wake-up-log`
+- `cycle-finished`
+- `cycle-failed`
+
+### Allowed transitions
+
+1. a wake-up enters `acting` with `cycle-start`
+2. while `acting`, milestone updates may advance forward through the checkpoint
+   sequence and may repeat when the operator handles several items in one
+   checkpoint family
+3. after `/land`, the cycle may move from `landing-issued` to
+   `post-landing-follow-through` and then to `post-merge-refresh`
+4. successful completion moves to `recording` and then `idle` with
+   `cycle-finished`
+5. failures move to `failed` with `cycle-failed`
+
+The progress contract should keep the current milestone summary, its timestamp,
+and an optional sequence number so readers can tell whether new progress has
+been published during the active cycle.
+
+## Failure-Class Matrix
+
+| Observed condition | Local facts available | Expected decision |
+| --- | --- | --- |
+| Active cycle started but no in-cycle milestone has been emitted yet | coarse state is `acting`; progress milestone is `cycle-start` | show active cycle start with the initial timestamp; do not infer a hang yet |
+| Operator command emits a new milestone successfully | updater receives a valid milestone payload | atomically update `status.json` and `status.md` so both surfaces reflect the new checkpoint |
+| Operator command keeps running but milestone timestamp stops advancing | coarse state remains `acting`; last milestone timestamp is old | preserve the last known milestone and timestamp so operators can see "active, no new progress since ..." without auto-failing the cycle |
+| Progress update payload is malformed | helper rejects invalid milestone input | leave the last valid progress entry intact and fail the helper call clearly so the prompt/tooling can be corrected |
+| Operator command exits successfully without any mid-cycle update beyond start | coarse state transitions to `recording` then `idle` | still show final completion state; tests should cover that the surface remains valid even if the command emitted no extra milestones |
+| Operator command exits with failure after partial progress | last valid milestone exists; exit code is non-zero | preserve the last valid milestone, mark the cycle as `failed`, and attach a terminal failure milestone/summary |
+
+## Storage Contract
+
+Use the existing operator status artifacts as the canonical storage surface.
+
+Planned contract:
+
+1. add an additive `progress` object to `status.json`
+2. render the same facts in a dedicated progress section inside `status.md`
+3. keep writes atomic so observers never see mismatched partial JSON/markdown
+4. avoid a separate durable store unless the implementation proves the
+   existing status files cannot support safe additive updates
+
+The `progress` object should minimally include:
+
+1. current milestone id
+2. human-readable summary
+3. last-updated timestamp
+4. sequence number or monotonic counter for the current cycle
+5. optional checkpoint family or related issue/PR identifiers when relevant
+
+## Observability Requirements
+
+1. `status.json` must expose enough machine-readable data for tooling to tell
+   which milestone the active wake-up last reached and when it last advanced
+2. `status.md` must surface the same information in a compact operator-facing
+   form
+3. the surface must make `/land` visible as a milestone distinct from later
+   post-landing follow-through
+4. the new fields must be additive and backward-compatible for existing status
+   readers that ignore unknown keys
+5. the status contract must remain understandable without reading the raw
+   operator cycle log
+
+## Implementation Steps
+
+1. Add a focused operator-progress helper under `src/observability/` plus a
+   small checked-in entry point the operator command can call.
+2. Extend the operator status contract and renderer so `status.json` and
+   `status.md` carry additive live-progress fields.
+3. Update `skills/symphony-operator/operator-loop.sh` to:
+   - initialize the progress block at cycle start
+   - export the updater path/contract to the active operator command
+   - finalize progress on success or failure without clobbering the last valid
+     in-cycle milestone
+4. Update `skills/symphony-operator/operator-prompt.md` and
+   `skills/symphony-operator/SKILL.md` so the operator emits milestone updates
+   at each major checkpoint and immediately after `/land`.
+5. Update operator docs where needed so the new live-progress fields and their
+   relationship to `control-state.json` are explicit.
+6. Add focused unit tests for the progress contract and integration coverage
+   for a long-running fake operator command that updates milestones while the
+   loop is still active.
+
+## Tests
+
+1. unit: progress payload validation and status rendering helpers
+2. integration: operator loop publishes initial progress at cycle start
+3. integration: a long-running fake operator command updates progress
+   mid-cycle and the test can read the updated milestone before the command
+   exits
+4. integration: final success preserves the last meaningful milestone and then
+   publishes completion
+5. integration: failure after partial progress surfaces `cycle-failed` without
+   losing the earlier milestone context
+6. regression: existing operator-loop status assertions stay valid aside from
+   the additive fields
+
+## Acceptance Scenarios
+
+1. Given a long wake-up handling completed-run report review, when the operator
+   moves from checkpoint selection into report work, then `status.json` and
+   `status.md` show a report-review milestone before the cycle ends.
+2. Given a wake-up that posts `/land`, when the operator issues the command and
+   continues into post-landing work, then the status surface shows
+   `landing-issued` and later `post-landing-follow-through` instead of staying
+   at one generic `acting` state.
+3. Given a wake-up that reaches post-merge refresh, when the operator is
+   checking runtime freshness and restart needs, then the status surface shows
+   that milestone with a fresh timestamp.
+4. Given a still-running wake-up whose last milestone is several minutes old,
+   when an operator reads `status.json` or `status.md`, then they can see the
+   last known milestone and its timestamp instead of mistaking the cycle for a
+   silently hung process.
+
+## Exit Criteria
+
+1. long operator cycles expose milestone progress through the checked-in status
+   artifacts during the cycle, not only before and after it
+2. `/land` and post-landing follow-through are distinguishable milestones
+3. the prompt and skill rely on the checked-in helper instead of ad hoc status
+   rewrites
+4. unit and integration tests cover mid-cycle progress visibility
+5. docs explain how to interpret the new fields and how they differ from
+   `control-state.json`
+
+## Deferred To Later Issues Or PRs
+
+1. automatic stale-progress classification or watchdog escalation
+2. streaming wake-up-log breadcrumbs during the cycle
+3. broader typed-runtime replacement of the shell operator loop
+4. richer milestone taxonomies if future operator work needs more granularity

--- a/skills/symphony-operator/SKILL.md
+++ b/skills/symphony-operator/SKILL.md
@@ -63,6 +63,12 @@ checkpoint algorithm. When the checked-in prompt and `control-state.json`
 disagree, trust the generated artifact and fix the prompt or code through the
 normal PR flow.
 
+The same status surface now carries live in-cycle milestone progress through an
+additive `progress` block in `status.json` plus matching milestone lines in
+`status.md`. Treat that surface as the operator's live-progress contract during
+long wake-up work; `control-state.json` remains the pre-cycle checkpoint
+ordering contract.
+
 ## Wake-Up Expectations
 
 1. Read the selected instance's standing context first, then the wake-up log.
@@ -74,6 +80,7 @@ normal PR flow.
 7. After posting a plan-review decision or `/land`, verify the factory observes it and transitions correctly.
 8. After a merge, fast-forward the selected instance root to `origin/main`, rerun the freshness checkpoint, and restart only when the runtime engine or selected `WORKFLOW.md` is actually stale.
 9. Use bounded, one-shot probes during the wake-up cycle. Prefer short reads over long-running watchers in the critical path.
+10. During long cycles, publish milestone progress with `pnpm tsx "$SYMPHONY_OPERATOR_PROGRESS_UPDATER" --milestone <id> --summary "<update>"` instead of rewriting status artifacts by hand.
 
 ## Operational Rules
 
@@ -86,6 +93,7 @@ normal PR flow.
 - In a wake-up cycle, favor short, bounded inspection commands over long-running watchers. If a secondary GitHub or watch-surface probe is slow or non-terminal, stop and continue from the latest successful control-surface read instead of waiting indefinitely.
 - Do not start `pnpm operator`, `pnpm operator:once`, or `operator-loop.sh` from inside an active wake-up shell. Use the supported factory-control and status commands instead of nesting the operator loop.
 - Use `pnpm tsx bin/symphony.ts factory watch` for continuous detached monitoring and `pnpm tsx bin/symphony.ts factory attach` when you need the full-screen TUI; do not use raw `screen -r <instance-session-name>` as the normal watch path because `Ctrl-C` there can kill the worker.
+- Use the checked-in progress updater exported as `SYMPHONY_OPERATOR_PROGRESS_UPDATER` for long-cycle milestones such as report review, release gating, plan review, `/land`, post-landing follow-through, post-merge refresh, and wake-up-log publication.
 - Treat `symphony:running` with no live detached runtime or no live runner visibility as an orphaned run and repair it.
 - Prefer `pnpm tsx bin/symphony.ts factory start|stop|restart` over manual `screen` and process cleanup.
 - Treat detached startup locale handling as repo-owned behavior: the supported factory-control path selects an installed UTF-8 locale, launches `screen -U`, and should fail clearly rather than relying on shell-local locale folklore.
@@ -96,6 +104,7 @@ normal PR flow.
 - If a PR's required checks remain non-terminal for an unusually long time but the same behavior can be reproduced locally, do not stop at the first fixed assertion failure. Keep the PR in active operator treatment until the full locally reproducible hang is resolved or reduced to clearly external infrastructure.
 - Keep runner assumptions provider-neutral. The current runtime may use `codex`, `claude-code`, or `generic-command`; do not assume every healthy run appears as a direct `codex exec` child process.
 - Keep release dependency truth in the typed `release-state.json` artifact, not only in markdown notes. Standing context may explain release sequencing, but prerequisite failure gating must remain inspectable through the typed artifact.
+- Keep in-cycle progress truth in the typed operator status surface. `status.json` / `status.md` should show which milestone the wake-up most recently reached and when it last advanced; `control-state.json` should not be overloaded into that live-progress role.
 - Treat plan review as a required operator checkpoint:
   - read the selected workflow's `tracker.plan_review` config first,
   - read the selected instance repository's `OPERATOR.md`, `WORKFLOW.md`, `AGENTS.md`, `README.md`, and relevant docs when they exist,

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -13,6 +13,8 @@ RECORD_OPERATOR_CYCLE="$REPO_ROOT/bin/record-operator-loop-cycle.ts"
 CONTROL_STATE_REFRESHER="$REPO_ROOT/bin/refresh-operator-control-state.ts"
 RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
+WRITE_OPERATOR_STATUS="$REPO_ROOT/bin/write-operator-status.ts"
+UPDATE_OPERATOR_PROGRESS="$REPO_ROOT/bin/update-operator-progress.ts"
 INSTANCE_KEY=""
 DETACHED_SESSION_NAME=""
 SELECTED_INSTANCE_ROOT=""
@@ -405,6 +407,7 @@ record_cycle_failure_before_command() {
   } >>"$log_file"
 
   record_operator_cycle
+  publish_progress "cycle-failed" "$cycle_message"
   write_status "failed" "$cycle_message"
 }
 
@@ -695,8 +698,9 @@ release_active_wake_up_lease() {
 write_status() {
   local state="$1"
   local message="$2"
-  local updated_at
+  local updated_at progress_json
   updated_at="$(now_utc)"
+  progress_json="$(read_current_progress_json)"
   load_release_state_snapshot
   if [ -f "$CONTROL_STATE" ]; then
     local control_state_exports
@@ -750,13 +754,13 @@ for (const [key, value] of Object.entries(defaults)) {
     RELEASE_BLOCKING_PREREQUISITE_NUMBER=""
     RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER=""
   fi
-
-  cat >"$STATUS_JSON" <<EOF
+  cat <<EOF | pnpm tsx "$WRITE_OPERATOR_STATUS" --status-json "$STATUS_JSON" --status-md "$STATUS_MD"
 {
   "version": 1,
   "state": "$(json_escape "$state")",
   "message": "$(json_escape "$message")",
   "updatedAt": "$(json_escape "$updated_at")",
+  "progress": $progress_json,
   "repoRoot": "$(json_escape "$REPO_ROOT")",
   "instanceKey": "$(json_escape "$INSTANCE_KEY")",
   "detachedSessionName": "$(json_escape "$DETACHED_SESSION_NAME")",
@@ -816,56 +820,36 @@ for (const [key, value] of Object.entries(defaults)) {
   "nextWakeAt": $(if [ -n "$NEXT_WAKE_AT" ]; then printf '"%s"' "$(json_escape "$NEXT_WAKE_AT")"; else printf 'null'; fi)
 }
 EOF
+}
 
-  cat >"$STATUS_MD" <<EOF
-# Symphony Operator Loop
+read_current_progress_json() {
+  if [ ! -f "$STATUS_JSON" ]; then
+    printf 'null'
+    return 0
+  fi
 
-- State: $state
-- Message: $message
-- Updated: $updated_at
-- Repo root: $REPO_ROOT
-- Instance key: $INSTANCE_KEY
-- Detached session: $DETACHED_SESSION_NAME
-- Selected instance root: $SELECTED_INSTANCE_ROOT
-- Operator state root: $INSTANCE_STATE_ROOT
-- Mode: $(if [ "$RUN_ONCE" -eq 1 ]; then printf 'once'; else printf 'continuous'; fi)
-- Interval seconds: $INTERVAL_SECONDS
-- Selected workflow: ${WORKFLOW_PATH:-n/a}
-- Provider: $OPERATOR_PROVIDER
-- Model: ${OPERATOR_MODEL:-default}
-- Command source: $OPERATOR_COMMAND_SOURCE
-- Base command: $BASE_OPERATOR_COMMAND
-- Effective command: $EFFECTIVE_OPERATOR_COMMAND
-- Resumable session enabled: $(if [ "$RESUME_SESSION" -eq 1 ]; then printf 'true'; else printf 'false'; fi)
-- Session state: $SESSION_STATE
-- Session mode: $OPERATOR_SESSION_MODE
-- Session summary: $OPERATOR_SESSION_SUMMARY
-- Session backend id: ${OPERATOR_SESSION_ID:-n/a}
-- Session reset reason: ${OPERATOR_SESSION_RESET_REASON:-n/a}
-- Standing context: $STANDING_CONTEXT
-- Wake-up log: $WAKE_UP_LOG
-- Release state: $RELEASE_STATE
-- Release advancement state: $RELEASE_ADVANCEMENT_STATE
-- Release summary: $RELEASE_STATE_SUMMARY
-- Release blocked by prerequisite: ${RELEASE_BLOCKING_PREREQUISITE_IDENTIFIER:-${RELEASE_BLOCKING_PREREQUISITE_NUMBER:-n/a}}
-- Ready promotion state: $READY_PROMOTION_STATE
-- Ready promotion summary: $READY_PROMOTION_SUMMARY
-- Ready promotion eligible issues: ${READY_PROMOTION_ELIGIBLE_ISSUES:-none}
-- Ready promotion added: ${READY_PROMOTION_ADDED:-none}
-- Ready promotion removed: ${READY_PROMOTION_REMOVED:-none}
-- Report review state: $REPORT_REVIEW_STATE
-- Prompt: $PROMPT_FILE
-- Operator control state: $CONTROL_STATE
-- Operator control posture: $OPERATOR_CONTROL_POSTURE
-- Operator control summary: $OPERATOR_CONTROL_SUMMARY
-- Operator control blocking checkpoint: ${OPERATOR_CONTROL_BLOCKING_CHECKPOINT:-none}
-- Operator control next action: ${OPERATOR_CONTROL_NEXT_ACTION_SUMMARY:-n/a}
-- Last cycle started: ${LAST_CYCLE_STARTED_AT:-n/a}
-- Last cycle finished: ${LAST_CYCLE_FINISHED_AT:-n/a}
-- Last cycle exit code: ${LAST_CYCLE_EXIT_CODE:-n/a}
-- Last cycle log: ${LAST_LOG_FILE:-n/a}
-- Next wake: ${NEXT_WAKE_AT:-n/a}
-EOF
+  STATUS_JSON="$STATUS_JSON" node -e '
+const fs = require("node:fs");
+try {
+  const raw = fs.readFileSync(process.env.STATUS_JSON, "utf8");
+  const parsed = JSON.parse(raw);
+  process.stdout.write(JSON.stringify(parsed.progress ?? null));
+} catch (error) {
+  process.stdout.write("null");
+}
+'
+}
+
+publish_progress() {
+  local milestone="$1"
+  local summary="$2"
+  shift 2
+  pnpm tsx "$UPDATE_OPERATOR_PROGRESS" \
+    --status-json "$STATUS_JSON" \
+    --status-md "$STATUS_MD" \
+    --milestone "$milestone" \
+    --summary "$summary" \
+    "$@" >/dev/null
 }
 
 ensure_runtime_paths() {
@@ -1007,6 +991,7 @@ run_cycle() {
   write_cycle_log_header "$log_file"
   emit_terminal_trace "waking up (${OPERATOR_PROVIDER}${OPERATOR_MODEL:+/$OPERATOR_MODEL}; $(describe_cycle_terminal_mode))"
   write_status "acting" "Running operator wake-up cycle"
+  publish_progress "cycle-start" "Wake-up cycle started."
   if ! acquire_active_wake_up_lease; then
     record_cycle_failure_before_command \
       "$log_file" \
@@ -1038,6 +1023,7 @@ run_cycle() {
     export SYMPHONY_OPERATOR_RELEASE_STATE="$RELEASE_STATE"
     export SYMPHONY_OPERATOR_STATUS_JSON="$STATUS_JSON"
     export SYMPHONY_OPERATOR_STATUS_MD="$STATUS_MD"
+    export SYMPHONY_OPERATOR_PROGRESS_UPDATER="$UPDATE_OPERATOR_PROGRESS"
     export SYMPHONY_OPERATOR_LOG_DIR="$LOG_DIR"
     export SYMPHONY_OPERATOR_PROMPT_FILE="$PROMPT_FILE"
     export SYMPHONY_OPERATOR_WORKFLOW_PATH="$WORKFLOW_PATH"
@@ -1072,12 +1058,14 @@ run_cycle() {
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"
+    publish_progress "cycle-finished" "$cycle_message"
     write_status "recording" "$cycle_message"
     # Leave the post-cycle recording state visible briefly before callers
     # transition to the next wait state.
     sleep "$RECORDING_SETTLE_SECONDS"
   else
     cycle_message="Operator cycle failed with exit code $exit_code"
+    publish_progress "cycle-failed" "$cycle_message"
     write_status "failed" "$cycle_message"
   fi
 
@@ -1123,6 +1111,16 @@ fi
 
 if [ ! -f "$RELEASE_STATE_CHECKER" ]; then
   echo "operator-loop: release-state checker not found: $RELEASE_STATE_CHECKER" >&2
+  exit 1
+fi
+
+if [ ! -f "$WRITE_OPERATOR_STATUS" ]; then
+  echo "operator-loop: operator status writer not found: $WRITE_OPERATOR_STATUS" >&2
+  exit 1
+fi
+
+if [ ! -f "$UPDATE_OPERATOR_PROGRESS" ]; then
+  echo "operator-loop: operator progress updater not found: $UPDATE_OPERATOR_PROGRESS" >&2
   exit 1
 fi
 

--- a/skills/symphony-operator/operator-loop.sh
+++ b/skills/symphony-operator/operator-loop.sh
@@ -14,7 +14,7 @@ CONTROL_STATE_REFRESHER="$REPO_ROOT/bin/refresh-operator-control-state.ts"
 RELEASE_STATE_CHECKER="$REPO_ROOT/bin/check-operator-release-state.ts"
 READY_PROMOTER="$REPO_ROOT/bin/promote-operator-ready-issues.ts"
 WRITE_OPERATOR_STATUS="$REPO_ROOT/bin/write-operator-status.ts"
-UPDATE_OPERATOR_PROGRESS="$REPO_ROOT/bin/update-operator-progress.ts"
+UPDATE_OPERATOR_PROGRESS="${SYMPHONY_OPERATOR_PROGRESS_UPDATER_PATH:-$REPO_ROOT/bin/update-operator-progress.ts}"
 INSTANCE_KEY=""
 DETACHED_SESSION_NAME=""
 SELECTED_INSTANCE_ROOT=""
@@ -76,6 +76,7 @@ OPERATOR_CONTROL_POSTURE="runtime-blocked"
 OPERATOR_CONTROL_SUMMARY="Operator control state is unavailable."
 OPERATOR_CONTROL_BLOCKING_CHECKPOINT=""
 OPERATOR_CONTROL_NEXT_ACTION_SUMMARY=""
+PUBLISH_PROGRESS_ERROR=""
 
 usage() {
   cat <<'EOF'
@@ -406,8 +407,12 @@ record_cycle_failure_before_command() {
     printf 'failure=%s\n' "$failure_message"
   } >>"$log_file"
 
+  write_status "failed" "$cycle_message"
+  if ! publish_progress "cycle-failed" "$cycle_message"; then
+    handle_progress_publish_failure "cycle-failed" "$PUBLISH_PROGRESS_ERROR"
+    return 1
+  fi
   record_operator_cycle
-  publish_progress "cycle-failed" "$cycle_message"
   write_status "failed" "$cycle_message"
 }
 
@@ -840,16 +845,60 @@ try {
 '
 }
 
+handle_progress_publish_failure() {
+  local milestone="$1"
+  local error_message="$2"
+  local cycle_message="Operator cycle failed while publishing progress milestone ${milestone}: ${error_message:-unknown error}"
+
+  emit_terminal_trace "$cycle_message"
+  if [ -n "$LAST_LOG_FILE" ]; then
+    {
+      printf 'progress_publish_failure_at=%s\n' "$(now_utc)"
+      printf 'progress_publish_failure_milestone=%s\n' "$milestone"
+      printf 'progress_publish_failure=%s\n' "${error_message:-unknown error}"
+    } >>"$LAST_LOG_FILE"
+  fi
+
+  if [ -z "$LAST_CYCLE_FINISHED_AT" ]; then
+    LAST_CYCLE_FINISHED_AT="$(now_utc)"
+  fi
+  if [ -z "$LAST_CYCLE_EXIT_CODE" ] || [ "$LAST_CYCLE_EXIT_CODE" -eq 0 ]; then
+    LAST_CYCLE_EXIT_CODE="1"
+  fi
+
+  if [ -n "$LAST_CYCLE_STARTED_AT" ] && [ -n "$LAST_LOG_FILE" ]; then
+    record_operator_cycle
+  fi
+  write_status "failed" "$cycle_message"
+}
+
 publish_progress() {
   local milestone="$1"
   local summary="$2"
+  local publish_output publish_status
   shift 2
-  pnpm tsx "$UPDATE_OPERATOR_PROGRESS" \
-    --status-json "$STATUS_JSON" \
-    --status-md "$STATUS_MD" \
-    --milestone "$milestone" \
-    --summary "$summary" \
-    "$@" >/dev/null
+
+  PUBLISH_PROGRESS_ERROR=""
+  set +e
+  publish_output="$(
+    pnpm tsx "$UPDATE_OPERATOR_PROGRESS" \
+      --status-json "$STATUS_JSON" \
+      --status-md "$STATUS_MD" \
+      --milestone "$milestone" \
+      --summary "$summary" \
+      "$@" 2>&1 >/dev/null
+  )"
+  publish_status=$?
+  set -e
+
+  if [ "$publish_status" -ne 0 ]; then
+    publish_output="$(printf '%s' "$publish_output" | tr '\r\n' ' ' | tr -s ' ')"
+    PUBLISH_PROGRESS_ERROR="${publish_output:-unknown error}"
+    echo "operator-loop: failed to publish progress milestone ${milestone}: $PUBLISH_PROGRESS_ERROR" >&2
+    return "$publish_status"
+  fi
+
+  return 0
 }
 
 ensure_runtime_paths() {
@@ -991,7 +1040,10 @@ run_cycle() {
   write_cycle_log_header "$log_file"
   emit_terminal_trace "waking up (${OPERATOR_PROVIDER}${OPERATOR_MODEL:+/$OPERATOR_MODEL}; $(describe_cycle_terminal_mode))"
   write_status "acting" "Running operator wake-up cycle"
-  publish_progress "cycle-start" "Wake-up cycle started."
+  if ! publish_progress "cycle-start" "Wake-up cycle started."; then
+    handle_progress_publish_failure "cycle-start" "$PUBLISH_PROGRESS_ERROR"
+    return 1
+  fi
   if ! acquire_active_wake_up_lease; then
     record_cycle_failure_before_command \
       "$log_file" \
@@ -1045,7 +1097,6 @@ run_cycle() {
 
   LAST_CYCLE_FINISHED_AT="$(now_utc)"
   LAST_CYCLE_EXIT_CODE="$exit_code"
-  record_operator_cycle
   if ! refresh_release_state_nonfatal; then
     :
   fi
@@ -1058,14 +1109,24 @@ run_cycle() {
 
   if [ "$exit_code" -eq 0 ]; then
     cycle_message="Operator cycle completed successfully"
-    publish_progress "cycle-finished" "$cycle_message"
+    write_status "recording" "$cycle_message"
+    if ! publish_progress "cycle-finished" "$cycle_message"; then
+      handle_progress_publish_failure "cycle-finished" "$PUBLISH_PROGRESS_ERROR"
+      return 1
+    fi
+    record_operator_cycle
     write_status "recording" "$cycle_message"
     # Leave the post-cycle recording state visible briefly before callers
     # transition to the next wait state.
     sleep "$RECORDING_SETTLE_SECONDS"
   else
     cycle_message="Operator cycle failed with exit code $exit_code"
-    publish_progress "cycle-failed" "$cycle_message"
+    write_status "failed" "$cycle_message"
+    if ! publish_progress "cycle-failed" "$cycle_message"; then
+      handle_progress_publish_failure "cycle-failed" "$PUBLISH_PROGRESS_ERROR"
+      return 1
+    fi
+    record_operator_cycle
     write_status "failed" "$cycle_message"
   fi
 

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -40,6 +40,13 @@ Operational constraints:
 - Keep runner assumptions provider-neutral; the factory may use `codex`, `claude-code`, or `generic-command`.
 - If durable repo changes are required, make them through the normal branch/PR flow instead of leaving the fix only in local notes.
 
+Status progress:
+
+- Use `SYMPHONY_OPERATOR_PROGRESS_UPDATER` to publish milestone updates during long wake-up work instead of editing `status.json` or `status.md` directly.
+- Run it as `pnpm tsx "$SYMPHONY_OPERATOR_PROGRESS_UPDATER" --milestone <milestone-id> --summary "<what changed>"` and include `--issue-number`, `--issue-identifier`, or `--pull-request-number` when they make the checkpoint clearer.
+- Publish a milestone when you enter completed-run report review work, release/prerequisite handling, plan-review or `/land` action work, immediately after posting `/land`, during post-landing follow-through, during post-merge refresh, and when writing the wake-up log after a long cycle.
+- Use only the checked-in milestone ids: `checkpoint-runtime`, `checkpoint-report-review`, `checkpoint-release`, `checkpoint-actions`, `landing-issued`, `post-landing-follow-through`, `post-merge-refresh`, and `wake-up-log`.
+
 Before finishing the cycle:
 
 1. Append a timestamped entry to `SYMPHONY_OPERATOR_WAKE_UP_LOG`.

--- a/src/observability/operator-status.ts
+++ b/src/observability/operator-status.ts
@@ -26,6 +26,31 @@ export type OperatorProgressMilestone =
   | "cycle-finished"
   | "cycle-failed";
 
+const validOperatorLoopStates = new Set<OperatorLoopState>([
+  "acquiring-lock",
+  "sleeping",
+  "acting",
+  "recording",
+  "idle",
+  "retrying",
+  "failed",
+  "stopping",
+]);
+
+const validOperatorProgressMilestones = new Set<OperatorProgressMilestone>([
+  "cycle-start",
+  "checkpoint-runtime",
+  "checkpoint-report-review",
+  "checkpoint-release",
+  "checkpoint-actions",
+  "landing-issued",
+  "post-landing-follow-through",
+  "post-merge-refresh",
+  "wake-up-log",
+  "cycle-finished",
+  "cycle-failed",
+]);
+
 export interface OperatorStatusProgressSnapshot {
   readonly milestone: OperatorProgressMilestone;
   readonly summary: string;
@@ -149,6 +174,427 @@ function renderProgressRelation(
   return [issue, pullRequest].filter((value) => value !== null).join(" / ");
 }
 
+function expectRecord(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectString(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): string {
+  if (typeof value !== "string") {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return value;
+}
+
+function expectNullableString(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): string | null {
+  if (value === null) {
+    return null;
+  }
+  return expectString(value, filePath, fieldPath);
+}
+
+function expectBoolean(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return value;
+}
+
+function expectInteger(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return value as number;
+}
+
+function expectNullableInteger(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): number | null {
+  if (value === null) {
+    return null;
+  }
+  return expectInteger(value, filePath, fieldPath);
+}
+
+function expectIntegerArray(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): readonly number[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => !Number.isInteger(entry))
+  ) {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return value as readonly number[];
+}
+
+function parseOperatorLoopState(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): OperatorLoopState {
+  const state = expectString(value, filePath, fieldPath);
+  if (!validOperatorLoopStates.has(state as OperatorLoopState)) {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return state as OperatorLoopState;
+}
+
+function parseOperatorProgressMilestone(
+  value: unknown,
+  filePath: string,
+  fieldPath: string,
+): OperatorProgressMilestone {
+  const milestone = expectString(value, filePath, fieldPath);
+  if (
+    !validOperatorProgressMilestones.has(milestone as OperatorProgressMilestone)
+  ) {
+    throw new Error(
+      `Malformed ${fieldPath} in operator status snapshot at ${filePath}`,
+    );
+  }
+  return milestone as OperatorProgressMilestone;
+}
+
+function parseOperatorStatusProgressSnapshot(
+  value: unknown,
+  filePath: string,
+): OperatorStatusProgressSnapshot | null {
+  if (value === null) {
+    return null;
+  }
+  const progress = expectRecord(value, filePath, "progress");
+  return {
+    milestone: parseOperatorProgressMilestone(
+      progress.milestone,
+      filePath,
+      "progress.milestone",
+    ),
+    summary: expectString(progress.summary, filePath, "progress.summary"),
+    updatedAt: expectString(progress.updatedAt, filePath, "progress.updatedAt"),
+    sequence: expectInteger(progress.sequence, filePath, "progress.sequence"),
+    relatedIssueNumber: expectNullableInteger(
+      progress.relatedIssueNumber,
+      filePath,
+      "progress.relatedIssueNumber",
+    ),
+    relatedIssueIdentifier: expectNullableString(
+      progress.relatedIssueIdentifier,
+      filePath,
+      "progress.relatedIssueIdentifier",
+    ),
+    relatedPullRequestNumber: expectNullableInteger(
+      progress.relatedPullRequestNumber,
+      filePath,
+      "progress.relatedPullRequestNumber",
+    ),
+    previousMilestone:
+      progress.previousMilestone === null
+        ? null
+        : parseOperatorProgressMilestone(
+            progress.previousMilestone,
+            filePath,
+            "progress.previousMilestone",
+          ),
+    previousSummary: expectNullableString(
+      progress.previousSummary,
+      filePath,
+      "progress.previousSummary",
+    ),
+    previousUpdatedAt: expectNullableString(
+      progress.previousUpdatedAt,
+      filePath,
+      "progress.previousUpdatedAt",
+    ),
+  };
+}
+
+function parseOperatorStatusSnapshot(
+  value: unknown,
+  filePath: string,
+): OperatorStatusSnapshot {
+  const snapshot = expectRecord(value, filePath, "root");
+  const operatorControl = expectRecord(
+    snapshot.operatorControl,
+    filePath,
+    "operatorControl",
+  );
+  const operatorSession = expectRecord(
+    snapshot.operatorSession,
+    filePath,
+    "operatorSession",
+  );
+  const releaseState = expectRecord(
+    snapshot.releaseState,
+    filePath,
+    "releaseState",
+  );
+  const releasePromotion = expectRecord(
+    releaseState.promotion,
+    filePath,
+    "releaseState.promotion",
+  );
+  const lastCycle = expectRecord(snapshot.lastCycle, filePath, "lastCycle");
+
+  const version = expectInteger(snapshot.version, filePath, "version");
+  if (version !== OPERATOR_STATUS_SCHEMA_VERSION) {
+    throw new Error(
+      `Malformed version in operator status snapshot at ${filePath}`,
+    );
+  }
+
+  return {
+    version: OPERATOR_STATUS_SCHEMA_VERSION,
+    state: parseOperatorLoopState(snapshot.state, filePath, "state"),
+    message: expectString(snapshot.message, filePath, "message"),
+    updatedAt: expectString(snapshot.updatedAt, filePath, "updatedAt"),
+    progress: parseOperatorStatusProgressSnapshot(snapshot.progress, filePath),
+    repoRoot: expectString(snapshot.repoRoot, filePath, "repoRoot"),
+    instanceKey: expectString(snapshot.instanceKey, filePath, "instanceKey"),
+    detachedSessionName: expectString(
+      snapshot.detachedSessionName,
+      filePath,
+      "detachedSessionName",
+    ),
+    selectedInstanceRoot: expectString(
+      snapshot.selectedInstanceRoot,
+      filePath,
+      "selectedInstanceRoot",
+    ),
+    operatorStateRoot: expectString(
+      snapshot.operatorStateRoot,
+      filePath,
+      "operatorStateRoot",
+    ),
+    pid: expectInteger(snapshot.pid, filePath, "pid"),
+    runOnce: expectBoolean(snapshot.runOnce, filePath, "runOnce"),
+    intervalSeconds: expectInteger(
+      snapshot.intervalSeconds,
+      filePath,
+      "intervalSeconds",
+    ),
+    provider: expectString(snapshot.provider, filePath, "provider"),
+    model: expectNullableString(snapshot.model, filePath, "model"),
+    commandSource: expectString(
+      snapshot.commandSource,
+      filePath,
+      "commandSource",
+    ),
+    command: expectString(snapshot.command, filePath, "command"),
+    effectiveCommand: expectString(
+      snapshot.effectiveCommand,
+      filePath,
+      "effectiveCommand",
+    ),
+    promptFile: expectString(snapshot.promptFile, filePath, "promptFile"),
+    operatorControl: {
+      path: expectString(
+        operatorControl.path,
+        filePath,
+        "operatorControl.path",
+      ),
+      posture: expectString(
+        operatorControl.posture,
+        filePath,
+        "operatorControl.posture",
+      ),
+      summary: expectString(
+        operatorControl.summary,
+        filePath,
+        "operatorControl.summary",
+      ),
+      blockingCheckpoint: expectNullableString(
+        operatorControl.blockingCheckpoint,
+        filePath,
+        "operatorControl.blockingCheckpoint",
+      ),
+      nextActionSummary: expectNullableString(
+        operatorControl.nextActionSummary,
+        filePath,
+        "operatorControl.nextActionSummary",
+      ),
+    },
+    standingContext: expectString(
+      snapshot.standingContext,
+      filePath,
+      "standingContext",
+    ),
+    wakeUpLog: expectString(snapshot.wakeUpLog, filePath, "wakeUpLog"),
+    operatorSession: {
+      enabled: expectBoolean(
+        operatorSession.enabled,
+        filePath,
+        "operatorSession.enabled",
+      ),
+      path: expectString(
+        operatorSession.path,
+        filePath,
+        "operatorSession.path",
+      ),
+      mode: expectString(
+        operatorSession.mode,
+        filePath,
+        "operatorSession.mode",
+      ),
+      summary: expectString(
+        operatorSession.summary,
+        filePath,
+        "operatorSession.summary",
+      ),
+      backendSessionId: expectNullableString(
+        operatorSession.backendSessionId,
+        filePath,
+        "operatorSession.backendSessionId",
+      ),
+      resetReason: expectNullableString(
+        operatorSession.resetReason,
+        filePath,
+        "operatorSession.resetReason",
+      ),
+    },
+    releaseState: {
+      path: expectString(releaseState.path, filePath, "releaseState.path"),
+      releaseId: expectNullableString(
+        releaseState.releaseId,
+        filePath,
+        "releaseState.releaseId",
+      ),
+      advancementState: expectString(
+        releaseState.advancementState,
+        filePath,
+        "releaseState.advancementState",
+      ),
+      summary: expectString(
+        releaseState.summary,
+        filePath,
+        "releaseState.summary",
+      ),
+      updatedAt: expectNullableString(
+        releaseState.updatedAt,
+        filePath,
+        "releaseState.updatedAt",
+      ),
+      blockingPrerequisiteNumber: expectNullableInteger(
+        releaseState.blockingPrerequisiteNumber,
+        filePath,
+        "releaseState.blockingPrerequisiteNumber",
+      ),
+      blockingPrerequisiteIdentifier: expectNullableString(
+        releaseState.blockingPrerequisiteIdentifier,
+        filePath,
+        "releaseState.blockingPrerequisiteIdentifier",
+      ),
+      promotion: {
+        state: expectString(
+          releasePromotion.state,
+          filePath,
+          "releaseState.promotion.state",
+        ),
+        summary: expectString(
+          releasePromotion.summary,
+          filePath,
+          "releaseState.promotion.summary",
+        ),
+        updatedAt: expectNullableString(
+          releasePromotion.updatedAt,
+          filePath,
+          "releaseState.promotion.updatedAt",
+        ),
+        eligibleIssueNumbers: expectIntegerArray(
+          releasePromotion.eligibleIssueNumbers,
+          filePath,
+          "releaseState.promotion.eligibleIssueNumbers",
+        ),
+        readyLabelsAdded: expectIntegerArray(
+          releasePromotion.readyLabelsAdded,
+          filePath,
+          "releaseState.promotion.readyLabelsAdded",
+        ),
+        readyLabelsRemoved: expectIntegerArray(
+          releasePromotion.readyLabelsRemoved,
+          filePath,
+          "releaseState.promotion.readyLabelsRemoved",
+        ),
+      },
+    },
+    reportReviewState: expectString(
+      snapshot.reportReviewState,
+      filePath,
+      "reportReviewState",
+    ),
+    selectedWorkflowPath: expectNullableString(
+      snapshot.selectedWorkflowPath,
+      filePath,
+      "selectedWorkflowPath",
+    ),
+    lastCycle: {
+      startedAt: expectNullableString(
+        lastCycle.startedAt,
+        filePath,
+        "lastCycle.startedAt",
+      ),
+      finishedAt: expectNullableString(
+        lastCycle.finishedAt,
+        filePath,
+        "lastCycle.finishedAt",
+      ),
+      exitCode: expectNullableInteger(
+        lastCycle.exitCode,
+        filePath,
+        "lastCycle.exitCode",
+      ),
+      logFile: expectNullableString(
+        lastCycle.logFile,
+        filePath,
+        "lastCycle.logFile",
+      ),
+    },
+    nextWakeAt: expectNullableString(
+      snapshot.nextWakeAt,
+      filePath,
+      "nextWakeAt",
+    ),
+  };
+}
+
 export function renderOperatorStatusSnapshot(
   snapshot: OperatorStatusSnapshot,
 ): string {
@@ -242,20 +688,17 @@ export async function writeOperatorStatusSnapshot(
 export async function readOperatorStatusSnapshot(
   filePath: string,
 ): Promise<OperatorStatusSnapshot> {
-  const parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    !("state" in parsed) ||
-    typeof parsed.state !== "string" ||
-    !("message" in parsed) ||
-    typeof parsed.message !== "string" ||
-    !("updatedAt" in parsed) ||
-    typeof parsed.updatedAt !== "string"
-  ) {
-    throw new Error(`Malformed operator status snapshot at ${filePath}`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse operator status snapshot at ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
-  return parsed as OperatorStatusSnapshot;
+  return parseOperatorStatusSnapshot(parsed, filePath);
 }
 
 export function advanceOperatorStatusProgress(args: {
@@ -263,11 +706,15 @@ export function advanceOperatorStatusProgress(args: {
   readonly update: OperatorStatusProgressUpdate;
 }): OperatorStatusProgressSnapshot {
   const updatedAt = args.update.updatedAt ?? new Date().toISOString();
+  const sequence =
+    args.update.milestone === "cycle-start"
+      ? 1
+      : (args.current?.sequence ?? 0) + 1;
   return {
     milestone: args.update.milestone,
     summary: args.update.summary,
     updatedAt,
-    sequence: (args.current?.sequence ?? 0) + 1,
+    sequence,
     relatedIssueNumber: args.update.relatedIssueNumber ?? null,
     relatedIssueIdentifier: args.update.relatedIssueIdentifier ?? null,
     relatedPullRequestNumber: args.update.relatedPullRequestNumber ?? null,

--- a/src/observability/operator-status.ts
+++ b/src/observability/operator-status.ts
@@ -1,0 +1,299 @@
+import fs from "node:fs/promises";
+import { writeJsonFileAtomic, writeTextFileAtomic } from "./atomic-file.js";
+
+export const OPERATOR_STATUS_SCHEMA_VERSION = 1 as const;
+
+export type OperatorLoopState =
+  | "acquiring-lock"
+  | "sleeping"
+  | "acting"
+  | "recording"
+  | "idle"
+  | "retrying"
+  | "failed"
+  | "stopping";
+
+export type OperatorProgressMilestone =
+  | "cycle-start"
+  | "checkpoint-runtime"
+  | "checkpoint-report-review"
+  | "checkpoint-release"
+  | "checkpoint-actions"
+  | "landing-issued"
+  | "post-landing-follow-through"
+  | "post-merge-refresh"
+  | "wake-up-log"
+  | "cycle-finished"
+  | "cycle-failed";
+
+export interface OperatorStatusProgressSnapshot {
+  readonly milestone: OperatorProgressMilestone;
+  readonly summary: string;
+  readonly updatedAt: string;
+  readonly sequence: number;
+  readonly relatedIssueNumber: number | null;
+  readonly relatedIssueIdentifier: string | null;
+  readonly relatedPullRequestNumber: number | null;
+  readonly previousMilestone: OperatorProgressMilestone | null;
+  readonly previousSummary: string | null;
+  readonly previousUpdatedAt: string | null;
+}
+
+export interface OperatorStatusSnapshot {
+  readonly version: typeof OPERATOR_STATUS_SCHEMA_VERSION;
+  readonly state: OperatorLoopState;
+  readonly message: string;
+  readonly updatedAt: string;
+  readonly progress: OperatorStatusProgressSnapshot | null;
+  readonly repoRoot: string;
+  readonly instanceKey: string;
+  readonly detachedSessionName: string;
+  readonly selectedInstanceRoot: string;
+  readonly operatorStateRoot: string;
+  readonly pid: number;
+  readonly runOnce: boolean;
+  readonly intervalSeconds: number;
+  readonly provider: string;
+  readonly model: string | null;
+  readonly commandSource: string;
+  readonly command: string;
+  readonly effectiveCommand: string;
+  readonly promptFile: string;
+  readonly operatorControl: {
+    readonly path: string;
+    readonly posture: string;
+    readonly summary: string;
+    readonly blockingCheckpoint: string | null;
+    readonly nextActionSummary: string | null;
+  };
+  readonly standingContext: string;
+  readonly wakeUpLog: string;
+  readonly operatorSession: {
+    readonly enabled: boolean;
+    readonly path: string;
+    readonly mode: string;
+    readonly summary: string;
+    readonly backendSessionId: string | null;
+    readonly resetReason: string | null;
+  };
+  readonly releaseState: {
+    readonly path: string;
+    readonly releaseId: string | null;
+    readonly advancementState: string;
+    readonly summary: string;
+    readonly updatedAt: string | null;
+    readonly blockingPrerequisiteNumber: number | null;
+    readonly blockingPrerequisiteIdentifier: string | null;
+    readonly promotion: {
+      readonly state: string;
+      readonly summary: string;
+      readonly updatedAt: string | null;
+      readonly eligibleIssueNumbers: readonly number[];
+      readonly readyLabelsAdded: readonly number[];
+      readonly readyLabelsRemoved: readonly number[];
+    };
+  };
+  readonly reportReviewState: string;
+  readonly selectedWorkflowPath: string | null;
+  readonly lastCycle: {
+    readonly startedAt: string | null;
+    readonly finishedAt: string | null;
+    readonly exitCode: number | null;
+    readonly logFile: string | null;
+  };
+  readonly nextWakeAt: string | null;
+}
+
+export interface OperatorStatusProgressUpdate {
+  readonly milestone: OperatorProgressMilestone;
+  readonly summary: string;
+  readonly updatedAt?: string | undefined;
+  readonly relatedIssueNumber?: number | null | undefined;
+  readonly relatedIssueIdentifier?: string | null | undefined;
+  readonly relatedPullRequestNumber?: number | null | undefined;
+}
+
+export interface OperatorStatusPaths {
+  readonly statusJsonPath: string;
+  readonly statusMdPath: string;
+}
+
+function nullable(value: string | null | undefined, fallback = "n/a"): string {
+  return value ?? fallback;
+}
+
+function renderNumberList(values: readonly number[]): string {
+  return values.length === 0
+    ? "none"
+    : values.map((value) => value.toString()).join(",");
+}
+
+function renderProgressRelation(
+  progress: OperatorStatusProgressSnapshot | null,
+): string {
+  if (progress === null) {
+    return "none";
+  }
+  const issue =
+    progress.relatedIssueIdentifier ??
+    (progress.relatedIssueNumber === null
+      ? null
+      : `#${progress.relatedIssueNumber.toString()}`);
+  const pullRequest =
+    progress.relatedPullRequestNumber === null
+      ? null
+      : `PR #${progress.relatedPullRequestNumber.toString()}`;
+  if (issue === null && pullRequest === null) {
+    return "none";
+  }
+  return [issue, pullRequest].filter((value) => value !== null).join(" / ");
+}
+
+export function renderOperatorStatusSnapshot(
+  snapshot: OperatorStatusSnapshot,
+): string {
+  return [
+    "# Symphony Operator Loop",
+    "",
+    `- State: ${snapshot.state}`,
+    `- Message: ${snapshot.message}`,
+    `- Updated: ${snapshot.updatedAt}`,
+    `- Progress milestone: ${snapshot.progress?.milestone ?? "none"}`,
+    `- Progress summary: ${snapshot.progress?.summary ?? "No cycle progress has been published yet."}`,
+    `- Progress updated: ${snapshot.progress?.updatedAt ?? "n/a"}`,
+    `- Progress sequence: ${snapshot.progress?.sequence.toString() ?? "n/a"}`,
+    `- Progress subject: ${renderProgressRelation(snapshot.progress)}`,
+    `- Previous progress milestone: ${snapshot.progress?.previousMilestone ?? "none"}`,
+    `- Previous progress summary: ${snapshot.progress?.previousSummary ?? "n/a"}`,
+    `- Previous progress updated: ${snapshot.progress?.previousUpdatedAt ?? "n/a"}`,
+    `- Repo root: ${snapshot.repoRoot}`,
+    `- Instance key: ${snapshot.instanceKey}`,
+    `- Detached session: ${snapshot.detachedSessionName}`,
+    `- Selected instance root: ${snapshot.selectedInstanceRoot}`,
+    `- Operator state root: ${snapshot.operatorStateRoot}`,
+    `- Mode: ${snapshot.runOnce ? "once" : "continuous"}`,
+    `- Interval seconds: ${snapshot.intervalSeconds.toString()}`,
+    `- Selected workflow: ${snapshot.selectedWorkflowPath ?? "n/a"}`,
+    `- Provider: ${snapshot.provider}`,
+    `- Model: ${snapshot.model ?? "default"}`,
+    `- Command source: ${snapshot.commandSource}`,
+    `- Base command: ${snapshot.command}`,
+    `- Effective command: ${snapshot.effectiveCommand}`,
+    `- Resumable session enabled: ${snapshot.operatorSession.enabled ? "true" : "false"}`,
+    `- Session state: ${snapshot.operatorSession.path}`,
+    `- Session mode: ${snapshot.operatorSession.mode}`,
+    `- Session summary: ${snapshot.operatorSession.summary}`,
+    `- Session backend id: ${snapshot.operatorSession.backendSessionId ?? "n/a"}`,
+    `- Session reset reason: ${snapshot.operatorSession.resetReason ?? "n/a"}`,
+    `- Standing context: ${snapshot.standingContext}`,
+    `- Wake-up log: ${snapshot.wakeUpLog}`,
+    `- Release state: ${snapshot.releaseState.path}`,
+    `- Release advancement state: ${snapshot.releaseState.advancementState}`,
+    `- Release summary: ${snapshot.releaseState.summary}`,
+    `- Release blocked by prerequisite: ${
+      snapshot.releaseState.blockingPrerequisiteIdentifier ??
+      snapshot.releaseState.blockingPrerequisiteNumber?.toString() ??
+      "n/a"
+    }`,
+    `- Ready promotion state: ${snapshot.releaseState.promotion.state}`,
+    `- Ready promotion summary: ${snapshot.releaseState.promotion.summary}`,
+    `- Ready promotion eligible issues: ${renderNumberList(snapshot.releaseState.promotion.eligibleIssueNumbers)}`,
+    `- Ready promotion added: ${renderNumberList(snapshot.releaseState.promotion.readyLabelsAdded)}`,
+    `- Ready promotion removed: ${renderNumberList(snapshot.releaseState.promotion.readyLabelsRemoved)}`,
+    `- Report review state: ${snapshot.reportReviewState}`,
+    `- Prompt: ${snapshot.promptFile}`,
+    `- Operator control state: ${snapshot.operatorControl.path}`,
+    `- Operator control posture: ${snapshot.operatorControl.posture}`,
+    `- Operator control summary: ${snapshot.operatorControl.summary}`,
+    `- Operator control blocking checkpoint: ${
+      snapshot.operatorControl.blockingCheckpoint ?? "none"
+    }`,
+    `- Operator control next action: ${
+      snapshot.operatorControl.nextActionSummary ?? "n/a"
+    }`,
+    `- Last cycle started: ${nullable(snapshot.lastCycle.startedAt)}`,
+    `- Last cycle finished: ${nullable(snapshot.lastCycle.finishedAt)}`,
+    `- Last cycle exit code: ${
+      snapshot.lastCycle.exitCode === null
+        ? "n/a"
+        : snapshot.lastCycle.exitCode.toString()
+    }`,
+    `- Last cycle log: ${nullable(snapshot.lastCycle.logFile)}`,
+    `- Next wake: ${nullable(snapshot.nextWakeAt)}`,
+  ].join("\n");
+}
+
+export async function writeOperatorStatusSnapshot(
+  paths: OperatorStatusPaths,
+  snapshot: OperatorStatusSnapshot,
+): Promise<void> {
+  await writeJsonFileAtomic(paths.statusJsonPath, snapshot, {
+    tempPrefix: ".operator-status",
+  });
+  await writeTextFileAtomic(
+    paths.statusMdPath,
+    `${renderOperatorStatusSnapshot(snapshot)}\n`,
+    {
+      tempPrefix: ".operator-status",
+    },
+  );
+}
+
+export async function readOperatorStatusSnapshot(
+  filePath: string,
+): Promise<OperatorStatusSnapshot> {
+  const parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("state" in parsed) ||
+    typeof parsed.state !== "string" ||
+    !("message" in parsed) ||
+    typeof parsed.message !== "string" ||
+    !("updatedAt" in parsed) ||
+    typeof parsed.updatedAt !== "string"
+  ) {
+    throw new Error(`Malformed operator status snapshot at ${filePath}`);
+  }
+  return parsed as OperatorStatusSnapshot;
+}
+
+export function advanceOperatorStatusProgress(args: {
+  readonly current: OperatorStatusProgressSnapshot | null;
+  readonly update: OperatorStatusProgressUpdate;
+}): OperatorStatusProgressSnapshot {
+  const updatedAt = args.update.updatedAt ?? new Date().toISOString();
+  return {
+    milestone: args.update.milestone,
+    summary: args.update.summary,
+    updatedAt,
+    sequence: (args.current?.sequence ?? 0) + 1,
+    relatedIssueNumber: args.update.relatedIssueNumber ?? null,
+    relatedIssueIdentifier: args.update.relatedIssueIdentifier ?? null,
+    relatedPullRequestNumber: args.update.relatedPullRequestNumber ?? null,
+    previousMilestone: args.current?.milestone ?? null,
+    previousSummary: args.current?.summary ?? null,
+    previousUpdatedAt: args.current?.updatedAt ?? null,
+  };
+}
+
+export async function updateOperatorStatusProgress(
+  paths: OperatorStatusPaths,
+  update: OperatorStatusProgressUpdate,
+): Promise<OperatorStatusSnapshot> {
+  const snapshot = await readOperatorStatusSnapshot(paths.statusJsonPath);
+  const nextUpdatedAt = update.updatedAt ?? new Date().toISOString();
+  const nextSnapshot: OperatorStatusSnapshot = {
+    ...snapshot,
+    updatedAt: nextUpdatedAt,
+    progress: advanceOperatorStatusProgress({
+      current: snapshot.progress,
+      update: {
+        ...update,
+        updatedAt: nextUpdatedAt,
+      },
+    }),
+  };
+  await writeOperatorStatusSnapshot(paths, nextSnapshot);
+  return nextSnapshot;
+}

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -325,6 +325,29 @@ async function waitForPathExists(
   throw new Error(`Timed out waiting for ${targetPath} to exist`);
 }
 
+async function waitForStatusJson<T>(
+  statusJsonPath: string,
+  predicate: (value: T) => boolean,
+  timeoutMs = 10000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(await fs.readFile(statusJsonPath, "utf8")) as T;
+      if (predicate(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Keep polling until the timeout expires.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(
+    `Timed out waiting for status predicate on ${statusJsonPath}`,
+  );
+}
+
 function buildAppendWakeUpLogCommand(entryTitle: string): string {
   const entry = `\n## ${entryTitle}\n- Appended by integration test.\n`;
   const program = `const fs = require("node:fs"); fs.appendFileSync(process.env.SYMPHONY_OPERATOR_WAKE_UP_LOG, ${JSON.stringify(entry)});`;
@@ -766,6 +789,195 @@ describe("operator loop workflow selection", () => {
       expect(statusJson.operatorControl.path).toBe(run.controlStatePath);
       expect(statusJson.operatorControl.posture).toBe("runtime-blocked");
       expect(statusJson.operatorControl.summary).toBe(controlState.summary);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes live progress milestones during a long wake-up cycle", async () => {
+    const tempDir = await createTempDir("symphony-operator-loop-progress-");
+    const workflowPath = await writeWorkflow(tempDir);
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
+    const markerPath = path.join(tempDir, "progress-mid-cycle.txt");
+    const commandPath = path.join(tempDir, "publish-progress.sh");
+    const childHolder: { current: ChildProcessWithoutNullStreams | null } = {
+      current: null,
+    };
+
+    try {
+      await fs.writeFile(
+        commandPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+pnpm tsx "$SYMPHONY_OPERATOR_PROGRESS_UPDATER" --milestone checkpoint-report-review --summary "Reviewing completed-run report follow-up for #344." --issue-number 344 --issue-identifier sociotechnica-org/symphony-ts#344 >/dev/null
+printf 'ready\\n' > ${JSON.stringify(markerPath)}
+sleep 2
+pnpm tsx "$SYMPHONY_OPERATOR_PROGRESS_UPDATER" --milestone post-merge-refresh --summary "Refreshing the selected instance after merge for #344." --issue-number 344 --issue-identifier sociotechnica-org/symphony-ts#344 --pull-request-number 512 >/dev/null
+sleep 1
+`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+
+      const child = spawn(
+        "bash",
+        [
+          path.join("skills", "symphony-operator", "operator-loop.sh"),
+          "--once",
+          "--workflow",
+          workflowPath,
+        ],
+        {
+          cwd: repoRoot,
+          env: buildTopLevelOperatorLoopEnv({
+            GH_TOKEN: "test-token",
+            SYMPHONY_OPERATOR_COMMAND: commandPath,
+          }),
+        },
+      );
+      childHolder.current = child;
+
+      await waitForPathExists(markerPath);
+      const midCycleStatus = await waitForStatusJson<{
+        readonly state: string;
+        readonly progress: {
+          readonly milestone: string;
+          readonly summary: string;
+          readonly sequence: number;
+          readonly relatedIssueNumber: number | null;
+          readonly previousMilestone: string | null;
+        } | null;
+      }>(
+        paths.statusJsonPath,
+        (value) => value.progress?.milestone === "checkpoint-report-review",
+      );
+      const midCycleStatusMd = await fs.readFile(paths.statusMdPath, "utf8");
+
+      expect(midCycleStatus.state).toBe("acting");
+      expect(midCycleStatus.progress?.milestone).toBe(
+        "checkpoint-report-review",
+      );
+      expect(midCycleStatus.progress?.summary).toContain(
+        "completed-run report follow-up",
+      );
+      expect(midCycleStatus.progress?.sequence).toBe(2);
+      expect(midCycleStatus.progress?.relatedIssueNumber).toBe(344);
+      expect(midCycleStatus.progress?.previousMilestone).toBe("cycle-start");
+      expect(midCycleStatusMd).toContain(
+        "- Progress milestone: checkpoint-report-review",
+      );
+
+      await new Promise<void>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", (code) => {
+          if (code === 0) {
+            resolve();
+            return;
+          }
+          reject(
+            new Error(
+              `Expected long-cycle operator loop to succeed, got ${code?.toString() ?? "unknown"}`,
+            ),
+          );
+        });
+      });
+      childHolder.current = null;
+
+      const finalStatus = JSON.parse(
+        await fs.readFile(paths.statusJsonPath, "utf8"),
+      ) as {
+        readonly state: string;
+        readonly progress: {
+          readonly milestone: string;
+          readonly sequence: number;
+          readonly previousMilestone: string | null;
+          readonly previousSummary: string | null;
+        } | null;
+      };
+      const finalStatusMd = await fs.readFile(paths.statusMdPath, "utf8");
+
+      expect(finalStatus.state).toBe("idle");
+      expect(finalStatus.progress?.milestone).toBe("cycle-finished");
+      expect(finalStatus.progress?.sequence).toBe(4);
+      expect(finalStatus.progress?.previousMilestone).toBe(
+        "post-merge-refresh",
+      );
+      expect(finalStatus.progress?.previousSummary).toContain(
+        "Refreshing the selected instance after merge",
+      );
+      expect(finalStatusMd).toContain("- Progress milestone: cycle-finished");
+      expect(finalStatusMd).toContain(
+        "- Previous progress milestone: post-merge-refresh",
+      );
+    } finally {
+      const childProcess = childHolder.current;
+      if (childProcess !== null) {
+        await terminateChildProcess(childProcess);
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces terminal cycle-failed progress without losing the prior checkpoint", async () => {
+    const tempDir = await createTempDir(
+      "symphony-operator-loop-progress-fail-",
+    );
+    const workflowPath = await writeWorkflow(tempDir);
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
+    const commandPath = path.join(tempDir, "publish-progress-fail.sh");
+
+    try {
+      await fs.writeFile(
+        commandPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+pnpm tsx "$SYMPHONY_OPERATOR_PROGRESS_UPDATER" --milestone checkpoint-actions --summary "Reviewing pending /land work for #344." --issue-number 344 --issue-identifier sociotechnica-org/symphony-ts#344 --pull-request-number 512 >/dev/null
+exit 7
+`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+
+      const failure = await runOperatorLoopExpectFailure(workflowPath, [], {
+        GH_TOKEN: "test-token",
+        SYMPHONY_OPERATOR_COMMAND: commandPath,
+      });
+      createdPaths.add(tempDir);
+      createdPaths.add(paths.operatorStateRoot);
+
+      const statusJson = JSON.parse(
+        await fs.readFile(paths.statusJsonPath, "utf8"),
+      ) as {
+        readonly state: string;
+        readonly progress: {
+          readonly milestone: string;
+          readonly previousMilestone: string | null;
+          readonly previousSummary: string | null;
+        } | null;
+        readonly lastCycle: {
+          readonly exitCode: number | null;
+        };
+      };
+      const statusMd = await fs.readFile(paths.statusMdPath, "utf8");
+
+      expect(failure.exitCode).toBe(7);
+      expect(statusJson.state).toBe("idle");
+      expect(statusJson.lastCycle.exitCode).toBe(7);
+      expect(statusJson.progress?.milestone).toBe("cycle-failed");
+      expect(statusJson.progress?.previousMilestone).toBe("checkpoint-actions");
+      expect(statusJson.progress?.previousSummary).toContain(
+        "pending /land work",
+      );
+      expect(statusMd).toContain("- Progress milestone: cycle-failed");
+      expect(statusMd).toContain(
+        "- Previous progress milestone: checkpoint-actions",
+      );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/integration/operator-loop.test.ts
+++ b/tests/integration/operator-loop.test.ts
@@ -983,6 +983,82 @@ exit 7
     }
   });
 
+  it("records a failed terminal status when progress publication breaks", async () => {
+    const tempDir = await createTempDir(
+      "symphony-operator-loop-progress-publish-fail-",
+    );
+    const workflowPath = await writeWorkflow(tempDir);
+    const instanceKey = deriveSymphonyInstanceKey(path.dirname(workflowPath));
+    const paths = deriveOperatorInstanceStatePaths({
+      operatorRepoRoot: repoRoot,
+      instanceKey,
+    });
+    const commandPath = path.join(tempDir, "break-progress-publish.sh");
+    const failingUpdaterPath = path.join(
+      tempDir,
+      "failing-progress-updater.ts",
+    );
+
+    try {
+      await fs.writeFile(
+        failingUpdaterPath,
+        `const args = process.argv.slice(2);
+const milestoneIndex = args.indexOf("--milestone");
+const milestone = milestoneIndex === -1 ? null : args[milestoneIndex + 1] ?? null;
+if (milestone === "cycle-failed") {
+  process.stderr.write("synthetic terminal progress failure\\n");
+  process.exit(17);
+}
+process.exit(0);
+`,
+        { encoding: "utf8" },
+      );
+      await fs.writeFile(
+        commandPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+exit 7
+`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+
+      const failure = await runOperatorLoopExpectFailure(workflowPath, [], {
+        GH_TOKEN: "test-token",
+        SYMPHONY_OPERATOR_COMMAND: commandPath,
+        SYMPHONY_OPERATOR_PROGRESS_UPDATER_PATH: failingUpdaterPath,
+      });
+      createdPaths.add(tempDir);
+      createdPaths.add(paths.operatorStateRoot);
+
+      const statusJson = JSON.parse(
+        await fs.readFile(paths.statusJsonPath, "utf8"),
+      ) as {
+        readonly state: string;
+        readonly message: string;
+        readonly progress: unknown;
+        readonly lastCycle: {
+          readonly exitCode: number | null;
+          readonly logFile: string | null;
+        };
+      };
+      const cycleLog = await fs.readFile(
+        statusJson.lastCycle.logFile ?? "",
+        "utf8",
+      );
+
+      expect(failure.exitCode).toBe(7);
+      expect(statusJson.state).toBe("idle");
+      expect(statusJson.message).toContain("finished one cycle with a failure");
+      expect(statusJson.progress).toBeNull();
+      expect(statusJson.lastCycle.exitCode).toBe(7);
+      expect(cycleLog).toContain(
+        "progress_publish_failure_milestone=cycle-failed",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a nested operator loop launched from inside a wake-up cycle", async () => {
     const parentDir = await createTempDir("symphony-operator-loop-parent-");
     const nestedDir = await createTempDir("symphony-operator-loop-nested-");

--- a/tests/unit/operator-status.test.ts
+++ b/tests/unit/operator-status.test.ts
@@ -82,7 +82,7 @@ function createSnapshot(
 }
 
 describe("operator status helpers", () => {
-  it("advances progress sequence and preserves the previous milestone", () => {
+  it("advances progress sequence, preserves the previous milestone, and resets sequence at the next cycle start", () => {
     const first = advanceOperatorStatusProgress({
       current: null,
       update: {
@@ -100,6 +100,22 @@ describe("operator status helpers", () => {
         relatedIssueNumber: 344,
       },
     });
+    const terminal = advanceOperatorStatusProgress({
+      current: second,
+      update: {
+        milestone: "cycle-finished",
+        summary: "Operator cycle completed successfully.",
+        updatedAt: "2026-04-09T12:03:00Z",
+      },
+    });
+    const nextCycleStart = advanceOperatorStatusProgress({
+      current: terminal,
+      update: {
+        milestone: "cycle-start",
+        summary: "Next wake-up cycle started.",
+        updatedAt: "2026-04-09T12:10:00Z",
+      },
+    });
 
     expect(first.sequence).toBe(1);
     expect(first.previousMilestone).toBeNull();
@@ -107,6 +123,9 @@ describe("operator status helpers", () => {
     expect(second.previousMilestone).toBe("cycle-start");
     expect(second.previousSummary).toBe("Wake-up cycle started.");
     expect(second.relatedIssueNumber).toBe(344);
+    expect(terminal.sequence).toBe(3);
+    expect(nextCycleStart.sequence).toBe(1);
+    expect(nextCycleStart.previousMilestone).toBe("cycle-finished");
   });
 
   it("writes markdown progress lines and keeps previous checkpoint context on terminal completion", async () => {
@@ -171,6 +190,30 @@ describe("operator status helpers", () => {
       );
       expect(statusMd).toContain(
         "- Progress subject: sociotechnica-org/symphony-ts#344 / PR #512",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed partial status snapshots before rendering can reuse them", async () => {
+    const tempDir = await createTempDir("symphony-operator-status-invalid-");
+    const statusJsonPath = path.join(tempDir, "status.json");
+
+    try {
+      await fs.writeFile(
+        statusJsonPath,
+        JSON.stringify({
+          version: 1,
+          state: "acting",
+          message: "partial",
+          updatedAt: "2026-04-09T12:00:00Z",
+        }),
+        "utf8",
+      );
+
+      await expect(readOperatorStatusSnapshot(statusJsonPath)).rejects.toThrow(
+        /Malformed operatorControl in operator status snapshot/,
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/unit/operator-status.test.ts
+++ b/tests/unit/operator-status.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  advanceOperatorStatusProgress,
+  readOperatorStatusSnapshot,
+  renderOperatorStatusSnapshot,
+  updateOperatorStatusProgress,
+  writeOperatorStatusSnapshot,
+  type OperatorStatusSnapshot,
+} from "../../src/observability/operator-status.js";
+import { createTempDir } from "../support/git.js";
+
+function createSnapshot(
+  overrides?: Partial<OperatorStatusSnapshot>,
+): OperatorStatusSnapshot {
+  return {
+    version: 1,
+    state: "acting",
+    message: "Running operator wake-up cycle",
+    updatedAt: "2026-04-09T12:00:00Z",
+    progress: null,
+    repoRoot: "/tmp/operator-repo",
+    instanceKey: "operator-test-123",
+    detachedSessionName: "symphony-factory-operator-test-123",
+    selectedInstanceRoot: "/tmp/selected-instance",
+    operatorStateRoot: "/tmp/operator-state",
+    pid: 12345,
+    runOnce: true,
+    intervalSeconds: 300,
+    provider: "codex",
+    model: "gpt-5.4-mini",
+    commandSource: "provider-template",
+    command: "codex exec -C . -",
+    effectiveCommand: "codex exec -C . -",
+    promptFile: "/tmp/operator-prompt.md",
+    operatorControl: {
+      path: "/tmp/control-state.json",
+      posture: "clear",
+      summary: "All checkpoints are clear.",
+      blockingCheckpoint: null,
+      nextActionSummary: null,
+    },
+    standingContext: "/tmp/standing-context.md",
+    wakeUpLog: "/tmp/wake-up-log.md",
+    operatorSession: {
+      enabled: false,
+      path: "/tmp/operator-session.json",
+      mode: "disabled",
+      summary: "Resumable operator sessions are disabled.",
+      backendSessionId: null,
+      resetReason: null,
+    },
+    releaseState: {
+      path: "/tmp/release-state.json",
+      releaseId: null,
+      advancementState: "unconfigured",
+      summary: "Release state is unavailable.",
+      updatedAt: null,
+      blockingPrerequisiteNumber: null,
+      blockingPrerequisiteIdentifier: null,
+      promotion: {
+        state: "unconfigured",
+        summary: "Ready promotion is unavailable.",
+        updatedAt: null,
+        eligibleIssueNumbers: [],
+        readyLabelsAdded: [],
+        readyLabelsRemoved: [],
+      },
+    },
+    reportReviewState: "/tmp/report-review-state.json",
+    selectedWorkflowPath: "/tmp/selected-instance/WORKFLOW.md",
+    lastCycle: {
+      startedAt: "2026-04-09T12:00:00Z",
+      finishedAt: null,
+      exitCode: null,
+      logFile: "/tmp/operator-cycle.log",
+    },
+    nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+describe("operator status helpers", () => {
+  it("advances progress sequence and preserves the previous milestone", () => {
+    const first = advanceOperatorStatusProgress({
+      current: null,
+      update: {
+        milestone: "cycle-start",
+        summary: "Wake-up cycle started.",
+        updatedAt: "2026-04-09T12:00:00Z",
+      },
+    });
+    const second = advanceOperatorStatusProgress({
+      current: first,
+      update: {
+        milestone: "checkpoint-report-review",
+        summary: "Reviewing completed-run report follow-up for #344.",
+        updatedAt: "2026-04-09T12:02:00Z",
+        relatedIssueNumber: 344,
+      },
+    });
+
+    expect(first.sequence).toBe(1);
+    expect(first.previousMilestone).toBeNull();
+    expect(second.sequence).toBe(2);
+    expect(second.previousMilestone).toBe("cycle-start");
+    expect(second.previousSummary).toBe("Wake-up cycle started.");
+    expect(second.relatedIssueNumber).toBe(344);
+  });
+
+  it("writes markdown progress lines and keeps previous checkpoint context on terminal completion", async () => {
+    const tempDir = await createTempDir("symphony-operator-status-");
+    const statusJsonPath = path.join(tempDir, "status.json");
+    const statusMdPath = path.join(tempDir, "status.md");
+
+    try {
+      await writeOperatorStatusSnapshot(
+        { statusJsonPath, statusMdPath },
+        createSnapshot(),
+      );
+
+      await updateOperatorStatusProgress(
+        { statusJsonPath, statusMdPath },
+        {
+          milestone: "cycle-start",
+          summary: "Wake-up cycle started.",
+          relatedIssueNumber: 344,
+          relatedIssueIdentifier: "sociotechnica-org/symphony-ts#344",
+        },
+      );
+      await updateOperatorStatusProgress(
+        { statusJsonPath, statusMdPath },
+        {
+          milestone: "post-merge-refresh",
+          summary: "Refreshing the selected instance after merge.",
+          relatedIssueNumber: 344,
+          relatedIssueIdentifier: "sociotechnica-org/symphony-ts#344",
+          relatedPullRequestNumber: 512,
+        },
+      );
+
+      const finalSnapshot = await updateOperatorStatusProgress(
+        { statusJsonPath, statusMdPath },
+        {
+          milestone: "cycle-finished",
+          summary: "Operator cycle completed successfully",
+          relatedIssueNumber: 344,
+          relatedIssueIdentifier: "sociotechnica-org/symphony-ts#344",
+          relatedPullRequestNumber: 512,
+        },
+      );
+      const storedSnapshot = await readOperatorStatusSnapshot(statusJsonPath);
+      const statusMd = await fs.readFile(statusMdPath, "utf8");
+
+      expect(storedSnapshot.progress).toEqual(finalSnapshot.progress);
+      expect(finalSnapshot.progress?.milestone).toBe("cycle-finished");
+      expect(finalSnapshot.progress?.sequence).toBe(3);
+      expect(finalSnapshot.progress?.previousMilestone).toBe(
+        "post-merge-refresh",
+      );
+      expect(finalSnapshot.progress?.previousSummary).toContain(
+        "Refreshing the selected instance",
+      );
+      expect(renderOperatorStatusSnapshot(finalSnapshot)).toContain(
+        "- Progress milestone: cycle-finished",
+      );
+      expect(statusMd).toContain("- Progress milestone: cycle-finished");
+      expect(statusMd).toContain(
+        "- Previous progress milestone: post-merge-refresh",
+      );
+      expect(statusMd).toContain(
+        "- Progress subject: sociotechnica-org/symphony-ts#344 / PR #512",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- move operator loop status rendering into a typed helper and add a checked-in CLI for in-cycle progress updates
- publish milestone progress from the operator loop and prompt so long wake-up cycles expose checkpoint movement in `status.json` and `status.md`
- add unit and operator-loop integration coverage for live mid-cycle milestones and terminal progress preservation

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run tests/unit/operator-status.test.ts`
- `pnpm exec vitest run tests/integration/operator-loop.test.ts -t "publishes live progress milestones during a long wake-up cycle"`
- `pnpm exec vitest run tests/integration/operator-loop.test.ts -t "surfaces terminal cycle-failed progress without losing the prior checkpoint"`
- `pnpm exec vitest run tests/integration/operator-loop.test.ts -t "publishes selected workflow metadata inside the instance-scoped operator state root"`
- `pnpm exec vitest run tests/integration/operator-loop.test.ts -t "writes and exports the operator control-state artifact"`

## Notes
- `pnpm test` is still blocked by the existing `tests/unit/tui-use.test.ts` environment failure (`Cannot find module 'tui-use/package.json'` / `tui-use/dist/session.js`).

Closes #344
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/symphony-ts/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
