### PR TITLE
[codex] Block landing on current-head Devin findings

### DIFF
--- a/docs/plans/358-current-head-devin-review-blockers/plan.md
+++ b/docs/plans/358-current-head-devin-review-blockers/plan.md
@@ -1,0 +1,74 @@
+# Issue 358 Plan: Block Landing On Current-Head Devin Review Findings
+
+## Status
+
+- implementation complete locally
+- plan approval waived by operator instruction: "fix it in symphony yes"
+
+## Goal
+
+Prevent GitHub PRs from reaching `awaiting-landing-command` or passing guarded landing when a current-head Devin review summary explicitly reports unresolved findings, including the newer wording `found 1 new potential issue`.
+
+## Scope
+
+- tighten Devin verdict parsing for current review/comment summary bodies
+- make the legacy approved-review-bot compatibility path treat current-head PR review findings as actionable blockers
+- add unit and integration regression tests for the PR-review-summary shape that caused Alexandria PR 39 to look landable
+- tighten operator guidance so `/land` is not posted solely because the status surface reports `awaiting-landing-command`
+
+## Non-Goals
+
+- redesign reviewer-app configuration
+- add native adapters for other reviewer apps
+- change GitHub transport queries beyond the existing review/comment/check surfaces
+- change runner, workspace, or orchestrator retry behavior
+
+## Current Gaps
+
+- The native Devin adapter only recognizes `found <n> potential issues`; it misses singular `issue` and `new potential issue(s)`.
+- The legacy approved-review-bot path counts current-head PR reviews as required reviewer coverage, but does not inspect their bodies for findings.
+- Operator instructions need an explicit reminder that `/land` requires clean current-head reviewer-app summary evidence, not only a clean lifecycle label.
+
+## Spec Alignment By Abstraction Level
+
+- Policy: PR lifecycle must not classify current-head reviewer-app findings as landable.
+- Configuration: no config shape changes; existing `reviewer_apps`, `review_bot_logins`, and `approved_review_bot_logins` contracts remain valid.
+- Coordination: orchestration consumes the corrected normalized lifecycle only; no orchestrator changes are needed.
+- Execution: no runner or workspace changes.
+- Integration: GitHub tracker normalization owns raw review-body parsing and legacy compatibility.
+- Observability: existing reviewer verdict and actionable-feedback surfaces should now explain the blocker; operator prompt gets a guardrail for status mismatches.
+
+## Architecture Boundaries
+
+- Devin-specific string parsing belongs in reviewer-app normalization helpers.
+- Legacy compatibility may call reviewer-app verdict helpers for known approved bot logins, but generic PR policy must stay app-agnostic.
+- Operator instructions may require an independent review-summary check before `/land`, but they must not become the only correctness mechanism.
+
+## Implementation Steps
+
+1. Extract or expose a reusable Devin verdict parser that recognizes current Devin pass and findings wording.
+2. Use that parser in both the native Devin adapter and the legacy approved-review-bot adapter.
+3. In legacy compatibility, convert current-head PR reviews with recognized issues-found verdicts into `pull-request-review` actionable feedback.
+4. Preserve clean current-head PR reviews as required-reviewer coverage.
+5. Add regression tests for native reviewer-app and legacy approved-review-bot configurations.
+6. Update the operator prompt to state that `awaiting-landing-command` is not sufficient if top-level current-head bot review summaries still report findings.
+
+## Tests
+
+- Unit: `createPullRequestSnapshot()` classifies `**Devin Review** found 1 new potential issue.` as `issues-found` for native Devin reviewer apps.
+- Unit: legacy `approvedReviewBotLogins: ["devin-ai-integration"]` treats the same current-head PR review body as actionable `pull-request-review` feedback.
+- Integration: `GitHubTracker.inspectIssueHandoff()` reports `rework-required` for the legacy Alexandria-style config when Devin leaves that current-head PR review summary.
+
+## Acceptance
+
+- A current-head Devin PR review saying `found 1 new potential issue` blocks landing.
+- Legacy Alexandria-style reviewer-bot config no longer treats that review as a clean required-reviewer pass.
+- Guarded landing remains blocked because the normalized pull-request snapshot contains actionable bot feedback.
+- Operator guidance no longer encourages `/land` from status alone when bot summary evidence contradicts it.
+
+## Verification
+
+- `pnpm exec vitest run tests/unit/pull-request-snapshot.test.ts tests/integration/github-bootstrap.test.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`

--- a/skills/symphony-operator/operator-prompt.md
+++ b/skills/symphony-operator/operator-prompt.md
@@ -30,7 +30,7 @@ Repository and policy rules:
 - If `SYMPHONY_OPERATOR_SELECTED_INSTANCE_ROOT` differs from `SYMPHONY_OPERATOR_REPO_ROOT`, read that selected repository's `WORKFLOW.md`, `AGENTS.md`, `README.md`, `OPERATOR.md`, and relevant docs when they exist. Do not apply `symphony-ts` planning standards to an external repository unless its own checked-in instructions say to.
 - If `SYMPHONY_OPERATOR_WORKFLOW_PATH` is set, use it when calling Symphony factory-control commands for the selected instance.
 - Before posting a plan-review decision, inspect the selected workflow's `tracker.plan_review` config and use its configured decision markers.
-- Before posting `/land`, respect the release checkpoint and only land work when CI is green, review is clean, and the usual landing guard conditions are satisfied.
+- Before posting `/land`, respect the release checkpoint and only land work when CI is green, review is clean, the usual landing guard conditions are satisfied, and a bounded GitHub PR check finds no current-head top-level reviewer-app review or comment summary that says issues, findings, or potential issues were found.
 
 Operational constraints:
 

--- a/src/tracker/reviewer-app-devin.ts
+++ b/src/tracker/reviewer-app-devin.ts
@@ -31,13 +31,17 @@ function isInformationalDevinBody(body: string): boolean {
   return DEVIN_INFORMATIONAL_HEADING.test(normalizeDevinBody(body));
 }
 
-function parseDevinVerdict(body: string): "pass" | "issues-found" | "unknown" {
-  if (/devin review:?\s*no issues found/i.test(body)) {
+export function parseDevinVerdict(
+  body: string,
+): "pass" | "issues-found" | "unknown" {
+  if (/\bdevin review\b[\s\S]*?\bno issues found\b/i.test(body)) {
     return "pass";
   }
   if (
-    /devin review:?.*found\s+\d+\s+potential issues/i.test(body) ||
-    /devin review:?.*issues found/i.test(body)
+    /\bdevin review\b[\s\S]*?\bfound\s+\d+\s+(?:new\s+)?potential\s+issues?\b/i.test(
+      body,
+    ) ||
+    /\bdevin review\b[\s\S]*?\bissues found\b/i.test(body)
   ) {
     return "issues-found";
   }

--- a/src/tracker/reviewer-app-devin.ts
+++ b/src/tracker/reviewer-app-devin.ts
@@ -31,19 +31,29 @@ function isInformationalDevinBody(body: string): boolean {
   return DEVIN_INFORMATIONAL_HEADING.test(normalizeDevinBody(body));
 }
 
+function devinReviewSummaryLines(body: string): string[] {
+  return body.split(/\r?\n/u).filter((line) => /\bdevin review\b/i.test(line));
+}
+
 export function parseDevinVerdict(
   body: string,
 ): "pass" | "issues-found" | "unknown" {
-  if (/\bdevin review\b[\s\S]*?\bno issues found\b/i.test(body)) {
-    return "pass";
+  const summaryLines = devinReviewSummaryLines(body);
+  if (summaryLines.length === 0) {
+    return "unknown";
   }
   if (
-    /\bdevin review\b[\s\S]*?\bfound\s+\d+\s+(?:new\s+)?potential\s+issues?\b/i.test(
-      body,
-    ) ||
-    /\bdevin review\b[\s\S]*?\bissues found\b/i.test(body)
+    summaryLines.some(
+      (line) =>
+        /\bfound\s+\d+\s+(?:new\s+)?potential\s+issues?\b/i.test(line) ||
+        (/\bissues found\b/i.test(line) &&
+          !/\bno\s+issues found\b/i.test(line)),
+    )
   ) {
     return "issues-found";
+  }
+  if (summaryLines.some((line) => /\bno\s+issues found\b/i.test(line))) {
+    return "pass";
   }
   return "unknown";
 }

--- a/src/tracker/reviewer-app-legacy.ts
+++ b/src/tracker/reviewer-app-legacy.ts
@@ -2,6 +2,7 @@ import type { ReviewFeedback } from "../domain/pull-request.js";
 import type { ReviewerAppSnapshot } from "./reviewer-app-types.js";
 import type { PullRequestCheck } from "../domain/pull-request.js";
 import { createGitHubLoginSet, normalizeGitHubLogin } from "./github-login.js";
+import { parseDevinVerdict } from "./reviewer-app-devin.js";
 
 const NON_ACTIONABLE_BOT_COMMENT_MARKERS = {
   cursorSummary: "<!-- CURSOR_SUMMARY -->",
@@ -86,6 +87,38 @@ function isActionableAcceptedBotBody(
 ): boolean {
   const normalized = normalizeBotCommentBody(body);
   return normalized.length > 0 && !isNonActionableBotBody(authorLogin, body);
+}
+
+function parseKnownBotVerdict(
+  authorLogin: string,
+  body: string,
+): "pass" | "issues-found" | "unknown" {
+  switch (normalizeGitHubLogin(authorLogin)) {
+    case "devin-ai-integration":
+      return parseDevinVerdict(body);
+    default:
+      return "unknown";
+  }
+}
+
+function createPullRequestReviewFeedback(review: {
+  readonly id: string;
+  readonly authorLogin: string | null;
+  readonly body: string;
+  readonly submittedAt: string;
+  readonly url: string;
+}): ReviewFeedback {
+  return {
+    id: review.id,
+    kind: "pull-request-review",
+    threadId: null,
+    authorLogin: review.authorLogin,
+    body: review.body,
+    createdAt: review.submittedAt,
+    url: review.url,
+    path: null,
+    line: null,
+  };
 }
 
 function observedApprovedReviewBotLoginsFromChecks(
@@ -191,6 +224,16 @@ export function createLegacyReviewerAppSnapshot(input: {
         path: null,
         line: null,
       })),
+    ...input.currentHeadPullRequestReviews
+      .filter((review) => {
+        const authorLogin = review.authorLogin;
+        return (
+          typeof authorLogin === "string" &&
+          acceptedBotLogins.has(normalizeGitHubLogin(authorLogin)) &&
+          parseKnownBotVerdict(authorLogin, review.body) === "issues-found"
+        );
+      })
+      .map(createPullRequestReviewFeedback),
   ];
   const observedApprovedReviewBotLogins = [
     ...new Set([

--- a/tests/integration/github-bootstrap.test.ts
+++ b/tests/integration/github-bootstrap.test.ts
@@ -1748,6 +1748,44 @@ describe("GitHubTracker", () => {
     });
   });
 
+  it("treats legacy Devin approved-review findings as rework-required", async () => {
+    const tracker = createTracker(server, undefined, ["devin-ai-integration"]);
+
+    await server.recordPullRequest({
+      title: "PR for issue 7",
+      body: "",
+      head: "symphony/7",
+      base: "main",
+    });
+    server.setPullRequestCheckRuns("symphony/7", [
+      { name: "CI", status: "completed", conclusion: "success" },
+      { name: "Devin Review", status: "completed", conclusion: "success" },
+    ]);
+    server.addPullRequestReview({
+      head: "symphony/7",
+      authorLogin: "devin-ai-integration",
+      body: "**Devin Review** found 1 new potential issue.\n\nView 6 additional findings in Devin Review.",
+      submittedAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    const lifecycle = await tracker.inspectIssueHandoff("symphony/7");
+
+    expect(lifecycle.kind).toBe("rework-required");
+    expect(lifecycle.actionableReviewFeedback).toHaveLength(1);
+    expect(lifecycle.actionableReviewFeedback[0]).toMatchObject({
+      kind: "pull-request-review",
+      authorLogin: "devin-ai-integration",
+    });
+
+    const landing = await tracker.executeLanding(lifecycle.pullRequest!);
+
+    expect(landing).toMatchObject({
+      kind: "blocked",
+      reason: "actionable-review-feedback",
+      lifecycleKind: "rework-required",
+    });
+  });
+
   it("blocks guarded landing when required approved bot review is missing", async () => {
     const tracker = createTracker(server, undefined, ["greptile[bot]"]);
 

--- a/tests/unit/pull-request-snapshot.test.ts
+++ b/tests/unit/pull-request-snapshot.test.ts
@@ -273,6 +273,60 @@ describe("createPullRequestSnapshot", () => {
     });
   });
 
+  it("recognizes current-head Devin PR review findings with singular new-issue wording", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [
+            {
+              id: "review-1",
+              author: { login: "devin-ai-integration" },
+              body: "**Devin Review** found 1 new potential issue.\n\nView 6 additional findings in Devin Review.",
+              submittedAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#review-1",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewerApps: devinReviewerApps,
+      reviewBotLogins: [],
+    });
+
+    expect(snapshot.reviewerVerdict).toBe("blocking-issues-found");
+    expect(snapshot.reviewerApps[0]).toMatchObject({
+      reviewerKey: "devin",
+      accepted: true,
+      required: true,
+      coverage: "observed",
+      status: "completed",
+      verdict: "issues-found",
+    });
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]).toMatchObject({
+      id: "review-1",
+      kind: "pull-request-review",
+      authorLogin: "devin-ai-integration",
+    });
+  });
+
   it("records required approved bot review presence from a clean summary comment", () => {
     const snapshot = createPullRequestSnapshot({
       branchName: "symphony/19",
@@ -559,6 +613,64 @@ describe("createPullRequestSnapshot", () => {
 
     expect(snapshot.requiredReviewerState).toBe("satisfied");
     expect(snapshot.observedReviewerKeys).toEqual(["legacy-bot-review"]);
+  });
+
+  it("treats legacy approved Devin PR review findings as actionable feedback", () => {
+    const snapshot = createPullRequestSnapshot({
+      branchName: "symphony/19",
+      pullRequest,
+      checks: [successfulDevinCheck],
+      reviewState: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                committedDate: "2026-03-06T00:00:00.000Z",
+              },
+            },
+          ],
+        },
+        comments: {
+          nodes: [],
+        },
+        reviews: {
+          nodes: [
+            {
+              id: "review-1",
+              author: { login: "devin-ai-integration" },
+              body: "**Devin Review** found 1 new potential issue.\n\nView 6 additional findings in Devin Review.",
+              submittedAt: "2026-03-06T01:00:00.000Z",
+              url: "https://example.test/pr/24#review-1",
+            },
+          ],
+        },
+        reviewThreads: {
+          nodes: [],
+        },
+      },
+      reviewBotLogins: ["devin-ai-integration"],
+      approvedReviewBotLogins: ["devin-ai-integration"],
+    });
+
+    const legacySnapshot = snapshot.reviewerApps.find(
+      (reviewer) => reviewer.reviewerKey === "legacy-bot-review",
+    );
+
+    expect(snapshot.reviewerVerdict).toBe("blocking-issues-found");
+    expect(legacySnapshot).toMatchObject({
+      reviewerKey: "legacy-bot-review",
+      accepted: true,
+      required: true,
+      coverage: "observed",
+      status: "completed",
+      verdict: "issues-found",
+    });
+    expect(snapshot.botActionableReviewFeedback).toHaveLength(1);
+    expect(snapshot.botActionableReviewFeedback[0]).toMatchObject({
+      id: "review-1",
+      kind: "pull-request-review",
+      authorLogin: "devin-ai-integration",
+    });
   });
 
   it("ignores informational Devin review threads for legacy approved bot review", () => {

--- a/tests/unit/reviewer-app-devin.test.ts
+++ b/tests/unit/reviewer-app-devin.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseDevinVerdict } from "../../src/tracker/reviewer-app-devin.js";
+
+describe("parseDevinVerdict", () => {
+  it("recognizes Devin issue summaries with singular new-issue wording", () => {
+    expect(
+      parseDevinVerdict(
+        "**Devin Review** found 1 new potential issue.\n\nView 6 additional findings in Devin Review.",
+      ),
+    ).toBe("issues-found");
+  });
+
+  it("recognizes clean Devin summaries", () => {
+    expect(parseDevinVerdict("## ✅ Devin Review: No Issues Found")).toBe(
+      "pass",
+    );
+  });
+
+  it("does not treat later no-issues text as an overriding pass", () => {
+    expect(
+      parseDevinVerdict(
+        "## Devin Review: Found 3 potential issues\n\n---\nInfo: no issues found in main module",
+      ),
+    ).toBe("issues-found");
+  });
+
+  it("keeps issue findings blocking when later file coverage says no issues were found", () => {
+    expect(
+      parseDevinVerdict(
+        "**Devin Review** found 1 new potential issue.\n\nNo issues found in 5 of 6 files reviewed.",
+      ),
+    ).toBe("issues-found");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes sociotechnica-org/symphony-ts#358.

This PR prevents Symphony from treating a PR as landable when Devin has left a current-head PR review summary that explicitly reports findings, including the newer wording observed on Alexandria PR #39: `found 1 new potential issue`.

## Changes

- Broaden the Devin verdict parser to recognize markdown-wrapped review summaries, singular `issue`, and `new potential issue(s)` wording.
- Reuse Devin verdict parsing in the legacy approved-review-bot compatibility path so Alexandria-style `approved_review_bot_logins: [devin-ai-integration]` configs block on current-head PR review findings.
- Add snapshot and GitHub tracker regressions for the native `reviewer_apps: devin` path and the legacy approved-review-bot path.
- Tighten operator `/land` guidance so operators check current-head reviewer-app summaries before landing.
- Add the issue #358 implementation plan with the operator waiver recorded.

## Validation

- `vitest run tests/unit/pull-request-snapshot.test.ts tests/integration/github-bootstrap.test.ts`
- `tsc --noEmit`
- `eslint . --ext .ts`

I also ran the full suite from the original dirty checkout before isolating this PR: `pnpm test` passed with 989 tests.